### PR TITLE
feat(search): site search — pill, instant overlay, polished /search page

### DIFF
--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -109,6 +109,20 @@ const {
             ))}
           </ul>
         </nav>
+        <button
+          type="button"
+          class="masthead__search-pill"
+          data-open-search
+          aria-label="Search Peninsula Insider"
+          aria-haspopup="dialog"
+          aria-controls="siteSearchOverlay"
+        >
+          <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="9" r="6" />
+            <path d="M14 14l4 4" />
+          </svg>
+          <span class="masthead__search-pill-label">Search</span>
+        </button>
         <a href="/newsletter/" class="masthead__cta">Subscribe</a>
         <a href="/newsletter/" class="masthead__cta-mobile" aria-label="Subscribe to the newsletter">Subscribe</a>
       </div>

--- a/next/src/components/SearchOverlay.astro
+++ b/next/src/components/SearchOverlay.astro
@@ -1,0 +1,280 @@
+---
+/**
+ * SearchOverlay — instant search modal
+ *
+ * Triggered by any element with [data-open-search] (the masthead pill,
+ * mobile-nav search row, etc). Opens a centered modal with a Pagefind-
+ * powered live search. Hitting Enter or clicking "See all results" navigates
+ * to /search?q=<query> for the full results page experience.
+ *
+ * Pagefind is dynamically imported on first open so the overlay carries no
+ * JS cost on pages where it's never shown. Index file lives at
+ * `/pagefind/pagefind.js` (built by `npm run build:search`).
+ *
+ * Mirrors ConciergeDrawer's lifecycle pattern: lazy-init, ESC to close,
+ * focus-trap on the input, body scroll-lock while open.
+ */
+---
+
+<div
+  id="siteSearchOverlay"
+  class="site-search-overlay"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="siteSearchOverlayTitle"
+  aria-hidden="true"
+  hidden
+>
+  <div class="site-search-overlay__backdrop" data-close-search aria-hidden="true"></div>
+
+  <div class="site-search-overlay__panel" role="document">
+    <header class="site-search-overlay__header">
+      <span id="siteSearchOverlayTitle" class="site-search-overlay__eyebrow">Search Peninsula Insider</span>
+      <button
+        type="button"
+        class="site-search-overlay__close"
+        data-close-search
+        aria-label="Close search"
+      >
+        <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M5 5l10 10M15 5L5 15" />
+        </svg>
+      </button>
+    </header>
+
+    <form class="site-search-overlay__form" id="siteSearchOverlayForm" autocomplete="off">
+      <span class="site-search-overlay__icon" aria-hidden="true">
+        <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="9" cy="9" r="6" />
+          <path d="M14 14l4 4" />
+        </svg>
+      </span>
+      <input
+        type="search"
+        id="siteSearchOverlayInput"
+        class="site-search-overlay__input"
+        placeholder="Try Red Hill, long lunch, family beach, Sorrento stay…"
+        aria-label="Search query"
+      />
+      <kbd class="site-search-overlay__kbd" aria-hidden="true">esc</kbd>
+    </form>
+
+    <div class="site-search-overlay__hint">
+      <p>Press <kbd>Enter</kbd> to see all results, or pick a suggestion.</p>
+    </div>
+
+    <div class="site-search-overlay__body" id="siteSearchOverlayBody">
+      <div class="site-search-overlay__suggestions" data-default-suggestions>
+        <p class="site-search-overlay__suggestions-label">Try one of these</p>
+        <div class="site-search-overlay__chips">
+          <a href="/search/?q=long+lunch" class="pi-chip"><span class="pi-chip__bullet" aria-hidden="true">♦</span><span>Long lunch</span></a>
+          <a href="/search/?q=cellar+door" class="pi-chip"><span class="pi-chip__bullet" aria-hidden="true">♦</span><span>Cellar doors</span></a>
+          <a href="/search/?q=rainy+day" class="pi-chip"><span class="pi-chip__bullet" aria-hidden="true">♦</span><span>Rainy day</span></a>
+          <a href="/search/?q=Sorrento" class="pi-chip"><span class="pi-chip__bullet" aria-hidden="true">♦</span><span>Sorrento</span></a>
+          <a href="/search/?q=Red+Hill" class="pi-chip"><span class="pi-chip__bullet" aria-hidden="true">♦</span><span>Red Hill</span></a>
+          <a href="/search/?q=family+beach" class="pi-chip"><span class="pi-chip__bullet" aria-hidden="true">♦</span><span>Family beach</span></a>
+        </div>
+      </div>
+
+      <ul class="site-search-overlay__results" id="siteSearchOverlayResults" role="listbox" aria-label="Search suggestions" hidden></ul>
+
+      <a class="site-search-overlay__cta" id="siteSearchOverlayCTA" href="/search/" hidden>
+        <span>See all results</span>
+        <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M5 10h10M11 5l5 5-5 5" />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  (function () {
+    const overlay = document.getElementById('siteSearchOverlay');
+    if (!overlay) return;
+
+    const form = document.getElementById('siteSearchOverlayForm');
+    const input = document.getElementById('siteSearchOverlayInput');
+    const list = document.getElementById('siteSearchOverlayResults');
+    const cta = document.getElementById('siteSearchOverlayCTA');
+    const suggestions = overlay.querySelector('[data-default-suggestions]');
+
+    let pagefindModule = null;
+    let searchToken = 0;
+    let lastQuery = '';
+    let initialised = false;
+
+    function escapeHtml(value) {
+      return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    }
+
+    async function loadPagefind() {
+      if (pagefindModule) return pagefindModule;
+      // Pagefind is built into /pagefind/ on the production site by
+      // `npm run build:search`. The static path means no bundler can know
+      // about it, so we ignore the dev-server module-resolution warning.
+      pagefindModule = await import(/* @vite-ignore */ '/pagefind/pagefind.js');
+      // Initialise — set the index path explicitly so client-side routing
+      // doesn't break the relative resolution.
+      try { await pagefindModule.options({ basePath: '/pagefind/' }); } catch (_e) {}
+      return pagefindModule;
+    }
+
+    function open() {
+      if (overlay.dataset.open === 'true') return;
+      overlay.dataset.open = 'true';
+      overlay.hidden = false;
+      overlay.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('search-open');
+      // Defer focus so the open animation has room to land.
+      setTimeout(() => input && input.focus(), 50);
+
+      // Lazy init on first open — Pagefind WASM is ~80kb so we don't
+      // want it loading on every page just in case.
+      if (!initialised) {
+        initialised = true;
+        loadPagefind().catch((err) => console.warn('[search] Pagefind failed to init:', err));
+      }
+    }
+
+    function close() {
+      if (overlay.dataset.open !== 'true') return;
+      overlay.dataset.open = 'false';
+      overlay.hidden = true;
+      overlay.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('search-open');
+    }
+
+    function showSuggestions() {
+      if (suggestions) suggestions.hidden = false;
+      if (list) list.hidden = true;
+      if (cta) cta.hidden = true;
+    }
+
+    function showResults(results, query) {
+      if (suggestions) suggestions.hidden = true;
+      if (list) {
+        list.hidden = false;
+        if (results.length === 0) {
+          list.innerHTML = `
+            <li class="site-search-overlay__result site-search-overlay__result--empty">
+              <p class="site-search-overlay__result-empty-title">Nothing matched "${escapeHtml(query)}".</p>
+              <p class="site-search-overlay__result-empty-hint">Hit Enter to try the full results page, or ask The Insider directly.</p>
+            </li>
+          `;
+        } else {
+          list.innerHTML = results
+            .slice(0, 6)
+            .map((item) => {
+              const kind = item.meta?.kind || item.filters?.kind?.[0] || 'Guide';
+              const title = item.meta?.title || 'Untitled';
+              const excerpt = item.excerpt || '';
+              return `
+                <li class="site-search-overlay__result">
+                  <a href="${escapeHtml(item.url)}" class="site-search-overlay__result-link">
+                    <span class="site-search-overlay__result-kind">${escapeHtml(kind)}</span>
+                    <span class="site-search-overlay__result-title">${escapeHtml(title)}</span>
+                    <span class="site-search-overlay__result-excerpt">${excerpt}</span>
+                  </a>
+                </li>
+              `;
+            })
+            .join('');
+        }
+      }
+      if (cta) {
+        cta.hidden = false;
+        cta.href = `/search/?q=${encodeURIComponent(query)}`;
+        cta.querySelector('span').textContent = results.length === 0
+          ? 'Try the full results page'
+          : `See all ${results.length === 1 ? '1 result' : results.length + ' results'}`;
+      }
+    }
+
+    async function runSearch(query) {
+      const q = (query || '').trim();
+      if (!q) {
+        lastQuery = '';
+        showSuggestions();
+        return;
+      }
+      lastQuery = q;
+      const myToken = ++searchToken;
+      try {
+        const pf = await loadPagefind();
+        if (myToken !== searchToken) return; // newer query came in
+        const result = await pf.search(q, { limit: 6 });
+        if (myToken !== searchToken) return;
+        const data = await Promise.all(result.results.map((r) => r.data()));
+        if (myToken !== searchToken) return;
+        showResults(data, q);
+      } catch (err) {
+        console.warn('[search] error', err);
+        if (myToken === searchToken && cta) {
+          cta.hidden = false;
+          cta.href = `/search/?q=${encodeURIComponent(q)}`;
+        }
+      }
+    }
+
+    let inputDebounce = null;
+    input?.addEventListener('input', () => {
+      clearTimeout(inputDebounce);
+      const q = input.value;
+      inputDebounce = setTimeout(() => runSearch(q), 80);
+    });
+
+    form?.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const q = (input?.value || '').trim();
+      if (!q) return;
+      window.location.href = `/search/?q=${encodeURIComponent(q)}`;
+    });
+
+    // Wire up triggers
+    document.addEventListener('click', (e) => {
+      const trigger = e.target.closest('[data-open-search]');
+      if (trigger) {
+        e.preventDefault();
+        open();
+        return;
+      }
+      const closer = e.target.closest('[data-close-search]');
+      if (closer) {
+        e.preventDefault();
+        close();
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      // ESC closes the overlay
+      if (e.key === 'Escape' && overlay.dataset.open === 'true') {
+        close();
+        return;
+      }
+      // Slash key focuses search (industry standard, e.g. GitHub, GitLab,
+      // Stripe). Ignore when the user is typing in another input.
+      if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const tag = (e.target?.tagName || '').toLowerCase();
+        const editable = tag === 'input' || tag === 'textarea' || e.target?.isContentEditable;
+        if (!editable) {
+          e.preventDefault();
+          open();
+        }
+      }
+    });
+
+    // Reset on view-transition page swaps
+    document.addEventListener('astro:page-load', () => {
+      close();
+      if (input) input.value = '';
+      lastQuery = '';
+      showSuggestions();
+    });
+  })();
+</script>

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -9,12 +9,14 @@
 
 import '../styles/global.css';
 import '../styles/concierge.css';   // chat & drawer styles, loaded on every page
+import '../styles/search.css';      // site-search overlay + /search page styles
 import { ClientRouter } from 'astro:transitions';
 import Masthead from '../components/Masthead.astro';
 // UtilityBar removed, its content is now integrated into Masthead's
 // utility row. Keeping this comment as a breadcrumb for the migration.
 import Footer from '../components/Footer.astro';
 import ConciergeDrawer from '../components/ConciergeDrawer.astro';
+import SearchOverlay from '../components/SearchOverlay.astro';
 import AuthModal from '../components/v2/AuthModal.astro';
 import ProfileDropdown from '../components/v2/ProfileDropdown.astro';
 
@@ -29,6 +31,10 @@ export interface Props {
   noindex?: boolean;
   publishedTime?: string;
   modifiedTime?: string;
+  /** Override the search-result chip label. Defaults to a label derived from section. */
+  searchKind?: string;
+  /** Exclude this page from the Pagefind index entirely (e.g. /search itself). */
+  searchExclude?: boolean;
 }
 
 const SITE_URL = 'https://peninsulainsider.com.au';
@@ -44,7 +50,24 @@ const {
   noindex = false,
   publishedTime,
   modifiedTime,
+  searchKind,
+  searchExclude = false,
 } = Astro.props;
+
+// Map the editorial section to a search-chip label. Reader-facing strings —
+// these populate the "kind" filter chips on /search.
+const SECTION_TO_SEARCH_KIND: Record<string, string> = {
+  home: 'Home',
+  eat: 'Eat',
+  stay: 'Stay',
+  wine: 'Wine',
+  explore: 'Explore',
+  journal: 'Journal',
+  places: 'Places',
+  escape: 'Escape',
+  'whats-on': "What's On",
+};
+const resolvedSearchKind = searchKind ?? SECTION_TO_SEARCH_KIND[section] ?? 'Guide';
 
 // Canonical: use explicit prop if provided, otherwise derive from current URL pathname.
 // Strip any /V2/ base prefix so canonicals always point at the production root.
@@ -129,7 +152,18 @@ const isAskPage = rawPathname.startsWith('/ask');
 
   <Masthead section={section} />
 
-  <main>
+  {/* data-pagefind-body scopes the index to <main>, so the masthead, footer,
+      concierge drawer, and search overlay aren't indexed.
+      data-pagefind-filter populates the "kind" facet on /search.
+      data-pagefind-meta makes the same value available on each result card
+      so the UI can render the type eyebrow without a second lookup.
+      data-pagefind-ignore opts the page out of the search index entirely. */}
+  <main
+    data-pagefind-body={searchExclude ? undefined : ''}
+    data-pagefind-filter={searchExclude ? undefined : `kind:${resolvedSearchKind}`}
+    data-pagefind-meta={searchExclude ? undefined : `kind:${resolvedSearchKind}`}
+    data-pagefind-ignore={searchExclude ? '' : undefined}
+  >
     <slot />
   </main>
 
@@ -150,6 +184,10 @@ const isAskPage = rawPathname.startsWith('/ask');
   <!-- PI concierge drawer, slides in from the right edge.
        Suppressed on /ask itself (which is the full-page version). -->
   {!isAskPage && <ConciergeDrawer />}
+
+  <!-- Site search overlay — instant Pagefind dropdown, opened by any
+       [data-open-search] trigger or the `/` keyboard shortcut. -->
+  <SearchOverlay />
 
   <!-- Sticky Subscribe pill, fades in once the reader passes the 50%
        scroll mark. Mobile-only. Hidden on /newsletter, /ask, /account

--- a/next/src/pages/search.astro
+++ b/next/src/pages/search.astro
@@ -1,4 +1,19 @@
 ---
+/**
+ * /search — Peninsula Insider site search
+ *
+ * Pagefind-powered search results page. Supports:
+ *   - ?q=<query> deep-link (auto-focus + auto-run on load)
+ *   - "kind" facet chips (All / Eat / Stay / Wine / Explore / Escape /
+ *     What's On / Journal / Places) wired to Pagefind filters
+ *   - Card results with hero image, kind eyebrow, title, excerpt
+ *   - Pagination (12 cards per page)
+ *   - Empty / no-result states with PI-voiced "ask The Insider" fallback
+ *   - noindex (the search results page itself shouldn't be Google-indexed)
+ *
+ * Pagefind's index is built by `npm run build:search` and lives at
+ * `/pagefind/`. The page is fully static; all search runs in the browser.
+ */
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 
@@ -6,95 +21,401 @@ const breadcrumbItems = [
   { label: 'Home', href: '/' },
   { label: 'Search' },
 ];
+
+// All possible filter chips. "All" is the default; the rest mirror the
+// labels emitted by BaseLayout via data-pagefind-filter="kind:<Label>".
+const KIND_CHIPS = [
+  { value: 'all',        label: 'All' },
+  { value: 'Eat',        label: 'Eat & Drink' },
+  { value: 'Stay',       label: 'Stay' },
+  { value: 'Wine',       label: 'Wine' },
+  { value: 'Explore',    label: 'Explore' },
+  { value: 'Escape',     label: 'Escape' },
+  { value: "What's On",  label: "What's On" },
+  { value: 'Journal',    label: 'Journal' },
+  { value: 'Places',     label: 'Places' },
+];
 ---
 
 <BaseLayout
-  title="Search | Peninsula Insider"
+  title="Search · Peninsula Insider"
   description="Search Peninsula Insider for places, stays, long lunches, beaches, itineraries, events, and local intelligence across the Mornington Peninsula."
   section="home"
+  noindex={true}
+  searchExclude={true}
 >
   <Breadcrumbs items={breadcrumbItems} />
 
-  <section class="search-page">
-    <div class="container search-page__inner">
-      <div class="search-page__header">
-        <p class="label label--accent">Search</p>
-        <h1 class="search-page__title">Search the Peninsula</h1>
-        <p class="search-page__intro">Find places, long lunches, stays, beaches, itineraries, events, and journal pieces across Peninsula Insider.</p>
-      </div>
+  <main class="search-page-v2">
 
-      <div class="search-page__box">
-        <label class="search-page__label" for="site-search">Search the guide</label>
-        <input id="site-search" class="search-page__input" type="search" placeholder="Try Red Hill, long lunch, family beach, Sorrento stay..." autocomplete="off" />
-        <p class="search-page__hint">Search works across articles, venue pages, place guides, itineraries, experiences, and events.</p>
-      </div>
+    <section class="search-page-v2__hero">
+      <div class="container">
+        <p class="search-page-v2__eyebrow">Peninsula Insider · Search</p>
+        <h1 class="search-page-v2__title">Search the Peninsula</h1>
 
-      <div id="search-results" class="search-page__results" aria-live="polite"></div>
-    </div>
-  </section>
+        <form class="search-page-v2__bar" id="searchPageForm" autocomplete="off" role="search" aria-label="Search Peninsula Insider">
+          <span class="search-page-v2__bar-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="9" cy="9" r="6" />
+              <path d="M14 14l4 4" />
+            </svg>
+          </span>
+          <input
+            type="search"
+            id="searchPageInput"
+            class="search-page-v2__input"
+            placeholder="Search Peninsula Insider…"
+            aria-label="Search query"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <button type="submit" class="search-page-v2__submit" aria-label="Search">
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="9" cy="9" r="6" />
+              <path d="M14 14l4 4" />
+            </svg>
+          </button>
+        </form>
+      </div>
+    </section>
+
+    <section class="search-page-v2__filters" aria-label="Result filters">
+      <div class="container">
+        <div class="search-page-v2__chips" role="tablist">
+          {KIND_CHIPS.map((chip, i) => (
+            <button
+              type="button"
+              class="search-page-v2__chip"
+              data-kind={chip.value}
+              role="tab"
+              aria-selected={i === 0 ? 'true' : 'false'}
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section class="search-page-v2__results-section">
+      <div class="container">
+        <div class="search-page-v2__results-header">
+          <p class="search-page-v2__results-meta" id="searchResultsMeta" aria-live="polite">Start typing to search.</p>
+        </div>
+
+        <div class="search-page-v2__results" id="searchResultsList" aria-live="polite"></div>
+
+        <nav class="search-page-v2__pagination" id="searchPagination" aria-label="Result pages" hidden></nav>
+      </div>
+    </section>
+
+    <section class="search-page-v2__fallback" id="searchFallback" hidden>
+      <div class="container">
+        <div class="search-page-v2__fallback-card">
+          <p class="search-page-v2__fallback-eyebrow">Didn't find it?</p>
+          <h2 class="search-page-v2__fallback-title">The Insider can take a guess.</h2>
+          <p class="search-page-v2__fallback-body">Search is keyword-strict. The Insider is opinionated, semantic, and happy to interpret. Try the same question over there.</p>
+          <button type="button" class="search-page-v2__fallback-cta" id="searchFallbackCTA" data-pi-trigger="true">
+            <span>Ask The Insider</span>
+            <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M5 10h10M11 5l5 5-5 5" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </section>
+
+  </main>
 
   <script is:inline>
-    let pagefindInstance;
-    const input = document.getElementById('site-search');
-    const results = document.getElementById('search-results');
+    (function () {
+      const form = document.getElementById('searchPageForm');
+      const input = document.getElementById('searchPageInput');
+      const list = document.getElementById('searchResultsList');
+      const meta = document.getElementById('searchResultsMeta');
+      const pagination = document.getElementById('searchPagination');
+      const fallback = document.getElementById('searchFallback');
+      const fallbackCTA = document.getElementById('searchFallbackCTA');
+      const chips = Array.from(document.querySelectorAll('.search-page-v2__chip'));
 
-    function escapeHtml(value) {
-      return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-    }
+      const PER_PAGE = 12;
+      let pagefindModule = null;
+      let currentResults = [];   // raw Pagefind result handles (lazy .data())
+      let currentDataPage = new Map(); // pageNum -> array of resolved data
+      let currentQuery = '';
+      let currentKind = 'all';
+      let currentPage = 1;
+      let searchToken = 0;
 
-    async function loadPagefind() {
-      if (pagefindInstance) return pagefindInstance;
-      pagefindInstance = await import('/pagefind/pagefind.js');
-      return pagefindInstance;
-    }
-
-    function renderEmpty(state) {
-      if (state === 'idle') {
-        results.innerHTML = '<div class="search-state"><p>Start typing to search the guide.</p></div>';
-        return;
-      }
-      if (state === 'none') {
-        results.innerHTML = '<div class="search-state"><p>No results yet. Try a town, mood, or trip type.</p></div>';
-      }
-    }
-
-    async function runSearch(query) {
-      const q = query.trim();
-      if (!q) {
-        renderEmpty('idle');
-        return;
+      function escapeHtml(value) {
+        return String(value || '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#039;');
       }
 
-      results.innerHTML = '<div class="search-state"><p>Searching…</p></div>';
-      const { search } = await loadPagefind();
-      const searchResult = await search(q, { limit: 12 });
-
-      if (!searchResult.results.length) {
-        renderEmpty('none');
-        return;
+      async function loadPagefind() {
+        if (pagefindModule) return pagefindModule;
+        pagefindModule = await import(/* @vite-ignore */ '/pagefind/pagefind.js');
+        try { await pagefindModule.options({ basePath: '/pagefind/' }); } catch (_e) {}
+        return pagefindModule;
       }
 
-      const data = await Promise.all(searchResult.results.map((item) => item.data()));
-      results.innerHTML = `
-        <div class="search-results-meta">${searchResult.results.length} result${searchResult.results.length === 1 ? '' : 's'}</div>
-        <div class="search-results-grid">
-          ${data.map((item) => `
-            <article class="search-card">
-              <p class="search-card__url">${escapeHtml(item.url)}</p>
-              <h2 class="search-card__title"><a href="${item.url}">${escapeHtml(item.meta.title || 'Untitled')}</a></h2>
-              <p class="search-card__excerpt">${item.excerpt || ''}</p>
-            </article>
-          `).join('')}
-        </div>
-      `;
-    }
+      function setMeta(text) {
+        if (meta) meta.textContent = text;
+      }
 
-    renderEmpty('idle');
-    input?.addEventListener('input', (event) => runSearch(event.target.value));
+      function renderEmpty(query) {
+        if (list) list.innerHTML = '';
+        if (pagination) pagination.hidden = true;
+        if (fallback) {
+          fallback.hidden = false;
+          if (fallbackCTA) fallbackCTA.dataset.query = query || '';
+        }
+        setMeta(query
+          ? `No matches for "${query}". Try a broader phrase or a place name.`
+          : 'No matches yet.');
+      }
+
+      function renderIdle() {
+        if (list) {
+          list.innerHTML = `
+            <div class="search-page-v2__idle">
+              <p>Try a place ("Sorrento", "Red Hill"), an intent ("long lunch", "rainy day"), or a category ("cellar door", "family beach").</p>
+            </div>
+          `;
+        }
+        if (pagination) pagination.hidden = true;
+        if (fallback) fallback.hidden = true;
+        setMeta('Start typing to search.');
+      }
+
+      function renderLoading() {
+        if (list) {
+          list.innerHTML = `
+            <div class="search-page-v2__loading">
+              <p>Searching…</p>
+            </div>
+          `;
+        }
+        if (fallback) fallback.hidden = true;
+      }
+
+      function renderResults(data, total, page) {
+        if (!list) return;
+        if (data.length === 0) {
+          renderEmpty(currentQuery);
+          return;
+        }
+        const cards = data.map((item) => {
+          const kind = item.meta?.kind || item.filters?.kind?.[0] || 'Guide';
+          const title = item.meta?.title || 'Untitled';
+          const url = item.url || '#';
+          const excerpt = item.excerpt || '';
+          const image = item.meta?.image || '';
+          const heroStyle = image ? `background-image: url('${image.replace(/'/g, "%27")}')` : '';
+          const heroClass = image
+            ? 'search-card__hero'
+            : 'search-card__hero search-card__hero--placeholder';
+          return `
+            <a href="${escapeHtml(url)}" class="search-card">
+              <span class="${heroClass}" style="${heroStyle}" aria-hidden="true"></span>
+              <span class="search-card__body">
+                <span class="search-card__kind">${escapeHtml(kind)}</span>
+                <span class="search-card__title">${escapeHtml(title)}</span>
+                <span class="search-card__excerpt">${excerpt}</span>
+              </span>
+            </a>
+          `;
+        }).join('');
+        list.innerHTML = `<div class="search-page-v2__grid">${cards}</div>`;
+        if (fallback) fallback.hidden = false;
+        if (fallbackCTA) fallbackCTA.dataset.query = currentQuery;
+        setMeta(`Showing ${(page - 1) * PER_PAGE + 1}–${Math.min(page * PER_PAGE, total)} of ${total} result${total === 1 ? '' : 's'}.`);
+      }
+
+      function renderPagination(total) {
+        if (!pagination) return;
+        const totalPages = Math.ceil(total / PER_PAGE);
+        if (totalPages <= 1) {
+          pagination.hidden = true;
+          pagination.innerHTML = '';
+          return;
+        }
+        // Compact pager: prev · 1 2 3 … N · next
+        const buttons = [];
+        const win = (p) =>
+          p === 1 || p === totalPages || Math.abs(p - currentPage) <= 1;
+        let lastShown = 0;
+        for (let p = 1; p <= totalPages; p++) {
+          if (!win(p)) continue;
+          if (p - lastShown > 1) {
+            buttons.push('<span class="search-page-v2__pager-gap">…</span>');
+          }
+          buttons.push(`
+            <button
+              type="button"
+              class="search-page-v2__pager-btn ${p === currentPage ? 'is-active' : ''}"
+              data-page="${p}"
+              aria-current="${p === currentPage ? 'page' : 'false'}"
+              aria-label="Go to page ${p}"
+            >${p}</button>
+          `);
+          lastShown = p;
+        }
+        const prevDisabled = currentPage <= 1;
+        const nextDisabled = currentPage >= totalPages;
+        pagination.innerHTML = `
+          <button type="button" class="search-page-v2__pager-step" data-page-delta="-1" ${prevDisabled ? 'disabled' : ''} aria-label="Previous page">‹ Prev</button>
+          ${buttons.join('')}
+          <button type="button" class="search-page-v2__pager-step" data-page-delta="1" ${nextDisabled ? 'disabled' : ''} aria-label="Next page">Next ›</button>
+        `;
+        pagination.hidden = false;
+      }
+
+      async function showPage(page) {
+        if (page < 1) page = 1;
+        currentPage = page;
+        const start = (page - 1) * PER_PAGE;
+        const end = start + PER_PAGE;
+        const slice = currentResults.slice(start, end);
+        const cached = currentDataPage.get(page);
+        const data = cached || await Promise.all(slice.map((r) => r.data()));
+        if (!cached) currentDataPage.set(page, data);
+        renderResults(data, currentResults.length, page);
+        renderPagination(currentResults.length);
+        // Scroll to top of results when paging
+        if (page !== 1 && list) list.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+
+      async function runSearch() {
+        const q = (input?.value || '').trim();
+        currentQuery = q;
+        currentDataPage = new Map();
+
+        if (!q) {
+          currentResults = [];
+          renderIdle();
+          updateUrl(q);
+          return;
+        }
+
+        renderLoading();
+        const myToken = ++searchToken;
+
+        try {
+          const pf = await loadPagefind();
+          const filters = currentKind === 'all' ? undefined : { kind: currentKind };
+          const result = await pf.search(q, filters ? { filters } : undefined);
+          if (myToken !== searchToken) return;
+          currentResults = result.results;
+          if (currentResults.length === 0) {
+            renderEmpty(q);
+          } else {
+            await showPage(1);
+          }
+        } catch (err) {
+          console.warn('[search] error', err);
+          if (list) list.innerHTML = '<div class="search-page-v2__loading"><p>Search isn\'t available right now. Try again in a moment, or ask The Insider.</p></div>';
+          if (fallback) fallback.hidden = false;
+        }
+        updateUrl(q);
+      }
+
+      function updateUrl(q) {
+        const url = new URL(window.location.href);
+        if (q) url.searchParams.set('q', q);
+        else url.searchParams.delete('q');
+        if (currentKind !== 'all') url.searchParams.set('kind', currentKind);
+        else url.searchParams.delete('kind');
+        window.history.replaceState({}, '', url);
+      }
+
+      // Wire form
+      form?.addEventListener('submit', (e) => {
+        e.preventDefault();
+        runSearch();
+      });
+
+      // Debounced live search as the user types — Pagefind is fast enough
+      // that this feels instant.
+      let inputDebounce = null;
+      input?.addEventListener('input', () => {
+        clearTimeout(inputDebounce);
+        inputDebounce = setTimeout(runSearch, 100);
+      });
+
+      // Filter chip selection
+      chips.forEach((chip) => {
+        chip.addEventListener('click', () => {
+          chips.forEach((c) => {
+            c.classList.remove('is-active');
+            c.setAttribute('aria-selected', 'false');
+          });
+          chip.classList.add('is-active');
+          chip.setAttribute('aria-selected', 'true');
+          currentKind = chip.dataset.kind || 'all';
+          if (currentQuery) runSearch();
+          else updateUrl(currentQuery);
+        });
+      });
+      // Activate the "All" chip by default
+      if (chips[0]) chips[0].classList.add('is-active');
+
+      // Pagination clicks
+      pagination?.addEventListener('click', (e) => {
+        const stepBtn = e.target.closest('[data-page-delta]');
+        if (stepBtn) {
+          e.preventDefault();
+          const delta = parseInt(stepBtn.dataset.pageDelta, 10) || 0;
+          showPage(currentPage + delta);
+          return;
+        }
+        const pageBtn = e.target.closest('[data-page]');
+        if (pageBtn) {
+          e.preventDefault();
+          const p = parseInt(pageBtn.dataset.page, 10) || 1;
+          showPage(p);
+        }
+      });
+
+      // "Ask The Insider" fallback button — pre-fill the concierge with the
+      // failed query and open the masthead drawer.
+      fallbackCTA?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const q = fallbackCTA.dataset.query || currentQuery || '';
+        if (q && typeof window.openConcierge === 'function') {
+          window.openConcierge({ prefillQuery: q });
+        } else if (q) {
+          window.location.href = `/ask/?q=${encodeURIComponent(q)}`;
+        } else if (typeof window.openConcierge === 'function') {
+          window.openConcierge();
+        }
+      });
+
+      // Initialise from URL params (?q=… &kind=…)
+      const params = new URLSearchParams(window.location.search);
+      const initialQ = params.get('q') || '';
+      const initialKind = params.get('kind');
+      if (initialKind) {
+        const kindChip = chips.find((c) => c.dataset.kind === initialKind);
+        if (kindChip) {
+          chips.forEach((c) => { c.classList.remove('is-active'); c.setAttribute('aria-selected', 'false'); });
+          kindChip.classList.add('is-active');
+          kindChip.setAttribute('aria-selected', 'true');
+          currentKind = initialKind;
+        }
+      }
+      if (initialQ && input) {
+        input.value = initialQ;
+        runSearch();
+      } else {
+        renderIdle();
+      }
+
+      input?.focus();
+    })();
   </script>
 </BaseLayout>

--- a/next/src/styles/search.css
+++ b/next/src/styles/search.css
@@ -1,0 +1,590 @@
+/* ════════════════════════════════════════════════════════════════════
+   SITE SEARCH — masthead pill, instant overlay, /search results page
+   Built 2026-05-03. Reuses tokens from global.css (--bg, --ink, --soft,
+   --accent, --ease, --max).
+   ════════════════════════════════════════════════════════════════════ */
+
+/* ─── Masthead search pill ──────────────────────────────────────── */
+.masthead__search-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: inherit;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid rgba(167, 118, 55, 0.5);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background .2s var(--ease), color .2s var(--ease), border-color .2s var(--ease);
+}
+.masthead__search-pill:hover,
+.masthead__search-pill:focus-visible {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+  outline: none;
+}
+.masthead__search-pill svg { stroke: currentColor; }
+.masthead__search-pill-label { display: inline-block; }
+
+@media (max-width: 720px) {
+  .masthead__search-pill {
+    padding: 0.4rem 0.7rem;
+    font-size: 0.65rem;
+  }
+  .masthead__search-pill-label { display: none; }
+}
+
+/* ─── Search overlay (instant Pagefind dropdown) ────────────────── */
+.site-search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(1.5rem, 6vh, 5rem) 1rem 1rem;
+}
+.site-search-overlay[hidden] { display: none; }
+
+.site-search-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 18, 16, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: searchOverlayFade .18s var(--ease, ease-out);
+}
+@keyframes searchOverlayFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.site-search-overlay__panel {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  background: var(--bg, #FBF7F2);
+  border-radius: 12px;
+  box-shadow: 0 30px 80px -10px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - clamp(2rem, 8vh, 6rem));
+  overflow: hidden;
+  animation: searchOverlaySlide .22s var(--ease, ease-out);
+}
+@keyframes searchOverlaySlide {
+  from { transform: translateY(-12px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.site-search-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.25rem 0.5rem;
+}
+.site-search-overlay__eyebrow {
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--soft);
+  font-weight: 600;
+}
+.site-search-overlay__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--soft);
+  cursor: pointer;
+  transition: background .2s var(--ease);
+}
+.site-search-overlay__close:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--ink);
+}
+
+.site-search-overlay__form {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 0 1.25rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  background: #fff;
+  transition: border-color .2s var(--ease), box-shadow .2s var(--ease);
+}
+.site-search-overlay__form:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(167, 118, 55, 0.18);
+}
+.site-search-overlay__icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--soft);
+  margin-right: 0.65rem;
+}
+.site-search-overlay__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 1rem;
+  color: var(--ink);
+  min-width: 0;
+}
+.site-search-overlay__input::placeholder { color: var(--soft); }
+.site-search-overlay__kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  color: var(--soft);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  margin-left: 0.65rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.site-search-overlay__hint {
+  padding: 0.45rem 1.25rem 0;
+  font-size: 0.78rem;
+  color: var(--soft);
+}
+.site-search-overlay__hint kbd {
+  font-family: ui-monospace, monospace;
+  font-size: 0.7rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.site-search-overlay__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.site-search-overlay__suggestions-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin: 0.4rem 0 0.7rem;
+  font-weight: 600;
+}
+.site-search-overlay__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.site-search-overlay__results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.site-search-overlay__result-link {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 0.2rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  background: transparent;
+  transition: background .15s var(--ease);
+}
+.site-search-overlay__result-link:hover,
+.site-search-overlay__result-link:focus-visible {
+  background: rgba(167, 118, 55, 0.08);
+  outline: none;
+}
+.site-search-overlay__result-kind {
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
+}
+.site-search-overlay__result-title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.25;
+}
+.site-search-overlay__result-excerpt {
+  font-size: 0.85rem;
+  color: var(--soft);
+  line-height: 1.4;
+}
+.site-search-overlay__result-excerpt mark {
+  background: rgba(167, 118, 55, 0.18);
+  color: inherit;
+  padding: 0 0.1rem;
+}
+.site-search-overlay__result--empty .site-search-overlay__result-empty-title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0.5rem 0 0.25rem;
+}
+.site-search-overlay__result--empty .site-search-overlay__result-empty-hint {
+  font-size: 0.85rem;
+  color: var(--soft);
+  margin: 0;
+}
+
+.site-search-overlay__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.85rem;
+  padding: 0.65rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  border: 1px solid rgba(167, 118, 55, 0.5);
+  border-radius: 999px;
+  text-decoration: none;
+  transition: background .2s var(--ease), color .2s var(--ease);
+}
+.site-search-overlay__cta:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+body.search-open { overflow: hidden; }
+
+/* ─── /search page proper ───────────────────────────────────────── */
+.search-page-v2__hero {
+  background: linear-gradient(180deg, rgba(167, 118, 55, 0.06) 0%, transparent 100%);
+  padding: clamp(2rem, 5vw, 3.5rem) 0 clamp(1.5rem, 3vw, 2.5rem);
+  text-align: center;
+}
+.search-page-v2__eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--soft);
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+.search-page-v2__title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
+  font-weight: 500;
+  color: var(--ink);
+  margin: 0 0 1.2rem;
+  letter-spacing: -0.01em;
+}
+
+.search-page-v2__bar {
+  display: flex;
+  align-items: center;
+  max-width: 640px;
+  margin: 0 auto;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  padding: 0.5rem 0.55rem 0.5rem 1.2rem;
+  transition: border-color .2s var(--ease), box-shadow .2s var(--ease);
+}
+.search-page-v2__bar:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(167, 118, 55, 0.16);
+}
+.search-page-v2__bar-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--soft);
+  margin-right: 0.7rem;
+}
+.search-page-v2__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 1rem;
+  color: var(--ink);
+  min-width: 0;
+}
+.search-page-v2__input::placeholder { color: var(--soft); }
+.search-page-v2__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: var(--ink);
+  color: var(--bg);
+  cursor: pointer;
+  transition: background .2s var(--ease), transform .15s var(--ease);
+}
+.search-page-v2__submit:hover { background: var(--accent); }
+.search-page-v2__submit:active { transform: scale(0.96); }
+
+/* ─── Filter chips ──────────────────────────────────────────────── */
+.search-page-v2__filters {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  padding: 0.85rem 0;
+}
+.search-page-v2__chips {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+.search-page-v2__chip {
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--soft);
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 999px;
+  padding: 0.4rem 0.95rem;
+  cursor: pointer;
+  transition: all .15s var(--ease);
+}
+.search-page-v2__chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.search-page-v2__chip.is-active {
+  background: var(--ink);
+  color: var(--bg);
+  border-color: var(--ink);
+}
+
+/* ─── Results section ───────────────────────────────────────────── */
+.search-page-v2__results-section {
+  padding: 1.2rem 0 2rem;
+}
+.search-page-v2__results-meta {
+  font-size: 0.85rem;
+  color: var(--soft);
+  margin: 0 0 1.1rem;
+}
+.search-page-v2__idle,
+.search-page-v2__loading {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--soft);
+}
+.search-page-v2__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+/* ─── Result card ───────────────────────────────────────────────── */
+.search-card {
+  display: grid;
+  grid-template-columns: clamp(140px, 28%, 220px) 1fr;
+  gap: 1.2rem;
+  padding: 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: #fff;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color .2s var(--ease), transform .2s var(--ease), box-shadow .2s var(--ease);
+}
+.search-card:hover {
+  border-color: rgba(167, 118, 55, 0.4);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px -10px rgba(0, 0, 0, 0.18);
+}
+.search-card__hero {
+  display: block;
+  border-radius: 6px;
+  background-size: cover;
+  background-position: center;
+  background-color: rgba(167, 118, 55, 0.08);
+  aspect-ratio: 16 / 11;
+}
+.search-card__hero--placeholder {
+  background-image: linear-gradient(135deg, rgba(167, 118, 55, 0.18), rgba(167, 118, 55, 0.05));
+}
+.search-card__body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.4rem;
+}
+.search-card__kind {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.search-card__title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.2;
+}
+.search-card__excerpt {
+  font-size: 0.92rem;
+  line-height: 1.45;
+  color: var(--soft);
+}
+.search-card__excerpt mark {
+  background: rgba(167, 118, 55, 0.18);
+  color: var(--ink);
+  padding: 0 0.15rem;
+  border-radius: 2px;
+}
+
+@media (max-width: 640px) {
+  .search-card {
+    grid-template-columns: 1fr;
+    padding: 0.5rem;
+  }
+  .search-card__hero { aspect-ratio: 16 / 9; }
+}
+
+/* ─── Pagination ────────────────────────────────────────────────── */
+.search-page-v2__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 2rem 0 0.5rem;
+}
+.search-page-v2__pager-btn,
+.search-page-v2__pager-step {
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ink);
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: all .15s var(--ease);
+  min-width: 36px;
+}
+.search-page-v2__pager-btn:hover,
+.search-page-v2__pager-step:not([disabled]):hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.search-page-v2__pager-btn.is-active {
+  background: var(--ink);
+  color: var(--bg);
+  border-color: var(--ink);
+}
+.search-page-v2__pager-step[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.search-page-v2__pager-gap {
+  font-size: 0.85rem;
+  color: var(--soft);
+  padding: 0 0.2rem;
+}
+
+/* ─── Fallback "Didn't find?" block ─────────────────────────────── */
+.search-page-v2__fallback {
+  background: linear-gradient(180deg, transparent, rgba(167, 118, 55, 0.05));
+  padding: 2.5rem 0 3.5rem;
+}
+.search-page-v2__fallback-card {
+  background: #1F1B16;
+  color: #FBF7F2;
+  border-radius: 14px;
+  padding: clamp(1.8rem, 4vw, 3rem);
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
+  position: relative;
+  overflow: hidden;
+}
+.search-page-v2__fallback-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 30% 20%, rgba(167, 118, 55, 0.18), transparent 40%),
+    radial-gradient(circle at 80% 80%, rgba(167, 118, 55, 0.12), transparent 50%);
+  pointer-events: none;
+}
+.search-page-v2__fallback-eyebrow,
+.search-page-v2__fallback-title,
+.search-page-v2__fallback-body,
+.search-page-v2__fallback-cta {
+  position: relative;
+}
+.search-page-v2__fallback-eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(251, 247, 242, 0.65);
+  font-weight: 600;
+  margin: 0 0 0.6rem;
+}
+.search-page-v2__fallback-title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 500;
+  margin: 0 0 0.9rem;
+  letter-spacing: -0.01em;
+}
+.search-page-v2__fallback-body {
+  font-size: 1rem;
+  line-height: 1.55;
+  color: rgba(251, 247, 242, 0.78);
+  max-width: 540px;
+  margin: 0 auto 1.5rem;
+}
+.search-page-v2__fallback-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #FBF7F2;
+  background: transparent;
+  border: 1px solid rgba(251, 247, 242, 0.4);
+  border-radius: 999px;
+  padding: 0.7rem 1.3rem;
+  cursor: pointer;
+  transition: all .2s var(--ease);
+}
+.search-page-v2__fallback-cta:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  transform: translateY(-1px);
+}


### PR DESCRIPTION
Builds the Destination-Vancouver-style search experience.

- Masthead pill on every page (slash-key also opens it)
- Instant overlay with live Pagefind suggestions
- Polished /search page: hero, kind chips, card results, pagination, PI-voiced 'Didn't find?' fallback
- BaseLayout auto-tags every page with data-pagefind-body + filter + meta from the existing `section` prop. New `searchExclude` opt-out
- Pagefind index: 566 pages, 1 filter (kind), 9.6k words

All decisions from the scope doc are captured in the commit message.