### PR TITLE
feat(events): launch-tier cron jobs

### DIFF
--- a/.github/workflows/events-archive-expired.yml
+++ b/.github/workflows/events-archive-expired.yml
@@ -1,0 +1,57 @@
+name: Events archive expired
+
+# Daily cron job 2 from the events registry design.
+#
+# Walks the events content collection, finds events whose endDate (or
+# startDate if no endDate) is more than 14 days past today, and sets
+# their status to "archived". Editor can flag `keepLive: true` on a
+# JSON file to opt out.
+#
+# Auto-archive only runs against one-off, annual, and seasonal events.
+# Weekly / monthly / ongoing events are never auto-archived; they're
+# managed by the recompute-occurrence cron.
+#
+# If the script changes any files, this workflow commits them directly
+# to main with a [skip ci] tag so the deploy doesn't double-fire.
+#
+# Schedule: 17:30 UTC daily = 03:30 Melbourne AEST / 04:30 AEDT.
+
+on:
+  schedule:
+    - cron: '30 17 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: events-archive-expired
+  cancel-in-progress: false
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run archive script
+        run: python next/scripts/archive-expired-events.py
+
+      - name: Commit changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [[ -n "$(git status --porcelain next/src/content/events/)" ]]; then
+            git add next/src/content/events/
+            git commit -m "ops(events): auto-archive expired events [skip ci]"
+            git push origin main
+          else
+            echo "No expired events to archive."
+          fi

--- a/.github/workflows/events-recompute-occurrence.yml
+++ b/.github/workflows/events-recompute-occurrence.yml
@@ -1,0 +1,49 @@
+name: Events recompute occurrence
+
+# Daily cron job 1 from the events registry design.
+#
+# For each recurring event (weekly, monthly, annual), recomputes the
+# `nextOccurrence` field. Idempotent: rerunning produces the same
+# result, so the workflow only commits when something actually changed.
+#
+# Schedule: 17:00 UTC daily = 03:00 Melbourne AEST / 04:00 AEDT.
+
+on:
+  schedule:
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: events-recompute-occurrence
+  cancel-in-progress: false
+
+jobs:
+  recompute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run recompute script
+        run: python next/scripts/recompute-occurrence.py
+
+      - name: Commit changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [[ -n "$(git status --porcelain next/src/content/events/)" ]]; then
+            git add next/src/content/events/
+            git commit -m "ops(events): refresh nextOccurrence for recurring events [skip ci]"
+            git push origin main
+          else
+            echo "No nextOccurrence changes."
+          fi

--- a/.github/workflows/events-weekly-rebuild.yml
+++ b/.github/workflows/events-weekly-rebuild.yml
@@ -1,0 +1,42 @@
+name: Events weekly rebuild
+
+# Cron job 3 from the events registry design (this-weekend refresh).
+#
+# Triggers a fresh deploy every Wednesday so time-sensitive event lists
+# (homepage "this weekend" strip, /whats-on/by-mood/this-weekend/, the
+# section hub event strips) reflect the upcoming weekend even if no
+# content commits have landed since the previous build.
+#
+# Doesn't change any files; just dispatches the existing build-and-deploy
+# workflow with an empty commit so the regenerated pages capture the
+# new "upcoming weekend" window.
+#
+# Schedule: 20:00 UTC Tuesday = 06:00 Melbourne AEST Wednesday / 07:00 AEDT.
+
+on:
+  schedule:
+    - cron: '0 20 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: events-weekly-rebuild
+  cancel-in-progress: false
+
+jobs:
+  trigger-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Empty commit to trigger deploy
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "ops(events): weekly rebuild for this-weekend refresh"
+          git push origin main

--- a/next/scripts/archive-expired-events.py
+++ b/next/scripts/archive-expired-events.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+archive-expired-events.py — daily cron job 2 from the events registry design.
+
+For each event where endDate (or startDate if no endDate) + 14 days is before
+today, set status to "archived". Editor can flag `keepLive: true` on a JSON
+file to opt out of auto-archive (handy for post-mortem windows).
+
+Auto-archive rule: only one-off and annual recurring events are eligible.
+Weekly / monthly / ongoing events never auto-archive.
+
+The script writes back to the JSON files in place. Diff is committed by the
+GitHub Actions workflow.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+GRACE_DAYS = 14
+EVENT_DIR = Path(__file__).resolve().parent.parent / 'src' / 'content' / 'events'
+ARCHIVE_ELIGIBLE_RECURRENCES = {'one-off', 'annual', 'seasonal'}
+
+
+def parse_date(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace('Z', '+00:00')).date()
+    except (ValueError, TypeError):
+        return None
+
+
+def main() -> int:
+    today = date.today()
+    cutoff = today - timedelta(days=GRACE_DAYS)
+    archived = []
+    skipped_keep_live = []
+
+    for path in sorted(EVENT_DIR.glob('*.json')):
+        try:
+            data = json.loads(path.read_text(encoding='utf-8'))
+        except Exception as e:
+            print(f"SKIP (parse error) {path.name}: {e}")
+            continue
+
+        if data.get('status') == 'archived':
+            continue
+        if data.get('keepLive') is True:
+            skipped_keep_live.append(path.stem)
+            continue
+
+        recurrence = data.get('recurrence', 'one-off')
+        if recurrence not in ARCHIVE_ELIGIBLE_RECURRENCES:
+            continue
+
+        end = parse_date(data.get('endDate')) or parse_date(data.get('startDate'))
+        if end is None:
+            continue
+        if end > cutoff:
+            continue
+
+        # For annual events, only archive if the event is more than 14 days
+        # past AND no nextOccurrence is set. Otherwise it's a recurring event
+        # waiting for next year's date.
+        if recurrence == 'annual' and data.get('nextOccurrence'):
+            next_occ = parse_date(data.get('nextOccurrence'))
+            if next_occ and next_occ >= today:
+                continue
+
+        data['status'] = 'archived'
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + '\n',
+                        encoding='utf-8')
+        archived.append(path.stem)
+
+    print(f"Archived: {len(archived)}")
+    if archived:
+        for slug in archived:
+            print(f"  - {slug}")
+    print(f"Skipped (keep-live flag): {len(skipped_keep_live)}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/next/scripts/recompute-occurrence.py
+++ b/next/scripts/recompute-occurrence.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+recompute-occurrence.py — daily cron job 1 from the events registry design.
+
+For each recurring event (weekly, monthly, annual), recompute the
+`nextOccurrence` field. Drops past dates from the upcoming list, computes
+the next future date from the recurrence rule.
+
+Recurrence rules supported:
+- weekly: nextOccurrence = next future date matching startDate's day-of-week
+- monthly: nextOccurrence = next future date matching startDate's day-of-month
+- annual: nextOccurrence = next future date matching startDate's month + day
+
+Writes back to JSON files in place. Idempotent: rerunning produces the
+same result. Diff is committed by the GitHub Actions workflow.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+EVENT_DIR = Path(__file__).resolve().parent.parent / 'src' / 'content' / 'events'
+RECURRING = {'weekly', 'monthly', 'annual'}
+
+
+def parse_date(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace('Z', '+00:00')).date()
+    except (ValueError, TypeError):
+        return None
+
+
+def next_weekly(start: date, today: date) -> date:
+    """Next future date matching start's day-of-week."""
+    target_weekday = start.weekday()
+    delta = (target_weekday - today.weekday()) % 7
+    if delta == 0 and today >= start:
+        delta = 7
+    return today + timedelta(days=delta)
+
+
+def next_monthly(start: date, today: date) -> date:
+    """Next future date matching start's day-of-month."""
+    day = start.day
+    candidate = date(today.year, today.month, min(day, _last_day_of_month(today.year, today.month)))
+    if candidate <= today:
+        # roll to next month
+        if today.month == 12:
+            candidate = date(today.year + 1, 1, min(day, 31))
+        else:
+            next_m = today.month + 1
+            candidate = date(today.year, next_m, min(day, _last_day_of_month(today.year, next_m)))
+    return candidate
+
+
+def next_annual(start: date, today: date) -> date:
+    """Next future date matching start's month + day."""
+    candidate_year = today.year
+    try:
+        candidate = date(candidate_year, start.month, start.day)
+    except ValueError:
+        # 29 Feb on a non-leap year, push to 1 March
+        candidate = date(candidate_year, start.month + 1, 1)
+    if candidate <= today:
+        candidate_year += 1
+        try:
+            candidate = date(candidate_year, start.month, start.day)
+        except ValueError:
+            candidate = date(candidate_year, start.month + 1, 1)
+    return candidate
+
+
+def _last_day_of_month(year: int, month: int) -> int:
+    if month == 12:
+        return 31
+    return (date(year, month + 1, 1) - timedelta(days=1)).day
+
+
+def main() -> int:
+    today = date.today()
+    updated = []
+
+    for path in sorted(EVENT_DIR.glob('*.json')):
+        try:
+            data = json.loads(path.read_text(encoding='utf-8'))
+        except Exception as e:
+            print(f"SKIP (parse error) {path.name}: {e}")
+            continue
+
+        recurrence = data.get('recurrence', 'one-off')
+        if recurrence not in RECURRING:
+            continue
+        if data.get('status') in ('archived', 'expired'):
+            continue
+
+        start = parse_date(data.get('startDate'))
+        if start is None:
+            continue
+
+        if recurrence == 'weekly':
+            next_occ = next_weekly(start, today)
+        elif recurrence == 'monthly':
+            next_occ = next_monthly(start, today)
+        else:  # annual
+            next_occ = next_annual(start, today)
+
+        new_value = next_occ.isoformat()
+        if data.get('nextOccurrence') == new_value:
+            continue
+
+        data['nextOccurrence'] = new_value
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + '\n',
+                        encoding='utf-8')
+        updated.append(f"{path.stem} -> {new_value}")
+
+    print(f"Updated nextOccurrence on {len(updated)} events")
+    for line in updated:
+        print(f"  - {line}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/next/src/content/events/autumn-winery-walk-2026.json
+++ b/next/src/content/events/autumn-winery-walk-2026.json
@@ -58,5 +58,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "red-hill"
+  "place": "red-hill",
+  "nextOccurrence": "2026-05-09"
 }

--- a/next/src/content/events/bass-flinders-gin-masterclass.json
+++ b/next/src/content/events/bass-flinders-gin-masterclass.json
@@ -57,5 +57,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "dromana"
+  "place": "dromana",
+  "nextOccurrence": "2026-05-08"
 }

--- a/next/src/content/events/boneo-community-market.json
+++ b/next/src/content/events/boneo-community-market.json
@@ -52,5 +52,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-05-16"
 }

--- a/next/src/content/events/briars-eco-explorers-autumn.json
+++ b/next/src/content/events/briars-eco-explorers-autumn.json
@@ -13,10 +13,16 @@
   "worthTheDrive": false,
   "firstTimer": false,
   "weather": "mixed",
-  "lens": ["family-saturday", "school-holidays", "free", "walk-in", "locals-know"],
+  "lens": [
+    "family-saturday",
+    "school-holidays",
+    "free",
+    "walk-in",
+    "locals-know"
+  ],
   "editorVerdict": "One of the Peninsula's best-hidden free family outings. Run by council, not tourism  -  which is why nobody knows about it. Fix that.",
   "editorNote": "The Briars is the Mornington Peninsula Shire's flagship bushland reserve and one of the most under-published family assets on the Peninsula. 230 hectares of wetlands, forest, and a working historic homestead that most visitors drive past on the way to the Hot Springs without stopping.\n\nThe Eco Explorers programme runs three to four times a year during school holidays  -  ranger-led walks for kids 4-10, typically free with booking, usually midweek mornings. For Autumn 2026 the sessions run 13-15 April, covering wetland birds, bandicoot habitat, and the reserve's regenerating forest.\n\nBook through the council Activities page. Allow 90 minutes for the session plus an hour for the homestead and the wildlife sanctuary at the back of the reserve. Pack proper shoes  -  the trails are real bush, not a concrete loop.",
-  "status": "expired",
+  "status": "archived",
   "publishedAt": "2026-04-09",
   "heroImage": {
     "src": "/images/sourced/explore-greens-bush-01.webp",

--- a/next/src/content/events/chocolaterie-junior-chocolatier.json
+++ b/next/src/content/events/chocolaterie-junior-chocolatier.json
@@ -14,10 +14,16 @@
   "worthTheDrive": true,
   "firstTimer": false,
   "weather": "rainy-day-rescue",
-  "lens": ["family-saturday", "school-holidays", "rainy-day", "ticketed", "worth-the-drive"],
+  "lens": [
+    "family-saturday",
+    "school-holidays",
+    "rainy-day",
+    "ticketed",
+    "worth-the-drive"
+  ],
   "editorVerdict": "The Peninsula's best rainy-day family rescue during school holidays. Book it the moment the forecast tips over.",
   "editorNote": "Junior Chocolatier is a two-hour hands-on class for kids 6-12 that is genuinely well-designed: the kids mould, decorate and box their own chocolates under a chocolatier's supervision, and they leave with the box actually made by them rather than bought at the front counter. It is exactly what a wet-afternoon school holiday needs.\n\nThe class runs multiple times through the Easter school holidays, typically 11am and 2pm slots. Book a week ahead  -  the rainy-day sessions sell out first. While the kids are in class, the adult-sized version of the cafe at the front of the store is open, which means coffee, a proper mocha, and 90 minutes of peace.\n\nPair with a short Flinders walk after if the weather clears, or a quick stop at the Pier takeaway if everyone is tired.",
-  "status": "expired",
+  "status": "archived",
   "publishedAt": "2026-04-09",
   "heroImage": {
     "src": "/images/sourced/category-cafe-02.webp",

--- a/next/src/content/events/crib-point-community-market.json
+++ b/next/src/content/events/crib-point-community-market.json
@@ -54,5 +54,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-05-09"
 }

--- a/next/src/content/events/crittenden-wines-king-s-birthday-wine-weekend-events.json
+++ b/next/src/content/events/crittenden-wines-king-s-birthday-wine-weekend-events.json
@@ -54,5 +54,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "dromana"
+  "place": "dromana",
+  "nextOccurrence": "2026-06-06"
 }

--- a/next/src/content/events/dromana-community-market.json
+++ b/next/src/content/events/dromana-community-market.json
@@ -54,5 +54,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "dromana"
+  "place": "dromana",
+  "nextOccurrence": "2026-05-30"
 }

--- a/next/src/content/events/emu-plains-market-balnarring.json
+++ b/next/src/content/events/emu-plains-market-balnarring.json
@@ -55,5 +55,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "balnarring"
+  "place": "balnarring",
+  "nextOccurrence": "2026-05-16"
 }

--- a/next/src/content/events/emu-plains-market.json
+++ b/next/src/content/events/emu-plains-market.json
@@ -53,5 +53,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "balnarring"
+  "place": "balnarring",
+  "nextOccurrence": "2026-05-17"
 }

--- a/next/src/content/events/hastings-thursday-street-market.json
+++ b/next/src/content/events/hastings-thursday-street-market.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "hastings"
+  "place": "hastings",
+  "nextOccurrence": "2026-05-07"
 }

--- a/next/src/content/events/heart-of-the-community-market-rosebud.json
+++ b/next/src/content/events/heart-of-the-community-market-rosebud.json
@@ -54,5 +54,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "rosebud"
+  "place": "rosebud",
+  "nextOccurrence": "2026-05-09"
 }

--- a/next/src/content/events/hill-ridge-community-market-september-2026-restart.json
+++ b/next/src/content/events/hill-ridge-community-market-september-2026-restart.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "red-hill"
+  "place": "red-hill",
+  "nextOccurrence": "2026-05-05"
 }

--- a/next/src/content/events/main-street-mornington-festival-2026.json
+++ b/next/src/content/events/main-street-mornington-festival-2026.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-10-18"
 }

--- a/next/src/content/events/michael-vale-exhibition-at-mprg.json
+++ b/next/src/content/events/michael-vale-exhibition-at-mprg.json
@@ -55,5 +55,6 @@
   "kidsGradeAuto": "B",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2027-02-28"
 }

--- a/next/src/content/events/mornington-christmas-festival-main-street-christmas-parade.json
+++ b/next/src/content/events/mornington-christmas-festival-main-street-christmas-parade.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-12-20"
 }

--- a/next/src/content/events/mornington-cup-2026.json
+++ b/next/src/content/events/mornington-cup-2026.json
@@ -13,10 +13,16 @@
   "worthTheDrive": true,
   "firstTimer": false,
   "weather": "sunny-only",
-  "lens": ["weekend-pick", "worth-the-drive", "date-idea", "ticketed", "locals-know"],
+  "lens": [
+    "weekend-pick",
+    "worth-the-drive",
+    "date-idea",
+    "ticketed",
+    "locals-know"
+  ],
   "editorVerdict": "If you come down for one event on the Peninsula this April, come for the Cup. It is the one day the town collectively takes the afternoon off, the food trucks actually mean it, and the 4pm light on the grass is the photograph you take home.",
   "editorNote": "Mornington Cup is the cleanest argument the Peninsula makes for a Saturday day trip that doesn't feel like one. Gates open mid-morning, the card runs through eight races, and the Cup itself is the fifth or sixth  -  which is the ideal arc for a long lunch that politely demands you stop eating around three and pay attention again.\n\nPark at the racecourse if you're early; walk in from Mornington village if you're not  -  it's a 25-minute stroll past the gardens and back beaches, and the pub lunch before or after is the move nobody tells you about. Bring proper shoes if you want to stand on the grass. Bring a hat if the sky is clear. Leave the kids with a grandparent  -  this is an adult day.\n\nThe Peninsula does not have a bigger single-day commercial event in its calendar, and it's the one day all of the region's hospitality points in the same direction at once.",
-  "status": "expired",
+  "status": "archived",
   "publishedAt": "2026-04-09",
   "heroImage": {
     "src": "/images/sourced/explore-mornington-foreshore-01.webp",

--- a/next/src/content/events/mornington-peninsula-winter-wine-weekend-winter-wine-festival.json
+++ b/next/src/content/events/mornington-peninsula-winter-wine-weekend-winter-wine-festival.json
@@ -61,5 +61,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "red-hill"
+  "place": "red-hill",
+  "nextOccurrence": "2026-06-06"
 }

--- a/next/src/content/events/mornington-racecourse-market-may-2026.json
+++ b/next/src/content/events/mornington-racecourse-market-may-2026.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-05-10"
 }

--- a/next/src/content/events/mornington-racecourse-market.json
+++ b/next/src/content/events/mornington-racecourse-market.json
@@ -55,5 +55,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-05-10"
 }

--- a/next/src/content/events/mornington-racecourse-monthly-market-june-2026.json
+++ b/next/src/content/events/mornington-racecourse-monthly-market-june-2026.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-05-14"
 }

--- a/next/src/content/events/mornington-tourist-railway-santa-specials.json
+++ b/next/src/content/events/mornington-tourist-railway-santa-specials.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "moorooduc"
+  "place": "moorooduc",
+  "nextOccurrence": "2026-12-06"
 }

--- a/next/src/content/events/mornington-wednesday-market-main-street-market.json
+++ b/next/src/content/events/mornington-wednesday-market-main-street-market.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-05-06"
 }

--- a/next/src/content/events/mt-eliza-farmers-market.json
+++ b/next/src/content/events/mt-eliza-farmers-market.json
@@ -53,5 +53,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-05-24"
 }

--- a/next/src/content/events/pearcedale-community-market.json
+++ b/next/src/content/events/pearcedale-community-market.json
@@ -55,5 +55,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-05-16"
 }

--- a/next/src/content/events/peninsula-hot-springs-bathe-in-cinema-thursdays.json
+++ b/next/src/content/events/peninsula-hot-springs-bathe-in-cinema-thursdays.json
@@ -57,5 +57,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "rye"
+  "place": "rye",
+  "nextOccurrence": "2026-05-07"
 }

--- a/next/src/content/events/peninsula-hot-springs-sound-healing-sessions.json
+++ b/next/src/content/events/peninsula-hot-springs-sound-healing-sessions.json
@@ -56,5 +56,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "rye"
+  "place": "rye",
+  "nextOccurrence": "2026-06-01"
 }

--- a/next/src/content/events/peninsula-hot-springs-sunday-sessions.json
+++ b/next/src/content/events/peninsula-hot-springs-sunday-sessions.json
@@ -80,5 +80,6 @@
     "license": "other-licensed"
   },
   "status": "published",
-  "publishedAt": "2026-04-09"
+  "publishedAt": "2026-04-09",
+  "nextOccurrence": "2026-05-11"
 }

--- a/next/src/content/events/peninsula-summer-music-festival-2027-save-the-date.json
+++ b/next/src/content/events/peninsula-summer-music-festival-2027-save-the-date.json
@@ -53,5 +53,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2027-01-02"
 }

--- a/next/src/content/events/red-hill-brewery-secret-stash-weekend.json
+++ b/next/src/content/events/red-hill-brewery-secret-stash-weekend.json
@@ -57,5 +57,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "red-hill"
+  "place": "red-hill",
+  "nextOccurrence": "2026-08-15"
 }

--- a/next/src/content/events/red-hill-market-first-saturday.json
+++ b/next/src/content/events/red-hill-market-first-saturday.json
@@ -14,7 +14,12 @@
   "worthTheDrive": true,
   "firstTimer": true,
   "weather": "all-weather",
-  "lens": ["family-saturday", "worth-the-drive", "walk-in", "locals-know"],
+  "lens": [
+    "family-saturday",
+    "worth-the-drive",
+    "walk-in",
+    "locals-know"
+  ],
   "editorVerdict": "If you only ever do one Peninsula market, do this one. Everything else is an understudy.",
   "editorNote": "Red Hill Market runs the first Saturday of the month from September through May and it is the only Peninsula market that genuinely earns the hype. 200+ stalls, proper makers (not reseller tat), a coffee queue worth joining, and enough produce, plants and small-run ceramics to replace a Sunday afternoon shop at a fancy deli.\n\nThe single best move: arrive 8:45am, park at the recreation reserve while it's still possible, do the food lap first, the craft lap second, the plants lap last. By 11am it's packed. By 12:30 it's over. Budget two hours, eat as you go, and drive up the ridge for an early lunch before the cellar doors fill.\n\nThe months to beat the crowds: October, March, May. The months to skip: any December weekend the market coincides with school-holiday traffic  -  park outside Red Hill village and walk in.",
   "publishedAt": "2026-04-09",
@@ -23,5 +28,6 @@
     "alt": "Red Hill Market stalls on a first Saturday morning",
     "credit": "Unsplash",
     "license": "tmp-unsplash"
-  }
+  },
+  "nextOccurrence": "2026-06-02"
 }

--- a/next/src/content/events/rocky-road-festival-mornington-peninsula-chocolaterie.json
+++ b/next/src/content/events/rocky-road-festival-mornington-peninsula-chocolaterie.json
@@ -57,5 +57,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "flinders"
+  "place": "flinders",
+  "nextOccurrence": "2027-05-01"
 }

--- a/next/src/content/events/rocky-road-festival-tasting-sessions.json
+++ b/next/src/content/events/rocky-road-festival-tasting-sessions.json
@@ -58,5 +58,6 @@
   "kidsGradeAuto": "B",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "flinders"
+  "place": "flinders",
+  "nextOccurrence": "2026-05-10"
 }

--- a/next/src/content/events/shoreham-community-market.json
+++ b/next/src/content/events/shoreham-community-market.json
@@ -55,5 +55,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "shoreham"
+  "place": "shoreham",
+  "nextOccurrence": "2026-05-17"
 }

--- a/next/src/content/events/sorrento-solstice-festival-fire-night.json
+++ b/next/src/content/events/sorrento-solstice-festival-fire-night.json
@@ -61,5 +61,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "sorrento"
+  "place": "sorrento",
+  "nextOccurrence": "2026-06-20"
 }

--- a/next/src/content/events/sorrento-writers-festival-2026.json
+++ b/next/src/content/events/sorrento-writers-festival-2026.json
@@ -13,7 +13,12 @@
   "worthTheDrive": true,
   "firstTimer": true,
   "weather": "all-weather",
-  "lens": ["weekend-pick", "worth-the-drive", "date-idea", "ticketed"],
+  "lens": [
+    "weekend-pick",
+    "worth-the-drive",
+    "date-idea",
+    "ticketed"
+  ],
   "editorVerdict": "Book the Sorrento weekend, not the day trip. The festival is pitched for people who want to eat, walk and read all three days  -  not tick off two sessions and drive home tired.",
   "editorNote": "Sorrento Writers Festival is the one Peninsula event that genuinely rewards planning the whole weekend around it. Book the Friday session, stay two nights, catch the Sunday morning panel, and you've had a holiday rather than a day out.\n\nThe programme leans literary-fiction, ideas and investigative journalism  -  national names, serious moderators, and the kind of Q&A you can't get in a Melbourne bookshop. The venues are all within a five-minute walk of Ocean Beach Road, which means you can walk from a morning session to a back-beach walk to lunch without ever starting a car.\n\nWhere to stay matters. Book a hotel inside Sorrento itself, not Rye or Blairgowrie  -  the festival is a walking festival and everyone you meet will be on foot.",
   "status": "past",
@@ -23,5 +28,6 @@
     "alt": "Readers gathering for a literary festival event on the Mornington Peninsula",
     "credit": "Unsplash",
     "license": "tmp-unsplash"
-  }
+  },
+  "nextOccurrence": "2027-04-23"
 }

--- a/next/src/content/events/soul-night-market-mornington.json
+++ b/next/src/content/events/soul-night-market-mornington.json
@@ -53,5 +53,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "mornington"
+  "place": "mornington",
+  "nextOccurrence": "2026-05-12"
 }

--- a/next/src/content/events/soul-night-market-sorrento-beach.json
+++ b/next/src/content/events/soul-night-market-sorrento-beach.json
@@ -53,5 +53,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "sorrento"
+  "place": "sorrento",
+  "nextOccurrence": "2026-05-22"
 }

--- a/next/src/content/events/sound-circle-full-moon-sound-journey-at-peninsula-hot-springs.json
+++ b/next/src/content/events/sound-circle-full-moon-sound-journey-at-peninsula-hot-springs.json
@@ -56,5 +56,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-06-01"
 }

--- a/next/src/content/events/stonier-fire-wine-winter-lunch.json
+++ b/next/src/content/events/stonier-fire-wine-winter-lunch.json
@@ -53,5 +53,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "merricks"
+  "place": "merricks",
+  "nextOccurrence": "2026-08-09"
 }

--- a/next/src/content/events/stonier-pies-pinot-king-s-birthday-weekend.json
+++ b/next/src/content/events/stonier-pies-pinot-king-s-birthday-weekend.json
@@ -54,5 +54,6 @@
   "kidsGradeAuto": "C",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "merricks"
+  "place": "merricks",
+  "nextOccurrence": "2026-06-06"
 }

--- a/next/src/content/events/sustainable-house-day-2026.json
+++ b/next/src/content/events/sustainable-house-day-2026.json
@@ -13,7 +13,10 @@
   "worthTheDrive": true,
   "firstTimer": false,
   "weather": "all-weather",
-  "lens": ["worth-the-drive", "rainy-day"],
+  "lens": [
+    "worth-the-drive",
+    "rainy-day"
+  ],
   "editorVerdict": "A mid-May reason to come down that the Peninsula's design-minded visitor will actually care about. Worth booking if sustainable architecture is your thing.",
   "editorNote": "Sustainable House Day gives the Peninsula's What's On calendar something it rarely has in mid-May: a reason to move through multiple towns with actual purpose. The open homes span Bittern, Safety Beach, and Rye, which gives the day a natural driving structure rather than the usual single-venue logic. The anchor is the Eco Living Display Centre at The Briars in Mount Martha — a permanent sustainability education site that warrants the visit on its own terms. This is not a festival or a market; it is a set of real homes opened by real owners who have made specific design decisions worth understanding. The audience is design-curious adults, not lifestyle tourists. If that is your register, this is one of the stronger mid-May Peninsula days on the calendar.",
   "publishedAt": "2026-04-26",
@@ -22,5 +25,6 @@
     "alt": "Safety Beach on the Mornington Peninsula",
     "credit": "Peninsula Insider",
     "license": "other-licensed"
-  }
+  },
+  "nextOccurrence": "2026-05-17"
 }

--- a/next/src/content/events/tootgarook-primary-school-market.json
+++ b/next/src/content/events/tootgarook-primary-school-market.json
@@ -53,5 +53,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-05-23"
 }

--- a/next/src/content/events/wild-mushroom-forage-lunch-with-the-kitchen.json
+++ b/next/src/content/events/wild-mushroom-forage-lunch-with-the-kitchen.json
@@ -52,5 +52,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-05-09"
 }

--- a/next/src/content/events/winter-camp-2026-the-ranch.json
+++ b/next/src/content/events/winter-camp-2026-the-ranch.json
@@ -56,5 +56,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "C",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-06-30"
 }

--- a/next/src/content/events/winter-wine-weekend-full-3-day-peninsula-program.json
+++ b/next/src/content/events/winter-wine-weekend-full-3-day-peninsula-program.json
@@ -53,5 +53,6 @@
   "manualFollowUpRequired": true,
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
-  "publishedAt": "2026-05-04"
+  "publishedAt": "2026-05-04",
+  "nextOccurrence": "2026-06-06"
 }

--- a/next/src/content/events/winter-wine-weekend-june.json
+++ b/next/src/content/events/winter-wine-weekend-june.json
@@ -13,7 +13,13 @@
   "worthTheDrive": true,
   "firstTimer": true,
   "weather": "all-weather",
-  "lens": ["weekend-pick", "worth-the-drive", "date-idea", "walk-in", "locals-know"],
+  "lens": [
+    "weekend-pick",
+    "worth-the-drive",
+    "date-idea",
+    "walk-in",
+    "locals-know"
+  ],
   "editorVerdict": "The best weekend of the Peninsula year for committed wine people. Cooler weather, smaller crowds, and the winemakers are often the ones pouring.",
   "editorNote": "Winter Wine Weekend is the single best cellar-door weekend the Peninsula runs. 40+ wineries open their doors across the long weekend in June, most of them with fires lit, set menus in the tasting rooms, and the winemakers themselves behind the bar rather than junior staff. It is the closest the region gets to the way Piedmont or Burgundy runs an open-cellars weekend.\n\nThe strategy: pick a two-property day rather than trying to hit six. Allow an hour and a half per visit. Book lunch at one of the bigger restaurants (Ten Minutes by Tractor, Polperro, Montalto) in the middle of the day, and keep the second tasting for late afternoon when the fire rooms are at their best.\n\nMid-June is the cheapest Peninsula weekend rate of the year for accommodation. Book the bed, then the lunch, then the tastings.",
   "publishedAt": "2026-04-09",
@@ -22,5 +28,6 @@
     "alt": "Pinot Noir grapes on the vine at Main Ridge",
     "credit": "CSIRO ScienceImage",
     "license": "wikimedia-cc-by"
-  }
+  },
+  "nextOccurrence": "2026-06-06"
 }

--- a/next/src/content/events/winter-wine-weekend-winter-wine-festival-red-hill-showgrounds.json
+++ b/next/src/content/events/winter-wine-weekend-winter-wine-festival-red-hill-showgrounds.json
@@ -58,5 +58,6 @@
   "kidsGradeAuto": "not-for-kids",
   "status": "published",
   "publishedAt": "2026-05-04",
-  "place": "red-hill"
+  "place": "red-hill",
+  "nextOccurrence": "2026-06-06"
 }


### PR DESCRIPTION
## Summary

**Phase 4** of the events registry. Three operational cron jobs from the launch-tier maturity phase in the registry design doc.

## Cron jobs shipped

| Job | Schedule | Action | Trigger |
|---|---|---|---|
| **archive-expired** | Daily 03:30 AEST | Archives events 14+ days past their end date | Cron + workflow_dispatch |
| **recompute-occurrence** | Daily 03:00 AEST | Updates `nextOccurrence` for recurring events | Cron + workflow_dispatch |
| **weekly-rebuild** | Wed 06:00 AEST | Empty commit to refresh time-sensitive event surfaces | Cron + workflow_dispatch |

## Scripts (`next/scripts/`)
- `archive-expired-events.py` — only one-off / annual / seasonal recurrences eligible; weekly/monthly/ongoing managed by the recompute script. Editor can flag `keepLive: true` to opt out (post-mortem windows).
- `recompute-occurrence.py` — idempotent. Recurrence rules: weekly (next future date matching day-of-week), monthly (day-of-month), annual (month + day).

## First-run results captured in this commit
- **Archived 3 events**: `briars-eco-explorers-autumn`, `chocolaterie-junior-chocolatier`, `mornington-cup-2026` — all ended more than 14 days ago. Status set to `archived`.
- **Recomputed nextOccurrence** on all recurring events. Idempotent: re-running produces zero diff.

## Workflow design
Each cron commits directly to `main` with `[skip ci]` so the auto-deploy doesn't double-fire on every cron tick. The weekly rebuild workflow does the opposite — its whole purpose is to trigger a deploy via empty commit, so no `[skip ci]`.

## Test plan
- [x] Both scripts idempotent (verified by running twice; second run = 0 changes)
- [x] Both scripts gate by recurrence type so weekly/monthly events are never archived
- [x] Build passes (1199 pages)
- [ ] Workflows verified once they run via cron (or manual workflow_dispatch trigger)

## What's deferred (per design doc maturity phases)
- **~250 events**: source URL check, duplicate detection, JSON-LD validation, stale check, needs-review queue, venue match rebuild, nearby recalc
- **~500 events**: standout candidate flag, low-quality flag, itinerary pairing rebuild
- **Also deferred**: `events-import-from-spreadsheet` workflow (needs a content-drop mechanism for the .xlsx — Drive integration or committed copy), `events-overlay-protection-audit` (built into the import workflow when that lands), concierge ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)