### PR TITLE
feat(discovery-phase-2): filter parity for Wine and Stay (WS2C)

### DIFF
--- a/next/src/components/VenueDirectory.astro
+++ b/next/src/components/VenueDirectory.astro
@@ -1,0 +1,328 @@
+---
+/**
+ * VenueDirectory — filterable venue grid (Phase 2 WS2A → WS2C).
+ *
+ * Drop into a section hub (Eat / Wine / Stay) and pass the venue list +
+ * the filter dimensions to enable. Renders the grid with per-card data
+ * attributes plus a filter UI; the controller script lives below and is
+ * idempotent across astro:page-load.
+ *
+ * Static-first: pre-renders all venues, hides non-matching cards on the
+ * client. URL query params encode filter state so filtered views are
+ * shareable. Use a unique `id` per page to avoid collisions if multiple
+ * directories ever appear together.
+ */
+import VenueCard from './VenueCard.astro';
+import { getCollection } from 'astro:content';
+
+export interface Props {
+  /** Stable id; used to scope the filter form to its grid. */
+  id: string;
+  /** Pre-filtered venue list (e.g. only restaurants and cafés for /eat/). */
+  venues: any[];
+  /** Route prefix passed through to VenueCard. */
+  hrefPrefix: string;
+  /** Eyebrow above the section heading. */
+  eyebrow?: string;
+  /** Section heading. */
+  heading: string;
+  /** Section sub-heading paragraph. */
+  sub?: string;
+  /** Optional secondary link (label + href). */
+  topLink?: { label: string; href: string };
+  /** Type filter chip set, in display order. */
+  typeOptions: Array<{ value: string; label: string }>;
+  /** Mood filter chip set, in display order. Empty array hides the row. */
+  moodOptions?: Array<{ value: string; label: string }>;
+  /** Toggles row to show. */
+  toggles?: { dogFriendly?: boolean; hatted?: boolean };
+}
+
+const {
+  id,
+  venues,
+  hrefPrefix,
+  eyebrow,
+  heading,
+  sub,
+  topLink,
+  typeOptions,
+  moodOptions = [],
+  toggles = { dogFriendly: false, hatted: false },
+} = Astro.props as Props;
+
+// Build the place options from the venue list itself so the dropdown only
+// ever shows towns that have at least one venue in this directory.
+const placesAll = await getCollection('places');
+const placeNameBySlug = new Map<string, string>(
+  placesAll.map((p) => [p.id ?? p.data.slug, p.data.name]),
+);
+const placeSlugs = Array.from(
+  new Set(
+    venues
+      .map((v) => (typeof v.data.place === 'string' ? v.data.place : v.data.place?.id))
+      .filter((slug): slug is string => Boolean(slug)),
+  ),
+);
+const placeOptions = placeSlugs
+  .map((slug) => ({ slug, name: placeNameBySlug.get(slug) ?? slug }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+function venueAttrs(venue: any): Record<string, string> {
+  const placeSlug = typeof venue.data.place === 'string' ? venue.data.place : venue.data.place?.id ?? '';
+  const moods: string[] = Array.isArray(venue.data.tags?.mood) ? venue.data.tags.mood : [];
+  const hats = Number(venue.data.authority?.hats ?? 0);
+  return {
+    'data-venue': '',
+    'data-place': placeSlug,
+    'data-type': venue.data.type,
+    'data-price': venue.data.priceBand ?? '',
+    'data-mood': moods.join(' '),
+    'data-dog-friendly': venue.data.dogFriendly ? '1' : '0',
+    'data-hatted': hats > 0 ? '1' : '0',
+  };
+}
+
+const showMood = moodOptions.length > 0;
+const showDog = !!toggles.dogFriendly;
+const showHatted = !!toggles.hatted;
+---
+
+<section class="venues venues--filterable" id={id}>
+  <div class="container">
+    <div class="venues__header">
+      <div>
+        {eyebrow && <p class="label label--accent">{eyebrow}</p>}
+        <h2 class="venues__title">{heading}</h2>
+        {sub && <p class="venues__sub">{sub}</p>}
+      </div>
+      {topLink && <a href={topLink.href} class="venues__link">{topLink.label}</a>}
+    </div>
+
+    <form class="venue-filters" data-filter-form data-filter-scope={id} aria-label={`Filter ${heading}`}>
+      <details class="venue-filters__panel" open>
+        <summary class="venue-filters__summary">
+          <span class="venue-filters__summary-label">Filter</span>
+          <span class="venue-filters__summary-count" data-filter-count>Showing all {venues.length}</span>
+        </summary>
+
+        <div class="venue-filters__row">
+          {placeOptions.length > 1 && (
+            <div class="venue-filters__group">
+              <label class="venue-filters__group-label" for={`venue-filter-place-${id}`}>Town</label>
+              <select id={`venue-filter-place-${id}`} class="venue-filters__select" data-filter-key="place">
+                <option value="">All towns</option>
+                {placeOptions.map((p) => (
+                  <option value={p.slug}>{p.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {typeOptions.length > 1 && (
+            <fieldset class="venue-filters__group">
+              <legend class="venue-filters__group-label">Format</legend>
+              <div class="venue-filters__chips">
+                {typeOptions.map((opt) => (
+                  <button
+                    type="button"
+                    class="venue-filters__chip"
+                    data-filter-key="type"
+                    data-filter-value={opt.value}
+                    aria-pressed="false"
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+          )}
+
+          <fieldset class="venue-filters__group">
+            <legend class="venue-filters__group-label">Price</legend>
+            <div class="venue-filters__chips venue-filters__chips--tight">
+              {(['$', '$$', '$$$', '$$$$'] as const).map((band) => (
+                <button
+                  type="button"
+                  class="venue-filters__chip venue-filters__chip--price"
+                  data-filter-key="price"
+                  data-filter-value={band}
+                  aria-pressed="false"
+                >
+                  {band}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {showMood && (
+            <fieldset class="venue-filters__group">
+              <legend class="venue-filters__group-label">Mood</legend>
+              <div class="venue-filters__chips">
+                {moodOptions.map((opt) => (
+                  <button
+                    type="button"
+                    class="venue-filters__chip"
+                    data-filter-key="mood"
+                    data-filter-value={opt.value}
+                    aria-pressed="false"
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+          )}
+
+          {(showDog || showHatted) && (
+            <div class="venue-filters__toggles">
+              {showDog && (
+                <label class="venue-filters__toggle">
+                  <input type="checkbox" data-filter-key="dog" />
+                  <span>Dog-friendly</span>
+                </label>
+              )}
+              {showHatted && (
+                <label class="venue-filters__toggle">
+                  <input type="checkbox" data-filter-key="hatted" />
+                  <span>Hatted only</span>
+                </label>
+              )}
+            </div>
+          )}
+
+          <button type="button" class="venue-filters__clear" data-filter-clear>Clear filters</button>
+        </div>
+      </details>
+    </form>
+
+    <div class="venues__grid" data-filter-grid={id}>
+      {venues.map((venue) => (
+        <div {...venueAttrs(venue)}>
+          <VenueCard venue={venue} hrefPrefix={hrefPrefix} />
+        </div>
+      ))}
+    </div>
+
+    <p class="venues__empty" data-filter-empty={id} hidden>
+      No venues match those filters. Try removing one of them, or
+      <a href="/ask/" data-pi-trigger="true">ask the Insider</a> for a recommendation.
+    </p>
+  </div>
+</section>
+
+<script is:inline define:vars={{ scopeId: id }}>
+  /* VenueDirectory filter controller. Scoped by id so multiple directories
+     on the same page (rare, but possible later) don't trample each other. */
+  (function () {
+    function bindOne() {
+      var form = document.querySelector('[data-filter-form][data-filter-scope="' + scopeId + '"]');
+      if (!form || form._piFilterBound) return;
+      form._piFilterBound = true;
+
+      var grid = document.querySelector('[data-filter-grid="' + scopeId + '"]');
+      var emptyEl = document.querySelector('[data-filter-empty="' + scopeId + '"]');
+      var countEl = form.querySelector('[data-filter-count]');
+      var cards = grid ? grid.querySelectorAll('[data-venue]') : [];
+      var totalCount = cards.length;
+
+      var state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
+
+      function readUrl() {
+        var p = new URLSearchParams(window.location.search);
+        state.place = p.get('place') || '';
+        state.type = p.get('type') || '';
+        state.price = p.get('price') || '';
+        state.mood = p.get('mood') || '';
+        state.dog = p.get('dog') === '1';
+        state.hatted = p.get('hatted') === '1';
+      }
+
+      function writeUrl() {
+        var p = new URLSearchParams();
+        if (state.place) p.set('place', state.place);
+        if (state.type) p.set('type', state.type);
+        if (state.price) p.set('price', state.price);
+        if (state.mood) p.set('mood', state.mood);
+        if (state.dog) p.set('dog', '1');
+        if (state.hatted) p.set('hatted', '1');
+        var qs = p.toString();
+        var url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
+        window.history.replaceState(null, '', url);
+      }
+
+      function syncControls() {
+        var placeSel = form.querySelector('[data-filter-key="place"]');
+        if (placeSel) placeSel.value = state.place;
+        form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
+          var key = btn.getAttribute('data-filter-key');
+          var val = btn.getAttribute('data-filter-value');
+          btn.setAttribute('aria-pressed', state[key] === val ? 'true' : 'false');
+        });
+        var dog = form.querySelector('input[data-filter-key="dog"]');
+        if (dog) dog.checked = state.dog;
+        var hat = form.querySelector('input[data-filter-key="hatted"]');
+        if (hat) hat.checked = state.hatted;
+      }
+
+      function apply() {
+        var visible = 0;
+        cards.forEach(function (card) {
+          var ok = true;
+          if (state.place && card.getAttribute('data-place') !== state.place) ok = false;
+          if (ok && state.type && card.getAttribute('data-type') !== state.type) ok = false;
+          if (ok && state.price && card.getAttribute('data-price') !== state.price) ok = false;
+          if (ok && state.mood) {
+            var moods = (card.getAttribute('data-mood') || '').split(/\s+/);
+            if (moods.indexOf(state.mood) === -1) ok = false;
+          }
+          if (ok && state.dog && card.getAttribute('data-dog-friendly') !== '1') ok = false;
+          if (ok && state.hatted && card.getAttribute('data-hatted') !== '1') ok = false;
+          card.classList.toggle('is-filtered-out', !ok);
+          if (ok) visible++;
+        });
+        if (countEl) {
+          var anyActive = state.place || state.type || state.price || state.mood || state.dog || state.hatted;
+          countEl.textContent = anyActive
+            ? 'Showing ' + visible + ' of ' + totalCount
+            : 'Showing all ' + totalCount;
+        }
+        if (emptyEl) {
+          if (visible === 0) emptyEl.removeAttribute('hidden');
+          else emptyEl.setAttribute('hidden', '');
+        }
+      }
+
+      function commit() { syncControls(); apply(); writeUrl(); }
+
+      form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var key = btn.getAttribute('data-filter-key');
+          var val = btn.getAttribute('data-filter-value');
+          state[key] = state[key] === val ? '' : val;
+          commit();
+        });
+      });
+      var placeSel = form.querySelector('[data-filter-key="place"]');
+      if (placeSel) placeSel.addEventListener('change', function () { state.place = placeSel.value; commit(); });
+      form.querySelectorAll('input[type="checkbox"][data-filter-key]').forEach(function (input) {
+        input.addEventListener('change', function () {
+          state[input.getAttribute('data-filter-key')] = input.checked;
+          commit();
+        });
+      });
+      var clear = form.querySelector('[data-filter-clear]');
+      if (clear) clear.addEventListener('click', function () {
+        state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
+        commit();
+      });
+
+      readUrl();
+      syncControls();
+      apply();
+    }
+
+    bindOne();
+    document.addEventListener('astro:page-load', bindOne);
+  })();
+</script>

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -7,6 +7,7 @@ import AudiencePicker from '../../components/AudiencePicker.astro';
 import CompareBlock from '../../components/CompareBlock.astro';
 import SectionDivider from '../../components/SectionDivider.astro';
 import VenueCard from '../../components/VenueCard.astro';
+import VenueDirectory from '../../components/VenueDirectory.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import EventStrip from '../../components/EventStrip.astro';
@@ -365,260 +366,20 @@ const faqSchema = {
   )}
 
   <!-- ═══════════════════════════════════════════════════════════════
-       8. FULL DIRECTORY (filterable, Phase 2 WS2A)
+       8. FULL DIRECTORY (filterable, Phase 2 WS2A — uses VenueDirectory)
        ═══════════════════════════════════════════════════════════════ -->
-  <section class="venues venues--filterable" id="all">
-    <div class="container">
-      <div class="venues__header">
-        <div>
-          <p class="label label--accent">Complete dining directory</p>
-          <h2 class="venues__title">All {venues.length} eat-and-drink venues</h2>
-          <p class="venues__sub">Ordered by editorial weight. Filter by town, format, price, mood, or suitability — the list re-shapes itself as you go.</p>
-        </div>
-        <a href="/eat/best-restaurants/" class="venues__link">Ranked top 15 →</a>
-      </div>
-
-      <form class="venue-filters" data-filter-form aria-label="Filter the dining directory">
-        <details class="venue-filters__panel" open>
-          <summary class="venue-filters__summary">
-            <span class="venue-filters__summary-label">Filter</span>
-            <span class="venue-filters__summary-count" data-filter-count>Showing all {venues.length}</span>
-          </summary>
-
-          <div class="venue-filters__row">
-            <div class="venue-filters__group">
-              <label class="venue-filters__group-label" for="venue-filter-place">Town</label>
-              <select id="venue-filter-place" class="venue-filters__select" data-filter-key="place">
-                <option value="">All towns</option>
-                {filterPlaceOptions.map((p) => (
-                  <option value={p.slug}>{p.name}</option>
-                ))}
-              </select>
-            </div>
-
-            <fieldset class="venue-filters__group">
-              <legend class="venue-filters__group-label">Format</legend>
-              <div class="venue-filters__chips">
-                {venueTypeOptions.map((opt) => (
-                  <button
-                    type="button"
-                    class="venue-filters__chip"
-                    data-filter-key="type"
-                    data-filter-value={opt.value}
-                    aria-pressed="false"
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </fieldset>
-
-            <fieldset class="venue-filters__group">
-              <legend class="venue-filters__group-label">Price</legend>
-              <div class="venue-filters__chips venue-filters__chips--tight">
-                {(['$', '$$', '$$$', '$$$$'] as const).map((band) => (
-                  <button
-                    type="button"
-                    class="venue-filters__chip venue-filters__chip--price"
-                    data-filter-key="price"
-                    data-filter-value={band}
-                    aria-pressed="false"
-                  >
-                    {band}
-                  </button>
-                ))}
-              </div>
-            </fieldset>
-
-            <fieldset class="venue-filters__group">
-              <legend class="venue-filters__group-label">Mood</legend>
-              <div class="venue-filters__chips">
-                {moodFilterOptions.map((opt) => (
-                  <button
-                    type="button"
-                    class="venue-filters__chip"
-                    data-filter-key="mood"
-                    data-filter-value={opt.value}
-                    aria-pressed="false"
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </fieldset>
-
-            <div class="venue-filters__toggles">
-              <label class="venue-filters__toggle">
-                <input type="checkbox" data-filter-key="dog" />
-                <span>Dog-friendly</span>
-              </label>
-              <label class="venue-filters__toggle">
-                <input type="checkbox" data-filter-key="hatted" />
-                <span>Hatted only</span>
-              </label>
-            </div>
-
-            <button type="button" class="venue-filters__clear" data-filter-clear>Clear filters</button>
-          </div>
-        </details>
-      </form>
-
-      <div class="venues__grid" data-filter-grid>
-        {venues.map((venue) => (
-          <div {...venueFilterAttrs(venue)}>
-            <VenueCard venue={venue} hrefPrefix="/eat" />
-          </div>
-        ))}
-      </div>
-
-      <p class="venues__empty" data-filter-empty hidden>
-        No venues match those filters. Try removing one of them, or
-        <a href="/ask/" data-pi-trigger="true">ask the Insider</a> for a recommendation.
-      </p>
-    </div>
-  </section>
-
-  <script is:inline>
-    /* Eat directory filter controller. Static-first: filtering is purely a
-       DOM hide/show pass over pre-rendered cards. URL state means a filtered
-       view is shareable.
-       Idempotent across astro:page-load. */
-    (function () {
-      function bindFilters() {
-        var form = document.querySelector('[data-filter-form]');
-        if (!form || form._piFilterBound) return;
-        form._piFilterBound = true;
-
-        var grid = document.querySelector('[data-filter-grid]');
-        var emptyEl = document.querySelector('[data-filter-empty]');
-        var countEl = form.querySelector('[data-filter-count]');
-        var cards = grid ? grid.querySelectorAll('[data-venue]') : [];
-        var totalCount = cards.length;
-
-        // State shape — single value per key for v1, except 'mood' which is
-        // also single (multi-mood would require a different match approach).
-        var state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
-
-        function readUrl() {
-          var p = new URLSearchParams(window.location.search);
-          state.place = p.get('place') || '';
-          state.type = p.get('type') || '';
-          state.price = p.get('price') || '';
-          state.mood = p.get('mood') || '';
-          state.dog = p.get('dog') === '1';
-          state.hatted = p.get('hatted') === '1';
-        }
-
-        function writeUrl() {
-          var p = new URLSearchParams();
-          if (state.place) p.set('place', state.place);
-          if (state.type) p.set('type', state.type);
-          if (state.price) p.set('price', state.price);
-          if (state.mood) p.set('mood', state.mood);
-          if (state.dog) p.set('dog', '1');
-          if (state.hatted) p.set('hatted', '1');
-          var qs = p.toString();
-          var url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
-          window.history.replaceState(null, '', url);
-        }
-
-        function syncControls() {
-          // Place select
-          var placeSel = form.querySelector('[data-filter-key="place"]');
-          if (placeSel) placeSel.value = state.place;
-          // Chips: aria-pressed reflects whether this value is the active one
-          form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
-            var key = btn.getAttribute('data-filter-key');
-            var val = btn.getAttribute('data-filter-value');
-            btn.setAttribute('aria-pressed', state[key] === val ? 'true' : 'false');
-          });
-          // Toggles
-          var dog = form.querySelector('input[data-filter-key="dog"]');
-          if (dog) dog.checked = state.dog;
-          var hat = form.querySelector('input[data-filter-key="hatted"]');
-          if (hat) hat.checked = state.hatted;
-        }
-
-        function apply() {
-          var visible = 0;
-          cards.forEach(function (card) {
-            var ok = true;
-            if (state.place && card.getAttribute('data-place') !== state.place) ok = false;
-            if (ok && state.type && card.getAttribute('data-type') !== state.type) ok = false;
-            if (ok && state.price && card.getAttribute('data-price') !== state.price) ok = false;
-            if (ok && state.mood) {
-              var moods = (card.getAttribute('data-mood') || '').split(/\s+/);
-              if (moods.indexOf(state.mood) === -1) ok = false;
-            }
-            if (ok && state.dog && card.getAttribute('data-dog-friendly') !== '1') ok = false;
-            if (ok && state.hatted && card.getAttribute('data-hatted') !== '1') ok = false;
-            card.classList.toggle('is-filtered-out', !ok);
-            if (ok) visible++;
-          });
-          if (countEl) {
-            var anyActive = state.place || state.type || state.price || state.mood || state.dog || state.hatted;
-            countEl.textContent = anyActive
-              ? 'Showing ' + visible + ' of ' + totalCount
-              : 'Showing all ' + totalCount;
-          }
-          if (emptyEl) {
-            if (visible === 0) emptyEl.removeAttribute('hidden');
-            else emptyEl.setAttribute('hidden', '');
-          }
-        }
-
-        function commit() {
-          syncControls();
-          apply();
-          writeUrl();
-        }
-
-        // Bind chip buttons (toggle: clicking the active chip clears it)
-        form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
-          btn.addEventListener('click', function () {
-            var key = btn.getAttribute('data-filter-key');
-            var val = btn.getAttribute('data-filter-value');
-            state[key] = state[key] === val ? '' : val;
-            commit();
-          });
-        });
-
-        // Bind place select
-        var placeSel = form.querySelector('[data-filter-key="place"]');
-        if (placeSel) {
-          placeSel.addEventListener('change', function () {
-            state.place = placeSel.value;
-            commit();
-          });
-        }
-
-        // Bind toggles
-        form.querySelectorAll('input[type="checkbox"][data-filter-key]').forEach(function (input) {
-          input.addEventListener('change', function () {
-            state[input.getAttribute('data-filter-key')] = input.checked;
-            commit();
-          });
-        });
-
-        // Clear all
-        var clear = form.querySelector('[data-filter-clear]');
-        if (clear) {
-          clear.addEventListener('click', function () {
-            state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
-            commit();
-          });
-        }
-
-        // Initial: read URL → apply
-        readUrl();
-        syncControls();
-        apply();
-      }
-
-      bindFilters();
-      document.addEventListener('astro:page-load', bindFilters);
-    })();
-  </script>
+  <VenueDirectory
+    id="eat-directory"
+    venues={venues}
+    hrefPrefix="/eat"
+    eyebrow="Complete dining directory"
+    heading={`All ${venues.length} eat-and-drink venues`}
+    sub="Ordered by editorial weight. Filter by town, format, price, mood, or suitability — the list re-shapes itself as you go."
+    topLink={{ label: 'Ranked top 15 →', href: '/eat/best-restaurants/' }}
+    typeOptions={venueTypeOptions}
+    moodOptions={moodFilterOptions}
+    toggles={{ dogFriendly: true, hatted: true }}
+  />
 
   <!-- ═══════════════════════════════════════════════════════════════
        9. FAQ

--- a/next/src/pages/stay/index.astro
+++ b/next/src/pages/stay/index.astro
@@ -6,6 +6,7 @@ import GuideHero from '../../components/GuideHero.astro';
 import CompareBlock from '../../components/CompareBlock.astro';
 import SectionDivider from '../../components/SectionDivider.astro';
 import VenueCard from '../../components/VenueCard.astro';
+import VenueDirectory from '../../components/VenueDirectory.astro';
 import ItineraryCard from '../../components/ItineraryCard.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
@@ -266,22 +267,35 @@ const faqSchema = {
   </section>
 
   <!-- ═══════════════════════════════════════════════════════════════
-       8. ALL STAYS, full directory
+       8. FULL STAY DIRECTORY (filterable, Phase 2 WS2C)
        ═══════════════════════════════════════════════════════════════ -->
-  <section class="venues" id="all">
-    <div class="container">
-      <div class="venues__header">
-        <div>
-          <p class="label label--accent">All stays</p>
-          <h2 class="venues__title">Every bed currently mapped, hotel to cottage</h2>
-          <p class="venues__sub">{blurb.line}</p>
-        </div>
-      </div>
-      <div class="venues__grid">
-        {venues.slice(0, 24).map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
-      </div>
-    </div>
-  </section>
+  <VenueDirectory
+    id="stay-directory"
+    venues={venues}
+    hrefPrefix="/stay"
+    eyebrow="All stays"
+    heading={`Every bed currently mapped, hotel to cottage (${venues.length})`}
+    sub={blurb.line}
+    typeOptions={[
+      { value: 'hotel',     label: 'Hotels' },
+      { value: 'villa',     label: 'Villas' },
+      { value: 'cottage',   label: 'Cottages' },
+      { value: 'glamping',  label: 'Glamping' },
+      { value: 'farm-stay', label: 'Farm stays' },
+      { value: 'spa',       label: 'Spa retreats' },
+    ]}
+    moodOptions={[
+      { value: 'cellar-door', label: 'Cellar-door country' },
+      { value: 'beach',       label: 'Beach-side' },
+      { value: 'waterfront',  label: 'Waterfront' },
+      { value: 'wellness',    label: 'Wellness' },
+      { value: 'fireplace',   label: 'Fireplace' },
+      { value: 'view',        label: 'A view' },
+      { value: 'romance',     label: 'Romance' },
+      { value: 'big-group',   label: 'Big group' },
+    ]}
+    toggles={{ dogFriendly: true, hatted: false }}
+  />
 
   <SectionDivider />
 

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -6,6 +6,7 @@ import GuideHero from '../../components/GuideHero.astro';
 import CompareBlock from '../../components/CompareBlock.astro';
 import SectionDivider from '../../components/SectionDivider.astro';
 import VenueCard from '../../components/VenueCard.astro';
+import VenueDirectory from '../../components/VenueDirectory.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
@@ -249,23 +250,32 @@ const faqSchema = {
   <SectionDivider />
 
   <!-- ═══════════════════════════════════════════════════════════════
-       6. ALL WINERIES, full directory
+       6. FULL WINE-COUNTRY DIRECTORY (filterable, Phase 2 WS2C)
        ═══════════════════════════════════════════════════════════════ -->
-  {wineries.length > 0 && (
-    <section class="venues venues--plain" id="wineries">
-      <div class="container">
-        <div class="venues__header">
-          <div>
-            <p class="label label--accent">All wineries</p>
-            <h2 class="venues__title">{wineries.length} cellar doors across the region</h2>
-            <p class="venues__sub">Sorted by authority. Expect a spread from three-hat destinations to back-road pinot rooms.</p>
-          </div>
-        </div>
-        <div class="venues__grid">
-          {wineries.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
-        </div>
-      </div>
-    </section>
+  {venues.length > 0 && (
+    <VenueDirectory
+      id="wine-directory"
+      venues={venues}
+      hrefPrefix="/wine"
+      eyebrow="Complete wine-country directory"
+      heading={`All ${venues.length} cellar doors, breweries, and producers`}
+      sub="Sorted by Halliday authority. Filter by town, format, price, or mood — pinot rooms, brewery yards, distillery cellars, ridge benchmarks, and producers all live in the same list."
+      typeOptions={[
+        { value: 'winery',     label: 'Wineries' },
+        { value: 'brewery',    label: 'Breweries' },
+        { value: 'distillery', label: 'Distilleries' },
+        { value: 'producer',   label: 'Producers' },
+      ]}
+      moodOptions={[
+        { value: 'long-lunch',  label: 'Long lunch' },
+        { value: 'view',        label: 'A view' },
+        { value: 'fireplace',   label: 'Fireplace' },
+        { value: 'garden',      label: 'Garden' },
+        { value: 'romance',     label: 'Romance' },
+        { value: 'cellar-door', label: 'Cellar door' },
+      ]}
+      toggles={{ dogFriendly: true, hatted: false }}
+    />
   )}
 
   <!-- ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Phase 2 WS2C. Extracts the /eat/ filter pattern into a reusable `VenueDirectory.astro` component and applies it to /wine/ and /stay/ so the same decision-led UX works across all three hubs.

### Refactor
- New `next/src/components/VenueDirectory.astro` — owns the filter form, per-card data attributes, place dropdown computation (only towns with at least one matching venue appear), and the inline JS controller. Scoped by `id` so multiple directories on one page can't trample each other.
- `/eat/` rewritten to use the component (≈245 inline lines deleted, replaced by a 12-line component call). Identical surface behaviour as before.

### New surfaces
- **/wine/** — full wine-country directory (59 venues across wineries, breweries, distilleries, producers) now filterable by town, format, price, mood (long lunch / view / fireplace / garden / romance / cellar door), and dog-friendly.
- **/stay/** — full stay directory (16 stays) replaces the slice(0, 24) section. Six formats (hotels, villas, cottages, glamping, farm stays, spa retreats), eight stay-relevant moods (cellar-door country / beach-side / waterfront / wellness / fireplace / view / romance / big group), dog-friendly toggle.

### Test plan
- [ ] Visit `/wine/` — confirm filter row, full 59 venue cards, place dropdown lists wine-country towns only.
- [ ] Filter by format (e.g. brewery) and confirm only breweries remain visible.
- [ ] Visit `/stay/` — confirm 16 cards, "Big group" mood chip works on the right venues.
- [ ] Visit `/eat/` — confirm behaviour unchanged from PR #50.
- [ ] Add `?type=winery&place=red-hill` to `/wine/` and confirm filters apply on load.

### Build
1200 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)