### PR TITLE
feat(discovery-phase-2): save / share lists (WS2E)

### DIFF
--- a/next/src/components/EventCard.astro
+++ b/next/src/components/EventCard.astro
@@ -7,6 +7,7 @@
  * every event carries at least one sentence of opinion.
  */
 import EventBadges from './EventBadges.astro';
+import SaveButton from './SaveButton.astro';
 import { eventCategoryLabel, eventDateLabel, routeSlug, heroBackgroundStyle } from '../lib/editorial';
 
 export interface Props {
@@ -68,5 +69,8 @@ const placeHref = placeId ? `/places/${placeId}/` : null;
     weather={event.data.weather}
     skipThis={event.data.skipThis}
   />
-  <a href={`/whats-on/${slug}`} class="event-card__cta">Read the full guide -></a>
+  <div class="event-card__actions">
+    <a href={`/whats-on/${slug}`} class="event-card__cta">Read the full guide -></a>
+    <SaveButton kind="event" slug={slug} title={event.data.title} href={`/whats-on/${slug}/`} />
+  </div>
 </article>

--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -49,6 +49,9 @@ const {
           <span class="masthead__weather-item"><strong>Sunset</strong> {sunset}</span>
         </span>
         <div class="masthead__utility-links v2-util__links">
+          <a href="/saved/" class="masthead__saved-link" data-saved-link hidden>
+            Saved <span class="masthead__saved-count" data-saved-count hidden>0</span>
+          </a>
           <a href="/#newsletter" data-auth-anonymous>Subscribe</a>
           <a href="/about/">About</a>
         </div>

--- a/next/src/components/SaveButton.astro
+++ b/next/src/components/SaveButton.astro
@@ -1,0 +1,54 @@
+---
+/**
+ * SaveButton — bookmark toggle attached to a venue or event card.
+ *
+ * Phase 2 WS2E. Local-storage-backed; no account required for v1. The
+ * actual storage logic lives in the inline controller injected once per
+ * page by SaveSiteController; this component just renders the toggle
+ * markup with stable data-* hooks the controller can find.
+ *
+ * Usage:
+ *   <SaveButton kind="venue" slug="montalto" title="Montalto" />
+ *   <SaveButton kind="event" slug="alba-fire-and-ice-sessions" title="Alba ..." />
+ */
+
+export interface Props {
+  /** Collection the saved item belongs to. */
+  kind: 'venue' | 'event';
+  /** Stable slug identifying the item. */
+  slug: string;
+  /** Human-readable title — used as the accessible name and stored alongside. */
+  title: string;
+  /** Optional URL override; defaults to the canonical detail-page route. */
+  href?: string;
+}
+
+const { kind, slug, title, href } = Astro.props as Props;
+const defaultHref = kind === 'event' ? `/whats-on/${slug}/` : `/eat/${slug}/`;
+const resolvedHref = href ?? defaultHref;
+---
+
+<button
+  type="button"
+  class="save-button"
+  data-save-toggle
+  data-save-kind={kind}
+  data-save-slug={slug}
+  data-save-title={title}
+  data-save-href={resolvedHref}
+  aria-pressed="false"
+  aria-label={`Save ${title}`}
+  title={`Save ${title} to your shortlist`}
+>
+  <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false" class="save-button__icon">
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M6 3 L18 3 L18 21 L12 16.5 L6 21 Z"
+    />
+  </svg>
+  <span class="save-button__label">Save</span>
+</button>

--- a/next/src/components/SaveSiteController.astro
+++ b/next/src/components/SaveSiteController.astro
@@ -1,0 +1,172 @@
+---
+/**
+ * SaveSiteController — site-wide controller for the save/share-list system.
+ *
+ * Injected once at the bottom of BaseLayout. Owns: localStorage read/write,
+ * binding click handlers to every [data-save-toggle] element on the page,
+ * keeping the saved-count badge in sync, and exposing a small
+ * `window.PISave` API the /saved/ page uses to render the list.
+ *
+ * Storage shape (key: 'pi:saved:v1'):
+ *   {
+ *     version: 1,
+ *     venues: [{ slug, title, href, savedAt }],
+ *     events: [{ slug, title, href, savedAt }],
+ *   }
+ *
+ * Phase 2 WS2E.
+ */
+---
+
+<script is:inline>
+  (function () {
+    if (window.PISave) return; // singleton guard
+    var KEY = 'pi:saved:v1';
+
+    function readStore() {
+      try {
+        var raw = localStorage.getItem(KEY);
+        if (!raw) return { version: 1, venues: [], events: [] };
+        var parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return { version: 1, venues: [], events: [] };
+        return {
+          version: 1,
+          venues: Array.isArray(parsed.venues) ? parsed.venues : [],
+          events: Array.isArray(parsed.events) ? parsed.events : [],
+        };
+      } catch (_e) {
+        return { version: 1, venues: [], events: [] };
+      }
+    }
+
+    function writeStore(store) {
+      try {
+        localStorage.setItem(KEY, JSON.stringify(store));
+      } catch (_e) {
+        /* localStorage may be unavailable (private mode, quota, blocked).
+           We fail silently — the UI just won't persist. The current page
+           still reflects the in-memory state for the session. */
+      }
+    }
+
+    var memoryStore = readStore();
+
+    function isSaved(kind, slug) {
+      var arr = kind === 'event' ? memoryStore.events : memoryStore.venues;
+      return arr.some(function (item) { return item.slug === slug; });
+    }
+
+    function toggle(kind, slug, title, href) {
+      var arr = kind === 'event' ? memoryStore.events : memoryStore.venues;
+      var idx = arr.findIndex(function (item) { return item.slug === slug; });
+      if (idx >= 0) {
+        arr.splice(idx, 1);
+      } else {
+        arr.push({ slug: slug, title: title, href: href, savedAt: Date.now() });
+      }
+      writeStore(memoryStore);
+      syncAll();
+      window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { kind: kind, slug: slug } }));
+      return !idx === false ? false : true; // returns new "is saved" state
+    }
+
+    function syncAll() {
+      // Toggle pressed state on every save button on the page.
+      document.querySelectorAll('[data-save-toggle]').forEach(function (btn) {
+        var kind = btn.getAttribute('data-save-kind');
+        var slug = btn.getAttribute('data-save-slug');
+        var on = isSaved(kind, slug);
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        var label = btn.querySelector('.save-button__label');
+        if (label) label.textContent = on ? 'Saved' : 'Save';
+      });
+      // Update count badge in masthead/footer if present.
+      var total = memoryStore.venues.length + memoryStore.events.length;
+      document.querySelectorAll('[data-saved-count]').forEach(function (el) {
+        el.textContent = String(total);
+        if (total > 0) el.removeAttribute('hidden');
+        else el.setAttribute('hidden', '');
+      });
+      document.querySelectorAll('[data-saved-link]').forEach(function (el) {
+        if (total > 0) el.removeAttribute('hidden');
+        else el.setAttribute('hidden', '');
+      });
+    }
+
+    function bindButtons() {
+      document.querySelectorAll('[data-save-toggle]').forEach(function (btn) {
+        if (btn._piSaveBound) return;
+        btn._piSaveBound = true;
+        btn.addEventListener('click', function (e) {
+          // Cards typically wrap the entire surface in a link; the save
+          // button must not also navigate when clicked.
+          e.preventDefault();
+          e.stopPropagation();
+          toggle(
+            btn.getAttribute('data-save-kind'),
+            btn.getAttribute('data-save-slug'),
+            btn.getAttribute('data-save-title'),
+            btn.getAttribute('data-save-href'),
+          );
+        });
+      });
+    }
+
+    function init() {
+      memoryStore = readStore();
+      bindButtons();
+      syncAll();
+    }
+
+    // Public API for the /saved/ page and any other consumers.
+    window.PISave = {
+      list: function () { return readStore(); },
+      isSaved: isSaved,
+      toggle: toggle,
+      clear: function (kind) {
+        if (!kind) memoryStore = { version: 1, venues: [], events: [] };
+        else if (kind === 'event') memoryStore.events = [];
+        else memoryStore.venues = [];
+        writeStore(memoryStore);
+        syncAll();
+        window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { cleared: kind || 'all' } }));
+      },
+      /**
+       * Merge an externally-supplied list into the user's saved store.
+       * Used by /saved/?v=... to ingest a shared list — items already in
+       * the store are not duplicated.
+       */
+      merge: function (incoming) {
+        if (!incoming) return;
+        function mergeArr(target, src) {
+          if (!Array.isArray(src)) return;
+          src.forEach(function (item) {
+            if (!item || !item.slug) return;
+            if (!target.some(function (e) { return e.slug === item.slug; })) {
+              target.push({
+                slug: item.slug,
+                title: item.title || item.slug,
+                href: item.href || '',
+                savedAt: item.savedAt || Date.now(),
+              });
+            }
+          });
+        }
+        mergeArr(memoryStore.venues, incoming.venues);
+        mergeArr(memoryStore.events, incoming.events);
+        writeStore(memoryStore);
+        syncAll();
+      },
+    };
+
+    init();
+    document.addEventListener('astro:page-load', init);
+    window.addEventListener('storage', function (e) {
+      // Cross-tab sync — when another tab updates the same key, refresh.
+      if (e.key === KEY) {
+        memoryStore = readStore();
+        syncAll();
+      }
+    });
+  })();
+</script>

--- a/next/src/components/VenueCard.astro
+++ b/next/src/components/VenueCard.astro
@@ -8,6 +8,7 @@
 
 import { resolveHeroSrc } from '../lib/editorial';
 import { verifiedFreshnessLabel, verificationFreshness } from '../lib/venues';
+import SaveButton from './SaveButton.astro';
 
 const typeLabel: Record<string, string> = {
   restaurant:  'Restaurant',
@@ -83,6 +84,7 @@ const verifiedTier = verificationFreshness(data.lastVerified);
     {data.bookingUrl && data.bookingProvider !== 'none' && (
       <a href={data.bookingUrl} target="_blank" rel="noopener noreferrer" class="venue-card__book" onClick={(e: any) => e.stopPropagation()}>Book</a>
     )}
+    <SaveButton kind="venue" slug={slug} title={data.name} href={href} />
   </div>
   {verifiedLabel && (
     <p class={`venue-card__verified venue-card__verified--${verifiedTier}`} aria-label={`Editorial freshness: ${verifiedLabel}`}>

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -20,6 +20,7 @@ import SearchOverlay from '../components/SearchOverlay.astro';
 import AuthModal from '../components/v2/AuthModal.astro';
 import ProfileDropdown from '../components/v2/ProfileDropdown.astro';
 import CookieBanner from '../components/CookieBanner.astro';
+import SaveSiteController from '../components/SaveSiteController.astro';
 
 export interface Props {
   title: string;
@@ -225,6 +226,10 @@ const isAskPage = rawPathname.startsWith('/ask');
   <!-- Cookie consent banner. Shows on first visit only; gates the
        gtag.js loader above via the 'pi:consent-changed' event. -->
   <CookieBanner />
+
+  <!-- Save / share-list controller (Phase 2 WS2E). Site-wide; binds save
+       buttons on every page, owns localStorage, exposes window.PISave. -->
+  <SaveSiteController />
 
   <!-- Sticky Subscribe pill, fades in once the reader passes the 50%
        scroll mark. Mobile-only. Hidden on /newsletter, /ask, /account

--- a/next/src/pages/saved.astro
+++ b/next/src/pages/saved.astro
@@ -1,0 +1,298 @@
+---
+/**
+ * /saved/ — the user's saved-list view (Phase 2 WS2E).
+ *
+ * Renders the contents of localStorage on the client. Supports two modes:
+ *   1. Personal mode (default): reads pi:saved:v1 from localStorage and
+ *      shows the user's currently-saved venues and events.
+ *   2. Shared mode: when the URL carries ?v=slug,slug&e=slug,slug, hydrates
+ *      that list from build-time data and offers a "Save these to my list"
+ *      action that merges into localStorage.
+ *
+ * Build-time work: pre-render lookup tables for every venue and event so
+ * the client can render a saved item by slug alone, without a network call.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import SectionHero from '../components/SectionHero.astro';
+import NewsletterBlock from '../components/NewsletterBlock.astro';
+import { routeSlug, venueHrefPrefix } from '../lib/editorial';
+
+const venues = await getCollection('venues');
+const events = await getCollection('events');
+
+/**
+ * Compact lookup tables for the client. Keep the payload tight: name + href
+ * + image + a one-line summary. Hero src and price are nice-to-have for
+ * the saved-list rendering and don't bloat the page meaningfully.
+ */
+const venueLookup = Object.fromEntries(
+  venues.map((v) => [
+    routeSlug(v),
+    {
+      slug: routeSlug(v),
+      title: v.data.name,
+      href: `${venueHrefPrefix(v.data.type)}/${routeSlug(v)}/`,
+      hero: v.data.heroImage?.src ?? '',
+      placeId: typeof v.data.place === 'string' ? v.data.place : v.data.place?.id ?? '',
+      type: v.data.type,
+      price: v.data.priceBand ?? '',
+      signature: v.data.signature ?? '',
+    },
+  ]),
+);
+const eventLookup = Object.fromEntries(
+  events.map((e) => [
+    routeSlug(e),
+    {
+      slug: routeSlug(e),
+      title: e.data.title,
+      href: `/whats-on/${routeSlug(e)}/`,
+      hero: e.data.heroImage?.src ?? '',
+      summary: e.data.summary ?? '',
+    },
+  ]),
+);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'My shortlist' },
+];
+---
+
+<BaseLayout
+  title="My shortlist · Peninsula Insider"
+  description="Your saved Peninsula venues and events. Saved on this device, sharable as a single link."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="My shortlist"
+    subEyebrow="Saved on this device"
+    title="Your <em>Peninsula</em> shortlist"
+    dek="Venues and events you've saved across the site, ready to share or come back to. Saved locally, no account needed. Share the link to send the whole list to a co-traveller."
+    gradient="journal"
+    visualLabel="Peninsula Insider · saved"
+  />
+
+  <section class="saved-page">
+    <div class="container">
+      <!-- Mode banner — appears in shared mode only. Set by inline JS. -->
+      <aside class="saved-banner" data-saved-banner hidden>
+        <div class="saved-banner__inner">
+          <p class="saved-banner__label">Shared shortlist</p>
+          <p class="saved-banner__body">Someone shared this Peninsula shortlist with you. You can browse it as is, or merge it into your own saved list on this device.</p>
+          <button type="button" class="saved-banner__action" data-saved-merge>Save these to my list</button>
+        </div>
+      </aside>
+
+      <div class="saved-toolbar">
+        <p class="saved-toolbar__count" data-saved-toolbar-count></p>
+        <div class="saved-toolbar__actions">
+          <button type="button" class="saved-toolbar__action" data-saved-share>Copy share link</button>
+          <button type="button" class="saved-toolbar__action saved-toolbar__action--ghost" data-saved-clear>Clear shortlist</button>
+        </div>
+      </div>
+
+      <h2 class="saved-section-heading">Saved venues <span class="saved-section-heading__count" data-saved-venues-count>0</span></h2>
+      <ul class="saved-list" data-saved-venues-list></ul>
+      <p class="saved-empty" data-saved-venues-empty hidden>
+        No venues saved yet. Hit the bookmark on any venue card across the site, then come back here.
+      </p>
+
+      <h2 class="saved-section-heading">Saved events <span class="saved-section-heading__count" data-saved-events-count>0</span></h2>
+      <ul class="saved-list" data-saved-events-list></ul>
+      <p class="saved-empty" data-saved-events-empty hidden>
+        No events saved yet. Save anything from <a href="/whats-on/">What's On</a> to build a weekend.
+      </p>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script
+  is:inline
+  define:vars={{ venueLookup, eventLookup }}
+>
+  /* /saved/ controller. Renders from window.PISave (set by
+     SaveSiteController) plus the build-time lookup tables above. */
+  (function () {
+    function escapeHtml(s) {
+      return String(s ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function parseShared() {
+      var p = new URLSearchParams(window.location.search);
+      var v = (p.get('v') || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+      var e = (p.get('e') || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+      if (!v.length && !e.length) return null;
+      return { venues: v, events: e };
+    }
+
+    function hydrate(slug, kind) {
+      if (kind === 'event') return eventLookup[slug] || { slug: slug, title: slug, href: '#', summary: '' };
+      return venueLookup[slug] || { slug: slug, title: slug, href: '#', signature: '' };
+    }
+
+    function renderItem(kind, hydrated, savedAt) {
+      var when = savedAt ? new Date(savedAt).toLocaleDateString('en-AU', { day: 'numeric', month: 'short' }) : '';
+      var hero = hydrated.hero
+        ? '<div class="saved-list__item-hero" style="background-image:url(' + escapeHtml(hydrated.hero) + ')"></div>'
+        : '<div class="saved-list__item-hero saved-list__item-hero--empty"></div>';
+      var sub = kind === 'event' ? (hydrated.summary || '') : (hydrated.signature || '');
+      var meta = '';
+      if (kind === 'venue') {
+        var place = hydrated.placeId
+          ? String(hydrated.placeId).replace(/-/g, ' ').replace(/\b\w/g, function (l) { return l.toUpperCase(); })
+          : '';
+        meta = [hydrated.type, hydrated.price, place].filter(Boolean).map(escapeHtml).join(' · ');
+      }
+      return ''
+        + '<li class="saved-list__item">'
+        +   '<a class="saved-list__item-link" href="' + escapeHtml(hydrated.href) + '">'
+        +     hero
+        +     '<div class="saved-list__item-body">'
+        +       (meta ? '<p class="saved-list__item-meta">' + meta + '</p>' : '')
+        +       '<h3 class="saved-list__item-title">' + escapeHtml(hydrated.title) + '</h3>'
+        +       (sub ? '<p class="saved-list__item-sub">' + escapeHtml(sub) + '</p>' : '')
+        +     '</div>'
+        +   '</a>'
+        +   '<button type="button" class="saved-list__item-remove" data-saved-remove data-kind="' + kind + '" data-slug="' + escapeHtml(hydrated.slug) + '" aria-label="Remove ' + escapeHtml(hydrated.title) + ' from your shortlist">Remove</button>'
+        + '</li>';
+    }
+
+    var venuesList = document.querySelector('[data-saved-venues-list]');
+    var eventsList = document.querySelector('[data-saved-events-list]');
+    var venuesEmpty = document.querySelector('[data-saved-venues-empty]');
+    var eventsEmpty = document.querySelector('[data-saved-events-empty]');
+    var venuesCount = document.querySelector('[data-saved-venues-count]');
+    var eventsCount = document.querySelector('[data-saved-events-count]');
+    var toolbarCount = document.querySelector('[data-saved-toolbar-count]');
+    var banner = document.querySelector('[data-saved-banner]');
+    var mergeBtn = document.querySelector('[data-saved-merge]');
+
+    function render(source) {
+      // source: { venues: [{ slug, title, href, savedAt }], events: [...] }
+      var vh = (source.venues || []).map(function (it) { return renderItem('venue', hydrate(it.slug, 'venue'), it.savedAt); }).join('');
+      var eh = (source.events || []).map(function (it) { return renderItem('event', hydrate(it.slug, 'event'), it.savedAt); }).join('');
+      if (venuesList) venuesList.innerHTML = vh;
+      if (eventsList) eventsList.innerHTML = eh;
+      if (venuesCount) venuesCount.textContent = '(' + (source.venues || []).length + ')';
+      if (eventsCount) eventsCount.textContent = '(' + (source.events || []).length + ')';
+      if (venuesEmpty) (source.venues || []).length ? venuesEmpty.setAttribute('hidden', '') : venuesEmpty.removeAttribute('hidden');
+      if (eventsEmpty) (source.events || []).length ? eventsEmpty.setAttribute('hidden', '') : eventsEmpty.removeAttribute('hidden');
+      var total = (source.venues || []).length + (source.events || []).length;
+      if (toolbarCount) {
+        toolbarCount.textContent = total === 0
+          ? 'Your shortlist is empty.'
+          : total + ' item' + (total === 1 ? '' : 's') + ' saved on this device.';
+      }
+      // Bind remove buttons
+      document.querySelectorAll('[data-saved-remove]').forEach(function (btn) {
+        if (btn._piRemoveBound) return;
+        btn._piRemoveBound = true;
+        btn.addEventListener('click', function () {
+          if (!window.PISave) return;
+          window.PISave.toggle(btn.getAttribute('data-kind'), btn.getAttribute('data-slug'), '', '');
+        });
+      });
+    }
+
+    function buildShareUrl(source) {
+      var p = new URLSearchParams();
+      var vSlugs = (source.venues || []).map(function (it) { return it.slug; }).filter(Boolean);
+      var eSlugs = (source.events || []).map(function (it) { return it.slug; }).filter(Boolean);
+      if (vSlugs.length) p.set('v', vSlugs.join(','));
+      if (eSlugs.length) p.set('e', eSlugs.join(','));
+      var qs = p.toString();
+      return window.location.origin + window.location.pathname + (qs ? '?' + qs : '');
+    }
+
+    function refresh() {
+      var shared = parseShared();
+      if (shared) {
+        // Shared mode: render from URL params (no localStorage interaction)
+        if (banner) banner.removeAttribute('hidden');
+        var hydratedShared = {
+          venues: shared.venues.map(function (slug) { return { slug: slug, title: '', href: '', savedAt: 0 }; }),
+          events: shared.events.map(function (slug) { return { slug: slug, title: '', href: '', savedAt: 0 }; }),
+        };
+        render(hydratedShared);
+      } else {
+        if (banner) banner.setAttribute('hidden', '');
+        var store = window.PISave ? window.PISave.list() : { venues: [], events: [] };
+        render(store);
+      }
+    }
+
+    // Toolbar actions
+    var shareBtn = document.querySelector('[data-saved-share]');
+    if (shareBtn) {
+      shareBtn.addEventListener('click', function () {
+        var store = parseShared() || (window.PISave ? window.PISave.list() : { venues: [], events: [] });
+        // For shared mode, re-encode the URL so it stays canonical.
+        var sourceForLink = parseShared()
+          ? {
+              venues: (parseShared().venues || []).map(function (s) { return { slug: s }; }),
+              events: (parseShared().events || []).map(function (s) { return { slug: s }; }),
+            }
+          : store;
+        var url = buildShareUrl(sourceForLink);
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(url).then(function () {
+            shareBtn.textContent = 'Copied!';
+            setTimeout(function () { shareBtn.textContent = 'Copy share link'; }, 2000);
+          }, function () {
+            window.prompt('Copy this share link:', url);
+          });
+        } else {
+          window.prompt('Copy this share link:', url);
+        }
+      });
+    }
+
+    var clearBtn = document.querySelector('[data-saved-clear]');
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function () {
+        if (!window.PISave) return;
+        if (window.confirm('Clear your entire saved shortlist?')) window.PISave.clear();
+      });
+    }
+
+    if (mergeBtn) {
+      mergeBtn.addEventListener('click', function () {
+        if (!window.PISave) return;
+        var shared = parseShared();
+        if (!shared) return;
+        var incoming = {
+          venues: shared.venues.map(function (slug) {
+            var h = hydrate(slug, 'venue');
+            return { slug: slug, title: h.title, href: h.href };
+          }),
+          events: shared.events.map(function (slug) {
+            var h = hydrate(slug, 'event');
+            return { slug: slug, title: h.title, href: h.href };
+          }),
+        };
+        window.PISave.merge(incoming);
+        // Drop the shared params and refresh the local view.
+        window.history.replaceState(null, '', window.location.pathname);
+        refresh();
+      });
+    }
+
+    refresh();
+    window.addEventListener('pi:save-changed', refresh);
+    document.addEventListener('astro:page-load', refresh);
+  })();
+</script>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -8362,3 +8362,281 @@ body.menu-open .subscribe-pill {
   font-size: 0.95rem;
   color: var(--soft);
 }
+
+/* ============================================================================
+   SAVE / SHORTLIST (Phase 2 WS2E)
+   Save button on cards, masthead Saved link, and /saved/ page.
+   ============================================================================ */
+
+.save-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.7rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--soft);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.save-button:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.save-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.save-button[aria-pressed="true"] {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(167, 118, 55, 0.08);
+}
+.save-button[aria-pressed="true"] .save-button__icon path {
+  fill: currentColor;
+}
+.save-button__icon {
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+/* Masthead "Saved (N)" link — hidden until at least one item saved. */
+.masthead__saved-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--accent);
+}
+.masthead__saved-count {
+  display: inline-block;
+  min-width: 1.4em;
+  text-align: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.05rem 0.35rem;
+  background: var(--accent);
+  color: var(--bg, #fff);
+  border-radius: 999px;
+}
+
+/* /saved/ page */
+.saved-page {
+  padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem);
+}
+.saved-banner {
+  border: 1px solid var(--accent);
+  background: rgba(167, 118, 55, 0.06);
+  padding: clamp(1rem, 2vw, 1.4rem);
+  margin-bottom: clamp(1.5rem, 3vw, 2rem);
+}
+.saved-banner__label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.55rem;
+}
+.saved-banner__body {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--dark);
+  margin: 0 0 0.85rem;
+}
+.saved-banner__action {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--bg, #fff);
+  border: 1px solid var(--accent);
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+}
+.saved-banner__action:hover {
+  background: var(--text, #1a1a1a);
+  border-color: var(--text, #1a1a1a);
+}
+
+.saved-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 1rem 0 1.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+.saved-toolbar__count {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  color: var(--soft);
+  margin: 0;
+}
+.saved-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+.saved-toolbar__action {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--bg, #fff);
+  border: 1px solid var(--accent);
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+}
+.saved-toolbar__action--ghost {
+  background: transparent;
+  color: var(--soft);
+  border-color: var(--border);
+}
+.saved-toolbar__action:hover { background: var(--text, #1a1a1a); border-color: var(--text, #1a1a1a); color: var(--bg, #fff); }
+.saved-toolbar__action--ghost:hover { color: var(--accent); border-color: var(--accent); background: transparent; }
+
+.saved-section-heading {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(1.4rem, 2.5vw, 1.85rem);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: clamp(1.5rem, 3vw, 2rem) 0 clamp(0.75rem, 1.5vw, 1rem);
+}
+.saved-section-heading__count {
+  color: var(--soft);
+  font-size: 0.75em;
+  margin-left: 0.4em;
+}
+
+.saved-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(0.85rem, 1.5vw, 1.1rem);
+}
+@media (min-width: 720px) {
+  .saved-list { grid-template-columns: 1fr 1fr; }
+}
+.saved-list__item {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+  position: relative;
+}
+.saved-list__item-link {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  text-decoration: none;
+  color: inherit;
+}
+.saved-list__item-hero {
+  flex-shrink: 0;
+  width: 96px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--bg, #fff);
+}
+.saved-list__item-hero--empty {
+  background: linear-gradient(135deg, rgba(167, 118, 55, 0.12), rgba(223, 197, 158, 0.08));
+}
+.saved-list__item-body {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+.saved-list__item-meta {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin: 0;
+}
+.saved-list__item-title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0;
+}
+.saved-list__item-sub {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--soft);
+  margin: 0.1rem 0 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.saved-list__item-remove {
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin: 0.6rem 0.6rem 0 0;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+}
+.saved-list__item-remove:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.saved-empty {
+  margin: 1rem 0 0;
+  padding: 1.5rem;
+  border: 1px dashed var(--border);
+  text-align: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  color: var(--soft);
+}
+.saved-empty a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* Adjust EventCard so the new actions row sits flush at the bottom. */
+.event-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: auto;
+  flex-wrap: wrap;
+}
+.event-card__actions .event-card__cta {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary

Phase 2 WS2E. Local-storage-backed shortlist + /saved/ page + shareable URLs. No account required for v1; the entire feature works on a fresh browser session.

## What ships

- **Save button on every venue and event card.** Toggle bookmark icon, swaps label Save ↔ Saved, persists to localStorage.
- **Masthead "Saved (N)" link** in the utility row. Hidden until ≥1 item saved.
- **/saved/ page** with two modes:
  - Personal: reads localStorage, renders the user's shortlist with Copy share link / Clear actions and per-item Remove.
  - Shared (`?v=slug,slug&e=slug,slug`): shows a banner with a "Save these to my list" merge action that ingests the shared list into the user's own.
- **Copy share link** uses `navigator.clipboard` with a `window.prompt` fallback.

## Architecture

- `SaveSiteController.astro` is a singleton injected by `BaseLayout`. It owns localStorage (`pi:saved:v1`), exposes a small `window.PISave` API (`list`, `isSaved`, `toggle`, `clear`, `merge`), handles cross-tab sync via the `storage` event, dispatches `pi:save-changed` for consumers. Idempotent across `astro:page-load`.
- `SaveButton.astro` carries `data-save-*` hooks the controller binds to. The component itself is dumb; all logic centralizes in the controller.
- Storage shape is versioned (`{ version: 1, venues: [...], events: [...] }`) so we can migrate cleanly later.
- /saved/ ships build-time lookup tables (slug → title/href/hero/place/type/price/summary) so any saved slug can render without a network call.

## Test plan
- [ ] Click the Save button on a venue card on /eat/ — confirm label swaps to Saved, masthead Saved link appears with count 1.
- [ ] Save items across /eat/, /wine/, /stay/, /whats-on/ — confirm count increments.
- [ ] Visit /saved/ — confirm the saved list appears with hero images, titles, and meta.
- [ ] Click Copy share link — confirm it copies a URL like `/saved/?v=...&e=...`.
- [ ] Open the shared URL in a private window — confirm the shared banner shows; click "Save these to my list" — confirm items merge into the local store and URL params drop.
- [ ] Click Clear shortlist — confirm the saved list empties.
- [ ] Open two tabs of /saved/, save in one, confirm the other updates via cross-tab sync.

## Build
1201 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)