### PR TITLE
seo: scaffold daily SEO ops + fix /places/* duplicate canonical bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,44 @@ Run the SQL migration at `ops/migrations/2026-04-30-concierge-chunks-fingerprint
 
 ---
 
+## 2026-05-01 — Claude (SEO ownership setup)
+
+### SEO ops infrastructure: GSC API automation + daily review cycle
+
+**Summary**
+Stood up a sustained, daily-cycle SEO operation owned by Claude. Automated Google Search Console API pulls, persistent tracking documents, baseline snapshot, and the first dated experiment queued for shipping tomorrow.
+
+**Files created**
+- `ops/scripts/seo/auth.mjs` — one-time OAuth bootstrap for the GSC API (loopback flow, saves refresh token to `ops/tokens/gsc-token.json`)
+- `ops/scripts/seo/pull.mjs` — daily pull: 28d/7d performance, top 100 queries+pages, daily trend, devices, countries, URL inspection for 14 priority URLs. Saves raw JSON to `ops/data/seo/YYYY-MM-DD.json` and appends a markdown digest to `ops/reports/seo/daily-log.md`
+- `ops/scripts/seo/config.mjs` — paths and `PRIORITY_URLS` list
+- `ops/scripts/seo/package.json` + `package-lock.json` — `googleapis` dep, scoped to this folder
+- `ops/scripts/seo/README.md` — script usage
+- `ops/reports/seo/baseline.md` — frozen 2026-05-01 reference; never edit
+- `ops/reports/seo/daily-log.md` — append-only journal, the doc reviewed every morning
+- `ops/reports/seo/experiments.md` — hypothesis-driven change log
+- `ops/reports/seo/backlog.md` — prioritised next actions
+- `ops/reports/seo/README.md` — operating cycle documentation
+
+**Pages affected**
+None directly. Infrastructure only.
+
+**Why it matters**
+Site is at 11.2% indexation rate (39/349 URLs) on a new domain. Sustained daily diagnose→ship→measure beats sporadic audits. Pulling from the GSC API means we can compare day-on-day movement and attribute changes to specific actions, instead of waiting for manual exports.
+
+**First findings from baseline pull (logged in `baseline.md`)**
+- Trajectory positive: clicks 2→8 WoW, impressions 539→1,009 WoW, but only 2 of 14 priority URLs are indexed
+- Critical bug discovered: every `/places/*` page emits a duplicate broken `<link rel="canonical" href=".../places/undefined">` due to `next/src/components/PlaceDetailTemplate.astro:62` reading `place.slug` (undefined) instead of `place.id`. Logged as experiment `2026-05-02-01` for tomorrow's first PR.
+- Stale GSC crawl data on 3 priority URLs (current HTML is correct; manual reindex requests recommended)
+- Dog-friendly content cluster is the dominant demand signal (5 of top 10 query impressions)
+
+**Follow-up**
+- Tomorrow (2026-05-02): ship experiment 2026-05-02-01 (canonical fix) as the first SEO PR under the new cycle
+- Submit `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` for manual reindex via GSC URL Inspection
+- Diagnose `http://` vs `https://` indexation observed in top-pages report
+
+---
+
 ## 2026-04-19 — Remy (subagent)
 
 ### New vertical hubs: Weddings, Corporate Events, Walks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,36 @@ Run the SQL migration at `ops/migrations/2026-04-30-concierge-chunks-fingerprint
 
 ---
 
+## 2026-05-01 — Claude (SEO experiment 2026-05-01-01)
+
+### Removed duplicate broken `<link rel="canonical">` from all place pages
+
+**Summary**
+Every page under `/places/*` was emitting **two `<link rel="canonical">` tags** in `<head>`, the second pointing to a non-existent URL `/places/undefined`. Plus duplicate `<title>`, meta description, og: tags, and JSON-LD. Removed the offending block.
+
+**Files changed**
+- `next/src/components/PlaceDetailTemplate.astro` — deleted the entire `<Fragment slot="head">` block (lines 79-88) and the unused locals that fed it (`canonical`, `placeTitle`, `placeDescription`, `ogImage`, `placeSchema` — lines 62-77). Replaced with a comment explaining why.
+
+**Pages affected**
+All 20 pages under `/places/*`: sorrento, red-hill, flinders, mornington, rye, portsea, main-ridge, dromana, mount-martha, cape-schanck, balnarring, merricks, point-nepean, plus 7 others.
+
+**Why it matters**
+The duplicate template-emitted canonical built `https://peninsulainsider.com.au/places/${place.slug}`, but `place.slug` is undefined in Astro's content-collection API (the correct property is `place.id`). So every place page sent Google a `<link rel="canonical" href=".../places/undefined">` pointing to a 404. Combined with the correct canonical from BaseLayout (which `places/[slug].astro` passes correctly), Google saw conflicting signals and was reluctant to index the pages — three priority place URLs were stuck on "Alternate page with proper canonical tag" status. The parent page (`places/[slug].astro`) already passes correct title/description/canonical/ogImage to BaseLayout and emits its own JSON-LD, so the entire template-side head block was redundant duplication.
+
+**Verification**
+- Ran `npm run build` — 955 pages built in 19.56s, no errors.
+- Spot-checked `dist/places/{red-hill,sorrento,flinders}/index.html`: each now has exactly one `<link rel="canonical">` pointing to the correct trailing-slash URL, exactly one `<title>` tag.
+
+**Hypothesis (logged in `ops/reports/seo/experiments.md` as 2026-05-01-01)**
+By 2026-05-16 (14d post-deploy), priority URL indexed count rises from 2/14 to ≥7/14.
+
+**Follow-up**
+- After auto-deploy completes: James to enable "Enforce HTTPS" in GitHub Pages settings (separate finding from this PR — `http://` URLs are currently served 200 OK, not redirected).
+- After auto-deploy completes: James to submit 20 priority URLs for manual reindexing in GSC URL Inspection (full list in `ops/reports/seo/daily-log.md`).
+- Re-pull GSC daily; measure indexation movement on 2026-05-09 (7d) and 2026-05-16 (14d).
+
+---
+
 ## 2026-05-01 — Claude (SEO ownership setup)
 
 ### SEO ops infrastructure: GSC API automation + daily review cycle

--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -59,33 +59,14 @@ if (itineraries.length > 0) anchors.push({ href: '#escapes', label: 'Escape plan
 if (articles.length > 0) anchors.push({ href: '#journal', label: 'From the journal', count: articles.length });
 
 const totalVenues = eatVenues.length + wineVenues.length + stayVenues.length;
-const canonical = `https://peninsulainsider.com.au/places/${place.slug}`;
-const placeTitle = `${place.data.name} Guide | Peninsula Insider`;
-const placeDescription = place.data.intro;
-const ogImage = place.data.heroImage?.src && !place.data.heroImage.src.includes('placeholder')
-  ? place.data.heroImage.src
-  : '/images/sourced/home-cover.webp';
-const placeSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'Place',
-  name: place.data.name,
-  description: place.data.intro,
-  url: canonical,
-  ...(ogImage !== '/images/sourced/home-cover.webp' ? { image: `https://peninsulainsider.com.au${ogImage}` } : {}),
-  containedInPlace: 'Mornington Peninsula',
-};
+// Head metadata (title/description/canonical/og/JSON-LD) is owned by the
+// parent page (places/[slug].astro) which passes the correct values to
+// BaseLayout. Emitting them here too produced duplicate <title> tags and a
+// broken <link rel="canonical" href=".../places/undefined"> on every place
+// page (the local var read place.slug, which is undefined; the correct
+// property is place.id). Removed 2026-05-01 — see ops/reports/seo/experiments.md
+// experiment 2026-05-01-01.
 ---
-
-<Fragment slot="head">
-  <title>{placeTitle}</title>
-  <meta name="description" content={placeDescription} />
-  <link rel="canonical" href={canonical} />
-  <meta property="og:title" content={placeTitle} />
-  <meta property="og:description" content={placeDescription} />
-  <meta property="og:url" content={canonical} />
-  <meta property="og:image" content={`https://peninsulainsider.com.au${ogImage}`} />
-  <script type="application/ld+json" set:html={JSON.stringify(placeSchema)} />
-</Fragment>
 
 <Breadcrumbs items={breadcrumbItems} />
 

--- a/ops/reports/seo/README.md
+++ b/ops/reports/seo/README.md
@@ -1,0 +1,30 @@
+# Peninsula Insider — SEO operations
+
+The doc set we read every morning. Owned by Claude (with James's review), updated daily.
+
+## The daily cycle
+
+Each weekday morning:
+1. Run `cd ops/scripts/seo && npm run pull` — fetches GSC data, appends to `daily-log.md`, saves raw to `ops/data/seo/YYYY-MM-DD.json`.
+2. Read the new entry in `daily-log.md`. Diagnose movement vs prior days, note what to investigate.
+3. Cross-reference with `experiments.md` — if we shipped a change recently, has it landed? Did it move the metric we predicted?
+4. Pick today's actions from `backlog.md`. Limit to 2–3 substantive changes per day so we can attribute results.
+5. Ship changes via PR. Log the experiment in `experiments.md` with hypothesis + how we'll measure.
+6. Update `backlog.md`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `daily-log.md` | Append-only journal. Each entry = one daily pull + interpretation + actions. **The doc we read every morning.** |
+| `baseline.md` | Frozen snapshot of where we started (May 2026). Reference point for "is it actually working?". Never edited. |
+| `url-inventory.md` | Every URL on the site, categorised as keep / improve / noindex / 410. Updated as we work the 283-page indexation backlog. |
+| `experiments.md` | Every change we ship is logged here with hypothesis, expected impact, and how we'll measure. Wins and losses both kept. |
+| `backlog.md` | Prioritised list of next actions. Pulled from each morning. |
+
+## Conventions
+
+- Every entry dated as `YYYY-MM-DD`.
+- Every shipped change references the PR.
+- Every experiment has a measurable hypothesis. "Improve X" is not a hypothesis; "increase CTR on /eat/best-restaurants from 1.2% to >2.5% within 21 days by rewriting the title and meta" is.
+- No em-dashes (project rule — use commas, periods, colons, parentheses).

--- a/ops/reports/seo/backlog.md
+++ b/ops/reports/seo/backlog.md
@@ -1,0 +1,40 @@
+# SEO backlog — Peninsula Insider
+
+Prioritised next actions. Pulled from each morning. Each item has impact (1-5), effort (1-5), and a one-line rationale.
+
+Sorted by impact/effort ratio.
+
+## P0 — this week
+
+- [ ] **Ship the place page canonical fix** (experiment 2026-05-02-01). *Impact 5, Effort 1.* One-line fix unlocks indexation on 20 pages and clears 3 of 14 priority URLs out of "Alternate canonical" purgatory. Pending PR.
+- [ ] **Manual reindex requests via GSC URL Inspection** for `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` (and the other 10 place pages once canonical fix is shipped). *Impact 4, Effort 1.* GSC has stale crawl data; current HTML is correct.
+- [ ] **CTR rewrite on `/whats-on/mornington-cup-2026`.** *Impact 4, Effort 1.* 228 impr at pos 7.6 with 0.44% CTR. New title + meta description targeted at "mornington cup 2026" and related queries. Hypothesis: CTR to ≥2.5% within 14 days.
+- [ ] **Diagnose http:// vs https:// indexation.** *Impact 3, Effort 1.* Top page reports include `http://peninsulainsider.com.au/` getting traffic. Confirm 301 status from http to https and test redirect.
+- [ ] **Audit & prune the 283 "Discovered – currently not indexed" URLs.** *Impact 5, Effort 3.* Pruning thin/templated pages should ~double indexation rate within 2-3 weeks per Google's behaviour with new sites. Need GSC export of the 283 URL list to begin.
+- [ ] **Investigate Apr 24-25 indexation jump (16 → 39).** *Impact 4, Effort 1.* Find what worked and reproduce. Likely candidate: a content push or manual indexing batch.
+- [ ] **Investigate the 4 address-string queries showing in top impressions.** *Impact 3, Effort 1.* Likely legacy directory pages still indexed. Should they be noindexed (address searches want a map, not a listing)?
+- [ ] **Internal linking audit on PRIORITY_URLS.** *Impact 4, Effort 2.* Each priority URL should be linked from ≥3 other pages. Currently unknown.
+
+## P1 — next 2-3 weeks
+
+- [ ] **SERP snippet pass on top 10 pages by impressions** (titles, meta descriptions, first 100-150 words). Per HANDOVER-CLAUDE.md priority A.
+- [ ] **Town hub depth** — Sorrento, Red Hill, Flinders, Mornington, Rye. Per HANDOVER priority B.
+- [ ] **Schema audit & gap-fill** across templates: Article/NewsArticle, BreadcrumbList, FAQPage, LocalBusiness, Organization, WebSite+SearchAction.
+- [ ] **Bing Webmaster Tools** submission & sitemap.
+
+## P2 — next 4-8 weeks
+
+- [ ] **Earn first quality backlink** (local Vic press, council site, regional tourism body, Broadsheet/Time Out). Single biggest crawl-budget unlock.
+- [ ] **FAQ blocks** added to top 10 pages with FAQPage schema.
+- [ ] **Image SEO pass** — alt text, file naming, dimensions for Discover eligibility.
+- [ ] **Google Discover preparation** — articles with 1200px+ images, fresh dates, strong titles.
+
+## Iceberg (consider later)
+
+- [ ] Programmatic suburb × intent pages (only after editorial credibility is established — premature now)
+- [ ] Newsletter subscriber growth funnel (out of SEO scope but related)
+- [ ] Competitor content gap analysis (after we have a baseline of our own performance)
+
+---
+
+_Items are added when discovered, prioritised when reviewed, removed when shipped (logged in `experiments.md`)._

--- a/ops/reports/seo/backlog.md
+++ b/ops/reports/seo/backlog.md
@@ -6,10 +6,11 @@ Sorted by impact/effort ratio.
 
 ## P0 — this week
 
-- [ ] **Ship the place page canonical fix** (experiment 2026-05-02-01). *Impact 5, Effort 1.* One-line fix unlocks indexation on 20 pages and clears 3 of 14 priority URLs out of "Alternate canonical" purgatory. Pending PR.
-- [ ] **Manual reindex requests via GSC URL Inspection** for `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` (and the other 10 place pages once canonical fix is shipped). *Impact 4, Effort 1.* GSC has stale crawl data; current HTML is correct.
-- [ ] **CTR rewrite on `/whats-on/mornington-cup-2026`.** *Impact 4, Effort 1.* 228 impr at pos 7.6 with 0.44% CTR. New title + meta description targeted at "mornington cup 2026" and related queries. Hypothesis: CTR to ≥2.5% within 14 days.
-- [ ] **Diagnose http:// vs https:// indexation.** *Impact 3, Effort 1.* Top page reports include `http://peninsulainsider.com.au/` getting traffic. Confirm 301 status from http to https and test redirect.
+- [x] **Ship the place page canonical fix** (experiment 2026-05-01-01). *Done 2026-05-01.* Awaiting deploy + manual reindex.
+- [x] **Diagnose http:// vs https:// indexation.** *Done 2026-05-01.* GitHub Pages serves both protocols 200 OK without redirecting. Action item escalated to James (enable Enforce HTTPS in repo Settings).
+- [ ] **(James, after deploy)** Enable "Enforce HTTPS" in GitHub Pages settings. *Impact 4, Effort 0.* 30-second click. Forces server-side 301 from http→https.
+- [ ] **(James, after deploy)** Submit 20 priority URLs to GSC URL Inspection across two days (full list in `daily-log.md` 2026-05-01 entry). *Impact 4, Effort 1.*
+- [ ] **CTR rewrite on `/whats-on/mornington-cup-2026`.** *Impact 4, Effort 1.* 228 impr at pos 7.6 with 0.44% CTR. New title + meta description targeted at "mornington cup 2026" and related queries. Hypothesis: CTR to ≥2.5% within 14 days. **Recommended next experiment.**
 - [ ] **Audit & prune the 283 "Discovered – currently not indexed" URLs.** *Impact 5, Effort 3.* Pruning thin/templated pages should ~double indexation rate within 2-3 weeks per Google's behaviour with new sites. Need GSC export of the 283 URL list to begin.
 - [ ] **Investigate Apr 24-25 indexation jump (16 → 39).** *Impact 4, Effort 1.* Find what worked and reproduce. Likely candidate: a content push or manual indexing batch.
 - [ ] **Investigate the 4 address-string queries showing in top impressions.** *Impact 3, Effort 1.* Likely legacy directory pages still indexed. Should they be noindexed (address searches want a map, not a listing)?

--- a/ops/reports/seo/baseline.md
+++ b/ops/reports/seo/baseline.md
@@ -1,0 +1,104 @@
+# Peninsula Insider — SEO baseline
+
+Frozen snapshot of where we started. Captured by `ops/scripts/seo/pull.mjs` on 2026-05-01.
+Reference point for "is the work actually moving the needle?". **Never edit this file.**
+
+## Date frozen
+
+2026-05-01 (data window: 2026-04-02 → 2026-04-29, 28 days)
+
+## Property
+
+`sc-domain:peninsulainsider.com.au` (Domain property — full subdomain coverage)
+
+## Headline
+
+| Metric | Last 7d (Apr 23-29) | Prev 7d (Apr 16-22) | Last 28d |
+|---|---:|---:|---:|
+| Clicks | 8 | 2 | 23 |
+| Impressions | 1,009 | 539 | 1,780 |
+| CTR | 0.79% | 0.37% | 1.29% |
+| Avg position | 17.4 | 16.6 | 16.7 |
+
+**Trajectory at baseline**: positive but small. Impressions ~doubled WoW (539 → 1,009), clicks 4×ed (2 → 8). Position drifted slightly (16.6 → 17.4) because the site is being shown for more queries deeper in the long-tail — healthy for a new site. CTR doubled but is still well below 2%, consistent with weak SERP snippets.
+
+## Indexation
+
+- **Total URLs known to GSC**: 349
+- **Indexed**: 39 (11.2%)
+- **Discovered – currently not indexed**: 283 (the dominant problem)
+- **Alternate page with proper canonical**: 21
+- **Excluded by noindex**: 3
+- **Crawled – currently not indexed**: 3
+
+**Priority URL indexation** (the 14 pages we explicitly want indexed):
+
+| Status | Count | URLs |
+|---|---:|---|
+| Indexed (PASS) | 2 | `/`, `/places/flinders/` |
+| Discovered – not indexed | 9 | `/eat/best-restaurants/`, `/wine/best-cellar-doors/`, `/explore/best-walks/`, `/journal/mornington-peninsula-day-trip/`, `/journal/mornington-peninsula-in-autumn/`, `/journal/mornington-peninsula-with-kids/`, `/places/sorrento/`, `/places/mornington/`, `/places/rye/` |
+| Alternate canonical | 3 | `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` |
+
+## Top 10 queries by impressions (last 28d)
+
+| # | Query | Impr | Clicks | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | dog friendly guide mornington peninsula | 38 | 0 | 0.00% | 8.8 |
+| 2 | 34 western parade point leo vic 3916 | 22 | 0 | 0.00% | 28.9 |
+| 3 | a dog-friendly guide mornington peninsula | 20 | 0 | 0.00% | 6.8 |
+| 4 | free things to do in mornington peninsula | 16 | 0 | 0.00% | 20.3 |
+| 5 | 20 junction road merricks north vic 3926 | 15 | 0 | 0.00% | 29.9 |
+| 6 | hotel near sorrento pier booking | 15 | 0 | 0.00% | 65.9 |
+| 7 | accommodation near peninsula hot springs | 11 | 0 | 0.00% | 69.4 |
+| 8 | dog friendly beaches mornington peninsula | 11 | 0 | 0.00% | 17.6 |
+| 9 | endota sorrento | 10 | 0 | 0.00% | 5.7 |
+| 10 | dog beaches mornington peninsula | 8 | 0 | 0.00% | 21.4 |
+
+## Top 10 pages by clicks (last 28d)
+
+| # | Page | Clicks | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | `http://peninsulainsider.com.au/` | 9 | 20 | 45.00% | 1.8 |
+| 2 | `/` | 7 | 48 | 14.58% | 2.2 |
+| 3 | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` | 3 | 42 | 7.14% | 6.0 |
+| 4 | `/eat/` | 2 | 107 | 1.87% | 34.5 |
+| 5 | `/journal/the-pub-guide` | 1 | 9 | 11.11% | 5.3 |
+| 6 | `/journal/three-italian-dinners/` | 1 | 20 | 5.00% | 7.3 |
+| 7 | `/whats-on/mornington-cup-2026` | 1 | 228 | 0.44% | 7.6 |
+| 8 | `/wine/` | 1 | 224 | 0.45% | 16.8 |
+| 9 | `http://peninsulainsider.com.au/journal/the-birthday-weekend` | 0 | 2 | 0.00% | 38.5 |
+| 10 | `http://peninsulainsider.com.au/journal/the-birthday-weekend/` | 0 | 28 | 0.00% | 6.1 |
+
+## Devices (last 28d)
+
+| Device | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| DESKTOP | 14 | 1,293 | 1.08% | 18.3 |
+| MOBILE | 9 | 480 | 1.88% | 12.4 |
+| TABLET | 0 | 7 | 0.00% | 11.7 |
+
+## Geography
+
+99.4% of impressions and 100% of clicks come from Australia (986 of 992 reportable impressions). Local intent is the engine.
+
+## Sitemap snapshot
+
+- **Sitemap URLs**: 240 (per `sitemap.xml` at this commit)
+- **Section breakdown**: journal 90, explore 43, eat 27, wine 25, places 20, whats-on 17, escape 6, stay 5, plus single pages for golf/dog-friendly/weddings/corporate-events/partners/ask
+- **Gap vs GSC**: GSC reports 349 URLs known. The ~109 URL gap is being investigated (likely legacy directory URLs, http:// vs https:// duplicates, slash variants).
+
+## Critical findings (Day 1 audit)
+
+1. **Duplicate broken canonical on every place page.** `next/src/components/PlaceDetailTemplate.astro:62` emits `<link rel="canonical" href=".../places/undefined">` because it reads `place.slug` (should be `place.id`). All 20 place pages affected. Compounded by `pages/places/[slug].astro` separately passing the correct canonical to BaseLayout — so each place page outputs **two `<link rel="canonical">` tags**. Logged as the first experiment.
+
+2. **Stale GSC crawl data on the "alternate canonical" priority URLs.** GSC last crawled `/stay/best-accommodation/` on 2026-04-13. The current HTML has the correct trailing-slash canonical, but Google still has the old (no-slash) data. The deindex-then-reindex pattern matches the Apr 18-21 dip in the chart. Manual reindex requests should accelerate recovery for these.
+
+3. **HTTP and trailing-slash variants are both being indexed.** Top page reports include `http://peninsulainsider.com.au/`, `http://peninsulainsider.com.au/journal/the-birthday-weekend` (no slash), and `http://peninsulainsider.com.au/journal/the-birthday-weekend/` (with slash) as distinct pages. GitHub Pages 301-redirects the no-slash version, but the http→https redirect status is unconfirmed. Splits link equity and confuses Google about which URL is canonical.
+
+4. **Dog-friendly content is the demand magnet.** 5 of the top 10 queries by impressions involve "dog friendly" or "dog beaches". `/journal/dog-friendly-mornington-peninsula` shows in 248+99 (slash variants) impressions but earns 0 clicks because the canonical bug splits the page, and snippet quality is unknown. This is the single highest-leverage content cluster.
+
+5. **`/whats-on/mornington-cup-2026`: 228 impressions, 0.44% CTR at position 7.6.** Title/meta rewrite alone could plausibly 5-10× clicks for this seasonal high-volume query.
+
+6. **Address-string queries**: 4 of the top 10 by impressions are exact street addresses (Pt Leo, Merricks North, Dromana, Sorrento). Suggests legacy directory listing pages still indexed. Worth investigating whether they should be noindexed (address searches want a map, not a listing).
+
+7. **Editorial dispatch / journal pages dominate the URL count** (90 of 240) but only one (`dog-friendly-cafes-pubs-wineries-mornington-peninsula`) appears in the top-clicks list. Most journal content has not yet earned ranking.

--- a/ops/reports/seo/daily-log.md
+++ b/ops/reports/seo/daily-log.md
@@ -148,11 +148,46 @@ Window (last 7d): 2026-04-23 → 2026-04-29
 - Authorised GSC API access. Token at `ops/tokens/gsc-token.json`.
 - Pulled first daily snapshot. Raw data at `ops/data/seo/2026-05-01.json`.
 - Wrote `baseline.md` (frozen reference).
-- Logged the canonical bug as the first experiment.
+- **Shipped experiment 2026-05-01-01**: removed the duplicate `<Fragment slot="head">` block from `next/src/components/PlaceDetailTemplate.astro` that was emitting a broken `<link rel="canonical" href=".../places/undefined">` on all 20 place pages, plus duplicate `<title>`, `<meta description>`, og: tags, and JSON-LD. Verified in local build: 955 pages built clean, each place page now has exactly one canonical pointing to the correct URL. **Awaiting deploy to live site.**
+- **Diagnosed http:// vs https://**: GitHub Pages is serving identical 200 OK responses on both protocols (no 301 redirect from http→https). The served HTML on the http:// version does include a canonical pointing to https://, so Google should consolidate eventually, but this is being handled the slow way. **Action for James: enable "Enforce HTTPS" in GitHub repo Settings → Pages.** This forces a 301 at the server level and is the proper fix.
+
+### Action items for James (manual UI work I cannot do via API)
+
+**After this PR is merged and the auto-deploy completes**, do the following in order:
+
+1. **Enable "Enforce HTTPS" in GitHub Pages**
+   - Go to: GitHub repo → Settings → Pages
+   - Tick **Enforce HTTPS**
+   - Saves immediately. Within 24 hours, all `http://peninsulainsider.com.au/*` URLs will 301-redirect to `https://`. Google will consolidate the duplicates over the following weeks.
+
+2. **Submit URLs for manual reindexing in GSC** (≤10/day quota)
+   - Go to: Search Console → URL Inspection
+   - Paste each URL one at a time, click **Request Indexing** after Google confirms the page is reachable.
+   - Day 1 batch (priority — paste in this order):
+     1. https://peninsulainsider.com.au/places/red-hill/
+     2. https://peninsulainsider.com.au/places/sorrento/
+     3. https://peninsulainsider.com.au/places/mornington/
+     4. https://peninsulainsider.com.au/places/rye/
+     5. https://peninsulainsider.com.au/stay/best-accommodation/
+     6. https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/
+     7. https://peninsulainsider.com.au/eat/best-restaurants/
+     8. https://peninsulainsider.com.au/wine/best-cellar-doors/
+     9. https://peninsulainsider.com.au/explore/best-walks/
+     10. https://peninsulainsider.com.au/journal/mornington-peninsula-day-trip/
+   - Day 2 batch (when quota resets):
+     1. https://peninsulainsider.com.au/journal/mornington-peninsula-in-autumn/
+     2. https://peninsulainsider.com.au/journal/mornington-peninsula-with-kids/
+     3. https://peninsulainsider.com.au/places/portsea/
+     4. https://peninsulainsider.com.au/places/main-ridge/
+     5. https://peninsulainsider.com.au/places/dromana/
+     6. https://peninsulainsider.com.au/places/mount-martha/
+     7. https://peninsulainsider.com.au/places/cape-schanck/
+     8. https://peninsulainsider.com.au/places/balnarring/
+     9. https://peninsulainsider.com.au/places/merricks/
+     10. https://peninsulainsider.com.au/places/point-nepean/
 
 ### Tomorrow's queue
 
-1. Ship the `PlaceDetailTemplate.astro` canonical fix (experiment 2026-05-02-01).
-2. Submit `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` for reindexing in GSC.
-3. Diagnose the http:// vs https:// indexation (curl the http variant, confirm 301).
-4. Pull again, log changes.
+1. Confirm deploy went through, re-run `npm run pull`, check whether GSC shows movement on the priority URLs.
+2. Pick the next P0 from `backlog.md`. Strong candidate: **CTR rewrite on `/whats-on/mornington-cup-2026`** (228 impr at pos 7.6 with 0.44% CTR — snippet rewrite alone could 5-10× clicks).
+3. Begin auditing the 283 "Discovered – not indexed" URLs (need GSC export).

--- a/ops/reports/seo/daily-log.md
+++ b/ops/reports/seo/daily-log.md
@@ -162,29 +162,37 @@ Window (last 7d): 2026-04-23 → 2026-04-29
 
 2. **Submit URLs for manual reindexing in GSC** (≤10/day quota)
    - Go to: Search Console → URL Inspection
-   - Paste each URL one at a time, click **Request Indexing** after Google confirms the page is reachable.
-   - Day 1 batch (priority — paste in this order):
-     1. https://peninsulainsider.com.au/places/red-hill/
-     2. https://peninsulainsider.com.au/places/sorrento/
-     3. https://peninsulainsider.com.au/places/mornington/
-     4. https://peninsulainsider.com.au/places/rye/
-     5. https://peninsulainsider.com.au/stay/best-accommodation/
-     6. https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/
-     7. https://peninsulainsider.com.au/eat/best-restaurants/
-     8. https://peninsulainsider.com.au/wine/best-cellar-doors/
-     9. https://peninsulainsider.com.au/explore/best-walks/
-     10. https://peninsulainsider.com.au/journal/mornington-peninsula-day-trip/
-   - Day 2 batch (when quota resets):
-     1. https://peninsulainsider.com.au/journal/mornington-peninsula-in-autumn/
-     2. https://peninsulainsider.com.au/journal/mornington-peninsula-with-kids/
-     3. https://peninsulainsider.com.au/places/portsea/
-     4. https://peninsulainsider.com.au/places/main-ridge/
-     5. https://peninsulainsider.com.au/places/dromana/
-     6. https://peninsulainsider.com.au/places/mount-martha/
-     7. https://peninsulainsider.com.au/places/cape-schanck/
-     8. https://peninsulainsider.com.au/places/balnarring/
-     9. https://peninsulainsider.com.au/places/merricks/
-     10. https://peninsulainsider.com.au/places/point-nepean/
+   - For each URL: triple-click the line in the code block to select it, copy, paste into the URL Inspection bar at the top of GSC, hit Enter, wait for Google to fetch, then click **Request Indexing**.
+
+   **Day 1 batch** (paste these one at a time):
+
+   ```
+   https://peninsulainsider.com.au/places/red-hill/
+   https://peninsulainsider.com.au/places/sorrento/
+   https://peninsulainsider.com.au/places/mornington/
+   https://peninsulainsider.com.au/places/rye/
+   https://peninsulainsider.com.au/stay/best-accommodation/
+   https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/
+   https://peninsulainsider.com.au/eat/best-restaurants/
+   https://peninsulainsider.com.au/wine/best-cellar-doors/
+   https://peninsulainsider.com.au/explore/best-walks/
+   https://peninsulainsider.com.au/journal/mornington-peninsula-day-trip/
+   ```
+
+   **Day 2 batch** (when the 10/day quota resets, ~24h later):
+
+   ```
+   https://peninsulainsider.com.au/journal/mornington-peninsula-in-autumn/
+   https://peninsulainsider.com.au/journal/mornington-peninsula-with-kids/
+   https://peninsulainsider.com.au/places/portsea/
+   https://peninsulainsider.com.au/places/main-ridge/
+   https://peninsulainsider.com.au/places/dromana/
+   https://peninsulainsider.com.au/places/mount-martha/
+   https://peninsulainsider.com.au/places/cape-schanck/
+   https://peninsulainsider.com.au/places/balnarring/
+   https://peninsulainsider.com.au/places/merricks/
+   https://peninsulainsider.com.au/places/point-nepean/
+   ```
 
 ### Tomorrow's queue
 

--- a/ops/reports/seo/daily-log.md
+++ b/ops/reports/seo/daily-log.md
@@ -1,0 +1,158 @@
+# Peninsula Insider — SEO daily log
+
+Appended by `ops/scripts/seo/pull.mjs`. Newest entries at the bottom.
+
+---
+
+## 2026-05-01 — daily pull
+
+Property: `sc-domain:peninsulainsider.com.au`
+Window (last 7d): 2026-04-23 → 2026-04-29
+
+### Headline (last 7d vs previous 7d)
+
+| Metric | Last 7d | Prev 7d | Δ | Last 28d |
+|---|---:|---:|---:|---:|
+| Clicks | 8 | 2 | 8  (+6 ↑) | 23 |
+| Impressions | 1,009 | 539 | 1,009  (+470 ↑) | 1,780 |
+| CTR | 0.79% | 0.37% | 0.79%  (+0.42% ↑) | 1.29% |
+| Avg position | 17.4 | 16.6 | 17.4  (+0.8 ↓) | 16.7 |
+
+### Indexation (priority URLs): 2 / 14 indexed
+
+| URL | Verdict | Coverage |
+|---|---|---|
+| `/` | PASS | Submitted and indexed |
+| `/eat/best-restaurants/` | NEUTRAL | Discovered - currently not indexed |
+| `/wine/best-cellar-doors/` | NEUTRAL | Discovered - currently not indexed |
+| `/explore/best-walks/` | NEUTRAL | Discovered - currently not indexed |
+| `/stay/best-accommodation/` | NEUTRAL | Alternate page with proper canonical tag |
+| `/journal/mornington-peninsula-day-trip/` | NEUTRAL | Discovered - currently not indexed |
+| `/journal/mornington-peninsula-in-autumn/` | NEUTRAL | Discovered - currently not indexed |
+| `/journal/mornington-peninsula-with-kids/` | NEUTRAL | Discovered - currently not indexed |
+| `/journal/dog-friendly-mornington-peninsula/` | NEUTRAL | Alternate page with proper canonical tag |
+| `/places/sorrento/` | NEUTRAL | Discovered - currently not indexed |
+| `/places/red-hill/` | NEUTRAL | Alternate page with proper canonical tag |
+| `/places/flinders/` | PASS | Submitted and indexed |
+| `/places/mornington/` | NEUTRAL | Discovered - currently not indexed |
+| `/places/rye/` | NEUTRAL | Discovered - currently not indexed |
+
+### Top 10 queries by clicks (last 28d)
+
+| # | Query | Clicks | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | laura at pt leo estate | 1 | 1 | 100.00% | 1.0 |
+| 2 | pt leo estate | 1 | 1 | 100.00% | 6.0 |
+| 3 | "endota" | 0 | 1 | 0.00% | 45.0 |
+| 4 | 111 ocean beach road sorrento vic 3943 | 0 | 1 | 0.00% | 9.0 |
+| 5 | 20 junction road merricks north vic 3926 | 0 | 15 | 0.00% | 29.9 |
+| 6 | 34 western parade point leo vic 3916 | 0 | 22 | 0.00% | 28.9 |
+| 7 | 42 brasser avenue dromana vic 3936 | 0 | 2 | 0.00% | 29.5 |
+| 8 | a dog-friendly guide mornington peninsula | 0 | 20 | 0.00% | 6.8 |
+| 9 | accommodation near peninsula hot springs | 0 | 11 | 0.00% | 69.4 |
+| 10 | advance mussel supply | 0 | 1 | 0.00% | 5.0 |
+
+### Top 10 queries by impressions (last 28d)
+
+| # | Query | Impr | Clicks | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | dog friendly guide mornington peninsula | 38 | 0 | 0.00% | 8.8 |
+| 2 | 34 western parade point leo vic 3916 | 22 | 0 | 0.00% | 28.9 |
+| 3 | a dog-friendly guide mornington peninsula | 20 | 0 | 0.00% | 6.8 |
+| 4 | free things to do in mornington peninsula | 16 | 0 | 0.00% | 20.3 |
+| 5 | 20 junction road merricks north vic 3926 | 15 | 0 | 0.00% | 29.9 |
+| 6 | hotel near sorrento pier booking | 15 | 0 | 0.00% | 65.9 |
+| 7 | accommodation near peninsula hot springs | 11 | 0 | 0.00% | 69.4 |
+| 8 | dog friendly beaches mornington peninsula | 11 | 0 | 0.00% | 17.6 |
+| 9 | endota sorrento | 10 | 0 | 0.00% | 5.7 |
+| 10 | dog beaches mornington peninsula | 8 | 0 | 0.00% | 21.4 |
+
+### CTR opportunity queries (≥20 impr, <2% CTR)
+
+| # | Query | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|
+| 1 | dog friendly guide mornington peninsula | 38 | 0.00% | 8.8 |
+| 2 | 34 western parade point leo vic 3916 | 22 | 0.00% | 28.9 |
+| 3 | a dog-friendly guide mornington peninsula | 20 | 0.00% | 6.8 |
+
+### Top 10 pages by clicks (last 28d)
+
+| # | Page | Clicks | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | `http://peninsulainsider.com.au/` | 9 | 20 | 45.00% | 1.8 |
+| 2 | `/` | 7 | 48 | 14.58% | 2.2 |
+| 3 | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` | 3 | 42 | 7.14% | 6.0 |
+| 4 | `/eat/` | 2 | 107 | 1.87% | 34.5 |
+| 5 | `/journal/the-pub-guide` | 1 | 9 | 11.11% | 5.3 |
+| 6 | `/journal/three-italian-dinners/` | 1 | 20 | 5.00% | 7.3 |
+| 7 | `/whats-on/mornington-cup-2026` | 1 | 228 | 0.44% | 7.6 |
+| 8 | `/wine/` | 1 | 224 | 0.45% | 16.8 |
+| 9 | `http://peninsulainsider.com.au/journal/the-birthday-weekend` | 0 | 2 | 0.00% | 38.5 |
+| 10 | `http://peninsulainsider.com.au/journal/the-birthday-weekend/` | 0 | 28 | 0.00% | 6.1 |
+
+### CTR opportunity pages (≥30 impr, <2% CTR)
+
+| # | Page | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|
+| 1 | `/journal/dog-friendly-mornington-peninsula` | 248 | 0.00% | 14.0 |
+| 2 | `/whats-on/mornington-cup-2026` | 228 | 0.44% | 7.6 |
+| 3 | `/wine/` | 224 | 0.45% | 16.8 |
+| 4 | `http://peninsulainsider.com.au/stay/hotel-sorrento` | 109 | 0.00% | 53.7 |
+| 5 | `/eat/` | 107 | 1.87% | 34.5 |
+| 6 | `/journal/dog-friendly-mornington-peninsula/` | 99 | 0.00% | 9.3 |
+| 7 | `/stay/` | 95 | 0.00% | 27.1 |
+| 8 | `/journal/the-chardonnay-case/` | 71 | 0.00% | 5.6 |
+| 9 | `/stay/best-accommodation` | 65 | 0.00% | 18.8 |
+| 10 | `/journal/the-pub-guide/` | 57 | 0.00% | 9.0 |
+
+### Devices (last 28d)
+
+| Device | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| DESKTOP | 14 | 1,293 | 1.08% | 18.3 |
+| MOBILE | 9 | 480 | 1.88% | 12.4 |
+| TABLET | 0 | 7 | 0.00% | 11.7 |
+
+### Top countries (last 28d)
+
+| Country | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| aus | 23 | 986 | 2.33% | 22.3 |
+| alb | 0 | 1 | 0.00% | 11.0 |
+| arg | 0 | 2 | 0.00% | 27.5 |
+| bfa | 0 | 1 | 0.00% | 6.0 |
+| bgd | 0 | 3 | 0.00% | 16.3 |
+| bgr | 0 | 1 | 0.00% | 7.0 |
+| blr | 0 | 1 | 0.00% | 20.0 |
+| bol | 0 | 1 | 0.00% | 4.0 |
+
+---
+
+### Notes (Day 1 baseline)
+
+**Trajectory**: positive. Impressions ~doubled WoW (539 → 1,009), clicks 4×ed (2 → 8). Position drift (16.6 → 17.4) is healthy long-tail expansion.
+
+**Critical bug found** — duplicate broken `<link rel="canonical" href=".../places/undefined">` on every place page. Source: [PlaceDetailTemplate.astro:62](next/src/components/PlaceDetailTemplate.astro:62) reads `place.slug` (undefined) instead of `place.id`. The page already passes a correct canonical via `[slug].astro` → BaseLayout, so we end up with two `<link rel="canonical">` tags on every `/places/*` URL. Logged as experiment **2026-05-02-01** (first action tomorrow).
+
+**Stale crawl data on 3 priority URLs** — `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` show "Alternate canonical" because GSC's last crawl (Apr 13-22) caught an older HTML state with no-trailing-slash canonicals. Current HTML is correct. Manual reindex requests should accelerate recovery — added to backlog.
+
+**Demand signal**: 5 of top 10 queries by impressions are "dog friendly" variants. Single biggest content cluster opportunity.
+
+**CTR opportunity**: `/whats-on/mornington-cup-2026` is at position 7.6 with 228 impressions and 0.44% CTR. Snippet rewrite is highest-leverage single change.
+
+**Address-string queries**: 4 of top 10 by impressions are exact street addresses. Suggests legacy directory pages still indexed and contributing to bloat. Investigate.
+
+### Actions taken today
+
+- Built the SEO ops infrastructure (`ops/scripts/seo/auth.mjs`, `pull.mjs`, `config.mjs`).
+- Authorised GSC API access. Token at `ops/tokens/gsc-token.json`.
+- Pulled first daily snapshot. Raw data at `ops/data/seo/2026-05-01.json`.
+- Wrote `baseline.md` (frozen reference).
+- Logged the canonical bug as the first experiment.
+
+### Tomorrow's queue
+
+1. Ship the `PlaceDetailTemplate.astro` canonical fix (experiment 2026-05-02-01).
+2. Submit `/stay/best-accommodation/`, `/journal/dog-friendly-mornington-peninsula/`, `/places/red-hill/` for reindexing in GSC.
+3. Diagnose the http:// vs https:// indexation (curl the http variant, confirm 301).
+4. Pull again, log changes.

--- a/ops/reports/seo/experiments.md
+++ b/ops/reports/seo/experiments.md
@@ -1,0 +1,35 @@
+# SEO experiments — Peninsula Insider
+
+Every shipped SEO change is logged here as a hypothesis-driven experiment. Wins and losses both kept; failed experiments are as informative as successful ones.
+
+## Format
+
+```
+## YYYY-MM-DD — short title
+- **PR**: link
+- **Pages affected**: list
+- **Hypothesis**: specific, measurable. "If we do X then metric Y will move from A to B by date Z."
+- **Mechanism**: why we expect it to work, in one sentence.
+- **Measurement**: which line in `daily-log.md` we'll read on date Z to confirm or refute.
+- **Outcome (filled later)**: what actually happened, hypothesis confirmed/refuted, what we learned.
+```
+
+## Queued experiments
+
+### 2026-05-02-01 — Fix duplicate broken `/places/undefined` canonical
+
+- **PR**: pending (to be opened 2026-05-02)
+- **Pages affected**: all 20 pages under `/places/*` (sorrento, red-hill, flinders, mornington, rye, etc.)
+- **Hypothesis**: removing the broken second canonical tag from `PlaceDetailTemplate.astro` will allow Google to resolve canonical signals correctly on all place pages, moving at least 5 of the 9 currently "Discovered – not indexed" priority place URLs into the index within 14 days. Specifically: by 2026-05-16, indexed priority URL count rises from 2/14 to ≥7/14.
+- **Mechanism**: `next/src/components/PlaceDetailTemplate.astro:62` builds `canonical` from `place.slug` which is `undefined` (correct property is `place.id`). The template then emits `<link rel="canonical" href=".../places/undefined">` via `Fragment slot="head"`. Meanwhile `next/src/pages/places/[slug].astro:115` separately passes a correct canonical to `BaseLayout`. Result: every place page has two `<link rel="canonical">` tags, the second pointing to a non-existent URL. Conflicting canonicals weaken Google's confidence in which URL to index. Removing the duplicate (and broken) canonical from the template should resolve the conflict.
+- **Mechanism alternative considered**: just fix `place.slug` → `place.id`. Rejected because two canonicals on one page is itself a violation, and the BaseLayout-driven canonical already covers this case.
+- **Measurement**: read the indexation status block in the daily log on 2026-05-09 (7d) and 2026-05-16 (14d). Cross-reference with the JSON snapshots. Headline metric: priority URL indexed count and `places/*` indexation status in `urlInspection`.
+- **Outcome (filled later)**: _pending_
+
+## Completed experiments
+
+_(none yet)_
+
+## Completed experiments
+
+_(none yet)_

--- a/ops/reports/seo/experiments.md
+++ b/ops/reports/seo/experiments.md
@@ -14,17 +14,18 @@ Every shipped SEO change is logged here as a hypothesis-driven experiment. Wins 
 - **Outcome (filled later)**: what actually happened, hypothesis confirmed/refuted, what we learned.
 ```
 
-## Queued experiments
+## Active experiments
 
-### 2026-05-02-01 — Fix duplicate broken `/places/undefined` canonical
+### 2026-05-01-01 — Remove duplicate broken `/places/undefined` canonical
 
-- **PR**: pending (to be opened 2026-05-02)
-- **Pages affected**: all 20 pages under `/places/*` (sorrento, red-hill, flinders, mornington, rye, etc.)
-- **Hypothesis**: removing the broken second canonical tag from `PlaceDetailTemplate.astro` will allow Google to resolve canonical signals correctly on all place pages, moving at least 5 of the 9 currently "Discovered – not indexed" priority place URLs into the index within 14 days. Specifically: by 2026-05-16, indexed priority URL count rises from 2/14 to ≥7/14.
-- **Mechanism**: `next/src/components/PlaceDetailTemplate.astro:62` builds `canonical` from `place.slug` which is `undefined` (correct property is `place.id`). The template then emits `<link rel="canonical" href=".../places/undefined">` via `Fragment slot="head"`. Meanwhile `next/src/pages/places/[slug].astro:115` separately passes a correct canonical to `BaseLayout`. Result: every place page has two `<link rel="canonical">` tags, the second pointing to a non-existent URL. Conflicting canonicals weaken Google's confidence in which URL to index. Removing the duplicate (and broken) canonical from the template should resolve the conflict.
-- **Mechanism alternative considered**: just fix `place.slug` → `place.id`. Rejected because two canonicals on one page is itself a violation, and the BaseLayout-driven canonical already covers this case.
-- **Measurement**: read the indexation status block in the daily log on 2026-05-09 (7d) and 2026-05-16 (14d). Cross-reference with the JSON snapshots. Headline metric: priority URL indexed count and `places/*` indexation status in `urlInspection`.
-- **Outcome (filled later)**: _pending_
+- **Status**: shipped to worktree branch `claude/goofy-chaplygin-91fbed` 2026-05-01. Awaiting deploy to live site.
+- **PR**: pending push (commit applied locally)
+- **Pages affected**: all 20 pages under `/places/*` (sorrento, red-hill, flinders, mornington, rye, portsea, main-ridge, dromana, mount-martha, cape-schanck, balnarring, merricks, point-nepean, plus 7 others)
+- **Hypothesis**: removing the duplicate `<Fragment slot="head">` block from `PlaceDetailTemplate.astro` will allow Google to resolve canonical signals correctly on all place pages, moving at least 5 of the 9 currently "Discovered – not indexed" priority place URLs into the index within 14 days. Specifically: by 2026-05-16, indexed priority URL count rises from 2/14 to ≥7/14.
+- **Mechanism**: `PlaceDetailTemplate.astro:62-77` defined a `canonical` const built from `place.slug` (undefined; correct property is `place.id`), then emitted it via `<Fragment slot="head">` along with duplicate `<title>`, `<meta description>`, og: tags, and a JSON-LD `Place` schema. The parent page (`places/[slug].astro:290-298`) already passes correct title/description/canonical/ogImage to `BaseLayout` and emits its own `placeSchema` JSON-LD. Result: every place page had **two `<link rel="canonical">` tags** (one correct, one pointing to `/places/undefined`), two `<title>` tags, duplicate og: tags, and duplicate JSON-LD. Removed the entire `<Fragment slot="head">` block and the unused locals that fed it.
+- **Verification** (2026-05-01): rebuilt locally with `npm run build` — 955 pages built in 19.56s, no errors. Spot-checked `dist/places/{red-hill,sorrento,flinders}/index.html`: each now has exactly one `<link rel="canonical">` pointing to the correct trailing-slash URL, exactly one `<title>` tag.
+- **Measurement**: read the indexation status block in `daily-log.md` on 2026-05-09 (7d after deploy) and 2026-05-16 (14d). Cross-reference with the JSON snapshots in `ops/data/seo/`. Headline metric: priority URL indexed count and `places/*` indexation status in `urlInspection`.
+- **Outcome (filled later)**: _pending — measure 2026-05-09 and 2026-05-16_
 
 ## Completed experiments
 

--- a/ops/scripts/seo/README.md
+++ b/ops/scripts/seo/README.md
@@ -1,0 +1,43 @@
+# Peninsula Insider — SEO ops scripts
+
+Daily Search Console pulls, indexation tracking, and the artefacts that drive the SEO daily review cycle.
+
+## One-time setup
+
+```bash
+cd ops/scripts/seo
+npm install
+npm run auth
+```
+
+`npm run auth` opens a browser to authorise the Google account that has Search Console access to `peninsulainsider.com.au`. Saves a refresh token to `ops/tokens/gsc-token.json` (gitignored). After this, all subsequent pulls are non-interactive.
+
+## Daily pull
+
+```bash
+cd ops/scripts/seo
+npm run pull
+```
+
+Outputs:
+
+| Path | Purpose |
+|---|---|
+| `ops/data/seo/YYYY-MM-DD.json` | Raw snapshot — performance, indexation, URL inspection results. Source of truth for diffs. |
+| `ops/reports/seo/daily-log.md` | Human-readable digest, appended each run. The doc we read every morning. |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `package.json` | Local deps (googleapis only) — does not affect the Astro build. |
+| `config.mjs` | Paths and the priority URL list inspected on every pull. Edit `PRIORITY_URLS` to change what gets URL-inspected. |
+| `auth.mjs` | One-time OAuth bootstrap. |
+| `pull.mjs` | Daily Search Console pull + digest renderer. |
+
+## Notes
+
+- GSC data has a ~2-day reporting lag — today's pull covers up to (today − 2).
+- URL inspection has a stricter quota (~2,000 URLs/day per property). Keep `PRIORITY_URLS` to ~20 URLs.
+- The OAuth refresh token in `ops/tokens/gsc-token.json` does not expire under normal use. If the pull starts failing with `invalid_grant`, re-run `npm run auth`.
+- Credentials never leave `ops/tokens/` and that directory is gitignored at repo root.

--- a/ops/scripts/seo/auth.mjs
+++ b/ops/scripts/seo/auth.mjs
@@ -1,0 +1,116 @@
+// One-time OAuth bootstrap for Google Search Console API access.
+// Run once: `npm run auth` from ops/scripts/seo/
+// Saves a refresh token to ops/tokens/gsc-token.json for non-interactive future use.
+
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import { URL } from 'node:url';
+import { exec } from 'node:child_process';
+import { google } from 'googleapis';
+import { PATHS, SCOPES } from './config.mjs';
+
+const openInBrowser = (url) => {
+  const platform = process.platform;
+  const cmd = platform === 'win32'
+    ? `start "" "${url}"`
+    : platform === 'darwin'
+      ? `open "${url}"`
+      : `xdg-open "${url}"`;
+  exec(cmd, (err) => {
+    if (err) console.log('(could not auto-open browser; copy the URL above manually)');
+  });
+};
+
+async function main() {
+  const raw = await fs.readFile(PATHS.clientSecret, 'utf8');
+  const { installed } = JSON.parse(raw);
+  if (!installed) throw new Error('client secret JSON is not an installed-app credential');
+  const { client_id, client_secret } = installed;
+
+  // Spin up a local server to catch the OAuth redirect
+  let listeningPort = 0;
+  const { code, port } = await new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const reqUrl = new URL(req.url, `http://localhost:${listeningPort}`);
+      const codeParam = reqUrl.searchParams.get('code');
+      const errorParam = reqUrl.searchParams.get('error');
+      if (errorParam) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(`<h1>OAuth error: ${errorParam}</h1><p>You can close this tab.</p>`);
+        server.close();
+        reject(new Error(`OAuth error: ${errorParam}`));
+        return;
+      }
+      if (!codeParam) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<h1>No code in callback</h1>');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<h1>Authorised. You can close this tab and return to the terminal.</h1>');
+      const capturedPort = listeningPort;
+      server.close();
+      resolve({ code: codeParam, port: capturedPort });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      listeningPort = server.address().port;
+      const redirectUri = `http://localhost:${listeningPort}`;
+      const oauth2 = new google.auth.OAuth2(client_id, client_secret, redirectUri);
+      const authUrl = oauth2.generateAuthUrl({
+        access_type: 'offline',
+        prompt: 'consent',
+        scope: SCOPES,
+      });
+      console.log('\n--- Google Search Console authorisation ---');
+      console.log('Opening browser. If it does not open, copy this URL:\n');
+      console.log(authUrl);
+      console.log('\nWaiting for redirect to http://localhost:' + listeningPort + ' ...\n');
+      openInBrowser(authUrl);
+    });
+    setTimeout(() => {
+      server.close();
+      reject(new Error('OAuth timeout after 15 minutes'));
+    }, 15 * 60 * 1000);
+  });
+
+  // Exchange the code for tokens
+  const redirectUri = `http://localhost:${port}`;
+  const oauth2 = new google.auth.OAuth2(client_id, client_secret, redirectUri);
+  const { tokens } = await oauth2.getToken(code);
+  if (!tokens.refresh_token) {
+    throw new Error('No refresh_token returned. Revoke prior consent at https://myaccount.google.com/permissions and re-run.');
+  }
+  oauth2.setCredentials(tokens);
+  await fs.writeFile(PATHS.token, JSON.stringify(tokens, null, 2), 'utf8');
+  console.log('Saved token to', PATHS.token);
+
+  // Verify by listing sites
+  const webmasters = google.webmasters({ version: 'v3', auth: oauth2 });
+  const sites = await webmasters.sites.list();
+  const list = sites.data.siteEntry || [];
+  console.log('\nAccessible Search Console properties:');
+  for (const s of list) {
+    console.log(`  - ${s.siteUrl} [${s.permissionLevel}]`);
+  }
+  const piMatch = list.find((s) =>
+    s.siteUrl.includes('peninsulainsider.com.au'),
+  );
+  if (!piMatch) {
+    console.log('\nWARNING: peninsulainsider.com.au not found in this account.');
+    console.log('You may have authorised the wrong Google account. Token saved anyway.');
+  } else {
+    await fs.writeFile(
+      PATHS.property,
+      JSON.stringify({ siteUrl: piMatch.siteUrl, permissionLevel: piMatch.permissionLevel }, null, 2),
+      'utf8',
+    );
+    console.log(`\nUsing property: ${piMatch.siteUrl}`);
+    console.log('Saved property to', PATHS.property);
+    console.log('\nReady. Run `npm run pull` to fetch the first daily report.');
+  }
+}
+
+main().catch((err) => {
+  console.error('\nAuth failed:', err.message);
+  process.exit(1);
+});

--- a/ops/scripts/seo/config.mjs
+++ b/ops/scripts/seo/config.mjs
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+export const PATHS = {
+  clientSecret: path.join(REPO_ROOT, 'ops', 'tokens', 'gsc-client-secret.json'),
+  token: path.join(REPO_ROOT, 'ops', 'tokens', 'gsc-token.json'),
+  property: path.join(REPO_ROOT, 'ops', 'tokens', 'gsc-property.json'),
+  dataDir: path.join(REPO_ROOT, 'ops', 'data', 'seo'),
+  logsDir: path.join(REPO_ROOT, 'ops', 'logs', 'seo'),
+  reportsDir: path.join(REPO_ROOT, 'ops', 'reports', 'seo'),
+  dailyLog: path.join(REPO_ROOT, 'ops', 'reports', 'seo', 'daily-log.md'),
+};
+
+export const SCOPES = ['https://www.googleapis.com/auth/webmasters.readonly'];
+
+export const PRIORITY_URLS = [
+  'https://peninsulainsider.com.au/',
+  'https://peninsulainsider.com.au/eat/best-restaurants/',
+  'https://peninsulainsider.com.au/wine/best-cellar-doors/',
+  'https://peninsulainsider.com.au/explore/best-walks/',
+  'https://peninsulainsider.com.au/stay/best-accommodation/',
+  'https://peninsulainsider.com.au/journal/mornington-peninsula-day-trip/',
+  'https://peninsulainsider.com.au/journal/mornington-peninsula-in-autumn/',
+  'https://peninsulainsider.com.au/journal/mornington-peninsula-with-kids/',
+  'https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/',
+  'https://peninsulainsider.com.au/places/sorrento/',
+  'https://peninsulainsider.com.au/places/red-hill/',
+  'https://peninsulainsider.com.au/places/flinders/',
+  'https://peninsulainsider.com.au/places/mornington/',
+  'https://peninsulainsider.com.au/places/rye/',
+];

--- a/ops/scripts/seo/package-lock.json
+++ b/ops/scripts/seo/package-lock.json
@@ -1,0 +1,596 @@
+{
+  "name": "pi-seo-ops",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-seo-ops",
+      "version": "0.1.0",
+      "dependencies": {
+        "googleapis": "^144.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/ops/scripts/seo/package.json
+++ b/ops/scripts/seo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pi-seo-ops",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "SEO ops scripts for Peninsula Insider — Google Search Console pulls, daily reports, indexation tracking.",
+  "scripts": {
+    "auth": "node auth.mjs",
+    "pull": "node pull.mjs",
+    "pull:verbose": "node pull.mjs --verbose"
+  },
+  "dependencies": {
+    "googleapis": "^144.0.0"
+  }
+}

--- a/ops/scripts/seo/pull.mjs
+++ b/ops/scripts/seo/pull.mjs
@@ -1,0 +1,305 @@
+// Daily pull from Google Search Console.
+// Usage: `npm run pull` from ops/scripts/seo/
+// Outputs:
+//   - ops/data/seo/YYYY-MM-DD.json          (raw snapshot for archival/diffing)
+//   - ops/reports/seo/daily-log.md          (appended human-readable digest)
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { google } from 'googleapis';
+import { PATHS, PRIORITY_URLS } from './config.mjs';
+
+const isoDate = (d) => d.toISOString().slice(0, 10);
+const TODAY = new Date();
+const dateMinus = (n) => {
+  const d = new Date(TODAY);
+  d.setUTCDate(d.getUTCDate() - n);
+  return isoDate(d);
+};
+
+const VERBOSE = process.argv.includes('--verbose');
+const log = (...args) => console.log(...args);
+const vlog = (...args) => { if (VERBOSE) console.log(...args); };
+
+async function getClient() {
+  const secret = JSON.parse(await fs.readFile(PATHS.clientSecret, 'utf8'));
+  const token = JSON.parse(await fs.readFile(PATHS.token, 'utf8'));
+  const { client_id, client_secret } = secret.installed;
+  const auth = new google.auth.OAuth2(client_id, client_secret);
+  auth.setCredentials(token);
+  auth.on('tokens', async (newTokens) => {
+    const merged = { ...token, ...newTokens };
+    await fs.writeFile(PATHS.token, JSON.stringify(merged, null, 2));
+    vlog('  (refreshed access token)');
+  });
+  return auth;
+}
+
+async function loadProperty() {
+  return JSON.parse(await fs.readFile(PATHS.property, 'utf8'));
+}
+
+async function sa(sc, siteUrl, body) {
+  const res = await sc.searchanalytics.query({ siteUrl, requestBody: body });
+  return res.data.rows || [];
+}
+
+async function inspect(sc, siteUrl, inspectionUrl) {
+  try {
+    const res = await sc.urlInspection.index.inspect({
+      requestBody: { siteUrl, inspectionUrl },
+    });
+    return res.data.inspectionResult;
+  } catch (err) {
+    return { error: err.message, code: err.code };
+  }
+}
+
+function pct(n) {
+  if (n === null || n === undefined || Number.isNaN(n)) return '—';
+  return `${(n * 100).toFixed(2)}%`;
+}
+function num(n) {
+  if (n === null || n === undefined) return '—';
+  return Number(n).toLocaleString('en-AU');
+}
+function pos(n) {
+  if (n === null || n === undefined) return '—';
+  return Number(n).toFixed(1);
+}
+function delta(curr, prev, fmt = num, invert = false) {
+  if (curr === null || prev === null || curr === undefined || prev === undefined) return fmt(curr);
+  const diff = curr - prev;
+  const sign = diff > 0 ? '+' : '';
+  const arrow = (invert ? -diff : diff) > 0 ? '↑' : (invert ? -diff : diff) < 0 ? '↓' : '·';
+  return `${fmt(curr)}  (${sign}${fmt(diff)} ${arrow})`;
+}
+
+async function main() {
+  const auth = await getClient();
+  const property = await loadProperty();
+  const sc = google.searchconsole({ version: 'v1', auth });
+
+  const runDate = isoDate(TODAY);
+  const endDate = dateMinus(2);              // GSC has ~2-day reporting lag
+  const startDate28 = dateMinus(29);
+  const startDate7 = dateMinus(8);
+  const startDatePrev7 = dateMinus(15);
+  const endDatePrev7 = dateMinus(9);
+
+  log(`\n  Run date:   ${runDate}`);
+  log(`  Property:   ${property.siteUrl}`);
+  log(`  Window:     ${startDate28} → ${endDate}  (28d)`);
+  log(`              ${startDate7} → ${endDate}  (7d)  vs  ${startDatePrev7} → ${endDatePrev7}  (prev 7d)\n`);
+
+  log('Pulling Search Analytics...');
+  const [
+    headline28,
+    headline7,
+    headlinePrev7,
+    daily28,
+    queries28,
+    pages28,
+    countries28,
+    devices28,
+  ] = await Promise.all([
+    sa(sc, property.siteUrl, { startDate: startDate28, endDate, dimensions: [], rowLimit: 1 }),
+    sa(sc, property.siteUrl, { startDate: startDate7, endDate, dimensions: [], rowLimit: 1 }),
+    sa(sc, property.siteUrl, { startDate: startDatePrev7, endDate: endDatePrev7, dimensions: [], rowLimit: 1 }),
+    sa(sc, property.siteUrl, { startDate: startDate28, endDate, dimensions: ['date'], rowLimit: 30 }),
+    sa(sc, property.siteUrl, { startDate: startDate28, endDate, dimensions: ['query'], rowLimit: 100 }),
+    sa(sc, property.siteUrl, { startDate: startDate28, endDate, dimensions: ['page'], rowLimit: 100 }),
+    sa(sc, property.siteUrl, { startDate: startDate28, endDate, dimensions: ['country'], rowLimit: 25 }),
+    sa(sc, property.siteUrl, { startDate: startDate28, endDate, dimensions: ['device'], rowLimit: 5 }),
+  ]);
+  log(`  ${queries28.length} queries · ${pages28.length} pages · ${daily28.length} days`);
+
+  log('\nInspecting priority URLs...');
+  const inspections = {};
+  for (const url of PRIORITY_URLS) {
+    const result = await inspect(sc, property.siteUrl, url);
+    inspections[url] = result;
+    const verdict = result?.indexStatusResult?.verdict || result?.error || 'UNKNOWN';
+    const coverage = result?.indexStatusResult?.coverageState || '';
+    log(`  ${verdict.padEnd(10)} ${coverage.padEnd(45)} ${url}`);
+    // small delay to be polite to the API (URL inspection has stricter quota)
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  const snapshot = {
+    runDate,
+    runTimestamp: new Date().toISOString(),
+    property: property.siteUrl,
+    ranges: {
+      last28d: { startDate: startDate28, endDate },
+      last7d: { startDate: startDate7, endDate },
+      prev7d: { startDate: startDatePrev7, endDate: endDatePrev7 },
+    },
+    headline: {
+      last28d: headline28[0] || null,
+      last7d: headline7[0] || null,
+      prev7d: headlinePrev7[0] || null,
+    },
+    daily: daily28,
+    queries: queries28,
+    pages: pages28,
+    countries: countries28,
+    devices: devices28,
+    inspections,
+  };
+
+  await fs.mkdir(PATHS.dataDir, { recursive: true });
+  const rawPath = path.join(PATHS.dataDir, `${runDate}.json`);
+  await fs.writeFile(rawPath, JSON.stringify(snapshot, null, 2));
+  log(`\nSaved raw snapshot: ${rawPath}`);
+
+  await fs.mkdir(PATHS.reportsDir, { recursive: true });
+  const digest = renderDigest(snapshot);
+  await appendDailyLog(digest);
+  log(`Appended digest:    ${PATHS.dailyLog}`);
+
+  log('\nDone.');
+}
+
+function renderDigest(s) {
+  const h7 = s.headline.last7d;
+  const hp = s.headline.prev7d;
+  const h28 = s.headline.last28d;
+
+  const indexedCount = Object.values(s.inspections).filter(
+    (i) => i?.indexStatusResult?.verdict === 'PASS',
+  ).length;
+  const inspectedCount = Object.keys(s.inspections).length;
+
+  const topQueriesByClicks = [...s.queries]
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, 10);
+  const topQueriesByImpressions = [...s.queries]
+    .sort((a, b) => b.impressions - a.impressions)
+    .slice(0, 10);
+  const opportunityQueries = [...s.queries]
+    .filter((q) => q.impressions >= 20 && q.ctr < 0.02)
+    .sort((a, b) => b.impressions - a.impressions)
+    .slice(0, 10);
+  const topPagesByClicks = [...s.pages]
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, 10);
+  const opportunityPages = [...s.pages]
+    .filter((p) => p.impressions >= 30 && p.ctr < 0.02)
+    .sort((a, b) => b.impressions - a.impressions)
+    .slice(0, 10);
+
+  const lines = [];
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(`## ${s.runDate} — daily pull`);
+  lines.push('');
+  lines.push(`Property: \`${s.property}\``);
+  lines.push(`Window (last 7d): ${s.ranges.last7d.startDate} → ${s.ranges.last7d.endDate}`);
+  lines.push('');
+  lines.push('### Headline (last 7d vs previous 7d)');
+  lines.push('');
+  lines.push('| Metric | Last 7d | Prev 7d | Δ | Last 28d |');
+  lines.push('|---|---:|---:|---:|---:|');
+  lines.push(`| Clicks | ${num(h7?.clicks)} | ${num(hp?.clicks)} | ${delta(h7?.clicks, hp?.clicks)} | ${num(h28?.clicks)} |`);
+  lines.push(`| Impressions | ${num(h7?.impressions)} | ${num(hp?.impressions)} | ${delta(h7?.impressions, hp?.impressions)} | ${num(h28?.impressions)} |`);
+  lines.push(`| CTR | ${pct(h7?.ctr)} | ${pct(hp?.ctr)} | ${delta(h7?.ctr, hp?.ctr, pct)} | ${pct(h28?.ctr)} |`);
+  lines.push(`| Avg position | ${pos(h7?.position)} | ${pos(hp?.position)} | ${delta(h7?.position, hp?.position, pos, true)} | ${pos(h28?.position)} |`);
+  lines.push('');
+  lines.push(`### Indexation (priority URLs): ${indexedCount} / ${inspectedCount} indexed`);
+  lines.push('');
+  lines.push('| URL | Verdict | Coverage |');
+  lines.push('|---|---|---|');
+  for (const [url, r] of Object.entries(s.inspections)) {
+    const v = r?.indexStatusResult?.verdict || (r?.error ? 'ERROR' : 'UNKNOWN');
+    const c = r?.indexStatusResult?.coverageState || (r?.error || '—');
+    lines.push(`| \`${url.replace('https://peninsulainsider.com.au', '')}\` | ${v} | ${c} |`);
+  }
+  lines.push('');
+  lines.push('### Top 10 queries by clicks (last 28d)');
+  lines.push('');
+  lines.push('| # | Query | Clicks | Impr | CTR | Pos |');
+  lines.push('|---:|---|---:|---:|---:|---:|');
+  topQueriesByClicks.forEach((q, i) => {
+    lines.push(`| ${i + 1} | ${q.keys[0]} | ${num(q.clicks)} | ${num(q.impressions)} | ${pct(q.ctr)} | ${pos(q.position)} |`);
+  });
+  lines.push('');
+  lines.push('### Top 10 queries by impressions (last 28d)');
+  lines.push('');
+  lines.push('| # | Query | Impr | Clicks | CTR | Pos |');
+  lines.push('|---:|---|---:|---:|---:|---:|');
+  topQueriesByImpressions.forEach((q, i) => {
+    lines.push(`| ${i + 1} | ${q.keys[0]} | ${num(q.impressions)} | ${num(q.clicks)} | ${pct(q.ctr)} | ${pos(q.position)} |`);
+  });
+  lines.push('');
+  if (opportunityQueries.length) {
+    lines.push('### CTR opportunity queries (≥20 impr, <2% CTR)');
+    lines.push('');
+    lines.push('| # | Query | Impr | CTR | Pos |');
+    lines.push('|---:|---|---:|---:|---:|');
+    opportunityQueries.forEach((q, i) => {
+      lines.push(`| ${i + 1} | ${q.keys[0]} | ${num(q.impressions)} | ${pct(q.ctr)} | ${pos(q.position)} |`);
+    });
+    lines.push('');
+  }
+  lines.push('### Top 10 pages by clicks (last 28d)');
+  lines.push('');
+  lines.push('| # | Page | Clicks | Impr | CTR | Pos |');
+  lines.push('|---:|---|---:|---:|---:|---:|');
+  topPagesByClicks.forEach((p, i) => {
+    const path = p.keys[0].replace('https://peninsulainsider.com.au', '');
+    lines.push(`| ${i + 1} | \`${path}\` | ${num(p.clicks)} | ${num(p.impressions)} | ${pct(p.ctr)} | ${pos(p.position)} |`);
+  });
+  lines.push('');
+  if (opportunityPages.length) {
+    lines.push('### CTR opportunity pages (≥30 impr, <2% CTR)');
+    lines.push('');
+    lines.push('| # | Page | Impr | CTR | Pos |');
+    lines.push('|---:|---|---:|---:|---:|');
+    opportunityPages.forEach((p, i) => {
+      const path = p.keys[0].replace('https://peninsulainsider.com.au', '');
+      lines.push(`| ${i + 1} | \`${path}\` | ${num(p.impressions)} | ${pct(p.ctr)} | ${pos(p.position)} |`);
+    });
+    lines.push('');
+  }
+  lines.push('### Devices (last 28d)');
+  lines.push('');
+  lines.push('| Device | Clicks | Impr | CTR | Pos |');
+  lines.push('|---|---:|---:|---:|---:|');
+  for (const d of s.devices) {
+    lines.push(`| ${d.keys[0]} | ${num(d.clicks)} | ${num(d.impressions)} | ${pct(d.ctr)} | ${pos(d.position)} |`);
+  }
+  lines.push('');
+  lines.push('### Top countries (last 28d)');
+  lines.push('');
+  lines.push('| Country | Clicks | Impr | CTR | Pos |');
+  lines.push('|---|---:|---:|---:|---:|');
+  for (const c of s.countries.slice(0, 8)) {
+    lines.push(`| ${c.keys[0]} | ${num(c.clicks)} | ${num(c.impressions)} | ${pct(c.ctr)} | ${pos(c.position)} |`);
+  }
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push('### Notes');
+  lines.push('_Add interpretation, decisions, and actions taken below._');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+async function appendDailyLog(digest) {
+  let header = '';
+  try {
+    await fs.access(PATHS.dailyLog);
+  } catch {
+    header = '# Peninsula Insider — SEO daily log\n\nAppended by `ops/scripts/seo/pull.mjs`. Newest entries at the bottom.\n';
+  }
+  await fs.appendFile(PATHS.dailyLog, header + digest, 'utf8');
+}
+
+main().catch((err) => {
+  console.error('\nPull failed:', err.message || err);
+  if (err.errors) console.error(JSON.stringify(err.errors, null, 2));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Two changes bundled into one PR (both 2026-05-01):

1. **SEO ops infrastructure** (`a7af2b6be`): stand up a sustained, daily-cycle SEO operation. GSC API automation, baseline snapshot, and tracking docs at `ops/reports/seo/`.

2. **Critical canonical bug fix** (`5c4b8343a`): every page under `/places/*` was emitting two `<link rel=\"canonical\">` tags in `<head>`, the second pointing to a non-existent URL `/places/undefined`. Plus duplicate `<title>`, meta description, og: tags, and JSON-LD. Removed the offending block from `PlaceDetailTemplate.astro`.

## Why

Site is at 11.2% indexation (39 of 349 URLs). Only 2 of 14 priority URLs are indexed. The canonical bug was a likely contributor — Google saw conflicting canonical signals on every place page and was reluctant to index. The infrastructure gives us a repeatable daily diagnose→ship→measure loop instead of sporadic audits.

## What's in this PR

**Infrastructure (no site impact):**
- `ops/scripts/seo/auth.mjs` — one-time OAuth for GSC API
- `ops/scripts/seo/pull.mjs` — daily pull, writes raw JSON + markdown digest
- `ops/scripts/seo/config.mjs` — paths + `PRIORITY_URLS` list
- `ops/reports/seo/{baseline,daily-log,experiments,backlog,README}.md`
- `ops/tokens/` (gitignored) — credentials

**Site change (one file):**
- `next/src/components/PlaceDetailTemplate.astro` — deleted the `<Fragment slot=\"head\">` block (lines 79-88) and the unused locals that fed it (lines 62-77). The parent page `places/[slug].astro` already passes correct title/description/canonical/ogImage to BaseLayout and emits its own placeSchema JSON-LD, so the entire template-side head block was redundant duplication on top of the broken canonical.

**Pages affected by the site change:** all 20 under `/places/*` (sorrento, red-hill, flinders, mornington, rye, portsea, main-ridge, dromana, mount-martha, cape-schanck, balnarring, merricks, point-nepean, plus 7 others).

## Verification

Built locally with `npm run build` — 955 pages built in 19.56s, no errors.

Spot-checked `dist/places/{red-hill,sorrento,flinders}/index.html`:
- Each now has exactly one `<link rel=\"canonical\">` pointing to the correct trailing-slash URL
- Each has exactly one `<title>` tag
- No `/places/undefined` references in any built HTML

## Hypothesis (logged in `ops/reports/seo/experiments.md` as `2026-05-01-01`)

By 2026-05-16 (14d post-deploy), priority URL indexed count rises from **2/14 to ≥7/14**.

## Test plan

- [ ] CI build passes
- [ ] After merge + auto-deploy: `curl -s \"https://peninsulainsider.com.au/places/red-hill/\" | grep -c canonical` returns `1`, not `2`
- [ ] Submit 20 priority URLs to GSC URL Inspection across two days (full list in `ops/reports/seo/daily-log.md`)
- [ ] Enable \"Enforce HTTPS\" in repo Settings → Pages (separate finding from this PR)
- [ ] Re-run `npm run pull` daily; measure indexation movement on 2026-05-09 and 2026-05-16

## Related findings (not in this PR — future work)

- HTTP and HTTPS both return 200 OK from GitHub Pages (no server-side redirect). Enable \"Enforce HTTPS\" to fix.
- 5 of top 10 query impressions are \"dog friendly\" variants — single biggest content cluster opportunity
- `/whats-on/mornington-cup-2026` at position 7.6 with 0.44% CTR — strong CTR rewrite candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)