### PR TITLE
feat(events): Hosted at block + venue page event strips

### DIFF
--- a/next/src/pages/eat/[slug].astro
+++ b/next/src/pages/eat/[slug].astro
@@ -2,7 +2,8 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import VenueDetailTemplate from '../../components/VenueDetailTemplate.astro';
-import { routeSlug, typeLabel, titleize } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { routeSlug, typeLabel, titleize, isUpcoming } from '../../lib/editorial';
 
 export async function getStaticPaths() {
   const eatTypes = ['restaurant', 'cafe', 'bakery', 'pub', 'market', 'winery'];
@@ -39,6 +40,18 @@ const itineraries = (await getCollection('itineraries'))
     itinerary.data.stops.some((stop) => String(stop.venue?.id ?? stop.venue ?? '') === slug)
   )
   .slice(0, 2);
+
+// Events at this venue: only render the strip when at least one event has
+// a clean venue ref pointing at this venue. Renders nothing for venues
+// that exist only as dining destinations (no event programme).
+const venueEvents = (await getCollection('events'))
+  .filter((event) => String(event.data.venue?.id ?? event.data.venue ?? '') === slug)
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
 
 const venuePlaceName = titleize(String(venue.data.place?.id ?? venue.data.place ?? ''));
 const venueTypeLabel = typeLabel[venue.data.type] ?? titleize(venue.data.type);
@@ -96,4 +109,14 @@ const venueSchema = {
 >
   <script type="application/ld+json" set:html={JSON.stringify(venueSchema)} />
   <VenueDetailTemplate venue={venue} section="eat" related={related} articles={articles} itineraries={itineraries} />
+
+  <EventStrip
+    events={venueEvents}
+    eyebrow="On the calendar here"
+    heading={`${venue.data.name} is also a real event venue`}
+    intro={`Upcoming events at ${venue.data.name}, with editorial notes when we have them.`}
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
+  />
 </BaseLayout>

--- a/next/src/pages/stay/[slug].astro
+++ b/next/src/pages/stay/[slug].astro
@@ -2,7 +2,8 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import VenueDetailTemplate from '../../components/VenueDetailTemplate.astro';
-import { routeSlug, typeLabel, titleize } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { routeSlug, typeLabel, titleize, isUpcoming } from '../../lib/editorial';
 
 export async function getStaticPaths() {
   const stayTypes = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'];
@@ -38,6 +39,16 @@ const itineraries = (await getCollection('itineraries'))
     itinerary.data.stops.some((stop) => String(stop.venue?.id ?? stop.venue ?? '') === slug)
   )
   .slice(0, 2);
+
+// Events at this venue, gated on a clean venue ref.
+const venueEvents = (await getCollection('events'))
+  .filter((event) => String(event.data.venue?.id ?? event.data.venue ?? '') === slug)
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
 
 const venuePlaceName = titleize(String(venue.data.place?.id ?? venue.data.place ?? ''));
 const venueTypeLabel = typeLabel[venue.data.type] ?? titleize(venue.data.type);
@@ -82,4 +93,14 @@ const venueSchema = {
 >
   <script type="application/ld+json" set:html={JSON.stringify(venueSchema)} />
   <VenueDetailTemplate venue={venue} section="stay" related={related} articles={articles} itineraries={itineraries} />
+
+  <EventStrip
+    events={venueEvents}
+    eyebrow="On the calendar here"
+    heading={`${venue.data.name} is also a real event venue`}
+    intro={`Upcoming events at ${venue.data.name}, with editorial notes when we have them.`}
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
+  />
 </BaseLayout>

--- a/next/src/pages/whats-on/[slug].astro
+++ b/next/src/pages/whats-on/[slug].astro
@@ -130,6 +130,52 @@ const breadcrumbItems = [
         </div>
 
         <aside class="event-detail__side">
+          {(venue || event.data.venueName) && (
+            <div class="event-detail__box event-detail__hosted">
+              <p class="event-detail__box-label">
+                Hosted at
+                {venue && <span class="event-detail__hosted-badge"> · ✦ Editor reviewed</span>}
+              </p>
+              <p class="event-detail__hosted-name">
+                {venue ? venue.data.name : event.data.venueName}
+              </p>
+              {(event.data.streetAddress || event.data.suburb) && (
+                <p class="event-detail__hosted-address">
+                  {event.data.streetAddress && <span>{event.data.streetAddress}</span>}
+                  {event.data.streetAddress && event.data.suburb && <span>, </span>}
+                  {event.data.suburb && <span>{event.data.suburb} VIC</span>}
+                </p>
+              )}
+              <ul class="event-detail__hosted-actions" role="list">
+                {venue && (
+                  <li>
+                    <a href={`${venueHrefPrefix(venue.data.type)}/${routeSlug(venue)}`}>
+                      Read the Insider's review &rarr;
+                    </a>
+                  </li>
+                )}
+                {event.data.organiser?.website && (
+                  <li>
+                    <a href={event.data.organiser.website} rel="nofollow noreferrer" target="_blank">
+                      Visit venue website &rarr;
+                    </a>
+                  </li>
+                )}
+                {event.data.coordinates && (
+                  <li>
+                    <a
+                      href={`https://www.google.com/maps?q=${event.data.coordinates.lat},${event.data.coordinates.lng}`}
+                      rel="nofollow noreferrer"
+                      target="_blank"
+                    >
+                      Get directions &rarr;
+                    </a>
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
+
           <div class="event-detail__box">
             <p class="event-detail__box-label">At a glance</p>
             <dl class="event-detail__box-list">
@@ -141,12 +187,6 @@ const breadcrumbItems = [
                 <div>
                   <dt>Where</dt>
                   <dd><a href={`/places/${routeSlug(place)}`}>{place.data.name}</a></dd>
-                </div>
-              )}
-              {venue && (
-                <div>
-                  <dt>Venue</dt>
-                  <dd><a href={`${venueHrefPrefix(venue.data.type)}/${routeSlug(venue)}`}>{venue.data.name}</a></dd>
                 </div>
               )}
               <div>

--- a/next/src/pages/wine/[slug].astro
+++ b/next/src/pages/wine/[slug].astro
@@ -2,7 +2,8 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import VenueDetailTemplate from '../../components/VenueDetailTemplate.astro';
-import { routeSlug, typeLabel, titleize } from '../../lib/editorial';
+import EventStrip from '../../components/EventStrip.astro';
+import { routeSlug, typeLabel, titleize, isUpcoming } from '../../lib/editorial';
 import {
   buildWinerySchema,
   buildRestaurantSchema,
@@ -46,6 +47,16 @@ const itineraries = (await getCollection('itineraries'))
   )
   .slice(0, 2);
 
+// Events at this venue, gated on a clean venue ref.
+const venueEvents = (await getCollection('events'))
+  .filter((event) => String(event.data.venue?.id ?? event.data.venue ?? '') === slug)
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
+
 const venuePlaceName = titleize(String(venue.data.place?.id ?? venue.data.place ?? ''));
 const venueTypeLabel = typeLabel[venue.data.type] ?? titleize(venue.data.type);
 const sigDesc = (venue.data.signature ?? '').trim();
@@ -86,4 +97,14 @@ schemas.push(
     <script type="application/ld+json" set:html={JSON.stringify(s)} />
   ))}
   <VenueDetailTemplate venue={venue} section="wine" related={related} articles={articles} itineraries={itineraries} />
+
+  <EventStrip
+    events={venueEvents}
+    eyebrow="On the calendar here"
+    heading={`${venue.data.name} is also a real event venue`}
+    intro={`Upcoming events at ${venue.data.name}, with editorial notes when we have them.`}
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
+  />
 </BaseLayout>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -5744,6 +5744,49 @@ p.has-drop-cap::first-letter {
   line-height: 1.45;
 }
 .event-detail__box-list dd a { color: var(--accent); border-bottom: 1px solid rgba(139, 78, 59, 0.4); }
+
+/* Hosted-at block: shows on every event detail page where venue info exists.
+   Differentiates PI-reviewed venues (✦ badge + review link) from event-host
+   venues (just the address + directions). The trust signal does the work. */
+.event-detail__hosted-badge {
+  font-weight: 500;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+}
+.event-detail__hosted-name {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+  line-height: 1.25;
+  color: var(--text);
+  margin: 0 0 0.35rem;
+  letter-spacing: -0.01em;
+}
+.event-detail__hosted-address {
+  font-size: 0.85rem;
+  color: var(--soft);
+  line-height: 1.5;
+  margin: 0 0 0.85rem;
+}
+.event-detail__hosted-actions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.event-detail__hosted-actions a {
+  font-size: 0.85rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(139, 78, 59, 0.4);
+  display: inline-block;
+}
+.event-detail__hosted-actions a:hover {
+  color: var(--text);
+  border-bottom-color: var(--text);
+}
 .event-detail__lenses {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

**Phase 5** of the events registry. Addresses the 80-of-87 events whose venue isn't in the venues collection. Upgrades venue rendering on event detail pages and gates the venue page event strip on a real venue ref.

## Editorial position

PI doesn't auto-create thin venue pages to satisfy the data model. Two patterns, rendered differently:

| Pattern | Count | What renders |
|---|---:|---|
| **Pattern 1** — venue in PI's curated collection | 7 | "Hosted at · ✦ Editor reviewed" + review link + website + directions |
| **Pattern 2** — event-host venue (gallery/showground/community park) | 80 | "Hosted at" + venue name + address + website + directions (no review link) |

The trust signal does the work: when there's no `✦ Editor reviewed` badge, we haven't reviewed the venue itself, only the event programme there.

## What ships

### Event detail page (`/whats-on/[slug]/`)
- New "Hosted at" sidebar block replaces the thin Venue line in At-a-glance.
- Conditional badge + review link based on `venue` ref presence.
- Always-on "Visit venue website" (from `organiser.website`) and "Get directions" (Google Maps via `coordinates`) when fields are populated.

### Venue detail pages (`/eat/[slug]/`, `/stay/[slug]/`, `/wine/[slug]/`)
- New EventStrip below VenueDetailTemplate.
- Gated: only renders if at least one upcoming event has a clean `venue` ref pointing at this venue.
- For the ~127 venues with no event programme, the strip is silent.

## Test plan
- [x] Local build (1199 pages)
- [x] PHS Sunday Sessions (venue ref): renders Editor-reviewed badge + review link + website + directions
- [x] Michael Vale exhibition (no venue ref): renders website + directions only, no badge
- [x] PHS venue page: event strip rendering
- [x] Tedesca Osteria (no upcoming events): no strip rendered (gating works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)