### PR TITLE
Remove 'What's mapped so far' from About page

### DIFF
--- a/next/src/pages/about.astro
+++ b/next/src/pages/about.astro
@@ -1,14 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import SectionHero from '../components/SectionHero.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
-
-const venues = await getCollection('venues');
-const articles = await getCollection('articles', ({ data }) => data.status === 'published');
-const places = await getCollection('places');
-const experiences = await getCollection('experiences');
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
@@ -86,35 +80,6 @@ const principles = [
             <p class="about-principle__body">{principle.body}</p>
           </article>
         ))}
-      </div>
-    </div>
-  </section>
-
-  <!-- Coverage stats -->
-  <section class="about-coverage">
-    <div class="container">
-      <div class="about-coverage__inner">
-        <p class="label label--accent">Current coverage</p>
-        <h2 class="about-coverage__title">What's mapped so far</h2>
-        <p class="about-coverage__dek">The rebuild is live and growing. Every number below represents a real, editorially reviewed page  -  not a scraped listing.</p>
-        <dl class="about-coverage__stats">
-          <div>
-            <dd>{venues.length}</dd>
-            <dt>Venues mapped</dt>
-          </div>
-          <div>
-            <dd>{articles.length}</dd>
-            <dt>Journal pieces</dt>
-          </div>
-          <div>
-            <dd>{places.length}</dd>
-            <dt>Place hubs</dt>
-          </div>
-          <div>
-            <dd>{experiences.length}</dd>
-            <dt>Walks & experiences</dt>
-          </div>
-        </dl>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Drops the build-progress stats block (135 venues / 78 journal / 20 places / 42 walks). It read as a developer dashboard rather than editorial. Page is tighter without it.