### PR TITLE
feat(events): cross-surface integration — EventStrip on hubs + places

### DIFF
--- a/next/src/components/EventStrip.astro
+++ b/next/src/components/EventStrip.astro
@@ -1,0 +1,266 @@
+---
+/**
+ * EventStrip — embedded events surface for hubs and detail pages.
+ *
+ * A small editorial strip (typically 3 events) for embedding on
+ * non-events pages. Examples: homepage "more this weekend," section
+ * hubs ("food and wine events coming up"), place pages ("events in
+ * this place"), venue pages ("events at this venue").
+ *
+ * Cards are simpler than the main EventCard — date pill, title, one
+ * editor-or-summary line, place. The full detail is one click away.
+ *
+ * Renders nothing if zero events match. Trust signal: the eyebrow
+ * always names the section so readers know they're looking at a
+ * curated slice.
+ */
+import type { CollectionEntry } from 'astro:content';
+import { eventCategoryLabel, eventDateLabel, routeSlug } from '../lib/editorial';
+
+type Event = CollectionEntry<'events'>;
+
+export interface Props {
+  events: Event[];
+  /** Eyebrow above the heading (small caps, accent colour). */
+  eyebrow?: string;
+  /** The section heading (Cormorant). */
+  heading?: string;
+  /** Optional editorial intro line under the heading. */
+  intro?: string;
+  /** Optional "see all" link with custom URL + label. */
+  moreHref?: string;
+  moreLabel?: string;
+  /** Cap visible events. Defaults to 3. */
+  limit?: number;
+  /** Background variant: 'paper' (default) or 'alt' (--bg-alt). */
+  variant?: 'paper' | 'alt';
+}
+
+const {
+  events,
+  eyebrow = 'On the calendar',
+  heading = 'Events coming up',
+  intro,
+  moreHref = '/whats-on/',
+  moreLabel = 'All events',
+  limit = 3,
+  variant = 'paper',
+} = Astro.props;
+
+const visible = events.slice(0, limit);
+---
+
+{visible.length > 0 && (
+  <section class={`event-strip event-strip--${variant}`} aria-label={heading}>
+    <div class="container">
+      <div class="event-strip__head">
+        <div>
+          {eyebrow && <p class="event-strip__eyebrow">{eyebrow}</p>}
+          <h2 class="event-strip__heading">{heading}</h2>
+          {intro && <p class="event-strip__intro">{intro}</p>}
+        </div>
+        <a href={moreHref} class="event-strip__more">{moreLabel} &rarr;</a>
+      </div>
+
+      <ul class="event-strip__grid" role="list">
+        {visible.map((event) => {
+          const slug = routeSlug(event);
+          const placeId = typeof event.data.place === 'string' ? event.data.place : event.data.place?.id;
+          const placeLabel = placeId
+            ? String(placeId).replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
+            : event.data.suburb;
+          const dateLabel = (() => {
+            if (event.data.recurrence === 'weekly') {
+              return `Every ${event.data.startDate.toLocaleDateString('en-AU', { weekday: 'long' })}`;
+            }
+            if (event.data.recurrence === 'monthly') {
+              return `Monthly`;
+            }
+            return eventDateLabel(event.data.startDate, event.data.endDate);
+          })();
+          const hasOverlay = Boolean(event.data.editorVerdict);
+          return (
+            <li class="event-strip__item">
+              <a href={`/whats-on/${slug}/`} class="event-strip__card">
+                <span class="event-strip__date">{dateLabel}</span>
+                <h3 class="event-strip__title">
+                  {hasOverlay && <span class="event-strip__pick" aria-label="Editor's pick">✦</span>}
+                  {event.data.title}
+                </h3>
+                {placeLabel && <p class="event-strip__place">{placeLabel}</p>}
+                <p class="event-strip__summary">
+                  {event.data.whyWeCare || event.data.summary}
+                </p>
+                <span class="event-strip__category">
+                  {eventCategoryLabel[event.data.category] ?? event.data.category}
+                </span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  </section>
+)}
+
+<style>
+  .event-strip {
+    padding: clamp(2rem, 4vw, 3.5rem) 0;
+  }
+  .event-strip--alt {
+    background: var(--bg-alt);
+  }
+  .event-strip--paper {
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .event-strip__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .event-strip__eyebrow {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.4rem;
+  }
+
+  .event-strip__heading {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(1.4rem, 2.6vw, 1.9rem);
+    font-weight: 500;
+    line-height: 1.15;
+    color: var(--text);
+    margin: 0;
+    letter-spacing: -0.015em;
+  }
+
+  .event-strip__intro {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--soft);
+    margin: 0.5rem 0 0;
+    max-width: 60ch;
+  }
+
+  .event-strip__more {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--accent);
+    text-decoration: none;
+    white-space: nowrap;
+    padding-bottom: 0.25rem;
+  }
+  .event-strip__more:hover {
+    color: var(--text);
+    text-decoration: underline;
+  }
+
+  .event-strip__grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem;
+  }
+
+  .event-strip__item {
+    display: flex;
+  }
+
+  .event-strip__card {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 1.1rem 1.2rem 1.3rem;
+    background: var(--white);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  }
+  .event-strip__card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px -16px rgba(0, 0, 0, 0.18);
+  }
+
+  .event-strip__date {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 0.55rem;
+  }
+
+  .event-strip__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.15rem;
+    font-weight: 500;
+    line-height: 1.2;
+    color: var(--text);
+    margin: 0 0 0.35rem;
+    letter-spacing: -0.01em;
+  }
+
+  .event-strip__pick {
+    color: var(--accent);
+    margin-right: 0.3rem;
+    font-size: 0.85em;
+  }
+
+  .event-strip__place {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin: 0 0 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .event-strip__summary {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.86rem;
+    line-height: 1.5;
+    color: var(--soft);
+    margin: 0;
+    flex: 1;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .event-strip__category {
+    margin-top: 0.85rem;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--soft);
+    align-self: flex-start;
+  }
+
+  @media (max-width: 900px) {
+    .event-strip__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+  @media (max-width: 560px) {
+    .event-strip__grid { grid-template-columns: 1fr; }
+    .event-strip__head { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  }
+</style>

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -9,7 +9,8 @@ import SectionDivider from '../../components/SectionDivider.astro';
 import VenueCard from '../../components/VenueCard.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
-import { routeSlug } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { isUpcoming, routeSlug } from '../../lib/editorial';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 const eatTypes = ['restaurant', 'cafe', 'bakery', 'pub', 'market', 'winery'];
@@ -32,6 +33,17 @@ const longLunches = longLunchSlugs
   .filter((venue): venue is NonNullable<typeof venue> => Boolean(venue));
 
 const casualStops = venues.filter((venue) => ['cafe', 'bakery'].includes(venue.data.type)).slice(0, 6);
+
+// Food + wine events coming up — surfaces from /whats-on/ on the section hub.
+const eatEventCategories = ['food-wine', 'cellar-door', 'market'];
+const eatEvents = (await getCollection('events'))
+  .filter((event) => eatEventCategories.includes(event.data.category))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
 
 const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
   .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
@@ -140,6 +152,16 @@ const faqSchema = {
        1.5 AUDIENCE PICKER: persona-led entry to the section
        ═══════════════════════════════════════════════════════════════ -->
   <AudiencePicker section="eat" />
+
+  <EventStrip
+    events={eatEvents}
+    eyebrow="Food and wine events coming up"
+    heading="Cellar door weekends and food events worth pencilling in"
+    intro="Pulled from the events registry. Tap an event for editorial notes, or see the full calendar for everything coming up."
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
+  />
 
   <!-- ═══════════════════════════════════════════════════════════════
        2. ORIENTATION: Red Hill plateau vs Bay corridor

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -10,11 +10,23 @@ import PlaceCard from '../../components/PlaceCard.astro';
 import ItineraryCard from '../../components/ItineraryCard.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
-import { routeSlug, currentSeason, seasonBlurb, experienceInSeason } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { routeSlug, currentSeason, seasonBlurb, experienceInSeason, isUpcoming } from '../../lib/editorial';
 import { buildCollectionPageSchema, buildFaqSchema, buildBreadcrumbSchema } from '../../lib/schema';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 const experiences = (await getCollection('experiences')).sort((a, b) => a.data.name.localeCompare(b.data.name));
+
+// Family + arts + nature events surfacing from /whats-on/.
+const exploreEventCategories = ['nature', 'family-programs', 'arts', 'exhibition', 'community', 'wellness'];
+const exploreEvents = (await getCollection('events'))
+  .filter((event) => exploreEventCategories.includes(event.data.category))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
 const places = await getCollection('places');
 const itinerariesAll = await getCollection('itineraries');
 const itinerarySlugs = ['flinders-and-cape-reset', 'ridge-to-sea-two-night-escape', 'sorrento-off-season-weekend'];
@@ -163,6 +175,16 @@ const breadcrumbSchema = buildBreadcrumbSchema([
         { label: 'Strongest moves', value: 'Peninsula Hot Springs, Alba Thermal Springs, Spa by Jackalope, Pt Leo Estate sculpture park, Red Hill Market, Mornington Peninsula Regional Gallery.' },
       ],
     }}
+  />
+
+  <EventStrip
+    events={exploreEvents}
+    eyebrow="Things on this weekend"
+    heading="Markets, exhibitions, family programs, walks"
+    intro="Pulled from the events registry across nature, family, arts, and community categories."
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -16,6 +16,8 @@ import ItineraryCard from '../components/ItineraryCard.astro';
 import ArticleCard from '../components/ArticleCard.astro';
 import EventCard from '../components/EventCard.astro';
 import WeekendPickerBlock from '../components/WeekendPickerBlock.astro';
+import EventStrip from '../components/EventStrip.astro';
+import { chips, eventsForChip, getChip } from '../lib/events';
 import InsiderPlans from '../components/InsiderPlans.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
 import { isUpcoming, routeSlug, stayTypes, currentSeason, seasonBlurb, inSeason, experienceInSeason, dispatchWeekend } from '../lib/editorial';
@@ -214,6 +216,22 @@ const seasonalExperiences = experiences
   <PillarNav />
 
   {weekendDispatch && <WeekendPickerBlock dispatch={weekendDispatch} weekend={`This weekend · ${dispatchWindow.label}`} />}
+
+  {(() => {
+    const chip = getChip('this-weekend');
+    const weekendEvents = chip ? eventsForChip(chip, eventsAll).slice(0, 3) : [];
+    return weekendEvents.length > 0 && (
+      <EventStrip
+        events={weekendEvents}
+        eyebrow="On the calendar this weekend"
+        heading="Three events worth a Saturday or Sunday"
+        intro="Pulled from the events registry, ranked by what they are actually like to attend. Tap through for the full list, or pick a mood (when it rains, worth the drive, after dark) on the events hub."
+        moreHref="/whats-on/"
+        moreLabel="See the full registry"
+        variant="alt"
+      />
+    );
+  })()}
 
   {intentResolved.length > 0 && (
     <section class="intent-strip" aria-label="Start from what you need">

--- a/next/src/pages/places/[slug].astro
+++ b/next/src/pages/places/[slug].astro
@@ -2,7 +2,8 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PlaceDetailTemplate from '../../components/PlaceDetailTemplate.astro';
-import { routeSlug, stayTypes, wineTypes } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { routeSlug, stayTypes, wineTypes, isUpcoming } from '../../lib/editorial';
 
 export async function getStaticPaths() {
   const places = await getCollection('places');
@@ -18,12 +19,28 @@ const places = await getCollection('places');
 const allExperiences = await getCollection('experiences');
 const allItineraries = await getCollection('itineraries');
 const allArticles = await getCollection('articles', ({ data }) => data.status === 'published');
+const allEvents = await getCollection('events');
 
 const placeSlug = routeSlug(place);
 const placeNameLower = place.data.name.toLowerCase();
 
 const venuesForPlace = allVenues
   .filter((venue) => String(venue.data.place?.id ?? venue.data.place) === placeSlug);
+
+// Events at this place: match place ref, OR suburb name (machine-imported
+// events without a clean place ref still surface if the suburb matches).
+const eventsForPlace = allEvents
+  .filter((event) => {
+    const eventPlace = String(event.data.place?.id ?? event.data.place ?? '');
+    if (eventPlace === placeSlug) return true;
+    return event.data.suburb?.toLowerCase() === placeNameLower;
+  })
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
 const venueSlugs = venuesForPlace.map((venue) => routeSlug(venue));
 const experiences = allExperiences
   .filter((experience) => String(experience.data.place?.id ?? experience.data.place) === placeSlug);
@@ -307,5 +324,15 @@ const placeSchema = {
     articles={articles}
     relatedPlaces={relatedPlaces}
     snapshotCards={snapshotCards}
+  />
+
+  <EventStrip
+    events={eventsForPlace}
+    eyebrow="On the calendar in this place"
+    heading={`Events in ${place.data.name}`}
+    intro={`Coming up in ${place.data.name}, pulled from the events registry.`}
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
   />
 </BaseLayout>

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -9,10 +9,22 @@ import VenueCard from '../../components/VenueCard.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
-import { routeSlug, currentSeason, seasonBlurb } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { routeSlug, currentSeason, seasonBlurb, isUpcoming } from '../../lib/editorial';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 const wineTypes = ['winery', 'producer', 'brewery', 'distillery'];
+
+// Cellar door + wine events surfacing from /whats-on/ on the wine hub.
+const wineEventCategories = ['cellar-door', 'food-wine'];
+const wineEvents = (await getCollection('events'))
+  .filter((event) => wineEventCategories.includes(event.data.category))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
 const venues = (await getCollection('venues'))
   .filter((venue) => wineTypes.includes(venue.data.type))
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
@@ -125,6 +137,15 @@ const faqSchema = {
         { label: 'Vibe', value: 'Quiet, focused, slightly more like work. Reward exceeds the effort.' },
       ],
     }}
+  />
+
+  <EventStrip
+    events={wineEvents}
+    eyebrow="Cellar door events"
+    heading="Release weekends and winemaker dinners worth a booking"
+    intro="The Peninsula's strongest event category, rarely treated as events. Tap an event for editorial notes."
+    moreHref="/whats-on/"
+    moreLabel="All events"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

**Phase 3** of the events registry. Embedded events surface (EventStrip) wired into the homepage, three section hubs, and place pages. Draws traffic from non-events surfaces back into `/whats-on/`.

## What ships

### `EventStrip.astro` (new)
Reusable 3-event strip. Eyebrow + Cormorant heading + 3 cards with date pill, title (with editor's-pick mark `✦` when an `editorVerdict` is present), place, summary or `whyWeCare`, and category. Two visual variants (`paper` / `alt`) for alternating section backgrounds. Renders nothing if zero events match — no empty sections.

### Surfaces wired
| Page | Filter | Position |
|---|---|---|
| `/` (homepage) | `this-weekend` chip definition | After WeekendPickerBlock |
| `/eat/` | food-wine + cellar-door + market | After AudiencePicker |
| `/wine/` | cellar-door + food-wine | After orientation CompareBlock |
| `/explore/` | nature + family-programs + arts + exhibition + community + wellness | After orientation CompareBlock |
| `/places/[slug]/` | place ref OR suburb name match | After PlaceDetailTemplate |

All sort by `visitorAppealScore` desc, top 3.

### Place page match logic
Matches both clean `place` refs AND suburb-name fallback, so the 21 imported events without clean place refs still surface on the right place page if their suburb matches the place name.

## Test plan
- [x] Local build (1199 pages)
- [x] EventStrip rendering verified on all 5 surface types

## Deferred to PR #4
- **Cron jobs at launch tier** — events-rolling-occurrence, events-archive-expired, events-this-weekend-refresh, events-jsonld-validate, events-import-from-spreadsheet, events-overlay-protection-audit, events-sitemap-rebuild
- **Concierge ingestion** of the events corpus
- **Venue page event strips** (venue → events match logic needs more thought; defer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)