### PR TITLE
fix(venues): correct 5 mismatched hero images

### DIFF
--- a/next/src/content/venues/afloat-mornington.json
+++ b/next/src/content/venues/afloat-mornington.json
@@ -41,8 +41,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/explore-mprg-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Afloat Mornington",
+    "src": "/images/sourced/explore-mornington-foreshore-01.webp",
+    "alt": "Mornington foreshore at the pier, editorial placeholder for Afloat Mornington pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/content/venues/flinders-general-store.json
+++ b/next/src/content/venues/flinders-general-store.json
@@ -41,8 +41,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/place-flinders-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Flinders General Store",
+    "src": "/images/sourced/category-cafe-02.webp",
+    "alt": "Village cafe interior, editorial placeholder for Flinders General Store pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/content/venues/flinders-pier-takeaway.json
+++ b/next/src/content/venues/flinders-pier-takeaway.json
@@ -39,8 +39,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/explore-cape-schanck-lighthouse-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Flinders Pier Takeaway",
+    "src": "/images/sourced/venue-dromana-pier-01.webp",
+    "alt": "Wooden Peninsula pier extending over the bay, editorial placeholder for Flinders Pier Takeaway pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/content/venues/port-phillip-estate.json
+++ b/next/src/content/venues/port-phillip-estate.json
@@ -112,8 +112,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/place-cape-schanck-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Port Phillip Estate",
+    "src": "/images/sourced/article-hatted-restaurants-01.webp",
+    "alt": "Hatted Peninsula winery dining room, editorial placeholder for Port Phillip Estate pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },

--- a/next/src/content/venues/stillwater-crittenden.json
+++ b/next/src/content/venues/stillwater-crittenden.json
@@ -51,8 +51,8 @@
     ]
   },
   "heroImage": {
-    "src": "/images/sourced/place-dromana-01.webp",
-    "alt": "Mornington Peninsula landscape \u2014 representative image for Stillwater at Crittenden",
+    "src": "/images/sourced/category-winery-03.webp",
+    "alt": "Lakeside Peninsula winery, editorial placeholder for Stillwater at Crittenden pending venue media",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },


### PR DESCRIPTION
## Summary
Five venue cards were rendering wrong-category placeholder images. All swapped to better-fitting category images from existing inventory; alts updated to honestly tag them as editorial placeholders pending venue media.

| Venue | Was | Now |
|---|---|---|
| Afloat Mornington | MPRG gallery (\`explore-mprg-01\`) | Mornington foreshore |
| Flinders General Store | Flinders place hero | Cafe interior |
| Flinders Pier Takeaway | Cape Schanck lighthouse | Peninsula pier (Dromana) |
| Port Phillip Estate | Cape Schanck place | Hatted-restaurant editorial |
| Stillwater at Crittenden | Dromana place hero | Winery |

## Broader scope
A scan showed **85 venues** currently use non-category images (article-*, explore-*, place-*) for their hero. Many are fine (a winery using a vineyard editorial image is on-brand), but a full image-sourcing audit is the right long-term fix. Flagging this for the image-sourcing pilot already in memory.

## Test plan
- [x] Local build (1051 pages)
- [x] All 5 venue HTML files contain new image references

🤖 Generated with [Claude Code](https://claude.com/claude-code)