### PR TITLE
feat: internal linking + nav architecture pass

### DIFF
--- a/next/src/components/EventCard.astro
+++ b/next/src/components/EventCard.astro
@@ -30,8 +30,12 @@ function recurrenceAwareDateLabel(data: any): string {
   return eventDateLabel(data.startDate, data.endDate);
 }
 const dateLabel = recurrenceAwareDateLabel(event.data);
-const placeLabel =
+const placeId =
   typeof event.data.place === 'string' ? event.data.place : event.data.place?.id;
+const placeLabel = placeId
+  ? String(placeId).replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())
+  : null;
+const placeHref = placeId ? `/places/${placeId}/` : null;
 ---
 
 <article class={`event-card ${featured ? 'event-card--featured' : ''}`}>
@@ -46,7 +50,9 @@ const placeLabel =
     <a href={`/whats-on/${slug}`}>{event.data.title}</a>
   </h3>
   {placeLabel && (
-    <p class="event-card__place">{String(placeLabel).replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}</p>
+    <p class="event-card__place">
+      {placeHref ? <a href={placeHref}>{placeLabel}</a> : placeLabel}
+    </p>
   )}
   <p class="event-card__summary">{event.data.summary}</p>
   {event.data.editorVerdict && (

--- a/next/src/components/Footer.astro
+++ b/next/src/components/Footer.astro
@@ -2,37 +2,22 @@
 /**
  * Footer  -  Peninsula Insider
  * Three-column footer with editorial nav, section links, and legal.
+ *
+ * Section + about links come from `lib/nav.ts` so the masthead, pillar grid,
+ * and footer stay in sync. The "Places" column is built from the live places
+ * collection so editorial picks lead but new published places surface
+ * automatically without a manual edit here.
  */
+import { getCollection } from 'astro:content';
+import {
+  footerSectionLinks as sectionLinks,
+  footerAboutLinks as aboutLinks,
+  buildFooterPlaceLinks,
+} from '../lib/nav';
+
 const year = new Date().getFullYear();
-
-const sectionLinks = [
-  { label: 'Eat & Drink', href: '/eat/' },
-  { label: 'Stay', href: '/stay/' },
-  { label: 'Wine Country', href: '/wine/' },
-  { label: 'Explore', href: '/explore/' },
-  { label: 'Golf', href: '/golf/' },
-  { label: 'Spa & Wellness', href: '/spa/' },
-  { label: 'Escape', href: '/escape/' },
-  { label: "What's On", href: '/whats-on/' },
-  { label: 'Journal', href: '/journal/' },
-];
-
-const placeLinks = [
-  { label: 'Red Hill', href: '/places/red-hill/' },
-  { label: 'Sorrento', href: '/places/sorrento/' },
-  { label: 'Flinders', href: '/places/flinders/' },
-  { label: 'Mornington', href: '/places/mornington/' },
-  { label: 'Portsea', href: '/places/portsea/' },
-  { label: 'Main Ridge', href: '/places/main-ridge/' },
-  { label: 'All places', href: '/places/' },
-];
-
-const aboutLinks = [
-  { label: 'About', href: '/about/' },
-  { label: 'Contact', href: '/contact/' },
-  { label: 'Newsletter', href: '/newsletter/' },
-  { label: 'Privacy', href: '/privacy/' },
-];
+const places = await getCollection('places');
+const placeLinks = buildFooterPlaceLinks(places);
 ---
 
 <footer class="footer">

--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -3,24 +3,13 @@
  * Masthead  -  Peninsula Insider
  * Sticky top bar. Highlights the current section.
  */
+import { mastheadNav as navItems } from '../lib/nav';
+
 export interface Props {
   section?: string;
 }
 
 const { section = 'home' } = Astro.props;
-
-// Primary masthead nav  -  seven slots: the six pillars plus the
-// What’s On dispatch row, which is the newest editorial lane and
-// the differentiator versus the DMO.
-const navItems = [
-  { key: 'eat',      label: 'Eat & Drink', href: '/eat'      },
-  { key: 'stay',     label: 'Stay',        href: '/stay'     },
-  { key: 'wine',     label: 'Wine',        href: '/wine'     },
-  { key: 'explore',  label: 'Explore',     href: '/explore'  },
-  { key: 'escape',   label: 'Escape',      href: '/escape'   },
-  { key: 'whats-on', label: "What’s On",   href: '/whats-on' },
-  { key: 'journal',  label: 'Journal',     href: '/journal'  },
-];
 ---
 
 <header class="masthead">

--- a/next/src/components/PillarNav.astro
+++ b/next/src/components/PillarNav.astro
@@ -3,73 +3,16 @@
  * Pillar navigation strip  -  shown on the homepage.
  * Each pillar has a line-art SVG icon sized and styled with the accent colour.
  */
-const pillars = [
-  {
-    href: '/eat',
-    name: 'Eat & Drink',
-    sub: 'Restaurants · Cellar Doors',
-    // Fork + knife crossed
-    icon: `<path d="M8 2 L8 22 M8 2 C6 4 5 6 5 9 C5 11 6 12 8 12 M16 2 L16 9 M20 2 L20 9 M18 2 L18 9 M18 9 L18 22" stroke-linecap="round" stroke-linejoin="round"/>`,
-  },
-  {
-    href: '/stay',
-    name: 'Stay',
-    sub: 'Hotels · Villas · Escapes',
-    // House with roof
-    icon: `<path d="M3 11 L12 3 L21 11 M5 10 L5 20 L19 20 L19 10 M10 20 L10 14 L14 14 L14 20" stroke-linecap="round" stroke-linejoin="round"/>`,
-  },
-  {
-    href: '/explore',
-    name: 'Explore',
-    sub: 'Walks · Beaches · Markets',
-    // Compass
-    icon: `<circle cx="12" cy="12" r="9"/><path d="M12 3 L12 5 M12 19 L12 21 M3 12 L5 12 M19 12 L21 12 M14 10 L10 14 M10 10 L14 14" stroke-linecap="round"/>`,
-  },
-  {
-    href: '/wine',
-    name: 'Wine Country',
-    sub: 'Wineries · Producers',
-    // Wine glass
-    icon: `<path d="M7 3 L17 3 L16 10 C16 13 14 15 12 15 C10 15 8 13 8 10 Z M12 15 L12 20 M8 20 L16 20" stroke-linecap="round" stroke-linejoin="round"/>`,
-  },
-  {
-    href: '/escape',
-    name: 'Escape',
-    sub: 'Itineraries · Slow Travel',
-    // Mountain range
-    icon: `<path d="M2 20 L8 10 L12 15 L16 7 L22 20 Z M8 10 L10 13 M16 7 L14 11" stroke-linecap="round" stroke-linejoin="round"/>`,
-  },
-  {
-    href: '/whats-on',
-    name: "What’s On",
-    sub: 'Weekend Picks · Events',
-    // Calendar
-    icon: `<rect x="3" y="5" width="18" height="16" rx="1"/><path d="M3 9 L21 9 M8 3 L8 7 M16 3 L16 7 M7 13 L9 13 M12 13 L14 13 M17 13 L19 13 M7 17 L9 17 M12 17 L14 17" stroke-linecap="round"/>`,
-  },
-  {
-    href: '/golf',
-    name: 'Golf',
-    sub: 'Courses · Weekend Rounds',
-    // Golf flag and ball
-    icon: `<path d="M6 3 L6 21 M6 4 L17 7 L6 10 M4 21 L8 21" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6" cy="18" r="1.2"/>`,
-  },
-  {
-    href: '/spa',
-    name: 'Spa',
-    sub: 'Hot Springs · Wellness',
-    // Steam rising from a bowl — wellness mark
-    icon: `<path d="M4 20 L20 20 M6 17 L18 17 M5 17 C5 14 8 12 12 12 C16 12 19 14 19 17 M10 8 C10 7 11 6 11 5 C11 4 10 3 10 3 M14 9 C14 8 15 7 15 6 C15 5 14 4 14 4" stroke-linecap="round" stroke-linejoin="round"/>`,
-  },
-];
+import { pillarNav } from '../lib/nav';
 ---
 
 <nav class="pillars" aria-label="Sections">
   <div class="container" style="padding: 0;">
     <div class="pillars__inner">
-      {pillars.map((p) => (
+      {pillarNav.map((p) => (
         <a href={p.href} class="pillar">
           <svg class="pillar__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true" set:html={p.icon} />
-          <span class="pillar__name" set:html={p.name.replace('&', '&amp;')} />
+          <span class="pillar__name" set:html={p.label.replace('&', '&amp;')} />
           <span class="pillar__sub">{p.sub}</span>
         </a>
       ))}

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -157,6 +157,7 @@ const venues = defineCollection({
     featuredPartner: z.boolean().default(false),
     lastVerified: z.coerce.date(),
     publishedAt: z.coerce.date(),
+    sitemapExclude: z.boolean().default(false),
   }),
 });
 
@@ -200,6 +201,7 @@ const experiences = defineCollection({
     gallery: z.array(imageRef).default([]),
     lastVerified: z.coerce.date(),
     publishedAt: z.coerce.date(),
+    sitemapExclude: z.boolean().default(false),
   }),
 });
 
@@ -217,6 +219,7 @@ const places = defineCollection({
     publishedAt: z.coerce.date(),
     tldr: z.array(z.string()).optional(),
     driveTime: z.string().optional(),
+    sitemapExclude: z.boolean().default(false),
   }),
 });
 
@@ -248,12 +251,16 @@ const articles = defineCollection({
     tags: z.array(z.string()).default([]),
     relatedVenues: z.array(reference('venues')).default([]),
     relatedExperiences: z.array(reference('experiences')).default([]),
+    relatedPlaces: z.array(reference('places')).default([]),
+    relatedArticles: z.array(reference('articles')).default([]),
+    relatedItineraries: z.array(reference('itineraries')).default([]),
     readingTimeMinutes: z.number().positive().optional(),
     featured: z.boolean().default(false),
     status: z.enum(['draft', 'review', 'scheduled', 'published']).default('draft'),
     lastVerified: z.coerce.date().optional(),
     clusterLinks: z.array(z.object({ label: z.string(), href: z.string() })).optional(),
     faq: z.array(z.object({ question: z.string(), answer: z.string() })).optional(),
+    sitemapExclude: z.boolean().default(false),
   }),
 });
 
@@ -420,6 +427,7 @@ const itineraries = defineCollection({
     editorNote: z.string(),
     publishedAt: z.coerce.date(),
     lastVerified: z.coerce.date().optional(),
+    sitemapExclude: z.boolean().default(false),
   }),
 });
 
@@ -482,6 +490,7 @@ const events = defineCollection({
     editorNote: z.string().optional(),
     heroImage: imageRef.optional(),
     publishedAt: z.coerce.date(),
+    sitemapExclude: z.boolean().default(false),
   }),
 });
 

--- a/next/src/lib/nav.ts
+++ b/next/src/lib/nav.ts
@@ -1,0 +1,200 @@
+/**
+ * Site-wide navigation source of truth.
+ *
+ * Components that render nav (Masthead, PillarNav, Footer, mobile nav) all
+ * import from here so the lanes stay in sync. The pillars list extends the
+ * core masthead nav with golf and spa, which are real top-level lanes but
+ * intentionally not in the masthead's seven-slot row.
+ *
+ * Editorial visual design is preserved — these arrays are shaped to feed the
+ * existing markup without changing it.
+ */
+
+export interface NavItem {
+  /** Stable key used for `aria-current` matching against a page's section. */
+  key: string;
+  label: string;
+  href: string;
+  /** Short editorial sub-line, used by the homepage pillar grid. */
+  sub?: string;
+  /** SVG `<path>` body for the pillar icon, when rendered in PillarNav. */
+  icon?: string;
+}
+
+/**
+ * The seven-slot masthead row. Order is editorial: pillars first, then the
+ * dispatch lane (What's On) and the Journal. Spa and Golf live in the
+ * extended pillar list, not the masthead.
+ */
+export const mastheadNav: NavItem[] = [
+  { key: 'eat',      label: 'Eat & Drink', href: '/eat'      },
+  { key: 'stay',     label: 'Stay',        href: '/stay'     },
+  { key: 'wine',     label: 'Wine',        href: '/wine'     },
+  { key: 'explore',  label: 'Explore',     href: '/explore'  },
+  { key: 'escape',   label: 'Escape',      href: '/escape'   },
+  { key: 'whats-on', label: "What’s On", href: '/whats-on' },
+  { key: 'journal',  label: 'Journal',     href: '/journal'  },
+];
+
+/**
+ * Homepage pillar strip — eight tiles with sub-lines and icons. The first
+ * five mirror the masthead pillars; What's On replaces Journal in this view,
+ * and Golf + Spa round out the lane set.
+ */
+export const pillarNav: NavItem[] = [
+  {
+    key: 'eat',
+    href: '/eat',
+    label: 'Eat & Drink',
+    sub: 'Restaurants · Cellar Doors',
+    icon: `<path d="M8 2 L8 22 M8 2 C6 4 5 6 5 9 C5 11 6 12 8 12 M16 2 L16 9 M20 2 L20 9 M18 2 L18 9 M18 9 L18 22" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  {
+    key: 'stay',
+    href: '/stay',
+    label: 'Stay',
+    sub: 'Hotels · Villas · Escapes',
+    icon: `<path d="M3 11 L12 3 L21 11 M5 10 L5 20 L19 20 L19 10 M10 20 L10 14 L14 14 L14 20" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  {
+    key: 'explore',
+    href: '/explore',
+    label: 'Explore',
+    sub: 'Walks · Beaches · Markets',
+    icon: `<circle cx="12" cy="12" r="9"/><path d="M12 3 L12 5 M12 19 L12 21 M3 12 L5 12 M19 12 L21 12 M14 10 L10 14 M10 10 L14 14" stroke-linecap="round"/>`,
+  },
+  {
+    key: 'wine',
+    href: '/wine',
+    label: 'Wine Country',
+    sub: 'Wineries · Producers',
+    icon: `<path d="M7 3 L17 3 L16 10 C16 13 14 15 12 15 C10 15 8 13 8 10 Z M12 15 L12 20 M8 20 L16 20" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  {
+    key: 'escape',
+    href: '/escape',
+    label: 'Escape',
+    sub: 'Itineraries · Slow Travel',
+    icon: `<path d="M2 20 L8 10 L12 15 L16 7 L22 20 Z M8 10 L10 13 M16 7 L14 11" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+  {
+    key: 'whats-on',
+    href: '/whats-on',
+    label: "What’s On",
+    sub: 'Weekend Picks · Events',
+    icon: `<rect x="3" y="5" width="18" height="16" rx="1"/><path d="M3 9 L21 9 M8 3 L8 7 M16 3 L16 7 M7 13 L9 13 M12 13 L14 13 M17 13 L19 13 M7 17 L9 17 M12 17 L14 17" stroke-linecap="round"/>`,
+  },
+  {
+    key: 'golf',
+    href: '/golf',
+    label: 'Golf',
+    sub: 'Courses · Weekend Rounds',
+    icon: `<path d="M6 3 L6 21 M6 4 L17 7 L6 10 M4 21 L8 21" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6" cy="18" r="1.2"/>`,
+  },
+  {
+    key: 'spa',
+    href: '/spa',
+    label: 'Spa',
+    sub: 'Hot Springs · Wellness',
+    icon: `<path d="M4 20 L20 20 M6 17 L18 17 M5 17 C5 14 8 12 12 12 C16 12 19 14 19 17 M10 8 C10 7 11 6 11 5 C11 4 10 3 10 3 M14 9 C14 8 15 7 15 6 C15 5 14 4 14 4" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
+];
+
+/**
+ * Footer "Sections" column. Mirrors the full lane set including spa, golf,
+ * and the dispatch row, with trailing slashes on every href because the site
+ * is configured `trailingSlash: 'always'`.
+ */
+export const footerSectionLinks: NavItem[] = [
+  { key: 'eat',              label: 'Eat & Drink',     href: '/eat/' },
+  { key: 'stay',             label: 'Stay',            href: '/stay/' },
+  { key: 'wine',             label: 'Wine Country',    href: '/wine/' },
+  { key: 'explore',          label: 'Explore',         href: '/explore/' },
+  { key: 'golf',             label: 'Golf',            href: '/golf/' },
+  { key: 'spa',              label: 'Spa & Wellness',  href: '/spa/' },
+  { key: 'escape',           label: 'Escape',          href: '/escape/' },
+  { key: 'whats-on',         label: "What's On",       href: '/whats-on/' },
+  { key: 'journal',          label: 'Journal',         href: '/journal/' },
+  { key: 'dog-friendly',     label: 'Dog Friendly',    href: '/dog-friendly/' },
+  { key: 'weddings',         label: 'Weddings',        href: '/weddings/' },
+  { key: 'corporate-events', label: 'Corporate',       href: '/corporate-events/' },
+];
+
+/**
+ * Footer "About" column.
+ */
+export const footerAboutLinks: NavItem[] = [
+  { key: 'about',      label: 'About',      href: '/about/' },
+  { key: 'contact',    label: 'Contact',    href: '/contact/' },
+  { key: 'newsletter', label: 'Newsletter', href: '/newsletter/' },
+  { key: 'privacy',    label: 'Privacy',    href: '/privacy/' },
+];
+
+/**
+ * Curated set of place hubs to surface in the footer "Places" column. These
+ * are the highest-intent place pages — the Footer can also load the live
+ * places collection and merge in any others, but this list anchors the
+ * editorial picks at the top.
+ */
+export const footerPlaceFeatured: ReadonlyArray<string> = [
+  'red-hill',
+  'sorrento',
+  'flinders',
+  'mornington',
+  'portsea',
+  'main-ridge',
+  'mount-martha',
+  'rye',
+  'merricks',
+  'balnarring',
+  'dromana',
+  'point-nepean',
+];
+
+/**
+ * Build the footer "Places" column from the full places collection. Returns
+ * the featured set first (in editorial order), then any additional published
+ * places not already in the featured list, capped to keep the column short.
+ *
+ * Pass `places` from `getCollection('places')` so this stays a build-time
+ * computation with no client JS.
+ */
+export function buildFooterPlaceLinks(
+  places: Array<{ id?: string; slug?: string; data: { slug?: string; name: string; sitemapExclude?: boolean } }>,
+  cap = 12,
+): NavItem[] {
+  const bySlug = new Map<string, { name: string }>();
+  for (const p of places) {
+    const slug = (p.data?.slug ?? p.slug ?? p.id ?? '').toString();
+    if (!slug) continue;
+    if (p.data?.sitemapExclude) continue;
+    bySlug.set(slug, { name: p.data.name });
+  }
+
+  const ordered: NavItem[] = [];
+  const seen = new Set<string>();
+
+  for (const slug of footerPlaceFeatured) {
+    const place = bySlug.get(slug);
+    if (!place) continue;
+    ordered.push({ key: slug, label: place.name, href: `/places/${slug}/` });
+    seen.add(slug);
+    if (ordered.length >= cap) break;
+  }
+
+  if (ordered.length < cap) {
+    const extras: NavItem[] = [];
+    for (const [slug, place] of bySlug) {
+      if (seen.has(slug)) continue;
+      extras.push({ key: slug, label: place.name, href: `/places/${slug}/` });
+    }
+    extras.sort((a, b) => a.label.localeCompare(b.label));
+    for (const extra of extras) {
+      if (ordered.length >= cap) break;
+      ordered.push(extra);
+    }
+  }
+
+  ordered.push({ key: 'all-places', label: 'All places', href: '/places/' });
+  return ordered;
+}

--- a/next/src/lib/related.ts
+++ b/next/src/lib/related.ts
@@ -1,0 +1,183 @@
+/**
+ * Reusable related-content helpers.
+ *
+ * Goal: give templates a consistent way to pick a small set of related
+ * entries when no explicit related-* references are populated, while always
+ * letting explicit references win. Scoring is intentionally simple — tags,
+ * place, and shared format — so the rails stay legible and predictable.
+ *
+ * These helpers expect Astro `getCollection(...)` entries with a `data`
+ * payload; they don't import the content runtime themselves so they're
+ * easy to unit-test if a harness is added later.
+ */
+
+import { routeSlug } from './editorial';
+
+type ContentEntry = {
+  id?: string;
+  slug?: string;
+  data: Record<string, any>;
+};
+
+/**
+ * Resolve an array of references (each `{ id }`) against a collection,
+ * returning entries in reference order. Useful for explicit `relatedX`
+ * fields where editorial order matters.
+ */
+export function resolveRefs<T extends ContentEntry>(
+  refs: Array<{ id?: string } | string> | undefined,
+  collection: T[],
+): T[] {
+  if (!refs || refs.length === 0) return [];
+  const want = refs.map((r) => (typeof r === 'string' ? r : String(r?.id ?? '')));
+  const bySlug = new Map<string, T>();
+  for (const entry of collection) {
+    bySlug.set(routeSlug(entry), entry);
+  }
+  const out: T[] = [];
+  const seen = new Set<string>();
+  for (const id of want) {
+    if (!id || seen.has(id)) continue;
+    const found = bySlug.get(id);
+    if (found) {
+      out.push(found);
+      seen.add(id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Score article→article relatedness. Higher score = more related.
+ *   +3 same format
+ *   +1 per shared tag
+ *   +2 if both list the same place in their content
+ */
+export function scoreArticleSimilarity(a: ContentEntry, b: ContentEntry): number {
+  let score = 0;
+  if (a.data.format && a.data.format === b.data.format) score += 3;
+  const aTags: string[] = a.data.tags ?? [];
+  const bTags: string[] = b.data.tags ?? [];
+  for (const tag of aTags) {
+    if (bTags.includes(tag)) score += 1;
+  }
+  return score;
+}
+
+/**
+ * Pick related articles for the given article: explicit references first,
+ * then a tag/format-similarity ranking, then a recency fallback. Always
+ * excludes the source article itself.
+ */
+export function pickRelatedArticles<T extends ContentEntry>(
+  article: T,
+  pool: T[],
+  options: { explicit?: Array<{ id?: string } | string>; limit?: number } = {},
+): T[] {
+  const limit = options.limit ?? 3;
+  const sourceSlug = routeSlug(article);
+  const explicit = resolveRefs(options.explicit, pool).filter(
+    (e) => routeSlug(e) !== sourceSlug,
+  );
+  if (explicit.length >= limit) return explicit.slice(0, limit);
+
+  const seen = new Set<string>(explicit.map((e) => routeSlug(e)));
+  const ranked = pool
+    .filter((entry) => routeSlug(entry) !== sourceSlug && !seen.has(routeSlug(entry)))
+    .map((entry) => ({ entry, score: scoreArticleSimilarity(article, entry) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const at = (a.entry.data.publishedAt as Date)?.getTime?.() ?? 0;
+      const bt = (b.entry.data.publishedAt as Date)?.getTime?.() ?? 0;
+      return bt - at;
+    });
+
+  const tail = ranked.map((x) => x.entry);
+  if (explicit.length + tail.length >= limit) {
+    return [...explicit, ...tail].slice(0, limit);
+  }
+
+  // Final fallback — most-recent articles, excluding anything already chosen.
+  const taken = new Set<string>([
+    ...explicit.map((e) => routeSlug(e)),
+    ...tail.map((e) => routeSlug(e)),
+  ]);
+  taken.add(sourceSlug);
+  const recent = pool
+    .filter((entry) => !taken.has(routeSlug(entry)))
+    .sort(
+      (a, b) =>
+        ((b.data.publishedAt as Date)?.getTime?.() ?? 0) -
+        ((a.data.publishedAt as Date)?.getTime?.() ?? 0),
+    );
+  return [...explicit, ...tail, ...recent].slice(0, limit);
+}
+
+/**
+ * Pick related venues/experiences/itineraries by place + tag overlap.
+ * Generic enough to use for any collection where entries carry a `place`
+ * reference and an optional `tags` block.
+ */
+export function pickRelatedByPlace<T extends ContentEntry>(
+  source: T,
+  pool: T[],
+  options: { limit?: number } = {},
+): T[] {
+  const limit = options.limit ?? 3;
+  const sourceSlug = routeSlug(source);
+  const sourcePlace = String(source.data.place?.id ?? source.data.place ?? '');
+  const sourceTags = new Set<string>([
+    ...(source.data.tags?.mood ?? []),
+    ...(source.data.tags?.season ?? []),
+    ...(source.data.tags?.audience ?? []),
+  ]);
+
+  return pool
+    .filter((entry) => routeSlug(entry) !== sourceSlug)
+    .map((entry) => {
+      let score = 0;
+      const entryPlace = String(entry.data.place?.id ?? entry.data.place ?? '');
+      if (sourcePlace && entryPlace === sourcePlace) score += 4;
+      const tags: string[] = [
+        ...(entry.data.tags?.mood ?? []),
+        ...(entry.data.tags?.season ?? []),
+        ...(entry.data.tags?.audience ?? []),
+      ];
+      for (const tag of tags) {
+        if (sourceTags.has(tag)) score += 1;
+      }
+      return { entry, score };
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((x) => x.entry);
+}
+
+/**
+ * Pick events that share a place with the source. Sorted by start date,
+ * upcoming first.
+ */
+export function pickRelatedEventsForPlace<T extends ContentEntry>(
+  placeId: string,
+  events: T[],
+  options: { limit?: number; from?: Date } = {},
+): T[] {
+  const limit = options.limit ?? 4;
+  const from = options.from ?? new Date();
+  return events
+    .filter((event) => {
+      const ep = String(event.data.place?.id ?? event.data.place ?? '');
+      if (ep !== placeId) return false;
+      const end = event.data.endDate ?? event.data.startDate;
+      if (!end) return true;
+      return (end as Date).getTime() >= from.getTime() - 24 * 60 * 60 * 1000;
+    })
+    .sort(
+      (a, b) =>
+        ((a.data.startDate as Date)?.getTime?.() ?? 0) -
+        ((b.data.startDate as Date)?.getTime?.() ?? 0),
+    )
+    .slice(0, limit);
+}

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -7,7 +7,10 @@ import VenueCard from '../../components/VenueCard.astro';
 import ExperienceCard from '../../components/ExperienceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import ClusterLinks from '../../components/ClusterLinks.astro';
+import ItineraryCard from '../../components/ItineraryCard.astro';
+import PlaceCard from '../../components/PlaceCard.astro';
 import { formatLabel, routeSlug, venueHrefPrefix, titleize, heroBackgroundStyle } from '../../lib/editorial';
+import { pickRelatedArticles, resolveRefs } from '../../lib/related';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ data }) => data.status === 'published');
@@ -27,32 +30,25 @@ const currentIndex = allArticles.findIndex((a) => routeSlug(a) === routeSlug(art
 const prevArticle = currentIndex < allArticles.length - 1 ? allArticles[currentIndex + 1] : null;
 const nextArticle = currentIndex > 0 ? allArticles[currentIndex - 1] : null;
 
-const moreArticles = allArticles
-  .filter((entry) => routeSlug(entry) !== routeSlug(article))
-  .filter((entry) => {
-    // Prefer same format or overlapping tags
-    if (entry.data.format === article.data.format) return true;
-    return entry.data.tags.some((tag) => article.data.tags.includes(tag));
-  })
-  .slice(0, 3);
-const moreFallback = allArticles
-  .filter((entry) => routeSlug(entry) !== routeSlug(article))
-  .slice(0, 3);
-const relatedArticles = moreArticles.length >= 2 ? moreArticles : moreFallback;
+// Related articles: explicit relatedArticles refs lead, then format/tag
+// similarity, then a recency fallback. Single helper keeps all three layers
+// in one place so no surface ever shows an empty rail.
+const relatedArticles = pickRelatedArticles(article, allArticles, {
+  explicit: article.data.relatedArticles,
+  limit: 3,
+});
 
-// Resolve related venues
 const allVenues = await getCollection('venues');
-const relatedVenueSlugs = (article.data.relatedVenues ?? []).map((entry: any) => String(entry.id ?? entry));
-const relatedVenues = allVenues
-  .filter((venue) => relatedVenueSlugs.includes(routeSlug(venue)))
-  .slice(0, 3);
+const relatedVenues = resolveRefs(article.data.relatedVenues, allVenues).slice(0, 3);
 
-// Resolve related experiences
 const allExperiences = await getCollection('experiences');
-const relatedExperienceSlugs = (article.data.relatedExperiences ?? []).map((entry: any) => String(entry.id ?? entry));
-const relatedExperiences = allExperiences
-  .filter((exp) => relatedExperienceSlugs.includes(routeSlug(exp)))
-  .slice(0, 3);
+const relatedExperiences = resolveRefs(article.data.relatedExperiences, allExperiences).slice(0, 3);
+
+const allPlaces = await getCollection('places');
+const relatedPlaces = resolveRefs(article.data.relatedPlaces, allPlaces).slice(0, 3);
+
+const allItineraries = await getCollection('itineraries');
+const relatedItineraries = resolveRefs(article.data.relatedItineraries, allItineraries).slice(0, 3);
 
 const authorLabel = article.data.houseByline
   ? 'The Peninsula Insider'
@@ -245,6 +241,40 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
         </div>
         <div class="experience-grid">
           {relatedExperiences.map((exp) => <ExperienceCard experience={exp} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {relatedPlaces.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Places anchored in this piece</p>
+            <h2 class="venues__title">Where on the Peninsula this lands</h2>
+          </div>
+          <a href="/places/" class="venues__link">All places →</a>
+        </div>
+        <div class="venues__grid">
+          {relatedPlaces.map((place) => <PlaceCard place={place} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {relatedItineraries.length > 0 && (
+    <section class="venues">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Make this a weekend</p>
+            <h2 class="venues__title">Itineraries that pick up where this piece leaves off</h2>
+          </div>
+          <a href="/escape/" class="venues__link">All itineraries →</a>
+        </div>
+        <div class="venues__grid">
+          {relatedItineraries.map((it) => <ItineraryCard itinerary={it} />)}
         </div>
       </div>
     </section>

--- a/next/src/pages/sitemap.xml.ts
+++ b/next/src/pages/sitemap.xml.ts
@@ -25,12 +25,13 @@ function dateStr(d?: Date): string | undefined {
 }
 
 export const GET: APIRoute = async () => {
-  const [venues, experiences, places, articles, itineraries] = await Promise.all([
+  const [venues, experiences, places, articles, itineraries, events] = await Promise.all([
     getCollection('venues'),
     getCollection('experiences'),
     getCollection('places'),
     getCollection('articles', ({ data }) => data.status === 'published'),
     getCollection('itineraries'),
+    getCollection('events'),
   ]);
 
   const eatTypes = ['restaurant', 'cafe', 'bakery', 'pub', 'market', 'winery'];
@@ -46,8 +47,12 @@ export const GET: APIRoute = async () => {
   // Homepage
   entries.push(url('/', 1.0, 'weekly'));
 
-  // Section index pages (whats-on and golf excluded — event/utility pages)
-  for (const section of ['eat', 'stay', 'wine', 'explore', 'escape', 'journal', 'places', 'spa', 'weddings', 'corporate-events', 'walks']) {
+  // Section index pages. /spa/ and /walks/ are intentionally omitted because
+  // astro.config.mjs redirects them to canonical homes (/explore/spas-and-wellness/
+  // and /explore/walks/); listing redirect URLs in the sitemap creates noise
+  // for crawlers. /whats-on/, /golf/, and /dog-friendly/ are real lanes and
+  // were missing from this list previously.
+  for (const section of ['eat', 'stay', 'wine', 'explore', 'escape', 'journal', 'places', 'whats-on', 'golf', 'dog-friendly', 'weddings', 'corporate-events']) {
     entries.push(url(`/${section}`, 0.9, 'weekly'));
   }
 
@@ -108,6 +113,21 @@ export const GET: APIRoute = async () => {
   // Itineraries
   for (const itinerary of itineraries.filter((i) => !i.data.sitemapExclude)) {
     entries.push(url(`/escape/${routeSlug(itinerary)}`, 0.7, 'weekly', dateStr(itinerary.data.publishedAt)));
+  }
+
+  // Event detail pages — emit each /whats-on/{slug}/. Events are a primary
+  // editorial lane (the dispatch differentiator) so they belong in the sitemap.
+  // Past one-off events stay in the index (the [slug] route generates a static
+  // page for every event), but skip them in the sitemap to avoid signalling
+  // stale URLs; recurring events keep emitting because they remain valid.
+  const today = new Date();
+  for (const event of events.filter((e) => !e.data.sitemapExclude)) {
+    const recurrence = event.data.recurrence ?? 'one-off';
+    const isRecurring = recurrence !== 'one-off';
+    const endish = event.data.endDate ?? event.data.startDate;
+    const stillCurrent = endish && endish.getTime() >= today.getTime() - 24 * 60 * 60 * 1000;
+    if (!isRecurring && !stillCurrent) continue;
+    entries.push(url(`/whats-on/${routeSlug(event)}`, 0.6, 'weekly', dateStr(event.data.publishedAt)));
   }
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
High-impact internal linking and site architecture work in the Astro source under \`next/\`.

- **Single source of truth for nav** — \`next/src/lib/nav.ts\` exports \`mastheadNav\`, \`pillarNav\`, \`footerSectionLinks\`, \`footerAboutLinks\`, and a \`buildFooterPlaceLinks()\` helper. \`Masthead.astro\`, \`PillarNav.astro\`, and \`Footer.astro\` now consume it. The masthead/pillar/footer lanes used to drift; they can't anymore.
- **Footer places are data-driven** — Footer reads the \`places\` collection at build time. The curated featured set leads (Red Hill, Sorrento, Flinders, Mornington, Portsea, Main Ridge, Mount Martha, Rye, Merricks, Balnarring, Dromana, Point Nepean) and the column auto-fills from any other published place. Surface count went from 6 → 12.
- **Crawlable event place links** — \`EventCard.astro\` now wraps the place label in \`<a href=\"/places/{id}/\">\` when a place reference resolves. Styling and accessibility preserved.
- **Sitemap parity with real lanes** — \`sitemap.xml.ts\`:
  - adds \`/whats-on/\`, \`/golf/\`, \`/dog-friendly/\`
  - removes \`/spa/\` and \`/walks/\` (both are redirects per \`astro.config.mjs\` — listing them confused crawlers)
  - enumerates every \`/whats-on/{slug}/\` event detail page, with past one-off events filtered out (recurring events keep emitting)
- **Article schema extended** — added \`relatedPlaces\`, \`relatedArticles\`, \`relatedItineraries\` references, plus \`sitemapExclude: z.boolean().default(false)\` on every collection that already used the field in JSON content (closes a class of pre-existing TS errors).
- **Journal related rails** — \`pages/journal/[slug].astro\` renders related places and related itineraries when populated. Article-to-article picks now go: explicit \`relatedArticles\` → format/tag-similarity score → recency fallback (via \`lib/related.ts\`).
- **Reusable scoring helpers** — \`next/src/lib/related.ts\` exports \`resolveRefs\`, \`pickRelatedArticles\`, \`pickRelatedByPlace\`, \`pickRelatedEventsForPlace\` for future template work.

## Validation
- \`npm run build\` (Node 22): **876 pages built, no errors caused by these changes**.
- \`npm run check\`: pre-existing TS errors in \`pages-drafts/\`, \`v2-staging/\`, and other unrelated files remain. None introduced by this PR. The five \`sitemapExclude\` errors in \`sitemap.xml.ts\` and the four in \`pages/{eat,explore,places,stay,wine}/[slug].astro\` are now **resolved** by the schema additions.
- Spot-checked generated \`dist/sitemap.xml\`: confirmed \`/whats-on/\`, \`/golf/\`, \`/dog-friendly/\` present; \`/spa/\` and \`/walks/\` absent; 16 event detail URLs enumerated.
- Spot-checked \`dist/whats-on/index.html\`: \`event-card__place\` now renders \`<a href=\"/places/{id}/\">\`.
- Spot-checked \`dist/index.html\` footer: 12 distinct \`/places/{slug}/\` links + \"All places\".

## Visual design
Preserved. The Masthead/Pillar/Footer markup is unchanged — only the data source moved to \`lib/nav.ts\`.

## Recommended follow-ups (out of scope here)
1. **Backfill \`relatedPlaces\`/\`relatedItineraries\`/\`relatedArticles\` on hub-guide articles** to convert the new schema fields into actual links. The wiring is in place; the JSON/MDX edits are an editorial pass.
2. **Refactor \`VenueDetailTemplate\` and \`PlaceDetailTemplate\` related-grid logic** to consume \`pickRelatedByPlace\` from \`lib/related.ts\`. Skipped here per scope guidance to avoid build risk.
3. **Pre-existing TS errors** outside this PR's scope: \`src/pages-drafts/\`, \`src/pages/v2-staging/\`, and a handful of stay/wine pages that read fields not in their schema. Worth a separate cleanup branch.
4. **Generic anchor labels** in template-level cards — left untouched here because the cards are generated per-entry; would need either a content-quality pass or a label generator from each entry's data.
5. **Commercial fields** (\`featuredPartner\`, \`affiliateNote\`) intentionally untouched — flagged in the audit as \"do not invent\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)