### PR TITLE
fix: search icon-only + 3 wrong venue images + journal hero

### DIFF
--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -109,21 +109,20 @@ const {
             ))}
           </ul>
         </nav>
+        <a href="/newsletter/" class="masthead__cta">Subscribe</a>
         <button
           type="button"
-          class="masthead__search-pill"
+          class="masthead__search-icon"
           data-open-search
           aria-label="Search Peninsula Insider"
           aria-haspopup="dialog"
           aria-controls="siteSearchOverlay"
         >
-          <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="9" cy="9" r="6" />
             <path d="M14 14l4 4" />
           </svg>
-          <span class="masthead__search-pill-label">Search</span>
         </button>
-        <a href="/newsletter/" class="masthead__cta">Subscribe</a>
         <a href="/newsletter/" class="masthead__cta-mobile" aria-label="Subscribe to the newsletter">Subscribe</a>
       </div>
     </div>

--- a/next/src/content/articles/the-four-hour-peninsula.md
+++ b/next/src/content/articles/the-four-hour-peninsula.md
@@ -5,8 +5,8 @@ author: "editorial"
 houseByline: true
 publishedAt: 2026-04-15
 heroImage:
-  src: "/images/sourced/article-orientation-drive-01.webp"
-  alt: "A panoramic view from Arthurs Seat across the Peninsula vineyards and bay in a late morning light — representative image"
+  src: "/images/sourced/home-cover-back-beach-horses-01.jpg"
+  alt: "Horses on the back beach at low light, the wide ocean coast that frames a four-hour Peninsula visit"
   credit: "Peninsula Insider"
   license: "tmp-unsplash"
 format: "service"

--- a/next/src/content/venues/allis-wine-bar.json
+++ b/next/src/content/venues/allis-wine-bar.json
@@ -42,8 +42,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/category-restaurant-03.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Allis Wine Bar",
+    "src": "/images/sourced/category-restaurant-02.webp",
+    "alt": "Wine bar interior, editorial placeholder for Allis Wine Bar pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/content/venues/avani-wines.json
+++ b/next/src/content/venues/avani-wines.json
@@ -48,8 +48,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/article-rainy-day-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Avani Wines",
+    "src": "/images/sourced/category-winery-04.webp",
+    "alt": "Mornington Peninsula winery vines, editorial placeholder for Avani Wines pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/content/venues/azuma-japanese.json
+++ b/next/src/content/venues/azuma-japanese.json
@@ -39,8 +39,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/category-restaurant-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Azuma Japanese",
+    "src": "/images/sourced/category-restaurant-06.webp",
+    "alt": "Restaurant interior, editorial placeholder for Azuma Japanese pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/styles/search.css
+++ b/next/src/styles/search.css
@@ -4,42 +4,38 @@
    --accent, --ease, --max).
    ════════════════════════════════════════════════════════════════════ */
 
-/* ─── Masthead search pill ──────────────────────────────────────── */
-.masthead__search-pill {
+/* ─── Masthead search icon ──────────────────────────────────────── */
+/* Icon-only button positioned to the right of the Subscribe CTA.
+   Editorial-restraint move: no label, no border, just the magnifying
+   glass picking up the accent on hover. */
+.masthead__search-icon {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
   font-family: inherit;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
   color: var(--accent);
   background: transparent;
-  border: 1px solid rgba(167, 118, 55, 0.5);
-  border-radius: 999px;
-  padding: 0.45rem 0.85rem;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  margin-left: 0.35rem;
   cursor: pointer;
-  white-space: nowrap;
   flex-shrink: 0;
-  transition: background .2s var(--ease), color .2s var(--ease), border-color .2s var(--ease);
+  transition: background .2s var(--ease), color .2s var(--ease);
 }
-.masthead__search-pill:hover,
-.masthead__search-pill:focus-visible {
-  background: var(--accent);
-  color: var(--bg);
-  border-color: var(--accent);
+.masthead__search-icon:hover,
+.masthead__search-icon:focus-visible {
+  background: rgba(167, 118, 55, 0.12);
+  color: var(--accent);
   outline: none;
 }
-.masthead__search-pill svg { stroke: currentColor; }
-.masthead__search-pill-label { display: inline-block; }
+.masthead__search-icon svg { stroke: currentColor; }
 
 @media (max-width: 720px) {
-  .masthead__search-pill {
-    padding: 0.4rem 0.7rem;
-    font-size: 0.65rem;
-  }
-  .masthead__search-pill-label { display: none; }
+  .masthead__search-icon { width: 32px; height: 32px; margin-left: 0.2rem; }
+  .masthead__search-icon svg { width: 16px; height: 16px; }
 }
 
 /* ─── Search overlay (instant Pagefind dropdown) ────────────────── */


### PR DESCRIPTION
## Summary
Five small fixes in one PR.

### UI
- **Search button**: drop the SEARCH label, icon-only magnifying glass, moved to the right of the Subscribe CTA. New \`.masthead__search-icon\` style; old \`.masthead__search-pill\` removed.

### Venue image fixes
Three venue cards on the Editor's Table row were showing wrong-category images. All three swapped to better-fitting category placeholders, with alts updated to honestly mark them as editorial placeholders pending venue media.
- **Avani Wines** was rendering the rainy-day editorial image (the MPRG gallery building). Now \`category-winery-04.webp\`.
- **Azuma Japanese** (sushi venue) was rendering a vineyard. Now \`category-restaurant-06.webp\`.
- **Allis Wine Bar** swapped to \`category-restaurant-02.webp\` for category alignment.

### Journal hero
- \`/journal/the-four-hour-peninsula/\` hero swapped to the home-cover back-beach horses image to match the homepage coastal palette.

## Follow-up needed
The three venue cards still need real venue photography. Long-term fix is an image-sourcing pass against each venue's press kit (Avani: avaniwines.com.au, Allis: tenminutesbytractor.com.au/allis, Azuma: contact venue directly).

## Test plan
- [x] Local build (1051 pages)
- [x] dist/index.html: \`masthead__search-icon\` present, \`masthead__search-pill\` gone, render order is \`masthead__cta\` then \`masthead__search-icon\`
- [x] All four image swaps present in built HTML for each affected page

🤖 Generated with [Claude Code](https://claude.com/claude-code)