### PR TITLE
About hero + concierge desktop masthead fix

### DIFF
--- a/next/src/pages/about.astro
+++ b/next/src/pages/about.astro
@@ -48,8 +48,8 @@ const principles = [
     title="Independent editorial. Honest, <em>opinionated</em> coverage."
     dek="Peninsula Insider is building the editorial guide the Mornington Peninsula doesn't have yet  -  one that treats readers like adults and venues like subjects, not clients."
     gradient="journal"
-    heroImage="/images/sourced/places-hub-hero-01.webp"
-    visualLabel="Peninsula Insider · editorial preview"
+    heroImage="/images/sourced/home-cover-back-beach-horses-01.jpg"
+    visualLabel="Peninsula Insider · the back beach"
   />
 
   <!-- Mission -->

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -7445,10 +7445,16 @@ body.menu-open .masthead { visibility: hidden; }
 /* When the concierge drawer is full-screen, hide every piece of sticky
    site chrome so the chat panel owns the viewport top-to-bottom. The
    drawer itself sits at z-index 10020. Body scroll locked so the page
-   underneath doesn't wander while the drawer is open. */
-body.concierge-open .masthead,
-body.concierge-open .subscribe-pill { visibility: hidden; }
-body.concierge-open { overflow: hidden; }
+   underneath doesn't wander while the drawer is open.
+   Mobile only: on desktop the drawer is a side panel, not full-screen,
+   so the masthead and subscribe pill stay visible and the page stays
+   scrollable. The 768px breakpoint matches the .masthead__nav mobile
+   collapse above. */
+@media (max-width: 768px) {
+  body.concierge-open .masthead,
+  body.concierge-open .subscribe-pill { visibility: hidden; }
+  body.concierge-open { overflow: hidden; }
+}
 
 /* 3) Article hero meta + byline rows: stack cleanly on mobile.
       Hairline separators stop making sense once wrapped. */


### PR DESCRIPTION
## Summary

Two small fixes on top of the merged bf branch:

- **About hero swap** ([ae3b8427f](https://github.com/richmondjw/peninsula-insider/commit/ae3b8427f)) — replaces the cloud preview image on /about/ with the back-beach horse riders shot already used on the homepage 8am–4pm slot. Better fit for the "honest, opinionated coverage" headline. Caption updated from "editorial preview" to "the back beach".

- **Concierge masthead fix on desktop** ([fe2b5ef54](https://github.com/richmondjw/peninsula-insider/commit/fe2b5ef54)) — the body.concierge-open visibility rule was unscoped, so opening the drawer on desktop hid the masthead and subscribe pill. The drawer is full-screen on mobile but a side panel on desktop, so the chrome-hiding rules now sit inside @media (max-width: 768px).

## Test plan

- [ ] /about/ hero shows the back-beach horse-riders image, not the cloud
- [ ] On desktop (>768px viewport), open the concierge drawer — the masthead and subscribe pill stay visible
- [ ] On mobile (<=768px viewport), open the concierge drawer — masthead and subscribe pill hide as before, body scroll locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)