### PR TITLE
fix(nav,home): mega-menu hover bug + remove Ask block from homepage

### DIFF
--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -237,8 +237,12 @@ const {
 })();
 </script>
 
-<!-- Masthead "More" mega-menu controller. Hover/focus opens; click toggles;
-     Escape and outside click close. Idempotent across astro:page-load. -->
+<!-- Masthead "More" mega-menu controller.
+     Hover opens softly (closes on mouseleave with a 250ms grace period to
+     bridge the cursor traversal between trigger and panel). Click locks the
+     panel open until Escape, outside-click, or another click on the trigger.
+     Touch input takes the click path because mouseenter is unreliable.
+     Idempotent across astro:page-load. -->
 <script is:inline>
 (function () {
   function bindMore() {
@@ -249,12 +253,16 @@ const {
       const panel = root.querySelector('[data-more-panel]');
       if (!trigger || !panel) return;
 
-      let open = false;
-      const setOpen = (next) => {
-        if (open === next) return;
-        open = next;
-        trigger.setAttribute('aria-expanded', next ? 'true' : 'false');
-        if (next) {
+      // mode: 'closed' | 'hover' | 'click'
+      // 'hover' closes on mouseleave (with grace period). 'click' is sticky
+      // and only closes on Escape, outside-click, or click on the trigger.
+      let mode = 'closed';
+      let leaveTimer = null;
+
+      const apply = () => {
+        var isOpen = mode !== 'closed';
+        trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        if (isOpen) {
           panel.removeAttribute('hidden');
           root.classList.add('is-open');
         } else {
@@ -262,24 +270,72 @@ const {
           root.classList.remove('is-open');
         }
       };
+      const setMode = (next) => {
+        if (mode === next) return;
+        mode = next;
+        apply();
+      };
+      const cancelLeave = () => {
+        if (leaveTimer) {
+          clearTimeout(leaveTimer);
+          leaveTimer = null;
+        }
+      };
 
+      // Click toggles between sticky-open and closed. Cancels any in-flight
+      // hover-close so a tap that follows a hover doesn't immediately drop.
       trigger.addEventListener('click', (e) => {
         e.preventDefault();
-        setOpen(!open);
+        e.stopPropagation();
+        cancelLeave();
+        setMode(mode === 'click' ? 'closed' : 'click');
       });
-      root.addEventListener('mouseenter', () => setOpen(true));
-      root.addEventListener('mouseleave', () => setOpen(false));
+
+      // Hover only opens if nothing's already happening. If the panel was
+      // click-locked, hover does nothing — leave the user's explicit choice
+      // alone.
+      root.addEventListener('mouseenter', () => {
+        cancelLeave();
+        if (mode === 'closed') setMode('hover');
+      });
+
+      // Hover-leave closes after a grace period; click-locked stays open.
+      // The grace period prevents the panel disappearing while the cursor
+      // travels from trigger to panel content.
+      root.addEventListener('mouseleave', () => {
+        if (mode !== 'hover') return;
+        cancelLeave();
+        leaveTimer = setTimeout(() => {
+          if (mode === 'hover') setMode('closed');
+          leaveTimer = null;
+        }, 250);
+      });
+
+      // Keyboard: focus moves out of the menu structure → close.
       root.addEventListener('focusout', (e) => {
-        if (!root.contains(e.relatedTarget)) setOpen(false);
+        if (!root.contains(e.relatedTarget)) {
+          cancelLeave();
+          setMode('closed');
+        }
       });
+
+      // Escape closes regardless of mode and returns focus to the trigger.
       document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && open) {
-          setOpen(false);
+        if (e.key === 'Escape' && mode !== 'closed') {
+          cancelLeave();
+          setMode('closed');
           trigger.focus();
         }
       });
+
+      // Outside click only kills 'click' mode. 'hover' mode handles itself
+      // via mouseleave — using the document click listener for hover would
+      // cause it to close on the panel's own clicks (link navigation).
       document.addEventListener('click', (e) => {
-        if (open && !root.contains(e.target)) setOpen(false);
+        if (mode === 'click' && !root.contains(e.target)) {
+          cancelLeave();
+          setMode('closed');
+        }
       });
     });
   }

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -2,7 +2,6 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import HomeCover from '../components/HomeCover.astro';
-import InsiderAsk from '../components/InsiderAsk.astro';
 import Shortlist from '../components/Shortlist.astro';
 import EditorsLetter from '../components/EditorsLetter.astro';
 import InsiderStripe from '../components/InsiderStripe.astro';
@@ -208,8 +207,6 @@ const seasonalExperiences = experiences
       ]}
     />
   )}
-
-  <InsiderAsk />
 
   <InsiderPlans />
 

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -406,7 +406,11 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .masthead__more-panel {
   position: absolute;
-  top: calc(100% + 0.65rem);
+  /* Sit flush with the bottom of the trigger so cursor traversal stays
+     inside the li's hit area. The visual breathing room comes from the
+     panel's own padding plus a transparent ::before bridge that extends
+     the hit area upward by a few pixels in case rounding creates a gap. */
+  top: 100%;
   right: 0;
   z-index: 60;
   min-width: 18rem;
@@ -415,6 +419,20 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   background: var(--paper, #fbf7f0);
   border: 1px solid var(--border);
   box-shadow: 0 18px 40px -20px rgba(40, 28, 14, 0.35);
+  /* Visual breathing room kept by translating the panel down without
+     creating a hover dead zone — the ::before bridge below covers it. */
+  transform: translateY(0.65rem);
+}
+.masthead__more-panel::before {
+  content: '';
+  position: absolute;
+  /* Cover the 0.65rem gap created by translateY plus a few px slack. */
+  top: -0.85rem;
+  left: 0;
+  right: 0;
+  height: 0.85rem;
+  background: transparent;
+  pointer-events: auto;
 }
 .masthead__more-panel[hidden] {
   display: none;


### PR DESCRIPTION
## Summary

Two production bugs reported after PR #47 shipped. Both fixed here.

### Nav — "More" panel was flashing away
Three issues compounded: (1) mouseenter opened the panel, then the click handler toggled it closed before the user could interact; (2) a 0.65rem CSS gap between trigger and panel created a cursor dead zone where `mouseleave` fired before the panel was reachable; (3) the document click listener killed the panel when users clicked links inside it.

Rewrote the controller around an explicit `mode` state (`'closed'`, `'hover'`, `'click'`). Hover and click can no longer conflict: click is sticky until Escape, outside-click, or another trigger click; hover opens softly with a 250ms grace period on mouseleave to bridge cursor traversal. Outside-click now only closes click-mode, so panel link clicks no longer kill hover-mode.

CSS pulls the panel flush with the trigger top edge (`top: 100%`) and creates the visual gap via `translateY` plus a transparent `::before` bridge that keeps the hover hit area continuous.

### Homepage — Ask block removed
Dropped the `<InsiderAsk />` block. The concierge still ships via the page-bottom drawer trigger and the dedicated `/ask/` page; the homepage no longer leads with the conversational prompt.

### Build
1200 pages, clean. Confirmed: homepage no longer contains `ASK THE INSIDER`; mega-menu panel and JS controller render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)