### PR TITLE
docs(insider): perf pass summary + eval reports

### DIFF
--- a/docs/insider-concierge-perf-pass-2026-05-02.md
+++ b/docs/insider-concierge-perf-pass-2026-05-02.md
@@ -1,0 +1,177 @@
+# Insider Concierge Performance Pass — Honest Findings
+
+**Date:** 2 May 2026
+**Author:** Remy
+**Scope:** Latency + quality optimization for The Insider concierge.
+
+---
+
+## TL;DR
+
+Server-side total latency is dominated by **Claude Sonnet 4.5 generation** (~80% of every request). Optimizations to retrieval, rerank, candidate pool, and prompt context only move the needle by ~0.5-1s out of ~17s. Reader-perceived latency is already addressed by the **streaming endpoint** (first token lands in 2-3s).
+
+To meaningfully cut backend total time further, the levers are:
+
+1. **DB indexes** (HNSW + GIN + btree) — migration ready at `ops/migrations/2026-05-03-concierge-chunks-perf-indexes.sql`. ~50-150ms gain. Apply via Supabase Studio when convenient.
+2. **Vercel region change** to Sydney — config change. ~100-300ms gain (DB is in `ap-southeast`; Vercel default is `iad1` US East). Requires `regions: ["syd1"]` in `vercel.json` plus a deploy.
+3. **Switch generation model to Claude Haiku 4.5** — env var change (`ANTHROPIC_MODEL_QUALITY=claude-haiku-4-5`). 5-10x faster (3-5s vs 9-15s). Quality risk needs an A/B against the eval set before flipping in production.
+
+The code is now structured so each is one decision, not a project.
+
+---
+
+## What landed in this pass (4 PRs, all merged)
+
+| PR | What | Effect |
+|---|---|---|
+| platform#3 | Per-step timing telemetry, max_tokens 900, pool 30→15, TOP_K 5→4, speculative retrieval | Speculative pattern broke recall |
+| platform#4 | Revert speculative retrieval to SQL-level filtering | Recall partially recovered |
+| platform#5 | On-demand unfiltered retrieval fallback when filtered set is sparse | Empty-pool regression closed |
+| platform#6 | TOP_K back to 5 — quality > marginal latency | Quality fully recovered |
+
+**Net code changes that stuck:**
+
+- **Per-step timing telemetry**. Every response now emits `_debug.timings`: `intent_and_embed_ms`, `retrieve_ms`, `rerank_ms`, `generate_ms`, `enrich_ms`, plus `ttft_ms` on the streaming path. We can see what we're optimizing.
+- **Candidate pool 30 → 15**. RRF returns half as many to Cohere; saves ~100-150ms on rerank with no recall cost.
+- **max_tokens 1500 → 900**. Output rarely exceeded 700 tokens; the slow tail is capped earlier.
+- **Fallback retrieval**: when filtered SQL returns < 6 results combined (vector + bm25), a second unfiltered round runs in parallel and merges. Closes the "intent classifier picked a too-narrow filter" regression.
+- **TOP_K 5 (preserved)**. Tried 4, lost 0.17 mean quality on the eval set; restored.
+
+**Quality changes that stuck:**
+
+- Recommendation **dedupe** in the enricher (first occurrence wins).
+- Prompt **diversity nudge**: the system prompt now explicitly tells the LLM to use distinct slugs and mix kinds when the context supports it.
+
+---
+
+## Eval results across passes (30-query frozen set)
+
+| Pass | Median latency | Mean quality |
+|---|---:|---:|
+| Baseline (post-dedupe, pre-perf) | 17.09s | 4.77 / 5 |
+| After pass 1 (speculative retrieval) | 13.77s | 4.10 / 5 ← speculative broke recall |
+| After pass 2 (revert speculative) | 14.38s | 4.13 / 5 ← still empty-pools |
+| After pass 3 (+ fallback retrieval) | 16.66s | 4.60 / 5 |
+| After pass 4 (+ TOP_K restored) | 17.88s | 4.63 / 5 |
+
+The variance in median across runs (±2s) is roughly the noise floor at this sample size. The honest read: the changes are essentially **quality-neutral** vs baseline, with the upside being **better observability**, **safer recall**, and **half the candidate pool** for the rerank step.
+
+---
+
+## What dominates latency, and why
+
+A typical query timing breakdown (from the new `_debug.timings`):
+
+| Step | Time | Share |
+|---|---:|---:|
+| `intent_and_embed_ms` (Haiku classify + OpenAI embed, parallel) | ~1,300ms | 8% |
+| `retrieve_ms` (Supabase pgvector + tsv) | ~200ms | 1% |
+| `rerank_ms` (Cohere) | ~300ms | 2% |
+| `generate_ms` (Sonnet 4.5, streaming) | ~13,000ms | **80%** |
+| `enrich_ms` (Supabase lookups) | ~250ms | 1% |
+| Network/cold-start variance | ~1,000ms | 6% |
+
+**Generation is the bottleneck. Everything else is measurement.**
+
+---
+
+## What can still meaningfully reduce backend total time
+
+### A. DB indexes (lowest risk; ready to apply)
+
+Migration is already at [ops/migrations/2026-05-03-concierge-chunks-perf-indexes.sql](../ops/migrations/2026-05-03-concierge-chunks-perf-indexes.sql). Idempotent. Adds:
+
+- HNSW index on `embedding` (vector_cosine_ops)
+- GIN on `text_tsv`
+- Compound btree on `(region, category, source_entity_type)`
+- Btree on `(chunk_purpose, page_slug)` for the place enricher
+- Btree on `extracted_at` for prune
+
+**Expected gain:** retrieve_ms 200ms → ~50-100ms. Modest now (corpus is 2k rows); compounds dramatically as the corpus grows past 10k.
+
+**To apply:** Supabase Studio → SQL editor → paste file → Run.
+
+### B. Vercel region change (one-line config)
+
+Currently the API runs in Vercel's default region (`iad1` = US East Virginia). Supabase is in `ap-southeast-2` (Sydney). Every retrieve, embed, rerank, and generate call crosses the Pacific.
+
+Add to `apps/api/vercel.json`:
+
+```json
+{
+  "regions": ["syd1"]
+}
+```
+
+**Expected gain:** 100-300ms shaved off every external call (retrieve_ms, enrich_ms, embed within intent_and_embed_ms). Cumulative ~400-800ms per request because there are several round trips.
+
+**Requires:** Vercel Pro plan (single region is allowed on Hobby; multi-region isn't). Check the project's plan before flipping.
+
+### C. Switch generation to Claude Haiku 4.5 (highest leverage; quality decision)
+
+Today: `ANTHROPIC_MODEL_QUALITY=claude-sonnet-4-5` (Vercel project env var, matches the code default).
+
+To flip: set `ANTHROPIC_MODEL_QUALITY=claude-haiku-4-5` in Vercel. No code change needed.
+
+**Expected gain:** Haiku 4.5 is roughly **5-10x faster** than Sonnet 4.5 for this kind of structured-output work. Median 17s → ~3-5s. Editorial voice quality drops measurably; the eval harness can confirm by how much.
+
+**Test plan before flipping:**
+
+```
+ANTHROPIC_MODEL_QUALITY=claude-haiku-4-5  # set in Vercel preview deployment
+node ops/scripts/insider-eval-runner.mjs --label haiku-test --concurrency=3
+```
+
+If mean quality stays ≥ 4.4 / 5, flip. If it drops below, keep Sonnet and look at hybrid strategies (Haiku for prose, Sonnet for the structured recommendations tool call).
+
+### D. Voyage 3 embeddings (medium risk)
+
+Already in env vars (`VOYAGE_API_KEY`, `VOYAGE_MODEL`); not yet used for query embedding. Voyage 3 is materially better at editorial-prose retrieval than `text-embedding-3-small` per published benchmarks.
+
+**Requires:** running the existing `apps/api/scripts/backfill-voyage-embeddings.ts` once to re-embed the corpus (~$0.50 one-off), then switching `embedQuery` to use Voyage. Both vectors must use the same embedding model.
+
+**Expected gain:** retrieval relevance improves measurably; latency neutral (Voyage is comparably fast). Quality lift, not latency.
+
+---
+
+## What we tried and reverted
+
+- **Speculative retrieval** (classify in parallel with retrieval, filter in memory). Saved ~400-700ms but tanked recall on filter-targeted queries because the top-25 unfiltered vector results often contained zero chunks in the filter region. **Reverted.** The fallback retrieval pattern in pass 3 is the safer middle ground.
+- **TOP_K 5 → 4**. Saved ~100ms input tokens but the LLM occasionally missed the most relevant chunk (e.g. Bushrangers Bay on a Cape Schanck walks query). **Reverted to 5.**
+
+---
+
+## Where the code is now
+
+```
+peninsula-insider-platform / apps/api/src/routes/concierge.ts
+  - parallel classify + embed
+  - SQL-filtered retrieval (matchCount=25)
+  - on-demand unfiltered fallback (when filtered total < 6)
+  - RRF merge top 15
+  - Cohere rerank to TOP_K=5
+  - Sonnet 4.5 generation (max_tokens=900)
+  - Per-step timings on every response
+  - sources[] for citations (already shipped)
+  - Telemetry: token usage + cost_approx_aud + gap_detected (already shipped)
+```
+
+---
+
+## Recommended next moves, in priority order
+
+1. **Apply the DB indexes migration** (5 min in Studio). No risk. Modest immediate gain. Compounds.
+2. **Run a Haiku eval** in Vercel preview environment. If quality holds, flip to Haiku in production. **This is the single biggest latency win available.** Median 17s → ~4s.
+3. **Add `regions: ["syd1"]` to vercel.json** if the project is on Pro tier. Otherwise document for the next plan upgrade.
+4. **Backfill Voyage embeddings** for retrieval quality. Quality lift, not latency. Defer until after Haiku decision lands.
+
+---
+
+## What stayed the same (and is fine)
+
+- Sonnet 4.5 system prompt with voice examples — kept; cache hits make repeat queries cheap and fast on warm caches.
+- Dedupe + diversity prompt nudges from the prior session.
+- Streaming endpoint — already optimal for reader perceived latency.
+- Telemetry pipeline — already populated cost, tokens, gaps, ttft.
+- Daily usage report — running on schedule; Telegram delivery working.
+- Source citations — already on the `sources` array of every response.

--- a/reports/insider-eval/after-perf-pass-1-2026-05-02.json
+++ b/reports/insider-eval/after-perf-pass-1-2026-05-02.json
@@ -1,0 +1,892 @@
+{
+  "label": "after-perf-pass-1",
+  "date": "2026-05-02",
+  "timestamp": "2026-05-02T14:44:35.261Z",
+  "api": "https://peninsula-insider-platform-api.vercel.app",
+  "summary": {
+    "total": 30,
+    "errors": 0,
+    "median_latency_ms": 13766,
+    "p95_latency_ms": 19604,
+    "median_server_latency_ms": 14910,
+    "mean_quality_score": 4.1,
+    "median_quality_score": 4,
+    "max_quality_score": 5,
+    "quality_distribution": {
+      "3": 9,
+      "4": 9,
+      "5": 12
+    },
+    "total_cost_aud_estimate": 0.382834
+  },
+  "results": [
+    {
+      "id": "long-lunch-red-hill",
+      "query": "Best long lunch on the Red Hill ridge for a Saturday",
+      "ok": true,
+      "latency_ms": 19595,
+      "server_latency_ms": 19394,
+      "timings": null,
+      "cost_aud": 0.027072,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes by tractor, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-walk-in",
+      "query": "Walk-in cellar door tasting on the Peninsula, no booking",
+      "ok": true,
+      "latency_ms": 17578,
+      "server_latency_ms": 17386,
+      "timings": null,
+      "cost_aud": 0.018963,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto piazza, foxeys, rare hare)"
+        ]
+      }
+    },
+    {
+      "id": "rainy-day-kids-rye",
+      "query": "Rainy Sunday with two kids, near Rye",
+      "ok": true,
+      "latency_ms": 16613,
+      "server_latency_ms": 16469,
+      "timings": null,
+      "cost_aud": 0.017375,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "rye hotel"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "sorrento-weekend-couple",
+      "query": "Plan a Sorrento weekend for a couple",
+      "ok": true,
+      "latency_ms": 18079,
+      "server_latency_ms": 17399,
+      "timings": {
+        "embed_ms": 94,
+        "retrieve_and_classify_ms": 1387,
+        "rerank_ms": 826,
+        "generate_ms": 14899,
+        "enrich_ms": 193
+      },
+      "cost_aud": 0.02367,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "sorrento",
+        "continental",
+        "point nepean"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "anniversary-dinner-view",
+      "query": "Anniversary dinner Friday night, somewhere with a view",
+      "ok": true,
+      "latency_ms": 17947,
+      "server_latency_ms": 17668,
+      "timings": {
+        "embed_ms": 87,
+        "retrieve_and_classify_ms": 1496,
+        "rerank_ms": 294,
+        "generate_ms": 15612,
+        "enrich_ms": 179
+      },
+      "cost_aud": 0.022536,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "laura"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "dog-friendly-cafe",
+      "query": "Dog friendly cafe on the Peninsula",
+      "ok": true,
+      "latency_ms": 3996,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: commonfolk, afloat, many little)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "best-walk-cape-schanck",
+      "query": "Best coastal walks near Cape Schanck",
+      "ok": true,
+      "latency_ms": 14533,
+      "server_latency_ms": 14493,
+      "timings": {
+        "embed_ms": 80,
+        "retrieve_and_classify_ms": 1334,
+        "rerank_ms": 319,
+        "generate_ms": 12586,
+        "enrich_ms": 174
+      },
+      "cost_aud": 0.015296,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "bushrangers bay"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "hatted-restaurants",
+      "query": "Hatted restaurants worth booking in advance",
+      "ok": true,
+      "latency_ms": 9843,
+      "server_latency_ms": 9804,
+      "timings": {
+        "embed_ms": 101,
+        "retrieve_and_classify_ms": 1360,
+        "rerank_ms": 325,
+        "generate_ms": 7830,
+        "enrich_ms": 188
+      },
+      "cost_aud": 0.013802,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "tedesca"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-stay-red-hill",
+      "query": "Where should we stay near Red Hill cellar doors",
+      "ok": true,
+      "latency_ms": 1490,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: jackalope, polperro, lindenderry)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "one-night-near-sorrento",
+      "query": "One night away, couple, near Sorrento",
+      "ok": true,
+      "latency_ms": 1462,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: hotel sorrento, continental, lon retreat)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "winery-with-kids",
+      "query": "Cellar door open Sunday with kids",
+      "ok": true,
+      "latency_ms": 13295,
+      "server_latency_ms": 13257,
+      "timings": {
+        "embed_ms": 89,
+        "retrieve_and_classify_ms": 1693,
+        "rerank_ms": 319,
+        "generate_ms": 10952,
+        "enrich_ms": 204
+      },
+      "cost_aud": 0.01377,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, willow creek, red hill estate)"
+        ]
+      }
+    },
+    {
+      "id": "winery-tour-day-trip",
+      "query": "Winery tour day trip from Melbourne",
+      "ok": true,
+      "latency_ms": 2002,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes, polperro)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "best-seafood",
+      "query": "Where do locals go for seafood on the Peninsula",
+      "ok": true,
+      "latency_ms": 21875,
+      "server_latency_ms": 21538,
+      "timings": {
+        "embed_ms": 90,
+        "retrieve_and_classify_ms": 1396,
+        "rerank_ms": 5743,
+        "generate_ms": 14125,
+        "enrich_ms": 184
+      },
+      "cost_aud": 0.020876,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 3,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pier street, fish bar, morning star)"
+        ]
+      }
+    },
+    {
+      "id": "best-bakery",
+      "query": "Best bakery for breakfast on the Peninsula",
+      "ok": true,
+      "latency_ms": 1474,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: sorrento bakery, balnarring bakehouse, salt and rye)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "thermal-springs-quiet",
+      "query": "Thermal springs without the crowds",
+      "ok": true,
+      "latency_ms": 12256,
+      "server_latency_ms": 12211,
+      "timings": {
+        "embed_ms": 91,
+        "retrieve_and_classify_ms": 1904,
+        "rerank_ms": 274,
+        "generate_ms": 9762,
+        "enrich_ms": 180
+      },
+      "cost_aud": 0.013064,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "alba"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "long-weekend-three-days",
+      "query": "Three day Peninsula trip, April long weekend, food and wine",
+      "ok": true,
+      "latency_ms": 1463,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: red hill, montalto, long lunch)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "rye-front-beach",
+      "query": "What is there to do at Rye front beach",
+      "ok": true,
+      "latency_ms": 13860,
+      "server_latency_ms": 13815,
+      "timings": {
+        "embed_ms": 86,
+        "retrieve_and_classify_ms": 1225,
+        "rerank_ms": 320,
+        "generate_ms": 12001,
+        "enrich_ms": 183
+      },
+      "cost_aud": 0.014355,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "rye",
+        "front beach",
+        "pier"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winter-weekend-fireplace",
+      "query": "Winter weekend with a fireplace and a wine list",
+      "ok": true,
+      "latency_ms": 13672,
+      "server_latency_ms": 13625,
+      "timings": {
+        "embed_ms": 103,
+        "retrieve_and_classify_ms": 1993,
+        "rerank_ms": 233,
+        "generate_ms": 11114,
+        "enrich_ms": 182
+      },
+      "cost_aud": 0.013253,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: jackalope, polperro, lindenderry)"
+        ]
+      }
+    },
+    {
+      "id": "where-to-eat-sorrento",
+      "query": "Where to eat in Sorrento on a Saturday night",
+      "ok": true,
+      "latency_ms": 1484,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: bistro elba, the baths, hotel sorrento)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "flinders-day",
+      "query": "How to spend a day in Flinders",
+      "ok": true,
+      "latency_ms": 17216,
+      "server_latency_ms": 17179,
+      "timings": {
+        "embed_ms": 91,
+        "retrieve_and_classify_ms": 1305,
+        "rerank_ms": 276,
+        "generate_ms": 15017,
+        "enrich_ms": 490
+      },
+      "cost_aud": 0.018432,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "flinders",
+        "hotel"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "no-driving-after-lunch",
+      "query": "Long lunch without too much driving back",
+      "ok": true,
+      "latency_ms": 14431,
+      "server_latency_ms": 14390,
+      "timings": {
+        "embed_ms": 89,
+        "retrieve_and_classify_ms": 1422,
+        "rerank_ms": 229,
+        "generate_ms": 12005,
+        "enrich_ms": 645
+      },
+      "cost_aud": 0.013869,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "foxeys"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "afternoon-pinot-tasting",
+      "query": "Afternoon pinot tasting with serious producers",
+      "ok": true,
+      "latency_ms": 12865,
+      "server_latency_ms": 12825,
+      "timings": {
+        "embed_ms": 104,
+        "retrieve_and_classify_ms": 1337,
+        "rerank_ms": 270,
+        "generate_ms": 10934,
+        "enrich_ms": 180
+      },
+      "cost_aud": 0.015404,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: paringa, kooyong, ten minutes)"
+        ]
+      }
+    },
+    {
+      "id": "bushrangers-bay",
+      "query": "How long is the Bushrangers Bay walk",
+      "ok": true,
+      "latency_ms": 14956,
+      "server_latency_ms": 14910,
+      "timings": {
+        "embed_ms": 119,
+        "retrieve_and_classify_ms": 1333,
+        "rerank_ms": 255,
+        "generate_ms": 13013,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.023225,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "bushrangers bay",
+        "cape schanck"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: article)"
+        ]
+      }
+    },
+    {
+      "id": "wedding-venue-winery",
+      "query": "Winery wedding venues on the Peninsula",
+      "ok": true,
+      "latency_ms": 16291,
+      "server_latency_ms": 16252,
+      "timings": {
+        "embed_ms": 103,
+        "retrieve_and_classify_ms": 1347,
+        "rerank_ms": 280,
+        "generate_ms": 14345,
+        "enrich_ms": 177
+      },
+      "cost_aud": 0.019125,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "montalto"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "art-gallery",
+      "query": "Best art gallery on the Peninsula",
+      "ok": true,
+      "latency_ms": 1457,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pt leo, sculpture, regional gallery)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "weekend-this-weekend",
+      "query": "What is on this weekend on the Peninsula",
+      "ok": true,
+      "latency_ms": 19604,
+      "server_latency_ms": 19567,
+      "timings": {
+        "embed_ms": 78,
+        "retrieve_and_classify_ms": 1221,
+        "rerank_ms": 247,
+        "generate_ms": 17831,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.023999,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "market"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "kids-thing-to-do",
+      "query": "Something to do with two kids in school holidays",
+      "ok": true,
+      "latency_ms": 15061,
+      "server_latency_ms": 15022,
+      "timings": {
+        "embed_ms": 116,
+        "retrieve_and_classify_ms": 1294,
+        "rerank_ms": 332,
+        "generate_ms": 13105,
+        "enrich_ms": 175
+      },
+      "cost_aud": 0.018675,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-views",
+      "query": "Cellar door with the best view",
+      "ok": true,
+      "latency_ms": 12693,
+      "server_latency_ms": 12655,
+      "timings": {
+        "embed_ms": 95,
+        "retrieve_and_classify_ms": 1457,
+        "rerank_ms": 313,
+        "generate_ms": 10584,
+        "enrich_ms": 206
+      },
+      "cost_aud": 0.021065,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 3,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pt leo, port phillip estate, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "balnarring-village",
+      "query": "Is Balnarring worth a visit",
+      "ok": true,
+      "latency_ms": 14145,
+      "server_latency_ms": 14104,
+      "timings": {
+        "embed_ms": 105,
+        "retrieve_and_classify_ms": 1331,
+        "rerank_ms": 324,
+        "generate_ms": 12152,
+        "enrich_ms": 192
+      },
+      "cost_aud": 0.015008,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "balnarring"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "negative-overrated",
+      "query": "Is Peninsula Hot Springs overrated",
+      "ok": true,
+      "latency_ms": 1552,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: peninsula hot springs, alba, crowd)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    }
+  ]
+}

--- a/reports/insider-eval/after-perf-pass-1-2026-05-02.md
+++ b/reports/insider-eval/after-perf-pass-1-2026-05-02.md
@@ -1,0 +1,57 @@
+# Insider eval — after-perf-pass-1 · 2026-05-02
+
+API: https://peninsula-insider-platform-api.vercel.app
+
+## Summary
+- Queries: 30 · errors: 0
+- Median latency: **13.77s** · p95: 19.60s
+- Median server latency: 14.91s
+- Median quality: **4/5** (mean 4.10)
+- Quality distribution: 3:9, 4:9, 5:12
+- Total cost: $0.3828 AUD
+
+## Diff vs baseline (`baseline-2026-05-02.json`)
+- Median latency: 17.09s → 13.77s (3.32s)
+- Mean quality: 4.77 → 4.10 (-0.67)
+- Total cost: $0.7187 → $0.3828 AUD
+
+## Per-query results
+| ID | Query | Latency | Quality | Recs | Issues |
+|---|---|---:|:---:|:---:|---|
+| long-lunch-red-hill | Best long lunch on the Red Hill ridge for a Saturday | 19.59s | 4/5 | 4 | no expected topic matched (looked for: montalto, ten minutes by tractor, polperro) |
+| cellar-door-walk-in | Walk-in cellar door tasting on the Peninsula, no booking | 17.58s | 4/5 | 2 | no expected topic matched (looked for: montalto piazza, foxeys, rare hare) |
+| rainy-day-kids-rye | Rainy Sunday with two kids, near Rye | 16.61s | 5/5 | 2 | — |
+| sorrento-weekend-couple | Plan a Sorrento weekend for a couple | 18.08s | 5/5 | 2 | — |
+| anniversary-dinner-view | Anniversary dinner Friday night, somewhere with a view | 17.95s | 5/5 | 3 | — |
+| dog-friendly-cafe | Dog friendly cafe on the Peninsula | 4.00s | 3/5 | 0 | no expected topic matched (looked for: commonfolk, afloat, many little); no expected kind matched (got: none) |
+| best-walk-cape-schanck | Best coastal walks near Cape Schanck | 14.53s | 5/5 | 1 | — |
+| hatted-restaurants | Hatted restaurants worth booking in advance | 9.84s | 5/5 | 1 | — |
+| where-to-stay-red-hill | Where should we stay near Red Hill cellar doors | 1.49s | 3/5 | 0 | no expected topic matched (looked for: jackalope, polperro, lindenderry); no expected kind matched (got: none) |
+| one-night-near-sorrento | One night away, couple, near Sorrento | 1.46s | 3/5 | 0 | no expected topic matched (looked for: hotel sorrento, continental, lon retreat); no expected kind matched (got: none) |
+| winery-with-kids | Cellar door open Sunday with kids | 13.29s | 4/5 | 1 | no expected topic matched (looked for: montalto, willow creek, red hill estate) |
+| winery-tour-day-trip | Winery tour day trip from Melbourne | 2.00s | 3/5 | 0 | no expected topic matched (looked for: montalto, ten minutes, polperro); no expected kind matched (got: none) |
+| best-seafood | Where do locals go for seafood on the Peninsula | 21.88s | 4/5 | 3 | no expected topic matched (looked for: pier street, fish bar, morning star) |
+| best-bakery | Best bakery for breakfast on the Peninsula | 1.47s | 3/5 | 0 | no expected topic matched (looked for: sorrento bakery, balnarring bakehouse, salt and rye); no expected kind matched (got: none) |
+| thermal-springs-quiet | Thermal springs without the crowds | 12.26s | 5/5 | 1 | — |
+| long-weekend-three-days | Three day Peninsula trip, April long weekend, food and wine | 1.46s | 3/5 | 0 | no expected topic matched (looked for: red hill, montalto, long lunch); no expected kind matched (got: none) |
+| rye-front-beach | What is there to do at Rye front beach | 13.86s | 5/5 | 1 | — |
+| winter-weekend-fireplace | Winter weekend with a fireplace and a wine list | 13.67s | 4/5 | 1 | no expected topic matched (looked for: jackalope, polperro, lindenderry) |
+| where-to-eat-sorrento | Where to eat in Sorrento on a Saturday night | 1.48s | 3/5 | 0 | no expected topic matched (looked for: bistro elba, the baths, hotel sorrento); no expected kind matched (got: none) |
+| flinders-day | How to spend a day in Flinders | 17.22s | 5/5 | 2 | — |
+| no-driving-after-lunch | Long lunch without too much driving back | 14.43s | 5/5 | 1 | — |
+| afternoon-pinot-tasting | Afternoon pinot tasting with serious producers | 12.87s | 4/5 | 1 | no expected topic matched (looked for: paringa, kooyong, ten minutes) |
+| bushrangers-bay | How long is the Bushrangers Bay walk | 14.96s | 4/5 | 3 | no expected kind matched (got: article) |
+| wedding-venue-winery | Winery wedding venues on the Peninsula | 16.29s | 5/5 | 2 | — |
+| art-gallery | Best art gallery on the Peninsula | 1.46s | 3/5 | 0 | no expected topic matched (looked for: pt leo, sculpture, regional gallery); no expected kind matched (got: none) |
+| weekend-this-weekend | What is on this weekend on the Peninsula | 19.60s | 5/5 | 3 | — |
+| kids-thing-to-do | Something to do with two kids in school holidays | 15.06s | 4/5 | 2 | no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze) |
+| cellar-door-views | Cellar door with the best view | 12.69s | 4/5 | 3 | no expected topic matched (looked for: pt leo, port phillip estate, montalto) |
+| balnarring-village | Is Balnarring worth a visit | 14.14s | 5/5 | 1 | — |
+| negative-overrated | Is Peninsula Hot Springs overrated | 1.55s | 3/5 | 0 | no expected topic matched (looked for: peninsula hot springs, alba, crowd); no expected kind matched (got: none) |
+
+## Median per-step timings (ms)
+- embed_ms: 93ms
+- retrieve_and_classify_ms: 1.35s
+- rerank_ms: 304ms
+- generate_ms: 12.37s
+- enrich_ms: 186ms

--- a/reports/insider-eval/after-perf-pass-2-2026-05-02.json
+++ b/reports/insider-eval/after-perf-pass-2-2026-05-02.json
@@ -1,0 +1,928 @@
+{
+  "label": "after-perf-pass-2",
+  "date": "2026-05-02",
+  "timestamp": "2026-05-02T14:48:50.377Z",
+  "api": "https://peninsula-insider-platform-api.vercel.app",
+  "summary": {
+    "total": 30,
+    "errors": 0,
+    "median_latency_ms": 14378,
+    "p95_latency_ms": 18714,
+    "median_server_latency_ms": 15340.5,
+    "mean_quality_score": 4.133333333333334,
+    "median_quality_score": 4,
+    "max_quality_score": 5,
+    "quality_distribution": {
+      "3": 8,
+      "4": 10,
+      "5": 12
+    },
+    "total_cost_aud_estimate": 0.433413
+  },
+  "results": [
+    {
+      "id": "long-lunch-red-hill",
+      "query": "Best long lunch on the Red Hill ridge for a Saturday",
+      "ok": true,
+      "latency_ms": 15798,
+      "server_latency_ms": 13973,
+      "timings": {
+        "embed_ms": 105,
+        "retrieve_and_classify_ms": 2033,
+        "rerank_ms": 324,
+        "generate_ms": 11311,
+        "enrich_ms": 200
+      },
+      "cost_aud": 0.018752,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes by tractor, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-walk-in",
+      "query": "Walk-in cellar door tasting on the Peninsula, no booking",
+      "ok": true,
+      "latency_ms": 2133,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto piazza, foxeys, rare hare)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "rainy-day-kids-rye",
+      "query": "Rainy Sunday with two kids, near Rye",
+      "ok": true,
+      "latency_ms": 1958,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: alba, peninsula hot springs, rye hotel)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "sorrento-weekend-couple",
+      "query": "Plan a Sorrento weekend for a couple",
+      "ok": true,
+      "latency_ms": 16929,
+      "server_latency_ms": 16888,
+      "timings": {
+        "embed_ms": 87,
+        "retrieve_and_classify_ms": 1561,
+        "rerank_ms": 281,
+        "generate_ms": 14770,
+        "enrich_ms": 189
+      },
+      "cost_aud": 0.022883,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "sorrento",
+        "continental",
+        "point nepean"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "anniversary-dinner-view",
+      "query": "Anniversary dinner Friday night, somewhere with a view",
+      "ok": true,
+      "latency_ms": 17580,
+      "server_latency_ms": 17543,
+      "timings": {
+        "embed_ms": 90,
+        "retrieve_and_classify_ms": 1241,
+        "rerank_ms": 243,
+        "generate_ms": 15786,
+        "enrich_ms": 182
+      },
+      "cost_aud": 0.022581,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pt leo, polperro, port phillip estate)"
+        ]
+      }
+    },
+    {
+      "id": "dog-friendly-cafe",
+      "query": "Dog friendly cafe on the Peninsula",
+      "ok": true,
+      "latency_ms": 1445,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: commonfolk, afloat, many little)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "best-walk-cape-schanck",
+      "query": "Best coastal walks near Cape Schanck",
+      "ok": true,
+      "latency_ms": 14322,
+      "server_latency_ms": 14257,
+      "timings": {
+        "embed_ms": 109,
+        "retrieve_and_classify_ms": 1313,
+        "rerank_ms": 277,
+        "generate_ms": 12367,
+        "enrich_ms": 191
+      },
+      "cost_aud": 0.016128,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "bushrangers bay"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "hatted-restaurants",
+      "query": "Hatted restaurants worth booking in advance",
+      "ok": true,
+      "latency_ms": 12833,
+      "server_latency_ms": 12790,
+      "timings": {
+        "embed_ms": 89,
+        "retrieve_and_classify_ms": 1298,
+        "rerank_ms": 272,
+        "generate_ms": 10956,
+        "enrich_ms": 175
+      },
+      "cost_aud": 0.013757,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "tedesca"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-stay-red-hill",
+      "query": "Where should we stay near Red Hill cellar doors",
+      "ok": true,
+      "latency_ms": 1437,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: jackalope, polperro, lindenderry)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "one-night-near-sorrento",
+      "query": "One night away, couple, near Sorrento",
+      "ok": true,
+      "latency_ms": 1623,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: hotel sorrento, continental, lon retreat)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "winery-with-kids",
+      "query": "Cellar door open Sunday with kids",
+      "ok": true,
+      "latency_ms": 10663,
+      "server_latency_ms": 10598,
+      "timings": {
+        "embed_ms": 87,
+        "retrieve_and_classify_ms": 1776,
+        "rerank_ms": 269,
+        "generate_ms": 8288,
+        "enrich_ms": 178
+      },
+      "cost_aud": 0.014247,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, willow creek, red hill estate)"
+        ]
+      }
+    },
+    {
+      "id": "winery-tour-day-trip",
+      "query": "Winery tour day trip from Melbourne",
+      "ok": true,
+      "latency_ms": 1435,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes, polperro)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "best-seafood",
+      "query": "Where do locals go for seafood on the Peninsula",
+      "ok": true,
+      "latency_ms": 17596,
+      "server_latency_ms": 17551,
+      "timings": {
+        "embed_ms": 83,
+        "retrieve_and_classify_ms": 1373,
+        "rerank_ms": 281,
+        "generate_ms": 15624,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.020831,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 3,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pier street, fish bar, morning star)"
+        ]
+      }
+    },
+    {
+      "id": "best-bakery",
+      "query": "Best bakery for breakfast on the Peninsula",
+      "ok": true,
+      "latency_ms": 1456,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: sorrento bakery, balnarring bakehouse, salt and rye)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "thermal-springs-quiet",
+      "query": "Thermal springs without the crowds",
+      "ok": true,
+      "latency_ms": 11275,
+      "server_latency_ms": 11224,
+      "timings": {
+        "embed_ms": 89,
+        "retrieve_and_classify_ms": 1350,
+        "rerank_ms": 273,
+        "generate_ms": 9310,
+        "enrich_ms": 202
+      },
+      "cost_aud": 0.012816,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "alba"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "long-weekend-three-days",
+      "query": "Three day Peninsula trip, April long weekend, food and wine",
+      "ok": true,
+      "latency_ms": 1507,
+      "server_latency_ms": null,
+      "timings": null,
+      "cost_aud": null,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 0,
+      "topic_hits": [],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 3,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: red hill, montalto, long lunch)",
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "rye-front-beach",
+      "query": "What is there to do at Rye front beach",
+      "ok": true,
+      "latency_ms": 14242,
+      "server_latency_ms": 14199,
+      "timings": {
+        "embed_ms": 94,
+        "retrieve_and_classify_ms": 1420,
+        "rerank_ms": 267,
+        "generate_ms": 11934,
+        "enrich_ms": 483
+      },
+      "cost_aud": 0.014108,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [
+        "rye",
+        "front beach"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winter-weekend-fireplace",
+      "query": "Winter weekend with a fireplace and a wine list",
+      "ok": true,
+      "latency_ms": 14067,
+      "server_latency_ms": 14013,
+      "timings": {
+        "embed_ms": 604,
+        "retrieve_and_classify_ms": 1330,
+        "rerank_ms": 323,
+        "generate_ms": 11559,
+        "enrich_ms": 197
+      },
+      "cost_aud": 0.013185,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 1,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: jackalope, polperro, lindenderry)"
+        ]
+      }
+    },
+    {
+      "id": "where-to-eat-sorrento",
+      "query": "Where to eat in Sorrento on a Saturday night",
+      "ok": true,
+      "latency_ms": 14710,
+      "server_latency_ms": 14066,
+      "timings": {
+        "intent_and_embed_ms": 1374,
+        "retrieve_ms": 200,
+        "rerank_ms": 453,
+        "generate_ms": 11843,
+        "enrich_ms": 195
+      },
+      "cost_aud": 0.018297,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "bistro elba",
+        "the baths"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "flinders-day",
+      "query": "How to spend a day in Flinders",
+      "ok": true,
+      "latency_ms": 12550,
+      "server_latency_ms": 12250,
+      "timings": {
+        "intent_and_embed_ms": 1307,
+        "retrieve_ms": 188,
+        "rerank_ms": 249,
+        "generate_ms": 10321,
+        "enrich_ms": 185
+      },
+      "cost_aud": 0.022109,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "flinders",
+        "hotel"
+      ],
+      "kind_hits": [
+        "venue",
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "no-driving-after-lunch",
+      "query": "Long lunch without too much driving back",
+      "ok": true,
+      "latency_ms": 18714,
+      "server_latency_ms": 18412,
+      "timings": {
+        "intent_and_embed_ms": 1320,
+        "retrieve_ms": 197,
+        "rerank_ms": 291,
+        "generate_ms": 16413,
+        "enrich_ms": 191
+      },
+      "cost_aud": 0.02691,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: foxeys, many little, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "afternoon-pinot-tasting",
+      "query": "Afternoon pinot tasting with serious producers",
+      "ok": true,
+      "latency_ms": 16753,
+      "server_latency_ms": 16707,
+      "timings": {
+        "intent_and_embed_ms": 1433,
+        "retrieve_ms": 198,
+        "rerank_ms": 356,
+        "generate_ms": 14541,
+        "enrich_ms": 179
+      },
+      "cost_aud": 0.026091,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "paringa",
+        "ten minutes"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "bushrangers-bay",
+      "query": "How long is the Bushrangers Bay walk",
+      "ok": true,
+      "latency_ms": 16365,
+      "server_latency_ms": 16325,
+      "timings": {
+        "intent_and_embed_ms": 1548,
+        "retrieve_ms": 193,
+        "rerank_ms": 238,
+        "generate_ms": 14166,
+        "enrich_ms": 180
+      },
+      "cost_aud": 0.024057,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "bushrangers bay",
+        "cape schanck"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: article)"
+        ]
+      }
+    },
+    {
+      "id": "wedding-venue-winery",
+      "query": "Winery wedding venues on the Peninsula",
+      "ok": true,
+      "latency_ms": 15823,
+      "server_latency_ms": 15777,
+      "timings": {
+        "intent_and_embed_ms": 1225,
+        "retrieve_ms": 188,
+        "rerank_ms": 285,
+        "generate_ms": 13886,
+        "enrich_ms": 193
+      },
+      "cost_aud": 0.021591,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: polperro, lindenderry, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "art-gallery",
+      "query": "Best art gallery on the Peninsula",
+      "ok": true,
+      "latency_ms": 17731,
+      "server_latency_ms": 17678,
+      "timings": {
+        "intent_and_embed_ms": 1389,
+        "retrieve_ms": 188,
+        "rerank_ms": 332,
+        "generate_ms": 15594,
+        "enrich_ms": 175
+      },
+      "cost_aud": 0.02048,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "sculpture",
+        "regional gallery"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "weekend-this-weekend",
+      "query": "What is on this weekend on the Peninsula",
+      "ok": true,
+      "latency_ms": 17839,
+      "server_latency_ms": 17792,
+      "timings": {
+        "intent_and_embed_ms": 1612,
+        "retrieve_ms": 192,
+        "rerank_ms": 322,
+        "generate_ms": 15487,
+        "enrich_ms": 179
+      },
+      "cost_aud": 0.023661,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "market"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "kids-thing-to-do",
+      "query": "Something to do with two kids in school holidays",
+      "ok": true,
+      "latency_ms": 14951,
+      "server_latency_ms": 14904,
+      "timings": {
+        "intent_and_embed_ms": 1269,
+        "retrieve_ms": 193,
+        "rerank_ms": 488,
+        "generate_ms": 12772,
+        "enrich_ms": 182
+      },
+      "cost_aud": 0.01755,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-views",
+      "query": "Cellar door with the best view",
+      "ok": true,
+      "latency_ms": 15858,
+      "server_latency_ms": 15810,
+      "timings": {
+        "intent_and_embed_ms": 1973,
+        "retrieve_ms": 186,
+        "rerank_ms": 334,
+        "generate_ms": 13136,
+        "enrich_ms": 181
+      },
+      "cost_aud": 0.023207,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pt leo, port phillip estate, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "balnarring-village",
+      "query": "Is Balnarring worth a visit",
+      "ok": true,
+      "latency_ms": 22213,
+      "server_latency_ms": 21933,
+      "timings": {
+        "intent_and_embed_ms": 8815,
+        "retrieve_ms": 200,
+        "rerank_ms": 291,
+        "generate_ms": 12404,
+        "enrich_ms": 223
+      },
+      "cost_aud": 0.019656,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "balnarring",
+        "village",
+        "bakery"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "negative-overrated",
+      "query": "Is Peninsula Hot Springs overrated",
+      "ok": true,
+      "latency_ms": 14434,
+      "server_latency_ms": 14387,
+      "timings": {
+        "intent_and_embed_ms": 1343,
+        "retrieve_ms": 182,
+        "rerank_ms": 234,
+        "generate_ms": 12452,
+        "enrich_ms": 176
+      },
+      "cost_aud": 0.020516,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "peninsula hot springs",
+        "alba",
+        "crowd"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    }
+  ]
+}

--- a/reports/insider-eval/after-perf-pass-2-2026-05-02.md
+++ b/reports/insider-eval/after-perf-pass-2-2026-05-02.md
@@ -1,0 +1,59 @@
+# Insider eval — after-perf-pass-2 · 2026-05-02
+
+API: https://peninsula-insider-platform-api.vercel.app
+
+## Summary
+- Queries: 30 · errors: 0
+- Median latency: **14.38s** · p95: 18.71s
+- Median server latency: 15.34s
+- Median quality: **4/5** (mean 4.13)
+- Quality distribution: 3:8, 4:10, 5:12
+- Total cost: $0.4334 AUD
+
+## Diff vs baseline (`baseline-2026-05-02.json`)
+- Median latency: 17.09s → 14.38s (2.71s)
+- Mean quality: 4.77 → 4.13 (-0.63)
+- Total cost: $0.7187 → $0.4334 AUD
+
+## Per-query results
+| ID | Query | Latency | Quality | Recs | Issues |
+|---|---|---:|:---:|:---:|---|
+| long-lunch-red-hill | Best long lunch on the Red Hill ridge for a Saturday | 15.80s | 4/5 | 2 | no expected topic matched (looked for: montalto, ten minutes by tractor, polperro) |
+| cellar-door-walk-in | Walk-in cellar door tasting on the Peninsula, no booking | 2.13s | 3/5 | 0 | no expected topic matched (looked for: montalto piazza, foxeys, rare hare); no expected kind matched (got: none) |
+| rainy-day-kids-rye | Rainy Sunday with two kids, near Rye | 1.96s | 3/5 | 0 | no expected topic matched (looked for: alba, peninsula hot springs, rye hotel); no expected kind matched (got: none) |
+| sorrento-weekend-couple | Plan a Sorrento weekend for a couple | 16.93s | 5/5 | 2 | — |
+| anniversary-dinner-view | Anniversary dinner Friday night, somewhere with a view | 17.58s | 4/5 | 3 | no expected topic matched (looked for: pt leo, polperro, port phillip estate) |
+| dog-friendly-cafe | Dog friendly cafe on the Peninsula | 1.45s | 3/5 | 0 | no expected topic matched (looked for: commonfolk, afloat, many little); no expected kind matched (got: none) |
+| best-walk-cape-schanck | Best coastal walks near Cape Schanck | 14.32s | 5/5 | 1 | — |
+| hatted-restaurants | Hatted restaurants worth booking in advance | 12.83s | 5/5 | 1 | — |
+| where-to-stay-red-hill | Where should we stay near Red Hill cellar doors | 1.44s | 3/5 | 0 | no expected topic matched (looked for: jackalope, polperro, lindenderry); no expected kind matched (got: none) |
+| one-night-near-sorrento | One night away, couple, near Sorrento | 1.62s | 3/5 | 0 | no expected topic matched (looked for: hotel sorrento, continental, lon retreat); no expected kind matched (got: none) |
+| winery-with-kids | Cellar door open Sunday with kids | 10.66s | 4/5 | 1 | no expected topic matched (looked for: montalto, willow creek, red hill estate) |
+| winery-tour-day-trip | Winery tour day trip from Melbourne | 1.44s | 3/5 | 0 | no expected topic matched (looked for: montalto, ten minutes, polperro); no expected kind matched (got: none) |
+| best-seafood | Where do locals go for seafood on the Peninsula | 17.60s | 4/5 | 2 | no expected topic matched (looked for: pier street, fish bar, morning star) |
+| best-bakery | Best bakery for breakfast on the Peninsula | 1.46s | 3/5 | 0 | no expected topic matched (looked for: sorrento bakery, balnarring bakehouse, salt and rye); no expected kind matched (got: none) |
+| thermal-springs-quiet | Thermal springs without the crowds | 11.28s | 5/5 | 1 | — |
+| long-weekend-three-days | Three day Peninsula trip, April long weekend, food and wine | 1.51s | 3/5 | 0 | no expected topic matched (looked for: red hill, montalto, long lunch); no expected kind matched (got: none) |
+| rye-front-beach | What is there to do at Rye front beach | 14.24s | 5/5 | 1 | — |
+| winter-weekend-fireplace | Winter weekend with a fireplace and a wine list | 14.07s | 4/5 | 1 | no expected topic matched (looked for: jackalope, polperro, lindenderry) |
+| where-to-eat-sorrento | Where to eat in Sorrento on a Saturday night | 14.71s | 5/5 | 2 | — |
+| flinders-day | How to spend a day in Flinders | 12.55s | 5/5 | 2 | — |
+| no-driving-after-lunch | Long lunch without too much driving back | 18.71s | 4/5 | 4 | no expected topic matched (looked for: foxeys, many little, polperro) |
+| afternoon-pinot-tasting | Afternoon pinot tasting with serious producers | 16.75s | 5/5 | 4 | — |
+| bushrangers-bay | How long is the Bushrangers Bay walk | 16.36s | 4/5 | 3 | no expected kind matched (got: article) |
+| wedding-venue-winery | Winery wedding venues on the Peninsula | 15.82s | 4/5 | 2 | no expected topic matched (looked for: polperro, lindenderry, montalto) |
+| art-gallery | Best art gallery on the Peninsula | 17.73s | 5/5 | 1 | — |
+| weekend-this-weekend | What is on this weekend on the Peninsula | 17.84s | 5/5 | 3 | — |
+| kids-thing-to-do | Something to do with two kids in school holidays | 14.95s | 4/5 | 2 | no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze) |
+| cellar-door-views | Cellar door with the best view | 15.86s | 4/5 | 3 | no expected topic matched (looked for: pt leo, port phillip estate, montalto) |
+| balnarring-village | Is Balnarring worth a visit | 22.21s | 5/5 | 2 | — |
+| negative-overrated | Is Peninsula Hot Springs overrated | 14.43s | 5/5 | 2 | — |
+
+## Median per-step timings (ms)
+- embed_ms: 90ms
+- retrieve_and_classify_ms: 1.36s
+- rerank_ms: 283ms
+- generate_ms: 12.61s
+- enrich_ms: 187ms
+- intent_and_embed_ms: 1.38s
+- retrieve_ms: 193ms

--- a/reports/insider-eval/after-perf-pass-3-2026-05-02.json
+++ b/reports/insider-eval/after-perf-pass-3-2026-05-02.json
@@ -1,0 +1,1003 @@
+{
+  "label": "after-perf-pass-3",
+  "date": "2026-05-02",
+  "timestamp": "2026-05-02T14:55:34.875Z",
+  "api": "https://peninsula-insider-platform-api.vercel.app",
+  "summary": {
+    "total": 30,
+    "errors": 0,
+    "median_latency_ms": 16662,
+    "p95_latency_ms": 19920,
+    "median_server_latency_ms": 16417,
+    "mean_quality_score": 4.6,
+    "median_quality_score": 5,
+    "max_quality_score": 5,
+    "quality_distribution": {
+      "4": 12,
+      "5": 18
+    },
+    "total_cost_aud_estimate": 0.6697019999999999
+  },
+  "results": [
+    {
+      "id": "long-lunch-red-hill",
+      "query": "Best long lunch on the Red Hill ridge for a Saturday",
+      "ok": true,
+      "latency_ms": 17794,
+      "server_latency_ms": 16972,
+      "timings": {
+        "intent_and_embed_ms": 1707,
+        "retrieve_ms": 539,
+        "rerank_ms": 373,
+        "generate_ms": 14159,
+        "enrich_ms": 194
+      },
+      "cost_aud": 0.026883,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes by tractor, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-walk-in",
+      "query": "Walk-in cellar door tasting on the Peninsula, no booking",
+      "ok": true,
+      "latency_ms": 18614,
+      "server_latency_ms": 16562,
+      "timings": {
+        "intent_and_embed_ms": 2073,
+        "retrieve_ms": 411,
+        "rerank_ms": 425,
+        "generate_ms": 13432,
+        "enrich_ms": 220
+      },
+      "cost_aud": 0.020957,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto piazza, foxeys, rare hare)"
+        ]
+      }
+    },
+    {
+      "id": "rainy-day-kids-rye",
+      "query": "Rainy Sunday with two kids, near Rye",
+      "ok": true,
+      "latency_ms": 17265,
+      "server_latency_ms": 15164,
+      "timings": {
+        "intent_and_embed_ms": 1357,
+        "retrieve_ms": 423,
+        "rerank_ms": 445,
+        "generate_ms": 12745,
+        "enrich_ms": 194
+      },
+      "cost_aud": 0.014868,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "rye hotel"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "sorrento-weekend-couple",
+      "query": "Plan a Sorrento weekend for a couple",
+      "ok": true,
+      "latency_ms": 14724,
+      "server_latency_ms": 14686,
+      "timings": {
+        "intent_and_embed_ms": 1346,
+        "retrieve_ms": 188,
+        "rerank_ms": 336,
+        "generate_ms": 12622,
+        "enrich_ms": 194
+      },
+      "cost_aud": 0.020061,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "sorrento",
+        "continental"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "anniversary-dinner-view",
+      "query": "Anniversary dinner Friday night, somewhere with a view",
+      "ok": true,
+      "latency_ms": 14934,
+      "server_latency_ms": 14869,
+      "timings": {
+        "intent_and_embed_ms": 1275,
+        "retrieve_ms": 192,
+        "rerank_ms": 243,
+        "generate_ms": 12970,
+        "enrich_ms": 189
+      },
+      "cost_aud": 0.021411,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "port phillip estate"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "dog-friendly-cafe",
+      "query": "Dog friendly cafe on the Peninsula",
+      "ok": true,
+      "latency_ms": 15731,
+      "server_latency_ms": 15685,
+      "timings": {
+        "intent_and_embed_ms": 1779,
+        "retrieve_ms": 180,
+        "rerank_ms": 280,
+        "generate_ms": 13266,
+        "enrich_ms": 180
+      },
+      "cost_aud": 0.022073,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: commonfolk, afloat, many little)"
+        ]
+      }
+    },
+    {
+      "id": "best-walk-cape-schanck",
+      "query": "Best coastal walks near Cape Schanck",
+      "ok": true,
+      "latency_ms": 15550,
+      "server_latency_ms": 15507,
+      "timings": {
+        "intent_and_embed_ms": 1503,
+        "retrieve_ms": 188,
+        "rerank_ms": 287,
+        "generate_ms": 13352,
+        "enrich_ms": 177
+      },
+      "cost_aud": 0.017622,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: bushrangers bay, cape schanck boardwalk, two bays)"
+        ]
+      }
+    },
+    {
+      "id": "hatted-restaurants",
+      "query": "Hatted restaurants worth booking in advance",
+      "ok": true,
+      "latency_ms": 12509,
+      "server_latency_ms": 12429,
+      "timings": {
+        "intent_and_embed_ms": 1297,
+        "retrieve_ms": 193,
+        "rerank_ms": 238,
+        "generate_ms": 10513,
+        "enrich_ms": 188
+      },
+      "cost_aud": 0.021227,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "tedesca"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-stay-red-hill",
+      "query": "Where should we stay near Red Hill cellar doors",
+      "ok": true,
+      "latency_ms": 19583,
+      "server_latency_ms": 19537,
+      "timings": {
+        "intent_and_embed_ms": 1309,
+        "retrieve_ms": 384,
+        "rerank_ms": 279,
+        "generate_ms": 17365,
+        "enrich_ms": 200
+      },
+      "cost_aud": 0.027621,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "polperro",
+        "lindenderry",
+        "lancemore"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "one-night-near-sorrento",
+      "query": "One night away, couple, near Sorrento",
+      "ok": true,
+      "latency_ms": 17883,
+      "server_latency_ms": 17829,
+      "timings": {
+        "intent_and_embed_ms": 1363,
+        "retrieve_ms": 384,
+        "rerank_ms": 292,
+        "generate_ms": 15600,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.022262,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "hotel sorrento",
+        "continental"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winery-with-kids",
+      "query": "Cellar door open Sunday with kids",
+      "ok": true,
+      "latency_ms": 16884,
+      "server_latency_ms": 16846,
+      "timings": {
+        "intent_and_embed_ms": 1402,
+        "retrieve_ms": 184,
+        "rerank_ms": 237,
+        "generate_ms": 14846,
+        "enrich_ms": 177
+      },
+      "cost_aud": 0.024975,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, willow creek, red hill estate)"
+        ]
+      }
+    },
+    {
+      "id": "winery-tour-day-trip",
+      "query": "Winery tour day trip from Melbourne",
+      "ok": true,
+      "latency_ms": 20162,
+      "server_latency_ms": 20114,
+      "timings": {
+        "intent_and_embed_ms": 1344,
+        "retrieve_ms": 412,
+        "rerank_ms": 288,
+        "generate_ms": 17880,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.02574,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "best-seafood",
+      "query": "Where do locals go for seafood on the Peninsula",
+      "ok": true,
+      "latency_ms": 15348,
+      "server_latency_ms": 15305,
+      "timings": {
+        "intent_and_embed_ms": 1327,
+        "retrieve_ms": 192,
+        "rerank_ms": 247,
+        "generate_ms": 13362,
+        "enrich_ms": 177
+      },
+      "cost_aud": 0.019971,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "pier street"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "best-bakery",
+      "query": "Best bakery for breakfast on the Peninsula",
+      "ok": true,
+      "latency_ms": 13570,
+      "server_latency_ms": 13529,
+      "timings": {
+        "intent_and_embed_ms": 1357,
+        "retrieve_ms": 186,
+        "rerank_ms": 356,
+        "generate_ms": 11444,
+        "enrich_ms": 186
+      },
+      "cost_aud": 0.022829,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "sorrento bakery",
+        "balnarring bakehouse"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "thermal-springs-quiet",
+      "query": "Thermal springs without the crowds",
+      "ok": true,
+      "latency_ms": 16430,
+      "server_latency_ms": 16382,
+      "timings": {
+        "intent_and_embed_ms": 1302,
+        "retrieve_ms": 191,
+        "rerank_ms": 304,
+        "generate_ms": 14388,
+        "enrich_ms": 197
+      },
+      "cost_aud": 0.022698,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "alba"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "long-weekend-three-days",
+      "query": "Three day Peninsula trip, April long weekend, food and wine",
+      "ok": true,
+      "latency_ms": 18260,
+      "server_latency_ms": 18212,
+      "timings": {
+        "intent_and_embed_ms": 1435,
+        "retrieve_ms": 187,
+        "rerank_ms": 283,
+        "generate_ms": 16110,
+        "enrich_ms": 197
+      },
+      "cost_aud": 0.02606,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "red hill",
+        "long lunch"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: venue)"
+        ]
+      }
+    },
+    {
+      "id": "rye-front-beach",
+      "query": "What is there to do at Rye front beach",
+      "ok": true,
+      "latency_ms": 16006,
+      "server_latency_ms": 15964,
+      "timings": {
+        "intent_and_embed_ms": 1358,
+        "retrieve_ms": 378,
+        "rerank_ms": 284,
+        "generate_ms": 13763,
+        "enrich_ms": 181
+      },
+      "cost_aud": 0.021911,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "rye",
+        "front beach",
+        "pier"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winter-weekend-fireplace",
+      "query": "Winter weekend with a fireplace and a wine list",
+      "ok": true,
+      "latency_ms": 18034,
+      "server_latency_ms": 17990,
+      "timings": {
+        "intent_and_embed_ms": 1338,
+        "retrieve_ms": 197,
+        "rerank_ms": 250,
+        "generate_ms": 16017,
+        "enrich_ms": 188
+      },
+      "cost_aud": 0.026298,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "polperro",
+        "lindenderry"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-eat-sorrento",
+      "query": "Where to eat in Sorrento on a Saturday night",
+      "ok": true,
+      "latency_ms": 16497,
+      "server_latency_ms": 16452,
+      "timings": {
+        "intent_and_embed_ms": 1668,
+        "retrieve_ms": 392,
+        "rerank_ms": 320,
+        "generate_ms": 13896,
+        "enrich_ms": 176
+      },
+      "cost_aud": 0.021263,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "bistro elba",
+        "the baths"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "flinders-day",
+      "query": "How to spend a day in Flinders",
+      "ok": true,
+      "latency_ms": 12695,
+      "server_latency_ms": 12650,
+      "timings": {
+        "intent_and_embed_ms": 1862,
+        "retrieve_ms": 186,
+        "rerank_ms": 324,
+        "generate_ms": 9717,
+        "enrich_ms": 561
+      },
+      "cost_aud": 0.021614,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "flinders",
+        "hotel"
+      ],
+      "kind_hits": [
+        "venue",
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "no-driving-after-lunch",
+      "query": "Long lunch without too much driving back",
+      "ok": true,
+      "latency_ms": 17762,
+      "server_latency_ms": 17712,
+      "timings": {
+        "intent_and_embed_ms": 1362,
+        "retrieve_ms": 192,
+        "rerank_ms": 244,
+        "generate_ms": 15721,
+        "enrich_ms": 193
+      },
+      "cost_aud": 0.025695,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: foxeys, many little, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "afternoon-pinot-tasting",
+      "query": "Afternoon pinot tasting with serious producers",
+      "ok": true,
+      "latency_ms": 19920,
+      "server_latency_ms": 19872,
+      "timings": {
+        "intent_and_embed_ms": 1432,
+        "retrieve_ms": 188,
+        "rerank_ms": 362,
+        "generate_ms": 17711,
+        "enrich_ms": 179
+      },
+      "cost_aud": 0.023009,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "paringa"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "bushrangers-bay",
+      "query": "How long is the Bushrangers Bay walk",
+      "ok": true,
+      "latency_ms": 16827,
+      "server_latency_ms": 16781,
+      "timings": {
+        "intent_and_embed_ms": 1307,
+        "retrieve_ms": 200,
+        "rerank_ms": 236,
+        "generate_ms": 14861,
+        "enrich_ms": 177
+      },
+      "cost_aud": 0.02327,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "bushrangers bay",
+        "cape schanck"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: article)"
+        ]
+      }
+    },
+    {
+      "id": "wedding-venue-winery",
+      "query": "Winery wedding venues on the Peninsula",
+      "ok": true,
+      "latency_ms": 19836,
+      "server_latency_ms": 19794,
+      "timings": {
+        "intent_and_embed_ms": 1575,
+        "retrieve_ms": 193,
+        "rerank_ms": 335,
+        "generate_ms": 17507,
+        "enrich_ms": 184
+      },
+      "cost_aud": 0.024359,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "montalto"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "art-gallery",
+      "query": "Best art gallery on the Peninsula",
+      "ok": true,
+      "latency_ms": 12139,
+      "server_latency_ms": 12093,
+      "timings": {
+        "intent_and_embed_ms": 1298,
+        "retrieve_ms": 188,
+        "rerank_ms": 279,
+        "generate_ms": 10328,
+        "enrich_ms": 0
+      },
+      "cost_aud": 0.016002,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 4,
+      "topic_hits": [
+        "sculpture",
+        "regional gallery"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "weekend-this-weekend",
+      "query": "What is on this weekend on the Peninsula",
+      "ok": true,
+      "latency_ms": 17452,
+      "server_latency_ms": 17411,
+      "timings": {
+        "intent_and_embed_ms": 1341,
+        "retrieve_ms": 196,
+        "rerank_ms": 331,
+        "generate_ms": 15351,
+        "enrich_ms": 192
+      },
+      "cost_aud": 0.024066,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "market"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "kids-thing-to-do",
+      "query": "Something to do with two kids in school holidays",
+      "ok": true,
+      "latency_ms": 15180,
+      "server_latency_ms": 15113,
+      "timings": {
+        "intent_and_embed_ms": 1238,
+        "retrieve_ms": 201,
+        "rerank_ms": 265,
+        "generate_ms": 13217,
+        "enrich_ms": 192
+      },
+      "cost_aud": 0.018338,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-views",
+      "query": "Cellar door with the best view",
+      "ok": true,
+      "latency_ms": 15146,
+      "server_latency_ms": 15095,
+      "timings": {
+        "intent_and_embed_ms": 1352,
+        "retrieve_ms": 201,
+        "rerank_ms": 281,
+        "generate_ms": 13083,
+        "enrich_ms": 178
+      },
+      "cost_aud": 0.023882,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pt leo, port phillip estate, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "balnarring-village",
+      "query": "Is Balnarring worth a visit",
+      "ok": true,
+      "latency_ms": 14631,
+      "server_latency_ms": 14578,
+      "timings": {
+        "intent_and_embed_ms": 1354,
+        "retrieve_ms": 185,
+        "rerank_ms": 292,
+        "generate_ms": 12558,
+        "enrich_ms": 189
+      },
+      "cost_aud": 0.018914,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "balnarring",
+        "village"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "negative-overrated",
+      "query": "Is Peninsula Hot Springs overrated",
+      "ok": true,
+      "latency_ms": 18072,
+      "server_latency_ms": 18029,
+      "timings": {
+        "intent_and_embed_ms": 1385,
+        "retrieve_ms": 186,
+        "rerank_ms": 293,
+        "generate_ms": 15973,
+        "enrich_ms": 192
+      },
+      "cost_aud": 0.023823,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 4,
+      "topic_hits": [
+        "peninsula hot springs",
+        "alba",
+        "crowd"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    }
+  ]
+}

--- a/reports/insider-eval/after-perf-pass-3-2026-05-02.md
+++ b/reports/insider-eval/after-perf-pass-3-2026-05-02.md
@@ -1,0 +1,57 @@
+# Insider eval — after-perf-pass-3 · 2026-05-02
+
+API: https://peninsula-insider-platform-api.vercel.app
+
+## Summary
+- Queries: 30 · errors: 0
+- Median latency: **16.66s** · p95: 19.92s
+- Median server latency: 16.42s
+- Median quality: **5/5** (mean 4.60)
+- Quality distribution: 4:12, 5:18
+- Total cost: $0.6697 AUD
+
+## Diff vs baseline (`baseline-2026-05-02.json`)
+- Median latency: 17.09s → 16.66s (424ms)
+- Mean quality: 4.77 → 4.60 (-0.17)
+- Total cost: $0.7187 → $0.6697 AUD
+
+## Per-query results
+| ID | Query | Latency | Quality | Recs | Issues |
+|---|---|---:|:---:|:---:|---|
+| long-lunch-red-hill | Best long lunch on the Red Hill ridge for a Saturday | 17.79s | 4/5 | 4 | no expected topic matched (looked for: montalto, ten minutes by tractor, polperro) |
+| cellar-door-walk-in | Walk-in cellar door tasting on the Peninsula, no booking | 18.61s | 4/5 | 2 | no expected topic matched (looked for: montalto piazza, foxeys, rare hare) |
+| rainy-day-kids-rye | Rainy Sunday with two kids, near Rye | 17.27s | 5/5 | 1 | — |
+| sorrento-weekend-couple | Plan a Sorrento weekend for a couple | 14.72s | 5/5 | 1 | — |
+| anniversary-dinner-view | Anniversary dinner Friday night, somewhere with a view | 14.93s | 5/5 | 2 | — |
+| dog-friendly-cafe | Dog friendly cafe on the Peninsula | 15.73s | 4/5 | 3 | no expected topic matched (looked for: commonfolk, afloat, many little) |
+| best-walk-cape-schanck | Best coastal walks near Cape Schanck | 15.55s | 4/5 | 1 | no expected topic matched (looked for: bushrangers bay, cape schanck boardwalk, two bays) |
+| hatted-restaurants | Hatted restaurants worth booking in advance | 12.51s | 5/5 | 2 | — |
+| where-to-stay-red-hill | Where should we stay near Red Hill cellar doors | 19.58s | 5/5 | 4 | — |
+| one-night-near-sorrento | One night away, couple, near Sorrento | 17.88s | 5/5 | 3 | — |
+| winery-with-kids | Cellar door open Sunday with kids | 16.88s | 4/5 | 3 | no expected topic matched (looked for: montalto, willow creek, red hill estate) |
+| winery-tour-day-trip | Winery tour day trip from Melbourne | 20.16s | 4/5 | 3 | no expected topic matched (looked for: montalto, ten minutes, polperro) |
+| best-seafood | Where do locals go for seafood on the Peninsula | 15.35s | 5/5 | 2 | — |
+| best-bakery | Best bakery for breakfast on the Peninsula | 13.57s | 5/5 | 3 | — |
+| thermal-springs-quiet | Thermal springs without the crowds | 16.43s | 5/5 | 2 | — |
+| long-weekend-three-days | Three day Peninsula trip, April long weekend, food and wine | 18.26s | 4/5 | 4 | no expected kind matched (got: venue) |
+| rye-front-beach | What is there to do at Rye front beach | 16.01s | 5/5 | 2 | — |
+| winter-weekend-fireplace | Winter weekend with a fireplace and a wine list | 18.03s | 5/5 | 4 | — |
+| where-to-eat-sorrento | Where to eat in Sorrento on a Saturday night | 16.50s | 5/5 | 2 | — |
+| flinders-day | How to spend a day in Flinders | 12.70s | 5/5 | 2 | — |
+| no-driving-after-lunch | Long lunch without too much driving back | 17.76s | 4/5 | 4 | no expected topic matched (looked for: foxeys, many little, polperro) |
+| afternoon-pinot-tasting | Afternoon pinot tasting with serious producers | 19.92s | 5/5 | 3 | — |
+| bushrangers-bay | How long is the Bushrangers Bay walk | 16.83s | 4/5 | 3 | no expected kind matched (got: article) |
+| wedding-venue-winery | Winery wedding venues on the Peninsula | 19.84s | 5/5 | 3 | — |
+| art-gallery | Best art gallery on the Peninsula | 12.14s | 4/5 | 0 | no expected kind matched (got: none) |
+| weekend-this-weekend | What is on this weekend on the Peninsula | 17.45s | 5/5 | 3 | — |
+| kids-thing-to-do | Something to do with two kids in school holidays | 15.18s | 4/5 | 2 | no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze) |
+| cellar-door-views | Cellar door with the best view | 15.15s | 4/5 | 3 | no expected topic matched (looked for: pt leo, port phillip estate, montalto) |
+| balnarring-village | Is Balnarring worth a visit | 14.63s | 5/5 | 2 | — |
+| negative-overrated | Is Peninsula Hot Springs overrated | 18.07s | 5/5 | 3 | — |
+
+## Median per-step timings (ms)
+- intent_and_embed_ms: 1.36s
+- retrieve_ms: 193ms
+- rerank_ms: 288ms
+- generate_ms: 13.83s
+- enrich_ms: 189ms

--- a/reports/insider-eval/after-perf-pass-4-2026-05-02.json
+++ b/reports/insider-eval/after-perf-pass-4-2026-05-02.json
@@ -1,0 +1,1005 @@
+{
+  "label": "after-perf-pass-4",
+  "date": "2026-05-02",
+  "timestamp": "2026-05-02T15:02:49.209Z",
+  "api": "https://peninsula-insider-platform-api.vercel.app",
+  "summary": {
+    "total": 30,
+    "errors": 0,
+    "median_latency_ms": 17876.5,
+    "p95_latency_ms": 22532,
+    "median_server_latency_ms": 17830.5,
+    "mean_quality_score": 4.633333333333334,
+    "median_quality_score": 5,
+    "max_quality_score": 5,
+    "quality_distribution": {
+      "4": 11,
+      "5": 19
+    },
+    "total_cost_aud_estimate": 0.7256819999999999
+  },
+  "results": [
+    {
+      "id": "long-lunch-red-hill",
+      "query": "Best long lunch on the Red Hill ridge for a Saturday",
+      "ok": true,
+      "latency_ms": 22532,
+      "server_latency_ms": 20342,
+      "timings": {
+        "intent_and_embed_ms": 1416,
+        "retrieve_ms": 202,
+        "rerank_ms": 347,
+        "generate_ms": 18188,
+        "enrich_ms": 188
+      },
+      "cost_aud": 0.027657,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes by tractor, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-walk-in",
+      "query": "Walk-in cellar door tasting on the Peninsula, no booking",
+      "ok": true,
+      "latency_ms": 24434,
+      "server_latency_ms": 22212,
+      "timings": {
+        "intent_and_embed_ms": 1380,
+        "retrieve_ms": 394,
+        "rerank_ms": 287,
+        "generate_ms": 19956,
+        "enrich_ms": 195
+      },
+      "cost_aud": 0.026361,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto piazza, foxeys, rare hare)"
+        ]
+      }
+    },
+    {
+      "id": "rainy-day-kids-rye",
+      "query": "Rainy Sunday with two kids, near Rye",
+      "ok": true,
+      "latency_ms": 19323,
+      "server_latency_ms": 18513,
+      "timings": {
+        "intent_and_embed_ms": 3299,
+        "retrieve_ms": 407,
+        "rerank_ms": 430,
+        "generate_ms": 14184,
+        "enrich_ms": 193
+      },
+      "cost_aud": 0.018792,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "rye hotel"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "sorrento-weekend-couple",
+      "query": "Plan a Sorrento weekend for a couple",
+      "ok": true,
+      "latency_ms": 17226,
+      "server_latency_ms": 17171,
+      "timings": {
+        "intent_and_embed_ms": 1481,
+        "retrieve_ms": 204,
+        "rerank_ms": 251,
+        "generate_ms": 14731,
+        "enrich_ms": 504
+      },
+      "cost_aud": 0.024597,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "sorrento",
+        "continental"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "anniversary-dinner-view",
+      "query": "Anniversary dinner Friday night, somewhere with a view",
+      "ok": true,
+      "latency_ms": 16445,
+      "server_latency_ms": 16360,
+      "timings": {
+        "intent_and_embed_ms": 1568,
+        "retrieve_ms": 193,
+        "rerank_ms": 282,
+        "generate_ms": 14116,
+        "enrich_ms": 201
+      },
+      "cost_aud": 0.024489,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "port phillip estate"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "dog-friendly-cafe",
+      "query": "Dog friendly cafe on the Peninsula",
+      "ok": true,
+      "latency_ms": 16327,
+      "server_latency_ms": 16198,
+      "timings": {
+        "intent_and_embed_ms": 1571,
+        "retrieve_ms": 184,
+        "rerank_ms": 247,
+        "generate_ms": 14016,
+        "enrich_ms": 180
+      },
+      "cost_aud": 0.022658,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: commonfolk, afloat, many little)"
+        ]
+      }
+    },
+    {
+      "id": "best-walk-cape-schanck",
+      "query": "Best coastal walks near Cape Schanck",
+      "ok": true,
+      "latency_ms": 16469,
+      "server_latency_ms": 16419,
+      "timings": {
+        "intent_and_embed_ms": 1563,
+        "retrieve_ms": 186,
+        "rerank_ms": 238,
+        "generate_ms": 14222,
+        "enrich_ms": 210
+      },
+      "cost_aud": 0.018887,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "bushrangers bay"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "hatted-restaurants",
+      "query": "Hatted restaurants worth booking in advance",
+      "ok": true,
+      "latency_ms": 17796,
+      "server_latency_ms": 17750,
+      "timings": {
+        "intent_and_embed_ms": 1650,
+        "retrieve_ms": 643,
+        "rerank_ms": 326,
+        "generate_ms": 14945,
+        "enrich_ms": 186
+      },
+      "cost_aud": 0.025542,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "laura",
+        "tedesca"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-stay-red-hill",
+      "query": "Where should we stay near Red Hill cellar doors",
+      "ok": true,
+      "latency_ms": 20023,
+      "server_latency_ms": 19973,
+      "timings": {
+        "intent_and_embed_ms": 1650,
+        "retrieve_ms": 395,
+        "rerank_ms": 321,
+        "generate_ms": 17412,
+        "enrich_ms": 195
+      },
+      "cost_aud": 0.029376,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "jackalope",
+        "polperro",
+        "lindenderry"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "one-night-near-sorrento",
+      "query": "One night away, couple, near Sorrento",
+      "ok": true,
+      "latency_ms": 18947,
+      "server_latency_ms": 18900,
+      "timings": {
+        "intent_and_embed_ms": 1530,
+        "retrieve_ms": 394,
+        "rerank_ms": 294,
+        "generate_ms": 16480,
+        "enrich_ms": 202
+      },
+      "cost_aud": 0.02444,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "hotel sorrento",
+        "continental"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winery-with-kids",
+      "query": "Cellar door open Sunday with kids",
+      "ok": true,
+      "latency_ms": 18416,
+      "server_latency_ms": 18363,
+      "timings": {
+        "intent_and_embed_ms": 1511,
+        "retrieve_ms": 195,
+        "rerank_ms": 284,
+        "generate_ms": 16189,
+        "enrich_ms": 184
+      },
+      "cost_aud": 0.026276,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, willow creek, red hill estate)"
+        ]
+      }
+    },
+    {
+      "id": "winery-tour-day-trip",
+      "query": "Winery tour day trip from Melbourne",
+      "ok": true,
+      "latency_ms": 20657,
+      "server_latency_ms": 20615,
+      "timings": {
+        "intent_and_embed_ms": 1442,
+        "retrieve_ms": 383,
+        "rerank_ms": 302,
+        "generate_ms": 18285,
+        "enrich_ms": 203
+      },
+      "cost_aud": 0.025637,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "best-seafood",
+      "query": "Where do locals go for seafood on the Peninsula",
+      "ok": true,
+      "latency_ms": 14336,
+      "server_latency_ms": 14259,
+      "timings": {
+        "intent_and_embed_ms": 1427,
+        "retrieve_ms": 191,
+        "rerank_ms": 244,
+        "generate_ms": 12215,
+        "enrich_ms": 182
+      },
+      "cost_aud": 0.021294,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "pier street"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "best-bakery",
+      "query": "Best bakery for breakfast on the Peninsula",
+      "ok": true,
+      "latency_ms": 15585,
+      "server_latency_ms": 15539,
+      "timings": {
+        "intent_and_embed_ms": 1367,
+        "retrieve_ms": 188,
+        "rerank_ms": 284,
+        "generate_ms": 13522,
+        "enrich_ms": 178
+      },
+      "cost_aud": 0.023976,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "sorrento bakery",
+        "balnarring bakehouse"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "thermal-springs-quiet",
+      "query": "Thermal springs without the crowds",
+      "ok": true,
+      "latency_ms": 18577,
+      "server_latency_ms": 18523,
+      "timings": {
+        "intent_and_embed_ms": 1554,
+        "retrieve_ms": 187,
+        "rerank_ms": 339,
+        "generate_ms": 16250,
+        "enrich_ms": 193
+      },
+      "cost_aud": 0.02376,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "alba"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "long-weekend-three-days",
+      "query": "Three day Peninsula trip, April long weekend, food and wine",
+      "ok": true,
+      "latency_ms": 20373,
+      "server_latency_ms": 20319,
+      "timings": {
+        "intent_and_embed_ms": 1384,
+        "retrieve_ms": 187,
+        "rerank_ms": 331,
+        "generate_ms": 18237,
+        "enrich_ms": 180
+      },
+      "cost_aud": 0.02687,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "red hill",
+        "long lunch",
+        "cellar door"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: venue)"
+        ]
+      }
+    },
+    {
+      "id": "rye-front-beach",
+      "query": "What is there to do at Rye front beach",
+      "ok": true,
+      "latency_ms": 14750,
+      "server_latency_ms": 14702,
+      "timings": {
+        "intent_and_embed_ms": 1395,
+        "retrieve_ms": 382,
+        "rerank_ms": 324,
+        "generate_ms": 12416,
+        "enrich_ms": 185
+      },
+      "cost_aud": 0.022545,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "rye",
+        "front beach",
+        "pier"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winter-weekend-fireplace",
+      "query": "Winter weekend with a fireplace and a wine list",
+      "ok": true,
+      "latency_ms": 18437,
+      "server_latency_ms": 18392,
+      "timings": {
+        "intent_and_embed_ms": 1312,
+        "retrieve_ms": 208,
+        "rerank_ms": 286,
+        "generate_ms": 16396,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.02673,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "polperro",
+        "lindenderry"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-eat-sorrento",
+      "query": "Where to eat in Sorrento on a Saturday night",
+      "ok": true,
+      "latency_ms": 15761,
+      "server_latency_ms": 15723,
+      "timings": {
+        "intent_and_embed_ms": 1578,
+        "retrieve_ms": 389,
+        "rerank_ms": 304,
+        "generate_ms": 13262,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.022019,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "bistro elba",
+        "the baths"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "flinders-day",
+      "query": "How to spend a day in Flinders",
+      "ok": true,
+      "latency_ms": 17069,
+      "server_latency_ms": 17031,
+      "timings": {
+        "intent_and_embed_ms": 1287,
+        "retrieve_ms": 197,
+        "rerank_ms": 283,
+        "generate_ms": 15086,
+        "enrich_ms": 178
+      },
+      "cost_aud": 0.022874,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "flinders",
+        "hotel"
+      ],
+      "kind_hits": [
+        "venue",
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "no-driving-after-lunch",
+      "query": "Long lunch without too much driving back",
+      "ok": true,
+      "latency_ms": 19139,
+      "server_latency_ms": 19092,
+      "timings": {
+        "intent_and_embed_ms": 1367,
+        "retrieve_ms": 190,
+        "rerank_ms": 335,
+        "generate_ms": 17012,
+        "enrich_ms": 188
+      },
+      "cost_aud": 0.02768,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: foxeys, many little, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "afternoon-pinot-tasting",
+      "query": "Afternoon pinot tasting with serious producers",
+      "ok": true,
+      "latency_ms": 18145,
+      "server_latency_ms": 18105,
+      "timings": {
+        "intent_and_embed_ms": 1316,
+        "retrieve_ms": 196,
+        "rerank_ms": 274,
+        "generate_ms": 16146,
+        "enrich_ms": 173
+      },
+      "cost_aud": 0.026078,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "paringa"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "bushrangers-bay",
+      "query": "How long is the Bushrangers Bay walk",
+      "ok": true,
+      "latency_ms": 15437,
+      "server_latency_ms": 15388,
+      "timings": {
+        "intent_and_embed_ms": 1248,
+        "retrieve_ms": 191,
+        "rerank_ms": 236,
+        "generate_ms": 13529,
+        "enrich_ms": 183
+      },
+      "cost_aud": 0.025695,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "experience",
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "bushrangers bay",
+        "cape schanck"
+      ],
+      "kind_hits": [
+        "experience"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "wedding-venue-winery",
+      "query": "Winery wedding venues on the Peninsula",
+      "ok": true,
+      "latency_ms": 17804,
+      "server_latency_ms": 17753,
+      "timings": {
+        "intent_and_embed_ms": 1310,
+        "retrieve_ms": 193,
+        "rerank_ms": 287,
+        "generate_ms": 15769,
+        "enrich_ms": 194
+      },
+      "cost_aud": 0.025029,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: polperro, lindenderry, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "art-gallery",
+      "query": "Best art gallery on the Peninsula",
+      "ok": true,
+      "latency_ms": 13995,
+      "server_latency_ms": 13944,
+      "timings": {
+        "intent_and_embed_ms": 1368,
+        "retrieve_ms": 276,
+        "rerank_ms": 280,
+        "generate_ms": 12020,
+        "enrich_ms": 0
+      },
+      "cost_aud": 0.019427,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 5,
+      "topic_hits": [
+        "sculpture"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "weekend-this-weekend",
+      "query": "What is on this weekend on the Peninsula",
+      "ok": true,
+      "latency_ms": 18484,
+      "server_latency_ms": 18437,
+      "timings": {
+        "intent_and_embed_ms": 1342,
+        "retrieve_ms": 196,
+        "rerank_ms": 326,
+        "generate_ms": 16398,
+        "enrich_ms": 175
+      },
+      "cost_aud": 0.0243,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "market"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "kids-thing-to-do",
+      "query": "Something to do with two kids in school holidays",
+      "ok": true,
+      "latency_ms": 19017,
+      "server_latency_ms": 18970,
+      "timings": {
+        "intent_and_embed_ms": 1292,
+        "retrieve_ms": 201,
+        "rerank_ms": 297,
+        "generate_ms": 17005,
+        "enrich_ms": 175
+      },
+      "cost_aud": 0.024188,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-views",
+      "query": "Cellar door with the best view",
+      "ok": true,
+      "latency_ms": 15901,
+      "server_latency_ms": 15852,
+      "timings": {
+        "intent_and_embed_ms": 1348,
+        "retrieve_ms": 182,
+        "rerank_ms": 286,
+        "generate_ms": 13836,
+        "enrich_ms": 200
+      },
+      "cost_aud": 0.022991,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: pt leo, port phillip estate, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "balnarring-village",
+      "query": "Is Balnarring worth a visit",
+      "ok": true,
+      "latency_ms": 14540,
+      "server_latency_ms": 14263,
+      "timings": {
+        "intent_and_embed_ms": 1317,
+        "retrieve_ms": 193,
+        "rerank_ms": 757,
+        "generate_ms": 11817,
+        "enrich_ms": 179
+      },
+      "cost_aud": 0.020183,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "balnarring",
+        "village"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "negative-overrated",
+      "query": "Is Peninsula Hot Springs overrated",
+      "ok": true,
+      "latency_ms": 17949,
+      "server_latency_ms": 17908,
+      "timings": {
+        "intent_and_embed_ms": 1393,
+        "retrieve_ms": 197,
+        "rerank_ms": 252,
+        "generate_ms": 15876,
+        "enrich_ms": 190
+      },
+      "cost_aud": 0.025331,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "peninsula hot springs",
+        "alba",
+        "crowd"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    }
+  ]
+}

--- a/reports/insider-eval/after-perf-pass-4-2026-05-02.md
+++ b/reports/insider-eval/after-perf-pass-4-2026-05-02.md
@@ -1,0 +1,57 @@
+# Insider eval — after-perf-pass-4 · 2026-05-02
+
+API: https://peninsula-insider-platform-api.vercel.app
+
+## Summary
+- Queries: 30 · errors: 0
+- Median latency: **17.88s** · p95: 22.53s
+- Median server latency: 17.83s
+- Median quality: **5/5** (mean 4.63)
+- Quality distribution: 4:11, 5:19
+- Total cost: $0.7257 AUD
+
+## Diff vs baseline (`baseline-2026-05-02.json`)
+- Median latency: 17.09s → 17.88s (+791ms)
+- Mean quality: 4.77 → 4.63 (-0.13)
+- Total cost: $0.7187 → $0.7257 AUD
+
+## Per-query results
+| ID | Query | Latency | Quality | Recs | Issues |
+|---|---|---:|:---:|:---:|---|
+| long-lunch-red-hill | Best long lunch on the Red Hill ridge for a Saturday | 22.53s | 4/5 | 4 | no expected topic matched (looked for: montalto, ten minutes by tractor, polperro) |
+| cellar-door-walk-in | Walk-in cellar door tasting on the Peninsula, no booking | 24.43s | 4/5 | 3 | no expected topic matched (looked for: montalto piazza, foxeys, rare hare) |
+| rainy-day-kids-rye | Rainy Sunday with two kids, near Rye | 19.32s | 5/5 | 2 | — |
+| sorrento-weekend-couple | Plan a Sorrento weekend for a couple | 17.23s | 5/5 | 2 | — |
+| anniversary-dinner-view | Anniversary dinner Friday night, somewhere with a view | 16.45s | 5/5 | 3 | — |
+| dog-friendly-cafe | Dog friendly cafe on the Peninsula | 16.33s | 4/5 | 3 | no expected topic matched (looked for: commonfolk, afloat, many little) |
+| best-walk-cape-schanck | Best coastal walks near Cape Schanck | 16.47s | 5/5 | 1 | — |
+| hatted-restaurants | Hatted restaurants worth booking in advance | 17.80s | 5/5 | 3 | — |
+| where-to-stay-red-hill | Where should we stay near Red Hill cellar doors | 20.02s | 5/5 | 4 | — |
+| one-night-near-sorrento | One night away, couple, near Sorrento | 18.95s | 5/5 | 3 | — |
+| winery-with-kids | Cellar door open Sunday with kids | 18.42s | 4/5 | 3 | no expected topic matched (looked for: montalto, willow creek, red hill estate) |
+| winery-tour-day-trip | Winery tour day trip from Melbourne | 20.66s | 4/5 | 3 | no expected topic matched (looked for: montalto, ten minutes, polperro) |
+| best-seafood | Where do locals go for seafood on the Peninsula | 14.34s | 5/5 | 2 | — |
+| best-bakery | Best bakery for breakfast on the Peninsula | 15.59s | 5/5 | 3 | — |
+| thermal-springs-quiet | Thermal springs without the crowds | 18.58s | 5/5 | 2 | — |
+| long-weekend-three-days | Three day Peninsula trip, April long weekend, food and wine | 20.37s | 4/5 | 4 | no expected kind matched (got: venue) |
+| rye-front-beach | What is there to do at Rye front beach | 14.75s | 5/5 | 2 | — |
+| winter-weekend-fireplace | Winter weekend with a fireplace and a wine list | 18.44s | 5/5 | 4 | — |
+| where-to-eat-sorrento | Where to eat in Sorrento on a Saturday night | 15.76s | 5/5 | 2 | — |
+| flinders-day | How to spend a day in Flinders | 17.07s | 5/5 | 2 | — |
+| no-driving-after-lunch | Long lunch without too much driving back | 19.14s | 4/5 | 4 | no expected topic matched (looked for: foxeys, many little, polperro) |
+| afternoon-pinot-tasting | Afternoon pinot tasting with serious producers | 18.14s | 5/5 | 4 | — |
+| bushrangers-bay | How long is the Bushrangers Bay walk | 15.44s | 5/5 | 3 | — |
+| wedding-venue-winery | Winery wedding venues on the Peninsula | 17.80s | 4/5 | 3 | no expected topic matched (looked for: polperro, lindenderry, montalto) |
+| art-gallery | Best art gallery on the Peninsula | 13.99s | 4/5 | 0 | no expected kind matched (got: none) |
+| weekend-this-weekend | What is on this weekend on the Peninsula | 18.48s | 5/5 | 3 | — |
+| kids-thing-to-do | Something to do with two kids in school holidays | 19.02s | 4/5 | 3 | no expected topic matched (looked for: moonlit sanctuary, chocolaterie, ashcombe maze) |
+| cellar-door-views | Cellar door with the best view | 15.90s | 4/5 | 3 | no expected topic matched (looked for: pt leo, port phillip estate, montalto) |
+| balnarring-village | Is Balnarring worth a visit | 14.54s | 5/5 | 2 | — |
+| negative-overrated | Is Peninsula Hot Springs overrated | 17.95s | 5/5 | 3 | — |
+
+## Median per-step timings (ms)
+- intent_and_embed_ms: 1.39s
+- retrieve_ms: 197ms
+- rerank_ms: 287ms
+- generate_ms: 15.43s
+- enrich_ms: 188ms

--- a/reports/insider-eval/baseline-2026-05-02.json
+++ b/reports/insider-eval/baseline-2026-05-02.json
@@ -1,0 +1,824 @@
+{
+  "label": "baseline",
+  "date": "2026-05-02",
+  "timestamp": "2026-05-02T14:41:17.918Z",
+  "api": "https://peninsula-insider-platform-api.vercel.app",
+  "summary": {
+    "total": 30,
+    "errors": 0,
+    "median_latency_ms": 17085.5,
+    "p95_latency_ms": 22845,
+    "median_server_latency_ms": 16925,
+    "mean_quality_score": 4.766666666666667,
+    "median_quality_score": 5,
+    "max_quality_score": 5,
+    "quality_distribution": {
+      "4": 7,
+      "5": 23
+    },
+    "total_cost_aud_estimate": 0.7186869999999999
+  },
+  "results": [
+    {
+      "id": "long-lunch-red-hill",
+      "query": "Best long lunch on the Red Hill ridge for a Saturday",
+      "ok": true,
+      "latency_ms": 22946,
+      "server_latency_ms": 20740,
+      "timings": null,
+      "cost_aud": 0.036134,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto, ten minutes by tractor, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "cellar-door-walk-in",
+      "query": "Walk-in cellar door tasting on the Peninsula, no booking",
+      "ok": true,
+      "latency_ms": 19104,
+      "server_latency_ms": 16966,
+      "timings": null,
+      "cost_aud": 0.02726,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: montalto piazza, foxeys, rare hare)"
+        ]
+      }
+    },
+    {
+      "id": "rainy-day-kids-rye",
+      "query": "Rainy Sunday with two kids, near Rye",
+      "ok": true,
+      "latency_ms": 18353,
+      "server_latency_ms": 16142,
+      "timings": null,
+      "cost_aud": 0.024907,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "rye hotel"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "sorrento-weekend-couple",
+      "query": "Plan a Sorrento weekend for a couple",
+      "ok": true,
+      "latency_ms": 16188,
+      "server_latency_ms": 16140,
+      "timings": null,
+      "cost_aud": 0.022712,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "sorrento",
+        "back beach",
+        "continental"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "anniversary-dinner-view",
+      "query": "Anniversary dinner Friday night, somewhere with a view",
+      "ok": true,
+      "latency_ms": 18833,
+      "server_latency_ms": 18786,
+      "timings": null,
+      "cost_aud": 0.027117,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "port phillip estate"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "dog-friendly-cafe",
+      "query": "Dog friendly cafe on the Peninsula",
+      "ok": true,
+      "latency_ms": 17057,
+      "server_latency_ms": 17006,
+      "timings": null,
+      "cost_aud": 0.023328,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "commonfolk"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "best-walk-cape-schanck",
+      "query": "Best coastal walks near Cape Schanck",
+      "ok": true,
+      "latency_ms": 13409,
+      "server_latency_ms": 13351,
+      "timings": null,
+      "cost_aud": 0.017222,
+      "recommendations_count": 1,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "bushrangers bay"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "hatted-restaurants",
+      "query": "Hatted restaurants worth booking in advance",
+      "ok": true,
+      "latency_ms": 18743,
+      "server_latency_ms": 18689,
+      "timings": null,
+      "cost_aud": 0.026127,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "barragunda"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-stay-red-hill",
+      "query": "Where should we stay near Red Hill cellar doors",
+      "ok": true,
+      "latency_ms": 15381,
+      "server_latency_ms": 15315,
+      "timings": null,
+      "cost_aud": 0.023508,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 3,
+      "topic_hits": [
+        "jackalope",
+        "polperro",
+        "lindenderry",
+        "lancemore"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "one-night-near-sorrento",
+      "query": "One night away, couple, near Sorrento",
+      "ok": true,
+      "latency_ms": 17114,
+      "server_latency_ms": 17060,
+      "timings": null,
+      "cost_aud": 0.022406,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 3,
+      "topic_hits": [
+        "hotel sorrento",
+        "continental"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winery-with-kids",
+      "query": "Cellar door open Sunday with kids",
+      "ok": true,
+      "latency_ms": 19586,
+      "server_latency_ms": 19536,
+      "timings": null,
+      "cost_aud": 0.027554,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "montalto"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winery-tour-day-trip",
+      "query": "Winery tour day trip from Melbourne",
+      "ok": true,
+      "latency_ms": 18819,
+      "server_latency_ms": 18779,
+      "timings": null,
+      "cost_aud": 0.020651,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "montalto",
+        "ten minutes"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "best-seafood",
+      "query": "Where do locals go for seafood on the Peninsula",
+      "ok": true,
+      "latency_ms": 15774,
+      "server_latency_ms": 15727,
+      "timings": null,
+      "cost_aud": 0.024453,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "pier street"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "best-bakery",
+      "query": "Best bakery for breakfast on the Peninsula",
+      "ok": true,
+      "latency_ms": 16000,
+      "server_latency_ms": 15951,
+      "timings": null,
+      "cost_aud": 0.025133,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "sorrento bakery",
+        "balnarring bakehouse"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "thermal-springs-quiet",
+      "query": "Thermal springs without the crowds",
+      "ok": true,
+      "latency_ms": 18321,
+      "server_latency_ms": 18282,
+      "timings": null,
+      "cost_aud": 0.023423,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "alba"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "long-weekend-three-days",
+      "query": "Three day Peninsula trip, April long weekend, food and wine",
+      "ok": true,
+      "latency_ms": 21596,
+      "server_latency_ms": 21553,
+      "timings": null,
+      "cost_aud": 0.026883,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "red hill",
+        "long lunch"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: venue)"
+        ]
+      }
+    },
+    {
+      "id": "rye-front-beach",
+      "query": "What is there to do at Rye front beach",
+      "ok": true,
+      "latency_ms": 13342,
+      "server_latency_ms": 13285,
+      "timings": null,
+      "cost_aud": 0.016524,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "rye",
+        "front beach"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "winter-weekend-fireplace",
+      "query": "Winter weekend with a fireplace and a wine list",
+      "ok": true,
+      "latency_ms": 16920,
+      "server_latency_ms": 16881,
+      "timings": null,
+      "cost_aud": 0.024323,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "polperro",
+        "lindenderry"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "where-to-eat-sorrento",
+      "query": "Where to eat in Sorrento on a Saturday night",
+      "ok": true,
+      "latency_ms": 14052,
+      "server_latency_ms": 14005,
+      "timings": null,
+      "cost_aud": 0.0185,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 2,
+      "topic_hits": [
+        "bistro elba",
+        "the baths"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "flinders-day",
+      "query": "How to spend a day in Flinders",
+      "ok": true,
+      "latency_ms": 20997,
+      "server_latency_ms": 20719,
+      "timings": null,
+      "cost_aud": 0.022559,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "flinders",
+        "hotel"
+      ],
+      "kind_hits": [
+        "venue",
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "no-driving-after-lunch",
+      "query": "Long lunch without too much driving back",
+      "ok": true,
+      "latency_ms": 22845,
+      "server_latency_ms": 22808,
+      "timings": null,
+      "cost_aud": 0.024507,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: foxeys, many little, polperro)"
+        ]
+      }
+    },
+    {
+      "id": "afternoon-pinot-tasting",
+      "query": "Afternoon pinot tasting with serious producers",
+      "ok": true,
+      "latency_ms": 18757,
+      "server_latency_ms": 18710,
+      "timings": null,
+      "cost_aud": 0.026978,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "paringa"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "bushrangers-bay",
+      "query": "How long is the Bushrangers Bay walk",
+      "ok": true,
+      "latency_ms": 16326,
+      "server_latency_ms": 16274,
+      "timings": null,
+      "cost_aud": 0.023922,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "bushrangers bay",
+        "cape schanck"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: article)"
+        ]
+      }
+    },
+    {
+      "id": "wedding-venue-winery",
+      "query": "Winery wedding venues on the Peninsula",
+      "ok": true,
+      "latency_ms": 17773,
+      "server_latency_ms": 17738,
+      "timings": null,
+      "cost_aud": 0.024435,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected topic matched (looked for: polperro, lindenderry, montalto)"
+        ]
+      }
+    },
+    {
+      "id": "art-gallery",
+      "query": "Best art gallery on the Peninsula",
+      "ok": true,
+      "latency_ms": 15754,
+      "server_latency_ms": 15705,
+      "timings": null,
+      "cost_aud": 0.020147,
+      "recommendations_count": 0,
+      "recommendation_kinds": [],
+      "sources_count": 5,
+      "topic_hits": [
+        "sculpture",
+        "regional gallery"
+      ],
+      "kind_hits": [],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 4,
+        "max": 5,
+        "reasons": [
+          "no expected kind matched (got: none)"
+        ]
+      }
+    },
+    {
+      "id": "weekend-this-weekend",
+      "query": "What is on this weekend on the Peninsula",
+      "ok": true,
+      "latency_ms": 16595,
+      "server_latency_ms": 16550,
+      "timings": null,
+      "cost_aud": 0.025605,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "market"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "kids-thing-to-do",
+      "query": "Something to do with two kids in school holidays",
+      "ok": true,
+      "latency_ms": 15313,
+      "server_latency_ms": 15270,
+      "timings": null,
+      "cost_aud": 0.018014,
+      "recommendations_count": 2,
+      "recommendation_kinds": [
+        "article",
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "ashcombe maze"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "cellar-door-views",
+      "query": "Cellar door with the best view",
+      "ok": true,
+      "latency_ms": 16885,
+      "server_latency_ms": 16826,
+      "timings": null,
+      "cost_aud": 0.026861,
+      "recommendations_count": 4,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "port phillip estate"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "balnarring-village",
+      "query": "Is Balnarring worth a visit",
+      "ok": true,
+      "latency_ms": 16936,
+      "server_latency_ms": 16884,
+      "timings": null,
+      "cost_aud": 0.022253,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue",
+        "article"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "balnarring",
+        "village",
+        "bakery"
+      ],
+      "kind_hits": [
+        "article"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    },
+    {
+      "id": "negative-overrated",
+      "query": "Is Peninsula Hot Springs overrated",
+      "ok": true,
+      "latency_ms": 18603,
+      "server_latency_ms": 18552,
+      "timings": null,
+      "cost_aud": 0.025241,
+      "recommendations_count": 3,
+      "recommendation_kinds": [
+        "venue"
+      ],
+      "sources_count": 5,
+      "topic_hits": [
+        "peninsula hot springs",
+        "alba",
+        "crowd"
+      ],
+      "kind_hits": [
+        "venue"
+      ],
+      "forbidden_hits": [],
+      "quality": {
+        "score": 5,
+        "max": 5,
+        "reasons": []
+      }
+    }
+  ]
+}

--- a/reports/insider-eval/baseline-2026-05-02.md
+++ b/reports/insider-eval/baseline-2026-05-02.md
@@ -1,0 +1,45 @@
+# Insider eval — baseline · 2026-05-02
+
+API: https://peninsula-insider-platform-api.vercel.app
+
+## Summary
+- Queries: 30 · errors: 0
+- Median latency: **17.09s** · p95: 22.84s
+- Median server latency: 16.93s
+- Median quality: **5/5** (mean 4.77)
+- Quality distribution: 4:7, 5:23
+- Total cost: $0.7187 AUD
+
+## Per-query results
+| ID | Query | Latency | Quality | Recs | Issues |
+|---|---|---:|:---:|:---:|---|
+| long-lunch-red-hill | Best long lunch on the Red Hill ridge for a Saturday | 22.95s | 4/5 | 4 | no expected topic matched (looked for: montalto, ten minutes by tractor, polperro) |
+| cellar-door-walk-in | Walk-in cellar door tasting on the Peninsula, no booking | 19.10s | 4/5 | 2 | no expected topic matched (looked for: montalto piazza, foxeys, rare hare) |
+| rainy-day-kids-rye | Rainy Sunday with two kids, near Rye | 18.35s | 5/5 | 2 | — |
+| sorrento-weekend-couple | Plan a Sorrento weekend for a couple | 16.19s | 5/5 | 2 | — |
+| anniversary-dinner-view | Anniversary dinner Friday night, somewhere with a view | 18.83s | 5/5 | 4 | — |
+| dog-friendly-cafe | Dog friendly cafe on the Peninsula | 17.06s | 5/5 | 3 | — |
+| best-walk-cape-schanck | Best coastal walks near Cape Schanck | 13.41s | 5/5 | 1 | — |
+| hatted-restaurants | Hatted restaurants worth booking in advance | 18.74s | 5/5 | 3 | — |
+| where-to-stay-red-hill | Where should we stay near Red Hill cellar doors | 15.38s | 5/5 | 3 | — |
+| one-night-near-sorrento | One night away, couple, near Sorrento | 17.11s | 5/5 | 3 | — |
+| winery-with-kids | Cellar door open Sunday with kids | 19.59s | 5/5 | 4 | — |
+| winery-tour-day-trip | Winery tour day trip from Melbourne | 18.82s | 5/5 | 2 | — |
+| best-seafood | Where do locals go for seafood on the Peninsula | 15.77s | 5/5 | 3 | — |
+| best-bakery | Best bakery for breakfast on the Peninsula | 16.00s | 5/5 | 4 | — |
+| thermal-springs-quiet | Thermal springs without the crowds | 18.32s | 5/5 | 2 | — |
+| long-weekend-three-days | Three day Peninsula trip, April long weekend, food and wine | 21.60s | 4/5 | 4 | no expected kind matched (got: venue) |
+| rye-front-beach | What is there to do at Rye front beach | 13.34s | 5/5 | 2 | — |
+| winter-weekend-fireplace | Winter weekend with a fireplace and a wine list | 16.92s | 5/5 | 3 | — |
+| where-to-eat-sorrento | Where to eat in Sorrento on a Saturday night | 14.05s | 5/5 | 2 | — |
+| flinders-day | How to spend a day in Flinders | 21.00s | 5/5 | 2 | — |
+| no-driving-after-lunch | Long lunch without too much driving back | 22.84s | 4/5 | 3 | no expected topic matched (looked for: foxeys, many little, polperro) |
+| afternoon-pinot-tasting | Afternoon pinot tasting with serious producers | 18.76s | 5/5 | 4 | — |
+| bushrangers-bay | How long is the Bushrangers Bay walk | 16.33s | 4/5 | 3 | no expected kind matched (got: article) |
+| wedding-venue-winery | Winery wedding venues on the Peninsula | 17.77s | 4/5 | 3 | no expected topic matched (looked for: polperro, lindenderry, montalto) |
+| art-gallery | Best art gallery on the Peninsula | 15.75s | 4/5 | 0 | no expected kind matched (got: none) |
+| weekend-this-weekend | What is on this weekend on the Peninsula | 16.59s | 5/5 | 4 | — |
+| kids-thing-to-do | Something to do with two kids in school holidays | 15.31s | 5/5 | 2 | — |
+| cellar-door-views | Cellar door with the best view | 16.89s | 5/5 | 4 | — |
+| balnarring-village | Is Balnarring worth a visit | 16.94s | 5/5 | 3 | — |
+| negative-overrated | Is Peninsula Hot Springs overrated | 18.60s | 5/5 | 3 | — |


### PR DESCRIPTION
Honest write-up of the latency pass. Backend latency is dominated by Sonnet 4.5 generation; the levers that move it materially are documented (DB indexes, Vercel region, Haiku flip, Voyage embeddings).