### PR TITLE
Partners: drop firewall-audit line

### DIFF
--- a/next/src/pages/partners/index.astro
+++ b/next/src/pages/partners/index.astro
@@ -36,8 +36,7 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
           publication is funded in part by the businesses who appear on it. What we do not do
           is let those businesses influence the editorial. Three rules hold the line: we work
           only with Peninsula businesses, the editor signs off everything that runs, and every
-          paid item is clearly labelled. Once a year we publish a firewall audit naming what
-          we ran, what we declined, and where the line strained.
+          paid item is clearly labelled.
         </p>
         <p>
           We are in our founding commercial year. Partnerships at this stage are selective, editorially led, and structured around fit.


### PR DESCRIPTION
Removes the once-a-year firewall-audit promise from the editorial firewall paragraph. Not on the roadmap; better to keep the three standing rules without an unfulfilled commitment.