### PR TITLE
fix(home): wire InsiderAsk into index.astro

### DIFF
--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import HomeCover from '../components/HomeCover.astro';
+import InsiderAsk from '../components/InsiderAsk.astro';
 import Shortlist from '../components/Shortlist.astro';
 import EditorsLetter from '../components/EditorsLetter.astro';
 import InsiderStripe from '../components/InsiderStripe.astro';
@@ -205,6 +206,8 @@ const seasonalExperiences = experiences
       ]}
     />
   )}
+
+  <InsiderAsk />
 
   <PillarNav />
 


### PR DESCRIPTION
## Summary
- Restores the InsiderAsk import and `<InsiderAsk />` placement in `next/src/pages/index.astro` that were lost in the PR #26 merge resolution.
- Without this, the Option C "Ask The Insider" primary block doesn't render on the homepage despite the component file being present.

## Test plan
- [x] Local build succeeds (1028 pages)
- [x] `dist/index.html` contains `insider-ask` markup and styles
- [ ] After merge, verify block renders between hero and pillar grid on https://peninsulainsider.com.au/

🤖 Generated with [Claude Code](https://claude.com/claude-code)