### PR TITLE
feat(discovery-phase-2): filterable Eat directory + What's On temporal tabs

### DIFF
--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -18,6 +18,65 @@ const venues = (await getCollection('venues'))
   .filter((venue) => eatTypes.includes(venue.data.type))
   .sort((a, b) => Number(b.data.authority?.hats ?? 0) - Number(a.data.authority?.hats ?? 0));
 
+// Filter dimensions for the directory grid (Phase 2, WS2A). Built from the
+// venue corpus so the filter row only ever shows values that actually have
+// matches. Place lookup uses the live places collection so the dropdown
+// shows pretty names rather than slugs.
+const placesAll = await getCollection('places');
+const placeNameBySlug = new Map<string, string>(
+  placesAll.map((p) => [p.id ?? p.data.slug, p.data.name]),
+);
+const venuePlaceSlugs = Array.from(
+  new Set(
+    venues
+      .map((v) => (typeof v.data.place === 'string' ? v.data.place : v.data.place?.id))
+      .filter((slug): slug is string => Boolean(slug)),
+  ),
+);
+const filterPlaceOptions = venuePlaceSlugs
+  .map((slug) => ({ slug, name: placeNameBySlug.get(slug) ?? slug }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const venueTypeOptions: Array<{ value: string; label: string }> = [
+  { value: 'restaurant', label: 'Restaurants' },
+  { value: 'cafe',       label: 'Cafés' },
+  { value: 'bakery',     label: 'Bakeries' },
+  { value: 'pub',        label: 'Pubs' },
+  { value: 'market',     label: 'Markets' },
+  { value: 'winery',     label: 'Wineries' },
+];
+
+const moodFilterOptions: Array<{ value: string; label: string }> = [
+  { value: 'long-lunch',   label: 'Long lunch' },
+  { value: 'family',       label: 'Family' },
+  { value: 'romance',      label: 'Romance' },
+  { value: 'view',         label: 'A view' },
+  { value: 'fireplace',    label: 'Fireplace' },
+  { value: 'rainy-day',    label: 'Rainy day' },
+  { value: 'waterfront',   label: 'Waterfront' },
+  { value: 'garden',       label: 'Garden' },
+];
+
+/**
+ * Build the data-* attribute payload for one venue's wrapper. Encodes the
+ * filterable dimensions in a form the inline JS can match against without
+ * any per-venue lookup.
+ */
+function venueFilterAttrs(venue: typeof venues[number]): Record<string, string> {
+  const placeSlug = typeof venue.data.place === 'string' ? venue.data.place : venue.data.place?.id ?? '';
+  const moods: string[] = Array.isArray(venue.data.tags?.mood) ? venue.data.tags.mood : [];
+  const hats = Number(venue.data.authority?.hats ?? 0);
+  return {
+    'data-venue': '',
+    'data-place': placeSlug,
+    'data-type': venue.data.type,
+    'data-price': venue.data.priceBand ?? '',
+    'data-mood': moods.join(' '),
+    'data-dog-friendly': venue.data.dogFriendly ? '1' : '0',
+    'data-hatted': hats > 0 ? '1' : '0',
+  };
+}
+
 const hattedCount = venues.filter((v) => Number(v.data.authority?.hats ?? 0) > 0).length;
 const twoHatCount = venues.filter((v) => Number(v.data.authority?.hats ?? 0) >= 2).length;
 const totalHats = venues.reduce((acc, v) => acc + Number(v.data.authority?.hats ?? 0), 0);
@@ -306,23 +365,260 @@ const faqSchema = {
   )}
 
   <!-- ═══════════════════════════════════════════════════════════════
-       8. FULL DIRECTORY
+       8. FULL DIRECTORY (filterable, Phase 2 WS2A)
        ═══════════════════════════════════════════════════════════════ -->
-  <section class="venues" id="all">
+  <section class="venues venues--filterable" id="all">
     <div class="container">
       <div class="venues__header">
         <div>
           <p class="label label--accent">Complete dining directory</p>
-          <h2 class="venues__title">All {venues.length} eat-and-drink venues, by authority</h2>
-          <p class="venues__sub">Ordered by editorial weight, hatted rooms first, then the places doing quiet, serious work below them.</p>
+          <h2 class="venues__title">All {venues.length} eat-and-drink venues</h2>
+          <p class="venues__sub">Ordered by editorial weight. Filter by town, format, price, mood, or suitability — the list re-shapes itself as you go.</p>
         </div>
         <a href="/eat/best-restaurants/" class="venues__link">Ranked top 15 →</a>
       </div>
-      <div class="venues__grid">
-        {venues.slice(0, 24).map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+
+      <form class="venue-filters" data-filter-form aria-label="Filter the dining directory">
+        <details class="venue-filters__panel" open>
+          <summary class="venue-filters__summary">
+            <span class="venue-filters__summary-label">Filter</span>
+            <span class="venue-filters__summary-count" data-filter-count>Showing all {venues.length}</span>
+          </summary>
+
+          <div class="venue-filters__row">
+            <div class="venue-filters__group">
+              <label class="venue-filters__group-label" for="venue-filter-place">Town</label>
+              <select id="venue-filter-place" class="venue-filters__select" data-filter-key="place">
+                <option value="">All towns</option>
+                {filterPlaceOptions.map((p) => (
+                  <option value={p.slug}>{p.name}</option>
+                ))}
+              </select>
+            </div>
+
+            <fieldset class="venue-filters__group">
+              <legend class="venue-filters__group-label">Format</legend>
+              <div class="venue-filters__chips">
+                {venueTypeOptions.map((opt) => (
+                  <button
+                    type="button"
+                    class="venue-filters__chip"
+                    data-filter-key="type"
+                    data-filter-value={opt.value}
+                    aria-pressed="false"
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <fieldset class="venue-filters__group">
+              <legend class="venue-filters__group-label">Price</legend>
+              <div class="venue-filters__chips venue-filters__chips--tight">
+                {(['$', '$$', '$$$', '$$$$'] as const).map((band) => (
+                  <button
+                    type="button"
+                    class="venue-filters__chip venue-filters__chip--price"
+                    data-filter-key="price"
+                    data-filter-value={band}
+                    aria-pressed="false"
+                  >
+                    {band}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <fieldset class="venue-filters__group">
+              <legend class="venue-filters__group-label">Mood</legend>
+              <div class="venue-filters__chips">
+                {moodFilterOptions.map((opt) => (
+                  <button
+                    type="button"
+                    class="venue-filters__chip"
+                    data-filter-key="mood"
+                    data-filter-value={opt.value}
+                    aria-pressed="false"
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <div class="venue-filters__toggles">
+              <label class="venue-filters__toggle">
+                <input type="checkbox" data-filter-key="dog" />
+                <span>Dog-friendly</span>
+              </label>
+              <label class="venue-filters__toggle">
+                <input type="checkbox" data-filter-key="hatted" />
+                <span>Hatted only</span>
+              </label>
+            </div>
+
+            <button type="button" class="venue-filters__clear" data-filter-clear>Clear filters</button>
+          </div>
+        </details>
+      </form>
+
+      <div class="venues__grid" data-filter-grid>
+        {venues.map((venue) => (
+          <div {...venueFilterAttrs(venue)}>
+            <VenueCard venue={venue} hrefPrefix="/eat" />
+          </div>
+        ))}
       </div>
+
+      <p class="venues__empty" data-filter-empty hidden>
+        No venues match those filters. Try removing one of them, or
+        <a href="/ask/" data-pi-trigger="true">ask the Insider</a> for a recommendation.
+      </p>
     </div>
   </section>
+
+  <script is:inline>
+    /* Eat directory filter controller. Static-first: filtering is purely a
+       DOM hide/show pass over pre-rendered cards. URL state means a filtered
+       view is shareable.
+       Idempotent across astro:page-load. */
+    (function () {
+      function bindFilters() {
+        var form = document.querySelector('[data-filter-form]');
+        if (!form || form._piFilterBound) return;
+        form._piFilterBound = true;
+
+        var grid = document.querySelector('[data-filter-grid]');
+        var emptyEl = document.querySelector('[data-filter-empty]');
+        var countEl = form.querySelector('[data-filter-count]');
+        var cards = grid ? grid.querySelectorAll('[data-venue]') : [];
+        var totalCount = cards.length;
+
+        // State shape — single value per key for v1, except 'mood' which is
+        // also single (multi-mood would require a different match approach).
+        var state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
+
+        function readUrl() {
+          var p = new URLSearchParams(window.location.search);
+          state.place = p.get('place') || '';
+          state.type = p.get('type') || '';
+          state.price = p.get('price') || '';
+          state.mood = p.get('mood') || '';
+          state.dog = p.get('dog') === '1';
+          state.hatted = p.get('hatted') === '1';
+        }
+
+        function writeUrl() {
+          var p = new URLSearchParams();
+          if (state.place) p.set('place', state.place);
+          if (state.type) p.set('type', state.type);
+          if (state.price) p.set('price', state.price);
+          if (state.mood) p.set('mood', state.mood);
+          if (state.dog) p.set('dog', '1');
+          if (state.hatted) p.set('hatted', '1');
+          var qs = p.toString();
+          var url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
+          window.history.replaceState(null, '', url);
+        }
+
+        function syncControls() {
+          // Place select
+          var placeSel = form.querySelector('[data-filter-key="place"]');
+          if (placeSel) placeSel.value = state.place;
+          // Chips: aria-pressed reflects whether this value is the active one
+          form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
+            var key = btn.getAttribute('data-filter-key');
+            var val = btn.getAttribute('data-filter-value');
+            btn.setAttribute('aria-pressed', state[key] === val ? 'true' : 'false');
+          });
+          // Toggles
+          var dog = form.querySelector('input[data-filter-key="dog"]');
+          if (dog) dog.checked = state.dog;
+          var hat = form.querySelector('input[data-filter-key="hatted"]');
+          if (hat) hat.checked = state.hatted;
+        }
+
+        function apply() {
+          var visible = 0;
+          cards.forEach(function (card) {
+            var ok = true;
+            if (state.place && card.getAttribute('data-place') !== state.place) ok = false;
+            if (ok && state.type && card.getAttribute('data-type') !== state.type) ok = false;
+            if (ok && state.price && card.getAttribute('data-price') !== state.price) ok = false;
+            if (ok && state.mood) {
+              var moods = (card.getAttribute('data-mood') || '').split(/\s+/);
+              if (moods.indexOf(state.mood) === -1) ok = false;
+            }
+            if (ok && state.dog && card.getAttribute('data-dog-friendly') !== '1') ok = false;
+            if (ok && state.hatted && card.getAttribute('data-hatted') !== '1') ok = false;
+            card.classList.toggle('is-filtered-out', !ok);
+            if (ok) visible++;
+          });
+          if (countEl) {
+            var anyActive = state.place || state.type || state.price || state.mood || state.dog || state.hatted;
+            countEl.textContent = anyActive
+              ? 'Showing ' + visible + ' of ' + totalCount
+              : 'Showing all ' + totalCount;
+          }
+          if (emptyEl) {
+            if (visible === 0) emptyEl.removeAttribute('hidden');
+            else emptyEl.setAttribute('hidden', '');
+          }
+        }
+
+        function commit() {
+          syncControls();
+          apply();
+          writeUrl();
+        }
+
+        // Bind chip buttons (toggle: clicking the active chip clears it)
+        form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var key = btn.getAttribute('data-filter-key');
+            var val = btn.getAttribute('data-filter-value');
+            state[key] = state[key] === val ? '' : val;
+            commit();
+          });
+        });
+
+        // Bind place select
+        var placeSel = form.querySelector('[data-filter-key="place"]');
+        if (placeSel) {
+          placeSel.addEventListener('change', function () {
+            state.place = placeSel.value;
+            commit();
+          });
+        }
+
+        // Bind toggles
+        form.querySelectorAll('input[type="checkbox"][data-filter-key]').forEach(function (input) {
+          input.addEventListener('change', function () {
+            state[input.getAttribute('data-filter-key')] = input.checked;
+            commit();
+          });
+        });
+
+        // Clear all
+        var clear = form.querySelector('[data-filter-clear]');
+        if (clear) {
+          clear.addEventListener('click', function () {
+            state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
+            commit();
+          });
+        }
+
+        // Initial: read URL → apply
+        readUrl();
+        syncControls();
+        apply();
+      }
+
+      bindFilters();
+      document.addEventListener('astro:page-load', bindFilters);
+    })();
+  </script>
 
   <!-- ═══════════════════════════════════════════════════════════════
        9. FAQ

--- a/next/src/pages/whats-on/index.astro
+++ b/next/src/pages/whats-on/index.astro
@@ -16,6 +16,7 @@ import {
   isUpcoming,
   routeSlug,
 } from '../../lib/editorial';
+import { eventInWindow, upcomingWeekend } from '../../lib/events';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 const now = new Date();
@@ -87,6 +88,53 @@ const totalEvents = events.length;
 const totalGroups = groups.length;
 const recurringCount = events.filter((e) => ['weekly', 'monthly', 'ongoing'].includes(e.data.recurrence)).length;
 const oneOffCount = totalEvents - recurringCount;
+
+// ── Temporal tabs (Phase 2 WS2B) ─────────────────────────────────────────
+// Pre-render four time-window slices so the tab bar swaps panels on the
+// client without re-fetching. Each slice caps at 9 events to keep the
+// page weight reasonable; deeper browsing falls back to the existing
+// category sections lower down.
+const dayMs = 24 * 60 * 60 * 1000;
+const todayStart = new Date(now);
+todayStart.setHours(0, 0, 0, 0);
+const todayEnd = new Date(todayStart.getTime() + dayMs - 1);
+
+const weekend = upcomingWeekend(now);
+
+const weekStart = todayStart;
+const weekEnd = new Date(todayStart.getTime() + 7 * dayMs - 1);
+
+const monthStart = todayStart;
+const monthEnd = new Date(todayStart.getTime() + 30 * dayMs - 1);
+
+const sortAppealThenDate = (a: typeof events[number], b: typeof events[number]) => {
+  const ap = a.data.visitorAppealScore ?? 0;
+  const bp = b.data.visitorAppealScore ?? 0;
+  if (ap !== bp) return bp - ap;
+  return a.data.startDate.getTime() - b.data.startDate.getTime();
+};
+
+const todayEvents = events.filter((e) => eventInWindow(e, todayStart, todayEnd))
+  .sort(sortAppealThenDate)
+  .slice(0, 9);
+const weekendEvents = events.filter((e) => eventInWindow(e, weekend.start, weekend.end))
+  .sort(sortAppealThenDate)
+  .slice(0, 9);
+const weekEvents = events.filter((e) => eventInWindow(e, weekStart, weekEnd))
+  .sort(sortAppealThenDate)
+  .slice(0, 9);
+const monthEvents = events.filter((e) => eventInWindow(e, monthStart, monthEnd))
+  .sort(sortAppealThenDate)
+  .slice(0, 9);
+
+const temporalTabs = [
+  { key: 'today',    label: 'Today',         items: todayEvents,   blurb: "What's on the Peninsula in the next 24 hours." },
+  { key: 'weekend',  label: 'This weekend',  items: weekendEvents, blurb: `The weekend ahead, ${weekend.label}. Recurring programmes always count.` },
+  { key: 'week',     label: 'This week',     items: weekEvents,    blurb: 'The next seven days, dispatched in editorial order.' },
+  { key: 'month',    label: 'This month',    items: monthEvents,   blurb: 'The next thirty days, sorted by appeal then date.' },
+];
+
+const initialTabKey = weekendEvents.length > 0 ? 'weekend' : (todayEvents.length > 0 ? 'today' : 'week');
 
 // ── Standouts of the season ──────────────────────────────────────────────
 // Top events ranked purely by visitor appeal score, irrespective of when
@@ -184,6 +232,104 @@ const faqSchema = {
       <EventChipBar active="hub" />
     </div>
   </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1.7 TEMPORAL TABS  -  Today / Weekend / Week / Month (Phase 2 WS2B)
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="whatson-temporal" aria-label="Events by time window">
+    <div class="container">
+      <div class="whatson-temporal__header">
+        <p class="label label--accent">By time</p>
+        <h2 class="whatson-temporal__title">Events by when, not by what</h2>
+        <p class="whatson-temporal__sub">The first question for any local night out is "when" — not category. Tabs below answer the four versions of "what's on" most readers actually ask.</p>
+      </div>
+
+      <div class="whatson-temporal__tabs" role="tablist" aria-label="Filter events by time window">
+        {temporalTabs.map((tab) => (
+          <button
+            type="button"
+            class="whatson-temporal__tab"
+            role="tab"
+            id={`whatson-temporal-tab-${tab.key}`}
+            aria-controls={`whatson-temporal-panel-${tab.key}`}
+            aria-selected={tab.key === initialTabKey ? 'true' : 'false'}
+            tabindex={tab.key === initialTabKey ? 0 : -1}
+            data-temporal-tab={tab.key}
+          >
+            <span class="whatson-temporal__tab-label">{tab.label}</span>
+            <span class="whatson-temporal__tab-count">{tab.items.length}</span>
+          </button>
+        ))}
+      </div>
+
+      {temporalTabs.map((tab) => (
+        <div
+          class="whatson-temporal__panel"
+          role="tabpanel"
+          id={`whatson-temporal-panel-${tab.key}`}
+          aria-labelledby={`whatson-temporal-tab-${tab.key}`}
+          data-temporal-panel={tab.key}
+          hidden={tab.key !== initialTabKey}
+        >
+          <p class="whatson-temporal__blurb">{tab.blurb}</p>
+          {tab.items.length > 0 ? (
+            <div class="event-grid">
+              {tab.items.map((event) => <EventCard event={event} />)}
+            </div>
+          ) : (
+            <p class="whatson-temporal__empty">
+              Nothing programmed in this window yet. Try a wider one, or check the editorial frame and category sections below for recurring programmes.
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <script is:inline>
+    /* What's On temporal-tab controller. Tabs swap which panel is visible.
+       Idempotent across astro:page-load. */
+    (function () {
+      function bindTemporal() {
+        var tabs = document.querySelectorAll('[data-temporal-tab]');
+        var panels = document.querySelectorAll('[data-temporal-panel]');
+        if (!tabs.length || !panels.length) return;
+        var first = tabs[0];
+        if (first._piTemporalBound) return;
+
+        function activate(key) {
+          tabs.forEach(function (t) {
+            var on = t.getAttribute('data-temporal-tab') === key;
+            t.setAttribute('aria-selected', on ? 'true' : 'false');
+            t.setAttribute('tabindex', on ? '0' : '-1');
+          });
+          panels.forEach(function (p) {
+            var on = p.getAttribute('data-temporal-panel') === key;
+            if (on) p.removeAttribute('hidden');
+            else p.setAttribute('hidden', '');
+          });
+        }
+
+        tabs.forEach(function (tab, idx) {
+          tab._piTemporalBound = true;
+          tab.addEventListener('click', function () {
+            activate(tab.getAttribute('data-temporal-tab'));
+          });
+          tab.addEventListener('keydown', function (e) {
+            if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+              e.preventDefault();
+              var dir = e.key === 'ArrowRight' ? 1 : -1;
+              var next = (idx + dir + tabs.length) % tabs.length;
+              tabs[next].focus();
+              activate(tabs[next].getAttribute('data-temporal-tab'));
+            }
+          });
+        });
+      }
+      bindTemporal();
+      document.addEventListener('astro:page-load', bindTemporal);
+    })();
+  </script>
 
   <!-- ═══════════════════════════════════════════════════════════════
        2. THE EDITORIAL FRAME, what we'd actually book and what to know

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -8056,3 +8056,309 @@ body.menu-open .subscribe-pill {
   opacity: 0;
   pointer-events: none;
 }
+
+/* ============================================================================
+   VENUE FILTERS (Phase 2 WS2A)
+   Filter row above the directory grid on /eat/. Reusable for /wine/ and /stay/
+   in WS2C. Static-first: filtering hides cards via .is-filtered-out, no
+   re-rendering. URL state means filtered views are shareable.
+   ============================================================================ */
+
+.venues--filterable .venues__header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: clamp(0.9rem, 1.8vw, 1.4rem);
+}
+
+.venue-filters {
+  margin: clamp(1rem, 2vw, 1.5rem) 0 clamp(1.5rem, 3vw, 2.25rem);
+  border: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+}
+.venue-filters__panel {
+  padding: 0;
+}
+.venue-filters__panel[open] .venue-filters__summary {
+  border-bottom: 1px solid var(--border);
+}
+.venue-filters__summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  font-family: 'Outfit', sans-serif;
+}
+.venue-filters__summary::-webkit-details-marker { display: none; }
+.venue-filters__summary::after {
+  content: '+';
+  font-size: 1.2rem;
+  font-weight: 300;
+  color: var(--soft);
+  transition: transform 0.2s ease;
+}
+.venue-filters__panel[open] .venue-filters__summary::after {
+  content: '−';
+}
+.venue-filters__summary-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.venue-filters__summary-count {
+  font-size: 0.88rem;
+  color: var(--soft);
+  margin-left: auto;
+  margin-right: 0.4rem;
+}
+
+.venue-filters__row {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.85rem, 1.5vw, 1.2rem);
+  padding: clamp(0.95rem, 1.8vw, 1.4rem) 1.1rem clamp(1.1rem, 2vw, 1.5rem);
+}
+@media (min-width: 920px) {
+  .venue-filters__row {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+  }
+}
+
+.venue-filters__group {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+.venue-filters__group-label {
+  display: block;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin-bottom: 0.45rem;
+}
+
+.venue-filters__select {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.92rem;
+  padding: 0.55rem 0.7rem;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border);
+  color: var(--dark);
+  min-width: 12rem;
+  cursor: pointer;
+}
+.venue-filters__select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.venue-filters__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.venue-filters__chips--tight { gap: 0.3rem; }
+
+.venue-filters__chip {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 0.45rem 0.85rem;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border);
+  color: var(--dark);
+  cursor: pointer;
+  border-radius: 999px;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.venue-filters__chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.venue-filters__chip[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--bg, #fff);
+  border-color: var(--accent);
+}
+.venue-filters__chip--price {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 0.4rem 0.8rem;
+}
+
+.venue-filters__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-self: stretch;
+  align-items: center;
+}
+.venue-filters__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.88rem;
+  color: var(--dark);
+  cursor: pointer;
+  user-select: none;
+}
+.venue-filters__toggle input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.venue-filters__clear {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--soft);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  padding: 0.25rem 0.1rem;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  align-self: center;
+}
+.venue-filters__clear:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Filtering: hide cards whose wrappers carry the is-filtered-out class.
+   Wrapper itself, not the inner VenueCard, so the layout reflows cleanly. */
+.venues__grid > [data-venue].is-filtered-out {
+  display: none;
+}
+
+.venues__empty {
+  margin: 1.5rem 0 0;
+  padding: 1.5rem;
+  border: 1px dashed var(--border);
+  text-align: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  color: var(--soft);
+}
+.venues__empty a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* ============================================================================
+   WHAT'S ON TEMPORAL TABS (Phase 2 WS2B)
+   Time-window discovery on /whats-on/. Today / Weekend / Week / Month.
+   Pre-rendered panels swap visibility via aria-selected. Keyboard arrows
+   move between tabs.
+   ============================================================================ */
+
+.whatson-temporal {
+  padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(1.5rem, 3vw, 2.5rem);
+}
+.whatson-temporal__header {
+  margin-bottom: clamp(1rem, 2vw, 1.5rem);
+  max-width: 720px;
+}
+.whatson-temporal__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(1.65rem, 3vw, 2.3rem);
+  font-weight: 500;
+  color: var(--text);
+  margin: 0.5rem 0 0.75rem;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.whatson-temporal__sub {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--soft);
+  margin: 0;
+}
+
+.whatson-temporal__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: clamp(1rem, 2vw, 1.5rem) 0 clamp(1.25rem, 2.5vw, 1.75rem);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0;
+}
+.whatson-temporal__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: 2px solid transparent;
+  color: var(--soft);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  margin-bottom: -1px;
+}
+.whatson-temporal__tab:hover { color: var(--accent); }
+.whatson-temporal__tab[aria-selected="true"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+.whatson-temporal__tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.whatson-temporal__tab-count {
+  display: inline-block;
+  min-width: 1.5em;
+  text-align: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.4rem;
+  background: var(--paper, #fbf7f0);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--soft);
+}
+.whatson-temporal__tab[aria-selected="true"] .whatson-temporal__tab-count {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.whatson-temporal__panel[hidden] { display: none; }
+.whatson-temporal__blurb {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.92rem;
+  color: var(--soft);
+  margin: 0 0 clamp(1rem, 2vw, 1.5rem);
+}
+.whatson-temporal__empty {
+  margin: 1rem 0 0;
+  padding: 1.5rem;
+  border: 1px dashed var(--border);
+  text-align: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  color: var(--soft);
+}


### PR DESCRIPTION
## Summary

First slice of [Discovery Layer Phase 2](../../JWR_PKM_2026/07-projects/peninsula-insider/discovery-layer-phase-2.md). Closes the central "browse-led → decision-led" gap on the two highest-traffic hubs.

### WS2A — Filterable Eat listings
The /eat/ directory now works. Full 134 venues filterable by town (dropdown, 20 towns), format (chips), price ($ to $$$$), mood (chips), dog-friendly toggle, hatted-only toggle. Active filters reflected in URL query params so filtered views are shareable.

Static-first: pre-rendered card list, JS hides/shows via data attributes. Single chip click toggles (active chip clears). Inline JS controller is idempotent across `astro:page-load`. Empty state with concierge fallback.

### WS2B — What's On temporal tabs
New section between the chip bar and editorial frame on /whats-on/. **Today · This Weekend · This Week · This Month** with per-tab event counts. Each panel pre-rendered with up to nine EventCards, sorted by appeal then date. Initial tab: Weekend if non-empty, else Today, else Week.

ARIA tablist + arrow-key navigation. Reuses existing `upcomingWeekend` and `eventInWindow` from lib/events.ts; no schema or new lib code.

## Files
- `next/src/pages/eat/index.astro` — directory section rebuilt as filterable grid; filter UI; inline JS controller.
- `next/src/pages/whats-on/index.astro` — temporal tabs section; inline JS controller.
- `next/src/styles/global.css` — venue-filters and whatson-temporal blocks.

## Test plan
- [ ] Visit `/eat/` — toggle a chip and confirm cards reflow; URL updates.
- [ ] Add `?place=red-hill&type=restaurant&price=$$$` to `/eat/` and confirm filters apply on load.
- [ ] Click an active chip and confirm it clears; click "Clear filters" and confirm everything resets.
- [ ] Apply a combination that yields zero matches — confirm empty state appears.
- [ ] Visit `/whats-on/` — confirm Weekend tab is active; click Today / Week / Month and confirm panels swap.
- [ ] Tab to a temporal tab via keyboard, press ArrowRight/ArrowLeft, confirm focus and selection move together.

## Build
1200 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)