### PR TITLE
remove(home): drop stats counter row from homepage

### DIFF
--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -7,7 +7,6 @@ import Shortlist from '../components/Shortlist.astro';
 import EditorsLetter from '../components/EditorsLetter.astro';
 import InsiderStripe from '../components/InsiderStripe.astro';
 import PillarNav from '../components/PillarNav.astro';
-import IssueFlag from '../components/IssueFlag.astro';
 import SectionDivider from '../components/SectionDivider.astro';
 import { formatLabel } from '../lib/editorial';
 import VenueCard from '../components/VenueCard.astro';
@@ -213,18 +212,6 @@ const seasonalExperiences = experiences
   <InsiderPlans />
 
   <PillarNav />
-
-  <IssueFlag
-    issueDate={issueDate}
-    context={seasonBlurbData.line}
-    stats={[
-      { label: 'Pieces',         value: issueStats.articles },
-      { label: 'Venues mapped',  value: issueStats.venues },
-      { label: 'Places',         value: issueStats.places },
-      { label: 'Walks & moves',  value: issueStats.experiences },
-      { label: 'Escape plans',   value: issueStats.itineraries },
-    ]}
-  />
 
   {weekendDispatch && <WeekendPickerBlock dispatch={weekendDispatch} weekend={`This weekend · ${dispatchWindow.label}`} />}
 


### PR DESCRIPTION
## Summary
Removes the IssueFlag stats block (Pieces · Venues mapped · Places · Walks & moves · Escape plans) from the homepage. Sat between PillarNav and the Weekend Picker; the page now flows directly from the pillar grid into the Weekend Picker.

The IssueFlag component file is left in place in case it's wanted later — only the import and render in index.astro are removed.

## Test plan
- [x] Local build (1050 pages)
- [x] dist/index.html: no \`issue-flag\` class, no "Venues mapped" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)