### PR TITLE
feat(audience): persona picker, first ship on /eat/

### DIFF
--- a/next/src/components/AudiencePicker.astro
+++ b/next/src/components/AudiencePicker.astro
@@ -1,0 +1,208 @@
+---
+/**
+ * AudiencePicker — primary discovery surface, persona-grid style.
+ *
+ * Sits at the top of section hubs (between hero and the first content
+ * block). Eight personas, each tile linking to the section-specific
+ * destination defined in src/lib/audiencePersonas.ts. When rendered on
+ * a section hub the picker resolves per-section routes; when rendered
+ * on the homepage the picker uses each persona's `default` route.
+ *
+ * Visual DNA matches InsiderAsk: editorial eyebrow, Cormorant heading,
+ * pill-shaped tiles in a 4-up desktop / 2-up mobile grid.
+ */
+
+import {
+  audiencePersonas,
+  personaRoute,
+  type SectionKey,
+} from '../lib/audiencePersonas';
+
+export interface Props {
+  /** Section the picker is being rendered on. Drives per-tile URL resolution. */
+  section?: SectionKey;
+  /** Eyebrow above the heading. */
+  eyebrow?: string;
+  /** Headline shown above the grid. */
+  heading?: string;
+  /** Editorial framing line under the heading. */
+  framing?: string;
+}
+
+const {
+  section,
+  eyebrow = 'Find your shape of weekend',
+  heading = 'What kind of visit are you planning?',
+  framing = "Eight ways into the Peninsula. Pick the one that fits and we'll surface the right pages first.",
+} = Astro.props;
+
+const tiles = audiencePersonas.map((p) => ({
+  ...p,
+  href: personaRoute(p, section),
+}));
+---
+
+<section class="audience-picker" aria-label="Pick your visit type">
+  <div class="container">
+    <div class="audience-picker__head">
+      <p class="audience-picker__eyebrow">{eyebrow}</p>
+      <h2 class="audience-picker__heading">{heading}</h2>
+      <p class="audience-picker__framing">{framing}</p>
+    </div>
+
+    <ul class="audience-picker__grid" role="list">
+      {tiles.map((tile) => (
+        <li class="audience-picker__tile-wrap">
+          <a href={tile.href} class="audience-picker__tile" data-persona={tile.slug}>
+            <span class="audience-picker__mark" aria-hidden="true">{tile.mark}</span>
+            <span class="audience-picker__label">{tile.label}</span>
+            <span class="audience-picker__dek">{tile.dek}</span>
+            <span class="audience-picker__arrow" aria-hidden="true">&rarr;</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .audience-picker {
+    background: var(--bg-alt);
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    padding: clamp(2.5rem, 5vw, 4rem) 0;
+  }
+
+  .audience-picker__head {
+    max-width: 720px;
+    margin: 0 auto 2rem;
+    text-align: center;
+  }
+
+  .audience-picker__eyebrow {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.6rem;
+  }
+
+  .audience-picker__heading {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(1.7rem, 3.6vw, 2.4rem);
+    font-weight: 500;
+    line-height: 1.15;
+    color: var(--text);
+    margin: 0 0 0.6rem;
+    letter-spacing: -0.015em;
+  }
+
+  .audience-picker__framing {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--soft);
+    margin: 0 auto;
+    max-width: 60ch;
+  }
+
+  .audience-picker__grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .audience-picker__tile-wrap { display: flex; }
+
+  .audience-picker__tile {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 1.1rem 1.1rem 1.2rem;
+    background: var(--white);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    text-decoration: none;
+    color: var(--text);
+    transition:
+      border-color 0.15s ease,
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .audience-picker__tile:hover,
+  .audience-picker__tile:focus-visible {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px -16px rgba(0, 0, 0, 0.18);
+    outline: none;
+  }
+
+  .audience-picker__mark {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    color: var(--accent);
+    line-height: 1;
+    margin-bottom: 0.6rem;
+  }
+
+  .audience-picker__label {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.2rem;
+    font-weight: 500;
+    line-height: 1.2;
+    color: var(--text);
+    margin: 0 0 0.35rem;
+    letter-spacing: -0.01em;
+  }
+
+  .audience-picker__dek {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.84rem;
+    line-height: 1.45;
+    color: var(--soft);
+    margin: 0;
+    flex: 1;
+  }
+
+  .audience-picker__arrow {
+    align-self: flex-end;
+    margin-top: 0.8rem;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    color: var(--accent);
+    opacity: 0.7;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  .audience-picker__tile:hover .audience-picker__arrow,
+  .audience-picker__tile:focus-visible .audience-picker__arrow {
+    opacity: 1;
+    transform: translateX(2px);
+  }
+
+  @media (max-width: 960px) {
+    .audience-picker__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 720px) {
+    .audience-picker__grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .audience-picker__head { text-align: left; }
+  }
+
+  @media (max-width: 420px) {
+    .audience-picker__tile { padding: 0.95rem; }
+    .audience-picker__label { font-size: 1.1rem; }
+    .audience-picker__dek { font-size: 0.8rem; }
+  }
+</style>

--- a/next/src/lib/audiencePersonas.ts
+++ b/next/src/lib/audiencePersonas.ts
@@ -1,0 +1,164 @@
+/**
+ * Audience persona registry — drives the AudiencePicker component.
+ *
+ * Each persona maps to a section-specific destination URL when one exists,
+ * and falls back to a cross-section default when it does not. Section keys
+ * match the masthead nav lanes: eat, stay, wine, explore, escape, fishing,
+ * boating. Adding a new persona or a new per-section route is the only
+ * place you should need to touch.
+ *
+ * All routes verified present in the Astro page tree on 2026-05-03.
+ */
+
+export type SectionKey =
+  | 'home'
+  | 'eat'
+  | 'stay'
+  | 'wine'
+  | 'explore'
+  | 'escape'
+  | 'fishing'
+  | 'boating';
+
+export interface AudiencePersona {
+  /** Stable id used in URLs and analytics. */
+  slug: string;
+  /** Tile title — short noun phrase, two words ideal. */
+  label: string;
+  /** Editorial dek under the label. One line. */
+  dek: string;
+  /** Single-character mark (✦ ◆ ◯ ○ etc) shown top-left of the tile. */
+  mark: string;
+  /**
+   * Per-section destination map. `default` is used when the current section
+   * does not have a tailored route, or when the picker is rendered outside
+   * any section (e.g. homepage).
+   */
+  routes: Partial<Record<SectionKey, string>> & { default: string };
+}
+
+export const audiencePersonas: AudiencePersona[] = [
+  {
+    slug: 'couples-weekend',
+    label: 'Couples weekend',
+    dek: 'Long lunches, slow stays, no schedules.',
+    mark: '◆',
+    routes: {
+      eat: '/eat/date-night/',
+      stay: '/stay/couples/',
+      wine: '/wine/best-cellar-doors/',
+      explore: '/explore/spas-and-wellness/',
+      escape: '/escape/mornington-peninsula-itinerary/',
+      default: '/escape/mornington-peninsula-itinerary/',
+    },
+  },
+  {
+    slug: 'family-with-kids',
+    label: 'Family with kids',
+    dek: 'Rooms that welcome them, days that hold them.',
+    mark: '✦',
+    routes: {
+      eat: '/eat/family-friendly/',
+      stay: '/stay/cottages/',
+      wine: '/explore/family-friendly/',
+      explore: '/explore/family-friendly/',
+      escape: '/explore/family-friendly/',
+      default: '/explore/family-friendly/',
+    },
+  },
+  {
+    slug: 'long-lunch',
+    label: 'Long lunch',
+    dek: 'Three-hour tables, hatted kitchens, vineyard fires.',
+    mark: '◯',
+    routes: {
+      eat: '/eat/hatted-restaurants/',
+      stay: '/stay/winery-accommodation/',
+      wine: '/wine/best-cellar-doors/',
+      explore: '/eat/long-lunch/',
+      escape: '/eat/hatted-restaurants/',
+      default: '/eat/hatted-restaurants/',
+    },
+  },
+  {
+    slug: 'wine-curious',
+    label: 'Wine curious',
+    dek: 'Cellar doors picked by what the wine actually does.',
+    mark: '◇',
+    routes: {
+      eat: '/eat/cellar-door-lunch/',
+      stay: '/stay/winery-accommodation/',
+      wine: '/wine/best-cellar-doors/',
+      explore: '/wine/best-cellar-doors/',
+      escape: '/wine/best-cellar-doors/',
+      default: '/wine/best-cellar-doors/',
+    },
+  },
+  {
+    slug: 'wellness-reset',
+    label: 'Wellness reset',
+    dek: 'Hot springs, walks that go the long way, slow rooms.',
+    mark: '○',
+    routes: {
+      eat: '/eat/long-lunch/',
+      stay: '/stay/wellness-retreats/',
+      wine: '/explore/spas-and-wellness/',
+      explore: '/explore/spas-and-wellness/',
+      escape: '/explore/spas-and-wellness/',
+      default: '/explore/spas-and-wellness/',
+    },
+  },
+  {
+    slug: 'dog-days',
+    label: 'Bring the dog',
+    dek: 'Tables, beaches, and rooms where dogs sit at the foot.',
+    mark: '◐',
+    routes: {
+      eat: '/eat/dog-friendly/',
+      stay: '/stay/dog-friendly/',
+      wine: '/wine/dog-friendly/',
+      explore: '/dog-friendly/',
+      escape: '/dog-friendly/',
+      default: '/dog-friendly/',
+    },
+  },
+  {
+    slug: 'big-group',
+    label: 'Big group, corporate',
+    dek: 'Tables of twelve, villas that sleep ten, retreats that book.',
+    mark: '◑',
+    routes: {
+      eat: '/eat/long-lunch/',
+      stay: '/stay/villas/',
+      wine: '/wine/best-cellar-doors/',
+      explore: '/corporate-events/',
+      escape: '/corporate-events/',
+      default: '/corporate-events/',
+    },
+  },
+  {
+    slug: 'first-time',
+    label: 'First-time visitor',
+    dek: "If it's your first weekend on the Peninsula, start here.",
+    mark: '✚',
+    routes: {
+      eat: '/eat/best-restaurants/',
+      stay: '/stay/where-to-stay-mornington-peninsula/',
+      wine: '/wine/best-wineries-mornington-peninsula/',
+      explore: '/escape/mornington-peninsula-itinerary/',
+      escape: '/escape/mornington-peninsula-itinerary/',
+      default: '/escape/mornington-peninsula-itinerary/',
+    },
+  },
+];
+
+/** Resolve a persona's destination URL for the current section. */
+export function personaRoute(
+  persona: AudiencePersona,
+  section: SectionKey | undefined,
+): string {
+  if (section && persona.routes[section]) {
+    return persona.routes[section] as string;
+  }
+  return persona.routes.default;
+}

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import GuideHero from '../../components/GuideHero.astro';
+import AudiencePicker from '../../components/AudiencePicker.astro';
 import CompareBlock from '../../components/CompareBlock.astro';
 import SectionDivider from '../../components/SectionDivider.astro';
 import VenueCard from '../../components/VenueCard.astro';
@@ -134,6 +135,11 @@ const faqSchema = {
     imageAlt="An Italian-leaning Peninsula dining room, table laid, light low"
     imageCredit="Peninsula Insider"
   />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1.5 AUDIENCE PICKER: persona-led entry to the section
+       ═══════════════════════════════════════════════════════════════ -->
+  <AudiencePicker section="eat" />
 
   <!-- ═══════════════════════════════════════════════════════════════
        2. ORIENTATION: Red Hill plateau vs Bay corridor


### PR DESCRIPTION
## Summary
- Adds a Destination-Vancouver-style persona picker to the top of section hubs, surfacing audience axes that already live in PI's venue/itinerary schema.
- Eight personas (Couples weekend, Family with kids, Long lunch, Wine curious, Wellness reset, Bring the dog, Big group/corporate, First-time visitor), each section-aware: tiles on /eat/ point at /eat/date-night/, on /stay/ they'll point at /stay/couples/, etc.
- First ship on /eat/ as proof of concept. Rollout plan after merge: /stay/, /wine/, /explore/, /escape/, /fishing/, /boating/ (one PR each, or one bundle if happy with the eat result).

## Files
- `next/src/lib/audiencePersonas.ts` — single source of truth, 8 personas × 5 section routes each
- `next/src/components/AudiencePicker.astro` — section-aware grid component, 4-up desktop / 3-up tablet / 2-up mobile
- `next/src/pages/eat/index.astro` — wired between GuideHero and CompareBlock (first-fold scroll)

## Test plan
- [x] Local build succeeds (1028 pages)
- [x] All 22 destination URLs verified against page tree
- [x] `dist/eat/index.html` contains all 8 persona tiles routing to eat-flavoured URLs
- [ ] After merge: verify on https://peninsulainsider.com.au/eat/

🤖 Generated with [Claude Code](https://claude.com/claude-code)