### PR TITLE
feat(discovery-phase-2): The Insider Map (WS2D)

### DIFF
--- a/next/src/lib/nav.ts
+++ b/next/src/lib/nav.ts
@@ -53,6 +53,7 @@ export const mastheadNav: NavItem[] = [
  * set rather than a sitemap dump.
  */
 export const mastheadMoreNav: NavItem[] = [
+  { key: 'map',              label: 'The Map',        href: '/map/',              dek: 'Every editorial pin, on one screen.' },
   { key: 'tour',             label: 'Tours',          href: '/tour/',             dek: 'Operator-led day trips and packages.' },
   { key: 'boating',          label: 'Boating',        href: '/boating/',          dek: 'Charters, hire, ramps, and tides.' },
   { key: 'golf',             label: 'Golf',           href: '/golf/',             dek: 'Courses on the cape.' },

--- a/next/src/pages/map.astro
+++ b/next/src/pages/map.astro
@@ -1,0 +1,430 @@
+---
+/**
+ * /map/ — The Insider Map (Phase 2 WS2D).
+ *
+ * Map-led discovery across venues, experiences, and place hubs. Static-first
+ * approach: every coordinate-bearing entry is serialised at build time into
+ * a JSON payload and shipped with the page; Leaflet plus the markercluster
+ * plugin are pulled from a CDN at runtime.
+ *
+ * The Peninsula's geography is dense (lots of cellar doors clustered around
+ * Red Hill and dining rooms in Sorrento), so clustering is essential — a
+ * raw pin map turns into a smear at default zoom.
+ *
+ * Layout: list panel + map. List is filterable by category; clicking a list
+ * item flies the map to the marker and opens the popup. Conversely, marker
+ * clicks open the same popup with a "Read full notes" link to the canonical
+ * detail page.
+ *
+ * Why Leaflet over Mapbox:
+ *  - No API key needed for OSM tiles.
+ *  - ~40KB gzipped vs Mapbox GL's ~200KB+.
+ *  - Sufficient for a regional discovery map; we don't need vector tiles or
+ *    3D for this product.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import { routeSlug, venueHrefPrefix } from '../lib/editorial';
+
+const venuesAll = await getCollection('venues');
+const experiencesAll = await getCollection('experiences');
+const placesAll = await getCollection('places');
+
+const placeNameBySlug = new Map<string, string>(
+  placesAll.map((p) => [p.id ?? p.data.slug, p.data.name]),
+);
+
+/** Map-pin payload kinds. The colour palette below keys off `category`, not
+ *  raw type, so we group venue subtypes into the same colour band. */
+type MapEntry = {
+  id: string;
+  category: 'eat' | 'wine' | 'stay' | 'experience' | 'place';
+  /** Sub-category — used for the popup chip and list meta line. */
+  type: string;
+  name: string;
+  href: string;
+  lat: number;
+  lng: number;
+  hero: string;
+  placeName: string;
+  /** Free text for the popup body. Trimmed for payload weight. */
+  blurb: string;
+};
+
+function venueCategory(type: string): MapEntry['category'] {
+  if (['winery', 'brewery', 'distillery', 'producer'].includes(type)) return 'wine';
+  if (['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'].includes(type)) return 'stay';
+  return 'eat';
+}
+
+function venueHref(slug: string, type: string): string {
+  return `${venueHrefPrefix(type)}/${slug}/`;
+}
+
+const venuePins: MapEntry[] = venuesAll
+  .filter((v) => v.data.coordinates && Number.isFinite(v.data.coordinates.lat))
+  .map((v) => {
+    const slug = routeSlug(v);
+    const placeId = typeof v.data.place === 'string' ? v.data.place : v.data.place?.id ?? '';
+    return {
+      id: `venue:${slug}`,
+      category: venueCategory(v.data.type),
+      type: v.data.type,
+      name: v.data.name,
+      href: venueHref(slug, v.data.type),
+      lat: v.data.coordinates!.lat,
+      lng: v.data.coordinates!.lng,
+      hero: v.data.heroImage?.src ?? '',
+      placeName: placeNameBySlug.get(placeId) ?? '',
+      blurb: (v.data.signature ?? '').slice(0, 160),
+    };
+  });
+
+const experiencePins: MapEntry[] = experiencesAll
+  .filter((e) => e.data.coordinates && Number.isFinite(e.data.coordinates.lat))
+  .filter((e) => !e.data.sitemapExclude)
+  .map((e) => {
+    const slug = routeSlug(e);
+    const placeId = typeof e.data.place === 'string' ? e.data.place : e.data.place?.id ?? '';
+    return {
+      id: `experience:${slug}`,
+      category: 'experience' as const,
+      type: e.data.type,
+      name: e.data.name,
+      href: `/explore/${slug}/`,
+      lat: e.data.coordinates!.lat,
+      lng: e.data.coordinates!.lng,
+      hero: e.data.heroImage?.src ?? '',
+      placeName: placeNameBySlug.get(placeId) ?? '',
+      blurb: (e.data.editorNote ?? '').slice(0, 160),
+    };
+  });
+
+const placePins: MapEntry[] = placesAll
+  .filter((p) => p.data.coordinates && Number.isFinite(p.data.coordinates.lat))
+  .filter((p) => !p.data.sitemapExclude)
+  .map((p) => {
+    const slug = p.id ?? p.data.slug;
+    return {
+      id: `place:${slug}`,
+      category: 'place' as const,
+      type: p.data.kind,
+      name: p.data.name,
+      href: `/places/${slug}/`,
+      lat: p.data.coordinates!.lat,
+      lng: p.data.coordinates!.lng,
+      hero: p.data.heroImage?.src ?? '',
+      placeName: '',
+      blurb: (p.data.intro ?? '').slice(0, 160),
+    };
+  });
+
+const allPins: MapEntry[] = [...placePins, ...venuePins, ...experiencePins];
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'The Insider Map' },
+];
+
+const categoryLegend: Array<{ key: MapEntry['category']; label: string; count: number }> = [
+  { key: 'place',      label: 'Places',      count: placePins.length },
+  { key: 'eat',        label: 'Eat & Drink', count: venuePins.filter((p) => p.category === 'eat').length },
+  { key: 'wine',       label: 'Wine',        count: venuePins.filter((p) => p.category === 'wine').length },
+  { key: 'stay',       label: 'Stay',        count: venuePins.filter((p) => p.category === 'stay').length },
+  { key: 'experience', label: 'Experiences', count: experiencePins.length },
+];
+---
+
+<BaseLayout
+  title="The Insider Map · Peninsula Insider"
+  description="The whole Mornington Peninsula on one map. Cellar doors, restaurants, stays, walks, beaches, towns — every entry editorially verified, all on one screen."
+  section="explore"
+  canonical="https://peninsulainsider.com.au/map/"
+>
+  <!-- Leaflet CSS, loaded from a CDN. The library is small enough that we
+       skip self-hosting for this v1; the script tag below loads the JS. -->
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
+  />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"
+  />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="map-page">
+    <div class="map-page__intro">
+      <div class="container">
+        <p class="label label--accent">The Insider Map</p>
+        <h1 class="map-page__title">The whole Peninsula, on one screen.</h1>
+        <p class="map-page__sub">{allPins.length} editorially verified entries across the region — places, dining rooms, cellar doors, stays, and the experiences worth the drive. Filter by category, click a pin for the editor's note, or open any entry in full.</p>
+      </div>
+    </div>
+
+    <div class="map-page__chrome">
+      <div class="map-page__filters" data-map-filters>
+        {categoryLegend.map((cat) => (
+          <button
+            type="button"
+            class={`map-pin-toggle map-pin-toggle--${cat.key}`}
+            data-map-toggle={cat.key}
+            aria-pressed="true"
+          >
+            <span class="map-pin-toggle__dot" aria-hidden="true"></span>
+            <span class="map-pin-toggle__label">{cat.label}</span>
+            <span class="map-pin-toggle__count">{cat.count}</span>
+          </button>
+        ))}
+      </div>
+
+      <div class="map-page__layout">
+        <aside class="map-page__list" aria-label="Map entries list">
+          <div class="map-page__list-header">
+            <input
+              type="search"
+              class="map-page__search"
+              placeholder="Search the map…"
+              aria-label="Search map entries"
+              data-map-search
+            />
+            <p class="map-page__list-count" data-map-list-count>{allPins.length} entries</p>
+          </div>
+          <ul class="map-page__entries" data-map-entries></ul>
+          <p class="map-page__list-empty" data-map-list-empty hidden>
+            No entries match — clear the search or re-enable a category above.
+          </p>
+        </aside>
+
+        <div class="map-page__canvas">
+          <div id="theInsiderMap" class="map-page__map" aria-label="Map of the Mornington Peninsula"></div>
+          <p class="map-page__attribution-note">Tiles by OpenStreetMap contributors. Editorial pins by Peninsula Insider.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Leaflet + markercluster, loaded after page render so the rest of the
+       site doesn't pay for these bytes when it doesn't need them. -->
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""
+    is:inline
+  ></script>
+  <script
+    src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"
+    is:inline
+  ></script>
+
+  <script is:inline define:vars={{ pins: allPins }}>
+    /* The Insider Map controller. Initialises Leaflet, plots clustered
+       markers, wires the list↔map sync, and implements the category and
+       text filters. Idempotent across astro:page-load. */
+    (function () {
+      function init() {
+        var container = document.getElementById('theInsiderMap');
+        if (!container || container._piMapBound) return;
+        if (typeof L === 'undefined') {
+          // Leaflet hasn't finished loading yet — retry once on next tick.
+          setTimeout(init, 100);
+          return;
+        }
+        container._piMapBound = true;
+
+        var map = L.map(container, {
+          attributionControl: true,
+          scrollWheelZoom: false, // ergonomic default; user can two-finger or +/- zoom
+        }).setView([-38.4, 145.0], 11);
+        // Re-enable scroll-wheel zoom on focus to keep the keyboard path useful.
+        container.addEventListener('focus', function () { map.scrollWheelZoom.enable(); });
+        container.addEventListener('blur', function () { map.scrollWheelZoom.disable(); });
+        // Click on map to enable scroll zoom (desktop convenience).
+        map.on('click', function () { map.scrollWheelZoom.enable(); });
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 18,
+          attribution: '© OpenStreetMap contributors',
+        }).addTo(map);
+
+        // Per-category icon. We use Leaflet DivIcons so we don't need image
+        // assets — the colour comes from CSS classes keyed off category.
+        function iconFor(cat) {
+          return L.divIcon({
+            className: 'map-pin map-pin--' + cat,
+            html: '<span class="map-pin__inner" aria-hidden="true"></span>',
+            iconSize: [22, 22],
+            iconAnchor: [11, 11],
+            popupAnchor: [0, -10],
+          });
+        }
+
+        function escapeHtml(s) {
+          return String(s ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+        }
+
+        function popupHtml(p) {
+          var hero = p.hero
+            ? '<div class="map-popup__hero" style="background-image:url(' + escapeHtml(p.hero) + ')"></div>'
+            : '';
+          var meta = [p.type, p.placeName].filter(Boolean).map(escapeHtml).join(' · ');
+          return ''
+            + '<div class="map-popup">'
+            +   hero
+            +   '<div class="map-popup__body">'
+            +     (meta ? '<p class="map-popup__meta">' + meta + '</p>' : '')
+            +     '<h3 class="map-popup__title">' + escapeHtml(p.name) + '</h3>'
+            +     (p.blurb ? '<p class="map-popup__blurb">' + escapeHtml(p.blurb) + '</p>' : '')
+            +     '<a class="map-popup__cta" href="' + escapeHtml(p.href) + '">Read the full notes →</a>'
+            +   '</div>'
+            + '</div>';
+        }
+
+        var clusterGroup = L.markerClusterGroup({
+          showCoverageOnHover: false,
+          maxClusterRadius: 45,
+        });
+
+        var markersById = {};
+        var entriesById = {};
+
+        pins.forEach(function (p) {
+          if (!Number.isFinite(p.lat) || !Number.isFinite(p.lng)) return;
+          var marker = L.marker([p.lat, p.lng], { icon: iconFor(p.category) });
+          marker.bindPopup(popupHtml(p), { maxWidth: 280, autoPanPadding: [40, 40] });
+          marker._piData = p;
+          clusterGroup.addLayer(marker);
+          markersById[p.id] = marker;
+          entriesById[p.id] = p;
+        });
+        map.addLayer(clusterGroup);
+
+        // Fit bounds to all markers, padded.
+        if (Object.keys(markersById).length > 0) {
+          var group = L.featureGroup(Object.values(markersById));
+          map.fitBounds(group.getBounds(), { padding: [30, 30], maxZoom: 13 });
+        }
+
+        // ─── List rendering & sync ─────────────────────────────────────
+        var listEl = document.querySelector('[data-map-entries]');
+        var listCountEl = document.querySelector('[data-map-list-count]');
+        var listEmptyEl = document.querySelector('[data-map-list-empty]');
+
+        // Filter state
+        var enabledCats = { place: true, eat: true, wine: true, stay: true, experience: true };
+        var query = '';
+
+        function entryMatches(p) {
+          if (!enabledCats[p.category]) return false;
+          if (!query) return true;
+          var hay = (p.name + ' ' + p.placeName + ' ' + p.type + ' ' + p.blurb).toLowerCase();
+          return hay.indexOf(query) !== -1;
+        }
+
+        function renderList() {
+          var visible = pins.filter(entryMatches);
+          // Sort: places first, then by name within category.
+          visible.sort(function (a, b) {
+            var rank = { place: 0, eat: 1, wine: 2, stay: 3, experience: 4 };
+            if (rank[a.category] !== rank[b.category]) return rank[a.category] - rank[b.category];
+            return a.name.localeCompare(b.name);
+          });
+          var html = visible.map(function (p) {
+            var meta = [p.type, p.placeName].filter(Boolean).map(escapeHtml).join(' · ');
+            return ''
+              + '<li class="map-page__entry map-page__entry--' + p.category + '" data-entry-id="' + escapeHtml(p.id) + '">'
+              +   '<button type="button" class="map-page__entry-button" data-entry-focus="' + escapeHtml(p.id) + '">'
+              +     '<span class="map-page__entry-dot map-page__entry-dot--' + p.category + '" aria-hidden="true"></span>'
+              +     '<span class="map-page__entry-text">'
+              +       '<span class="map-page__entry-name">' + escapeHtml(p.name) + '</span>'
+              +       (meta ? '<span class="map-page__entry-meta">' + meta + '</span>' : '')
+              +     '</span>'
+              +   '</button>'
+              + '</li>';
+          }).join('');
+          if (listEl) listEl.innerHTML = html;
+          if (listCountEl) {
+            listCountEl.textContent = visible.length === pins.length
+              ? pins.length + ' entries'
+              : visible.length + ' of ' + pins.length + ' entries';
+          }
+          if (listEmptyEl) {
+            if (visible.length === 0) listEmptyEl.removeAttribute('hidden');
+            else listEmptyEl.setAttribute('hidden', '');
+          }
+          // Bind clicks
+          if (listEl) {
+            listEl.querySelectorAll('[data-entry-focus]').forEach(function (btn) {
+              btn.addEventListener('click', function () {
+                var id = btn.getAttribute('data-entry-focus');
+                var marker = markersById[id];
+                if (!marker) return;
+                clusterGroup.zoomToShowLayer(marker, function () {
+                  marker.openPopup();
+                });
+              });
+            });
+          }
+        }
+
+        function applyMarkerVisibility() {
+          // Markercluster doesn't support per-marker hiding cleanly; we
+          // remove and re-add markers for filter-out behaviour.
+          clusterGroup.clearLayers();
+          pins.forEach(function (p) {
+            if (!entryMatches(p)) return;
+            var marker = markersById[p.id];
+            if (marker) clusterGroup.addLayer(marker);
+          });
+        }
+
+        function commit() {
+          applyMarkerVisibility();
+          renderList();
+        }
+
+        // Bind category toggles
+        document.querySelectorAll('[data-map-toggle]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var cat = btn.getAttribute('data-map-toggle');
+            enabledCats[cat] = !enabledCats[cat];
+            btn.setAttribute('aria-pressed', enabledCats[cat] ? 'true' : 'false');
+            commit();
+          });
+        });
+
+        // Bind search box (debounced)
+        var searchEl = document.querySelector('[data-map-search]');
+        if (searchEl) {
+          var debounce = null;
+          searchEl.addEventListener('input', function () {
+            clearTimeout(debounce);
+            debounce = setTimeout(function () {
+              query = searchEl.value.trim().toLowerCase();
+              commit();
+            }, 150);
+          });
+        }
+
+        // Initial render
+        renderList();
+      }
+
+      init();
+      document.addEventListener('astro:page-load', init);
+    })();
+  </script>
+</BaseLayout>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -8640,3 +8640,308 @@ body.menu-open .subscribe-pill {
 .event-card__actions .event-card__cta {
   margin-top: 0;
 }
+
+/* ============================================================================
+   THE INSIDER MAP (Phase 2 WS2D)
+   Map-led discovery on /map/. Leaflet + markercluster from CDN; everything
+   below is the page chrome around the map canvas.
+   ============================================================================ */
+
+.map-page {
+  padding: 0 0 clamp(2rem, 4vw, 3rem);
+}
+.map-page__intro {
+  padding: clamp(1.25rem, 3vw, 2rem) 0 clamp(1rem, 2vw, 1.5rem);
+  border-bottom: 1px solid var(--border);
+}
+.map-page__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  color: var(--text);
+  margin: 0.4rem 0 0.7rem;
+}
+.map-page__sub {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--soft);
+  max-width: 760px;
+  margin: 0;
+}
+
+.map-page__chrome {
+  padding-top: clamp(1rem, 2vw, 1.5rem);
+}
+.map-page__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0 clamp(1rem, 2vw, 1.5rem) clamp(0.85rem, 1.5vw, 1.1rem);
+  border-bottom: 1px solid var(--border);
+}
+
+.map-pin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.5rem 0.85rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  background: transparent;
+  color: var(--dark);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+}
+.map-pin-toggle[aria-pressed="false"] {
+  opacity: 0.45;
+  background: var(--paper, #fbf7f0);
+}
+.map-pin-toggle:hover { border-color: var(--accent); }
+.map-pin-toggle__dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 2px solid var(--bg, #fff);
+  box-shadow: 0 0 0 1px rgba(40, 28, 14, 0.25);
+}
+.map-pin-toggle--place .map-pin-toggle__dot      { background: #6b4d2c; }
+.map-pin-toggle--eat .map-pin-toggle__dot        { background: #b3592a; }
+.map-pin-toggle--wine .map-pin-toggle__dot       { background: #7b1e3c; }
+.map-pin-toggle--stay .map-pin-toggle__dot       { background: #4a6a4f; }
+.map-pin-toggle--experience .map-pin-toggle__dot { background: #2f6e8a; }
+.map-pin-toggle__count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--soft);
+  padding-left: 0.2rem;
+}
+
+.map-page__layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  min-height: 70vh;
+}
+@media (min-width: 880px) {
+  .map-page__layout {
+    grid-template-columns: 320px 1fr;
+    min-height: 75vh;
+  }
+}
+
+.map-page__list {
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  background: var(--paper, #fbf7f0);
+}
+@media (min-width: 880px) {
+  .map-page__list {
+    border-right: 1px solid var(--border);
+    border-bottom: 0;
+    max-height: 75vh;
+    overflow-y: auto;
+  }
+}
+.map-page__list-header {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.map-page__search {
+  width: 100%;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.92rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--border);
+  background: var(--bg, #fff);
+  color: var(--dark);
+  margin-bottom: 0.5rem;
+}
+.map-page__search:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.map-page__list-count {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin: 0;
+}
+
+.map-page__entries {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0;
+}
+.map-page__entry-button {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0.7rem 1rem;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.map-page__entry-button:hover,
+.map-page__entry-button:focus-visible {
+  background: rgba(167, 118, 55, 0.08);
+  outline: none;
+}
+.map-page__entry-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 0.4rem;
+  border: 2px solid var(--bg, #fff);
+  box-shadow: 0 0 0 1px rgba(40, 28, 14, 0.25);
+}
+.map-page__entry-dot--place      { background: #6b4d2c; }
+.map-page__entry-dot--eat        { background: #b3592a; }
+.map-page__entry-dot--wine       { background: #7b1e3c; }
+.map-page__entry-dot--stay       { background: #4a6a4f; }
+.map-page__entry-dot--experience { background: #2f6e8a; }
+.map-page__entry-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1;
+}
+.map-page__entry-name {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.05rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--text);
+  line-height: 1.2;
+}
+.map-page__entry-meta {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--soft);
+}
+.map-page__list-empty {
+  margin: 0.85rem 1rem;
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  text-align: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+  color: var(--soft);
+}
+
+.map-page__canvas {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+.map-page__map {
+  flex: 1;
+  min-height: 65vh;
+  /* Leaflet resets some box-sizing locally; ensure a sane base. */
+  z-index: 0;
+}
+.map-page__attribution-note {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  color: var(--soft);
+  text-align: right;
+  padding: 0.45rem 1rem 0.7rem;
+  margin: 0;
+  border-top: 1px solid var(--border);
+}
+
+/* Custom Leaflet pins. DivIcon-based — no external image assets. */
+.map-pin {
+  background: transparent;
+  border: 0;
+}
+.map-pin__inner {
+  display: block;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 3px solid var(--bg, #fff);
+  box-shadow: 0 2px 6px -2px rgba(0, 0, 0, 0.6);
+}
+.map-pin--place .map-pin__inner      { background: #6b4d2c; }
+.map-pin--eat .map-pin__inner        { background: #b3592a; }
+.map-pin--wine .map-pin__inner       { background: #7b1e3c; }
+.map-pin--stay .map-pin__inner       { background: #4a6a4f; }
+.map-pin--experience .map-pin__inner { background: #2f6e8a; }
+
+/* Popup body styled to match the rest of the brand. Leaflet's default
+   popup chrome is left in place; we just style the inner content. */
+.map-popup {
+  width: 240px;
+  font-family: 'Outfit', sans-serif;
+}
+.map-popup__hero {
+  height: 110px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--paper, #fbf7f0);
+  margin: -8px -12px 8px;
+}
+.map-popup__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.map-popup__meta {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin: 0;
+}
+.map-popup__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.2;
+}
+.map-popup__blurb {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--dark);
+  margin: 0;
+}
+.map-popup__cta {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(167, 118, 55, 0.45);
+  align-self: flex-start;
+}
+.map-popup__cta:hover {
+  border-bottom-color: var(--accent);
+}


### PR DESCRIPTION
## Summary

Phase 2 WS2D — final workstream. Map-led discovery at `/map/` across every editorial pin on the Peninsula. **Phase 2 complete after this PR.**

194 pins from existing `coordinates` fields: 19 place hubs, 59 eat, 59 wine, 16 stay, 41 experiences.

## What ships

- **`/map/` page** with Leaflet + markercluster (CDN-loaded with SRI where available). OSM tiles with attribution.
- **Two-column layout** on desktop (320px filterable list + map canvas); mobile stacks list above map.
- **Five colour-coded categories** with chip toggles + per-category counts.
- **Free-text search** with 150ms debounce — matches name, place, type, blurb.
- **List ↔ map sync** — click a list entry to fly to the marker (`zoomToShowLayer` to expand its cluster), click a marker for a popup with hero, meta, blurb, and a "Read full notes →" CTA.
- **Custom DivIcon markers** — coloured circles with white ring, no image assets shipped.
- **Scroll-wheel zoom off by default**, enables on click/focus so users can scroll past the map without it eating their gestures.
- **"The Map" added to the More mega-menu** as the first item, so it's one click from any page.

## Why Leaflet over Mapbox
- No API key needed for OSM tiles
- ~40 KB gzipped vs Mapbox GL ~200 KB+
- Sufficient feature set for a regional discovery map; we don't need vector tiles or 3D

## Test plan
- [ ] Visit `/map/` — confirm map renders with ~194 clustered pins, fitted to Peninsula bounds.
- [ ] Click "Wine" toggle off — confirm wine pins disappear from both map and list.
- [ ] Type "Red Hill" in the search — confirm list narrows to Red Hill items.
- [ ] Click a list entry — confirm map flies to the pin and popup opens.
- [ ] Click a marker — confirm popup with hero / title / blurb / CTA.
- [ ] Click "Read full notes →" — confirm navigation to the canonical detail page.
- [ ] Resize to mobile width — confirm list stacks above the map.
- [ ] Open More menu — confirm "The Map" appears as the first item.

## Build
1206 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)