### PR TITLE
feat(animations): Lenis smooth scroll, view transitions, and site-wide micro-interactions

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "peninsula-insider-next",
       "version": "0.0.1",
+      "dependencies": {
+        "lenis": "^1.3.23"
+      },
       "devDependencies": {
         "@astrojs/check": "^0.9.0",
         "astro": "^6.1.6",
@@ -3305,6 +3308,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lenis": {
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.23.tgz",
+      "integrity": "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "playground",
+        "playground/*"
+      ],
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkroomengineering"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "react": ">=17.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/longest-streak": {

--- a/next/package.json
+++ b/next/package.json
@@ -18,5 +18,8 @@
     "astro": "^6.1.6",
     "pagefind": "^1.3.0",
     "typescript": "^5.5.0"
+  },
+  "dependencies": {
+    "lenis": "^1.3.23"
   }
 }

--- a/next/src/components/CoverHero.astro
+++ b/next/src/components/CoverHero.astro
@@ -80,7 +80,42 @@ const hl = seasonalHeadlines[season];
   .hero-v2__journal-link a:hover { color: rgba(253,252,250,0.75); }
   .hero-v2__scroll-hint { position: absolute; bottom: 1.5rem; right: clamp(1.25rem,4vw,3rem); z-index: 2; display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
   .hero-v2__scroll-label { font-family: Outfit,system-ui,sans-serif; font-size: 0.55rem; font-weight: 500; letter-spacing: 0.2em; text-transform: uppercase; color: rgba(253,252,250,0.3); writing-mode: vertical-rl; }
-  .hero-v2__scroll-line { width: 1px; height: 40px; background: linear-gradient(to bottom, rgba(253,252,250,0.3), transparent); }
+  .hero-v2__scroll-line { width: 1px; height: 40px; background: rgba(253,252,250,0.35); }
+
+  @media (prefers-reduced-motion: no-preference) {
+    @keyframes riseIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    @keyframes scrollTravel {
+      0%   { transform: scaleY(0); transform-origin: top; opacity: 0.8; }
+      50%  { transform: scaleY(1); transform-origin: top; opacity: 0.8; }
+      51%  { transform-origin: bottom; }
+      100% { transform: scaleY(0); transform-origin: bottom; opacity: 0.2; }
+    }
+    .hero-v2__eyebrow {
+      animation: fadeIn 0.6s var(--ease) 0.15s both;
+    }
+    .hero-v2__headline {
+      animation: riseIn 0.75s var(--ease) 0.35s both;
+    }
+    .hero-v2__dek {
+      animation: fadeIn 0.6s var(--ease) 0.65s both;
+    }
+    .hero-v2__ctas {
+      animation: fadeIn 0.5s var(--ease) 0.85s both;
+    }
+    .hero-v2__journal-link {
+      animation: fadeIn 0.5s var(--ease) 1.0s both;
+    }
+    .hero-v2__scroll-line {
+      animation: scrollTravel 2.2s var(--ease) 1.5s infinite;
+    }
+  }
   @media (max-width: 768px) {
     .hero-v2 { min-height: 85vh; }
     .hero-v2__bg { background-position: center 30%; background-attachment: scroll; }

--- a/next/src/components/FeatureArticle.astro
+++ b/next/src/components/FeatureArticle.astro
@@ -19,7 +19,8 @@ const featureImgStyle = heroBackgroundStyle(article.data);
 <section class="feature">
   <div class="container">
     <div class="feature__inner">
-      <div class="feature__image-block" aria-hidden="true" style={featureImgStyle}>
+      <div class="feature__image-block" aria-hidden="true">
+        <div class="feature__image-bg" style={featureImgStyle}></div>
         <div class="feature__image-overlay"></div>
         <span class="feature__image-tag">
           {formatLabel[article.data.format] ?? article.data.format}

--- a/next/src/components/NewsletterBlock.astro
+++ b/next/src/components/NewsletterBlock.astro
@@ -42,3 +42,19 @@ const {
     </div>
   </div>
 </section>
+
+<script>
+  const section = document.getElementById('newsletter');
+  if (section && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          section.classList.add('newsletter--visible');
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.15 }
+    );
+    observer.observe(section);
+  }
+</script>

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@
  */
 
 import '../styles/global.css';
+import { ClientRouter } from 'astro:transitions';
 import Masthead from '../components/Masthead.astro';
 import Footer from '../components/Footer.astro';
 
@@ -95,6 +96,9 @@ const ogImageAbsolute = ogImage.startsWith('http')
     logo: `${SITE_URL}/images/sourced/home-cover.webp`,
   })} />
 
+  <!-- View transitions: client-side routing with page fade -->
+  <ClientRouter />
+
   <!-- Beehiiv embed script — required for newsletter iframe to function -->
   <script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
 
@@ -149,6 +153,44 @@ const ogImageAbsolute = ogImage.startsWith('http')
   <!-- Enhancement JS -->
   <script is:inline src="/assets/newsletter-enhance.js"></script>
   <script is:inline src="/assets/scroll-animations.js"></script>
+
+  <!-- Lenis smooth scroll — buttery weighted physics on every page -->
+  <script>
+    import Lenis from 'lenis';
+
+    let lenis: InstanceType<typeof Lenis> | null = null;
+    let rafId: number | null = null;
+
+    function startLenis() {
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+      lenis = new Lenis({
+        duration: 1.4,
+        easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+        wheelMultiplier: 0.9,
+        touchMultiplier: 1.0,
+        smoothTouch: false,
+      });
+
+      function raf(time: number) {
+        lenis!.raf(time);
+        rafId = requestAnimationFrame(raf);
+      }
+      rafId = requestAnimationFrame(raf);
+    }
+
+    function stopLenis() {
+      if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+      if (lenis) { lenis.destroy(); lenis = null; }
+    }
+
+    // Boot on first load
+    startLenis();
+
+    // Restart cleanly after each view-transition page swap
+    document.addEventListener('astro:before-swap', stopLenis);
+    document.addEventListener('astro:page-load', startLenis);
+  </script>
 
 </body>
 </html>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -31,7 +31,36 @@
    RESET
    ========================================================= */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: smooth; font-size: 16px; }
+html { scroll-behavior: auto; font-size: 16px; } /* Lenis overrides scroll physics */
+
+/* =========================================================
+   LENIS SMOOTH SCROLL — required base CSS
+   ========================================================= */
+html.lenis, html.lenis body { height: auto; }
+.lenis.lenis-smooth { scroll-behavior: auto !important; }
+.lenis.lenis-smooth [data-lenis-prevent] { overscroll-behavior: contain; }
+.lenis.lenis-stopped { overflow: hidden; }
+
+/* =========================================================
+   VIEW TRANSITIONS — page fade between routes
+   ========================================================= */
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes vt-fade-out { to   { opacity: 0; } }
+  @keyframes vt-fade-in  { from { opacity: 0; } }
+
+  ::view-transition-old(root) {
+    animation: 180ms ease-out vt-fade-out both;
+  }
+  ::view-transition-new(root) {
+    animation: 340ms ease-out vt-fade-in both;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-image-pair(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) { animation: none !important; }
+}
 
 body {
   font-family: 'Outfit', system-ui, -apple-system, sans-serif;
@@ -120,6 +149,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   list-style: none;
 }
 .masthead__nav a {
+  position: relative;
   font-size: 0.7rem;
   font-weight: 500;
   letter-spacing: 0.05em;
@@ -128,8 +158,25 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   transition: color .2s var(--ease);
   white-space: nowrap;
 }
-.masthead__nav a:hover,
+.masthead__nav a::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform .38s var(--ease);
+}
+.masthead__nav a:hover { color: var(--accent); }
+.masthead__nav a:hover::after { transform: scaleX(1); }
 .masthead__nav a[aria-current="page"] { color: var(--accent); }
+.masthead__nav a[aria-current="page"]::after { transform: scaleX(1); transition: none; }
+@media (prefers-reduced-motion: reduce) {
+  .masthead__nav a::after { transition: none; }
+}
 .masthead__cta {
   font-size: 0.72rem;
   font-weight: 600;
@@ -466,9 +513,21 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   aspect-ratio: 3 / 2;
   border-radius: 2px;
   overflow: hidden;
+}
+.feature__image-bg {
+  position: absolute;
+  inset: 0;
   background: linear-gradient(135deg,#C9B99A 0%,#A89278 30%,#8B7055 60%,#6E5440 100%);
   background-size: cover;
   background-position: center;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .feature__image-bg {
+    transition: transform 0.7s var(--ease);
+  }
+  .feature__image-block:hover .feature__image-bg {
+    transform: scale(1.035);
+  }
 }
 .feature__image-overlay {
   position: absolute;
@@ -596,6 +655,13 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   display: flex;
   flex-direction: column;
   gap: 0;
+  box-shadow: inset 2px 0 0 transparent;
+  transition: box-shadow 0.35s var(--ease);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .venue-card:hover {
+    box-shadow: inset 2px 0 0 var(--accent);
+  }
 }
 .venue-card__top {
   display: flex;
@@ -755,6 +821,14 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .place-card__image {
+    transition: transform 0.65s var(--ease);
+  }
+  .place-card:hover .place-card__image {
+    transform: scale(1.04);
+  }
 }
 
 /* =========================================================
@@ -2527,6 +2601,15 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   background-size: cover;
   background-position: center;
   border-bottom: 1px solid var(--border);
+  overflow: hidden;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .event-card__hero {
+    transition: transform 0.65s var(--ease);
+  }
+  .event-card:hover .event-card__hero {
+    transform: scale(1.04);
+  }
 }
 .event-card__top,
 .event-card__name,
@@ -3957,4 +4040,33 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .newsletter__form--standalone .newsletter__status--err {
   color: #c0392b;
+}
+
+/* =========================================================
+   NEWSLETTER ENTRANCE ANIMATION
+   Fade-up on scroll into view. JS adds .newsletter--visible
+   via IntersectionObserver in NewsletterBlock.astro.
+   ========================================================= */
+@media (prefers-reduced-motion: no-preference) {
+  .newsletter__label,
+  .newsletter__title,
+  .newsletter__body {
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.65s var(--ease), transform 0.65s var(--ease);
+  }
+  .newsletter--visible .newsletter__label {
+    opacity: 1;
+    transform: none;
+  }
+  .newsletter--visible .newsletter__title {
+    opacity: 1;
+    transform: none;
+    transition-delay: 0.13s;
+  }
+  .newsletter--visible .newsletter__body {
+    opacity: 1;
+    transform: none;
+    transition-delay: 0.26s;
+  }
 }


### PR DESCRIPTION
## Summary

- **Lenis smooth scroll** — physics-based scroll (duration 1.4, exponential easing) across every page, with clean teardown/reinit on view transitions
- **Astro View Transitions** — 180ms fade-out / 340ms fade-in between every page navigation via `ClientRouter`
- **CoverHero entrance** — staggered fade/rise animations for eyebrow, headline, dek, CTAs, and looping scroll-line indicator
- **Masthead nav** — `::after` underline slides in via `scaleX` on hover and active page
- **VenueCard** — left accent bar slides in on hover
- **PlaceCard + EventCard** — hero image scales `1.04` on card hover
- **FeatureArticle** — separate image-bg layer scales `1.035` on hover (non-breaking HTML change: one extra wrapper div)
- **NewsletterBlock** — `IntersectionObserver` triggers staggered fade-in when section enters viewport

## What this touches

Every page (BaseLayout carries Lenis + View Transitions). All motion wrapped in `prefers-reduced-motion: no-preference` — accessibility clean.

## Test plan

- [ ] Homepage: cover hero entrance plays on load; scroll feels weighted/buttery
- [ ] Navigate between pages: fade-out/fade-in transition visible
- [ ] Hover venue cards, place cards, event cards: image zoom and accent bar
- [ ] Scroll to newsletter on any page: text cascades in
- [ ] Masthead nav links: underline slides in on hover
- [ ] Test with `prefers-reduced-motion: reduce` enabled — all animations disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)