### PR TITLE
feat(venues): listing hours + live status (Discovery Phase 1, WS3)

### DIFF
--- a/next/src/components/VenueCard.astro
+++ b/next/src/components/VenueCard.astro
@@ -7,6 +7,7 @@
  */
 
 import { resolveHeroSrc } from '../lib/editorial';
+import { verifiedFreshnessLabel, verificationFreshness } from '../lib/venues';
 
 const typeLabel: Record<string, string> = {
   restaurant:  'Restaurant',
@@ -47,6 +48,8 @@ const moodTags = Array.isArray(data.tags?.mood) ? data.tags.mood.slice(0, 2) : [
 const summaryLine = [shortAddress, data.priceBand].filter(Boolean).join(' · ');
 const heroSrc = resolveHeroSrc(data);
 const heroAlt = data.heroImage?.alt ?? data.name ?? '';
+const verifiedLabel = verifiedFreshnessLabel(data.lastVerified);
+const verifiedTier = verificationFreshness(data.lastVerified);
 ---
 
 <article class="venue-card">
@@ -81,4 +84,10 @@ const heroAlt = data.heroImage?.alt ?? data.name ?? '';
       <a href={data.bookingUrl} target="_blank" rel="noopener noreferrer" class="venue-card__book" onClick={(e: any) => e.stopPropagation()}>Book</a>
     )}
   </div>
+  {verifiedLabel && (
+    <p class={`venue-card__verified venue-card__verified--${verifiedTier}`} aria-label={`Editorial freshness: ${verifiedLabel}`}>
+      <span class="venue-card__verified-dot" aria-hidden="true"></span>
+      {verifiedLabel}
+    </p>
+  )}
 </article>

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -1,5 +1,6 @@
 ---
 import { placeLabel, typeLabel, routeSlug, titleize, venueHrefPrefix, heroBackgroundStyle } from '../lib/editorial';
+import { resolveLiveStatusUrl, verifiedFreshnessLabel } from '../lib/venues';
 import Breadcrumbs from './Breadcrumbs.astro';
 import NewsletterBlock from './NewsletterBlock.astro';
 import VenueCard from './VenueCard.astro';
@@ -17,6 +18,8 @@ export interface Props {
 
 const { venue, section, related = [], articles = [], itineraries = [] } = Astro.props;
 const data = venue.data;
+const liveStatusUrl = resolveLiveStatusUrl(data);
+const verifiedLabel = verifiedFreshnessLabel(data.lastVerified);
 const sectionLabel = section === 'stay' ? 'Stay' : section === 'wine' ? 'Wine Country' : 'Eat & Drink';
 const sectionHref = `/${section}`;
 const hats = data.authority?.hats ?? 0;
@@ -203,10 +206,26 @@ const isClosed = data.status === 'closed';
             </>
           )}
 
-          {data.lastVerified && (
+          {data.hoursNote && (
+            <>
+              <dt>Hours</dt>
+              <dd>{data.hoursNote}</dd>
+            </>
+          )}
+
+          <>
+            <dt>Live status</dt>
+            <dd>
+              <a href={liveStatusUrl} target="_blank" rel="noopener noreferrer">
+                Check current hours →
+              </a>
+            </dd>
+          </>
+
+          {verifiedLabel && (
             <>
               <dt>Verified</dt>
-              <dd>{data.lastVerified.toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}</dd>
+              <dd>{verifiedLabel}</dd>
             </>
           )}
 

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -156,6 +156,19 @@ const venues = defineCollection({
     affiliateNote: z.string().optional(),
     featuredPartner: z.boolean().default(false),
     lastVerified: z.coerce.date(),
+    /**
+     * Free-text hours summary surfaced on the venue page (e.g.
+     * "Sat–Sun 11am–5pm" or "Closed Tue–Wed"). Optional. When absent,
+     * the page falls back to the "Check live status" link only.
+     */
+    hoursNote: z.string().optional(),
+    /**
+     * Optional override for the live-status link URL. When omitted the
+     * page builds a Google Maps search query from the venue name and
+     * address, which is generally good enough to land on the operator's
+     * Google profile with current open/closed state and live hours.
+     */
+    liveStatusUrl: z.string().url().optional(),
     publishedAt: z.coerce.date(),
     sitemapExclude: z.boolean().default(false),
   }),

--- a/next/src/lib/venues.ts
+++ b/next/src/lib/venues.ts
@@ -1,0 +1,79 @@
+/**
+ * Venue helpers — opening-hours freshness, live-status URL fallback, and
+ * verification chip copy. Discovery Layer Phase 1, workstream 3.
+ *
+ * Kept separate from editorial.ts because that module is generic across all
+ * collections; this is venue-specific.
+ */
+
+import type { CollectionEntry } from 'astro:content';
+
+export type Venue = CollectionEntry<'venues'>;
+
+/**
+ * Build a Google Maps search URL for a venue. Used as the live-status link
+ * fallback when no explicit `liveStatusUrl` is set on the venue. Lands on
+ * Google's place card where current open/closed state and hours are kept
+ * fresh by Google's own data pipeline.
+ */
+export function googleMapsSearchUrl(name: string, address?: string | null): string {
+  const query = [name, address, 'Mornington Peninsula', 'VIC', 'Australia']
+    .filter((part) => part && String(part).trim().length > 0)
+    .join(', ');
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}
+
+/**
+ * Resolve the live-status URL for a venue: explicit override first, then a
+ * Google Maps fallback. Always returns a usable URL.
+ */
+export function resolveLiveStatusUrl(data: Venue['data']): string {
+  if (data.liveStatusUrl && data.liveStatusUrl.trim()) {
+    return data.liveStatusUrl.trim();
+  }
+  return googleMapsSearchUrl(data.name, data.address);
+}
+
+/**
+ * Return a short freshness label for the venue's `lastVerified` date.
+ * Optimised for legibility in a card chip or sidebar row:
+ *   - "Verified this month" (≤ 35 days old)
+ *   - "Verified [Mon] [YYYY]" otherwise
+ *
+ * The 35-day threshold rather than "this calendar month" handles the awkward
+ * "verified yesterday but it's the 1st of next month" case where the calendar
+ * answer would say "last month" even though the data is one day old.
+ */
+export function verifiedFreshnessLabel(lastVerified: Date | string | undefined): string | null {
+  if (!lastVerified) return null;
+  const date = typeof lastVerified === 'string' ? new Date(lastVerified) : lastVerified;
+  if (Number.isNaN(date.getTime())) return null;
+
+  const now = new Date();
+  const days = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (days <= 35) return 'Verified this month';
+  return `Verified ${date.toLocaleDateString('en-AU', { month: 'short', year: 'numeric' })}`;
+}
+
+/**
+ * "How fresh" tier — used to colour the verification chip on cards.
+ *   - 'fresh': verified in the last 35 days
+ *   - 'recent': 36–120 days
+ *   - 'stale': 121+ days (or unknown)
+ *
+ * The aim is to give readers a fast, honest signal about how recently the
+ * editorial team confirmed the venue's status, without presenting a precise
+ * age that would imply more accuracy than the verification rhythm warrants.
+ */
+export function verificationFreshness(
+  lastVerified: Date | string | undefined,
+): 'fresh' | 'recent' | 'stale' {
+  if (!lastVerified) return 'stale';
+  const date = typeof lastVerified === 'string' ? new Date(lastVerified) : lastVerified;
+  if (Number.isNaN(date.getTime())) return 'stale';
+  const days = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+  if (days <= 35) return 'fresh';
+  if (days <= 120) return 'recent';
+  return 'stale';
+}

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -1253,6 +1253,35 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   border-radius: 999px;
   transition: border-color 0.18s var(--ease), color 0.18s var(--ease), background 0.18s var(--ease);
 }
+/* Editorial-freshness chip on venue cards. Three tiers, colour-coded:
+   fresh (≤35 days, accent), recent (36–120 days, soft), stale (older or
+   unknown, muted). The aim is an honest signal, not a precise age. */
+.venue-card__verified {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0.6rem 0 0;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+}
+.venue-card__verified-dot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+.venue-card__verified--fresh { color: var(--accent); }
+.venue-card__verified--recent { color: var(--soft); }
+.venue-card__verified--stale {
+  color: var(--soft);
+  opacity: 0.7;
+}
+
 .venue-card__book:hover {
   border-color: rgba(121, 92, 58, 0.3);
   color: #4d3925;


### PR DESCRIPTION
## Summary

Closes Discovery Layer Phase 1 by shipping the sixth and final workstream — listing hours and live status. The "open now / current hours" gap surfaced in the May UX review is now closed for every venue page.

[Project plan + progress log](https://github.com/richmondjw/peninsula-insider/blob/main/../../JWR_PKM_2026/07-projects/peninsula-insider/discovery-layer-phase-1.md) (vault).

## Approach

Rather than mirroring full opening-hours data into the venue schema (which would create a freshness liability of its own), this leans on Google's live data:

- **Editorial freshness** comes from PI: a `lastVerified` date already on every venue, surfaced as a "Verified this month" / "Verified [Mon YYYY]" label on cards and detail pages.
- **Live status** comes from Google: every venue page has a "Check current hours →" link that lands on the operator's Google place card, where Google maintains current open/closed state.
- **Free-text override** for editorial notes: the new optional `hoursNote` field surfaces on the venue page when set ("Sat–Sun 11am–5pm" or "Closed Tue–Wed"), but isn't required — venues without it degrade to the live-status link plus verified date.

## Files

- `next/src/content.config.ts` — adds `hoursNote` (string optional) and `liveStatusUrl` (URL optional) to the venues schema.
- `next/src/lib/venues.ts` (new) — `googleMapsSearchUrl`, `resolveLiveStatusUrl`, `verifiedFreshnessLabel`, `verificationFreshness`.
- `next/src/components/VenueDetailTemplate.astro` — facts list grows Hours, Live status, and Verified rows.
- `next/src/components/VenueCard.astro` — new editorial-freshness chip beneath the action row, three colour tiers (fresh/recent/stale).
- `next/src/styles/global.css` — chip styles.

## Editorial-ops handoff

The "top 50 venues with hand-verified hours notes" item from the project plan is a curatorial task, not a code change. The framework ships now; backfill happens at editorial pace via the JSON files. The field is documented inline in the schema.

## Test plan

- [ ] Visit any venue (e.g. `/eat/montalto/`) — facts list shows Hours (when set), Live status with "Check current hours →" linking to Google Maps, and Verified label.
- [ ] Visit `/eat/` or any place hub — venue cards show a small "Verified this month" chip beneath the actions, accent-coloured for recently verified venues.
- [ ] Add a `hoursNote` to one venue's JSON, rebuild, and confirm the Hours row appears.
- [ ] Add a `liveStatusUrl` override to one venue and confirm the link uses the override instead of the Maps fallback.

## Build

1200 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)