### PR TITLE
Batch UI fixes: masthead, about, footer, concierge desktop

### DIFF
--- a/next/src/components/Footer.astro
+++ b/next/src/components/Footer.astro
@@ -28,7 +28,7 @@ const placeLinks = buildFooterPlaceLinks(places);
     <div class="v2-colophon__grid">
       <div class="v2-col-sect v2-col-sect--brand">
         <p>An editorial product about one small, well-defined place. Every venue visited. Every opinion earned. Dispatched weekly.</p>
-        <span class="v2-col-sect__label">Vol 04 <span class="v2-col-sect__ornament">·</span> Autumn 2026 issue <span class="v2-col-sect__ornament">·</span> Published in Victoria.</span>
+        <span class="v2-col-sect__label">Published in Victoria.</span>
         <p class="v2-col-sect__disclaimer">Peninsula Insider is an editorial platform sharing curated recommendations based on our own research and experience.</p>
         <p class="v2-col-sect__disclaimer">While we aim to keep information accurate, details such as opening hours, pricing, and availability may change. Please confirm directly with venues before visiting.</p>
         <p class="v2-col-sect__disclaimer">From time to time, we may work with partners or accept invitations. Where this occurs, it will be disclosed within the relevant content. Our recommendations remain independently curated.</p>

--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -28,7 +28,7 @@ export interface Props {
 const {
   section = 'home',
   issueMark = 'Vol 04',
-  issueLabel = 'The Autumn Issue · April 2026',
+  issueLabel = 'The Autumn Issue',
   port = 'Port Phillip',
   portTemp = '16°C',
   sunset = '5:48 pm',
@@ -54,7 +54,6 @@ const {
         </span>
         <div class="masthead__utility-links v2-util__links">
           <a href="/#newsletter" data-auth-anonymous>Subscribe</a>
-          <a href="#" data-open-auth data-auth-anonymous>Sign in</a>
           <a href="/account/" data-auth-signed-in hidden>Account</a>
           <a href="/about/">About</a>
         </div>

--- a/next/src/components/UtilityBar.astro
+++ b/next/src/components/UtilityBar.astro
@@ -18,7 +18,7 @@ export interface Props {
 
 const {
   issueMark = 'Vol 04',
-  issueLabel = 'The Autumn Issue · April 2026',
+  issueLabel = 'The Autumn Issue',
   port = 'Port Phillip',
   portTemp = '16°C',
   sunset = '5:48 pm',

--- a/next/src/components/v2/UtilityBar.astro
+++ b/next/src/components/v2/UtilityBar.astro
@@ -5,7 +5,7 @@ export interface Props {
 }
 const {
   issueMark = 'Vol 04',
-  issueLabel = 'The Autumn Issue · April 2026',
+  issueLabel = 'The Autumn Issue',
 } = Astro.props;
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL

--- a/next/src/pages/about.astro
+++ b/next/src/pages/about.astro
@@ -1,14 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import SectionHero from '../components/SectionHero.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
-
-const venues = await getCollection('venues');
-const articles = await getCollection('articles', ({ data }) => data.status === 'published');
-const places = await getCollection('places');
-const experiences = await getCollection('experiences');
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
@@ -48,8 +42,8 @@ const principles = [
     title="Independent editorial. Honest, <em>opinionated</em> coverage."
     dek="Peninsula Insider is building the editorial guide the Mornington Peninsula doesn't have yet  -  one that treats readers like adults and venues like subjects, not clients."
     gradient="journal"
-    heroImage="/images/sourced/places-hub-hero-01.webp"
-    visualLabel="Peninsula Insider · editorial preview"
+    heroImage="/images/sourced/home-cover-back-beach-horses-01.jpg"
+    visualLabel="Peninsula Insider · the back beach"
   />
 
   <!-- Mission -->
@@ -86,35 +80,6 @@ const principles = [
             <p class="about-principle__body">{principle.body}</p>
           </article>
         ))}
-      </div>
-    </div>
-  </section>
-
-  <!-- Coverage stats -->
-  <section class="about-coverage">
-    <div class="container">
-      <div class="about-coverage__inner">
-        <p class="label label--accent">Current coverage</p>
-        <h2 class="about-coverage__title">What's mapped so far</h2>
-        <p class="about-coverage__dek">The rebuild is live and growing. Every number below represents a real, editorially reviewed page  -  not a scraped listing.</p>
-        <dl class="about-coverage__stats">
-          <div>
-            <dd>{venues.length}</dd>
-            <dt>Venues mapped</dt>
-          </div>
-          <div>
-            <dd>{articles.length}</dd>
-            <dt>Journal pieces</dt>
-          </div>
-          <div>
-            <dd>{places.length}</dd>
-            <dt>Place hubs</dt>
-          </div>
-          <div>
-            <dd>{experiences.length}</dd>
-            <dt>Walks & experiences</dt>
-          </div>
-        </dl>
       </div>
     </div>
   </section>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -5901,6 +5901,10 @@ p.has-drop-cap::first-letter {
 .about-masthead {
   padding: 4rem 0 5rem;
 }
+
+.about-colophon {
+  padding: 4rem 0 5rem;
+}
 .about-masthead__credits {
   margin-top: 2.5rem;
   padding-top: 2rem;
@@ -7435,13 +7439,16 @@ p.has-drop-cap::first-letter {
       by the burger script in BaseLayout. */
 body.menu-open .masthead { visibility: hidden; }
 
-/* When the concierge drawer is full-screen, hide every piece of sticky
-   site chrome so the chat panel owns the viewport top-to-bottom. The
-   drawer itself sits at z-index 10020. Body scroll locked so the page
-   underneath doesn't wander while the drawer is open. */
-body.concierge-open .masthead,
-body.concierge-open .subscribe-pill { visibility: hidden; }
-body.concierge-open { overflow: hidden; }
+/* When the concierge drawer is full-screen on mobile, hide every piece
+   of sticky site chrome so the chat panel owns the viewport top-to-bottom.
+   On desktop the drawer is a side panel, not full-screen, so the masthead
+   and subscribe pill stay visible and the page stays scrollable. The
+   768px breakpoint matches the .masthead__nav mobile collapse. */
+@media (max-width: 768px) {
+  body.concierge-open .masthead,
+  body.concierge-open .subscribe-pill { visibility: hidden; }
+  body.concierge-open { overflow: hidden; }
+}
 
 /* 3) Article hero meta + byline rows: stack cleanly on mobile.
       Hairline separators stop making sense once wrapped. */


### PR DESCRIPTION
Re-applies the previously-merged-then-reverted About changes plus a stack of new ones:

1. Masthead — remove ' · April 2026' from issue label (3 components)
2. Masthead — remove non-functional 'Sign in' link
3. About — swap hero to back-beach horses (homepage ocean image)
4. About — remove 'What's mapped so far' coverage stats block
5. About — add padding to .about-colophon (was flush with NewsletterBlock)
6. Concierge desktop fix — masthead-hiding CSS now mobile-only
7. Footer — drop 'Vol 04 · Autumn 2026 issue ·' from imprint line

Build clean at 1027 pages.