### PR TITLE
feat(discovery-phase-3): typeahead site search (WS3A)

### DIFF
--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -14,6 +14,7 @@
  * All CSS lives in global.css under "MASTHEAD V3".
  */
 import { mastheadNav as navItems, mastheadMoreNav as moreItems } from '../lib/nav';
+import Typeahead from './Typeahead.astro';
 
 export interface Props {
   section?: string;
@@ -152,21 +153,12 @@ const {
             </li>
           </ul>
         </nav>
-        <!-- Visual order: search icon, then Subscribe, far-right.
-             Search sits to the immediate left of the Subscribe pill. -->
-        <button
-          type="button"
-          class="masthead__search-icon"
-          data-open-search
-          aria-label="Search Peninsula Insider"
-          aria-haspopup="dialog"
-          aria-controls="siteSearchOverlay"
-        >
-          <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="9" cy="9" r="6" />
-            <path d="M14 14l4 4" />
-          </svg>
-        </button>
+        <!-- Visual order: typeahead (instant search), then Subscribe.
+             Phase 3 WS3A — replaces the prior search-icon button which
+             opened the SearchOverlay. The overlay component is still
+             mounted by BaseLayout as a fallback path; the typeahead's
+             "View all results" footer link routes there if needed. -->
+        <Typeahead />
         <a href="/newsletter/" class="masthead__cta">Subscribe</a>
         <a href="/newsletter/" class="masthead__cta-mobile" aria-label="Subscribe to the newsletter">Subscribe</a>
       </div>

--- a/next/src/components/Typeahead.astro
+++ b/next/src/components/Typeahead.astro
@@ -1,0 +1,411 @@
+---
+/**
+ * Typeahead — masthead-mounted instant search (Phase 3 WS3A).
+ *
+ * Replaces the search-icon button as the primary search affordance. The
+ * existing SearchOverlay component is kept on disk and mounted in
+ * BaseLayout so we have a one-line rollback if typeahead misbehaves —
+ * see Phase 3 progress log for the rationale.
+ *
+ * Behaviour:
+ *  - Click / focus / "/" key opens the input.
+ *  - Type-as-you-go debounced 150ms; results group by kind.
+ *  - Up/Down arrows move the focus ring; Enter opens; Esc closes.
+ *  - Mobile: input expands into a full-screen panel for thumb reach.
+ *  - "View all results" footer link goes to /search/?q=…
+ *
+ * Pagefind module loaded lazily on first focus (~80kb WASM); the
+ * markup is static.
+ */
+---
+
+<div class="typeahead" data-typeahead-root>
+  <button
+    type="button"
+    class="typeahead__trigger"
+    data-typeahead-trigger
+    aria-expanded="false"
+    aria-controls="typeaheadPanel"
+    aria-label="Search Peninsula Insider"
+  >
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="9" cy="9" r="6" />
+      <path d="M14 14l4 4" />
+    </svg>
+    <span class="typeahead__trigger-label">Search</span>
+    <kbd class="typeahead__trigger-kbd" aria-hidden="true">/</kbd>
+  </button>
+
+  <div
+    class="typeahead__panel"
+    id="typeaheadPanel"
+    data-typeahead-panel
+    role="combobox"
+    aria-haspopup="listbox"
+    aria-expanded="false"
+    aria-owns="typeaheadResults"
+    hidden
+  >
+    <div class="typeahead__panel-inner">
+      <form class="typeahead__form" data-typeahead-form autocomplete="off" role="search">
+        <span class="typeahead__form-icon" aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="9" cy="9" r="6" />
+            <path d="M14 14l4 4" />
+          </svg>
+        </span>
+        <input
+          type="search"
+          class="typeahead__input"
+          data-typeahead-input
+          placeholder="Search venues, events, places, articles…"
+          aria-label="Search Peninsula Insider"
+          aria-controls="typeaheadResults"
+          aria-autocomplete="list"
+        />
+        <button
+          type="button"
+          class="typeahead__close"
+          data-typeahead-close
+          aria-label="Close search"
+        >
+          <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 5l10 10M15 5L5 15" />
+          </svg>
+        </button>
+      </form>
+
+      <div class="typeahead__suggestions" data-typeahead-suggestions>
+        <p class="typeahead__suggestions-label">Try one of these</p>
+        <div class="typeahead__chips">
+          {[
+            { q: 'long lunch',     label: 'Long lunch' },
+            { q: 'cellar door',    label: 'Cellar doors' },
+            { q: 'rainy day',      label: 'Rainy day' },
+            { q: 'Sorrento',       label: 'Sorrento' },
+            { q: 'Red Hill',       label: 'Red Hill' },
+            { q: 'family beach',   label: 'Family beach' },
+          ].map((c) => (
+            <button type="button" class="typeahead__chip" data-typeahead-chip={c.q}>
+              <span class="typeahead__chip-bullet" aria-hidden="true">♦</span>
+              <span>{c.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <ul
+        class="typeahead__results"
+        id="typeaheadResults"
+        data-typeahead-results
+        role="listbox"
+        aria-label="Search results"
+        hidden
+      ></ul>
+
+      <div class="typeahead__footer" data-typeahead-footer hidden>
+        <a class="typeahead__footer-link" data-typeahead-all-link href="/search/">
+          View all results
+          <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  /* Typeahead controller — lazy-loads Pagefind on first focus, debounces
+     search, groups results by kind, supports keyboard navigation, and
+     falls back to /search/?q=… for the full results page.
+     Idempotent across astro:page-load. */
+  (function () {
+    var state = {
+      pagefind: null,
+      loading: null,
+      bound: false,
+    };
+
+    function init() {
+      if (state.bound) return;
+      var root = document.querySelector('[data-typeahead-root]');
+      if (!root) return;
+      state.bound = true;
+
+      var trigger = root.querySelector('[data-typeahead-trigger]');
+      var panel = root.querySelector('[data-typeahead-panel]');
+      var form = root.querySelector('[data-typeahead-form]');
+      var input = root.querySelector('[data-typeahead-input]');
+      var closeBtn = root.querySelector('[data-typeahead-close]');
+      var suggestions = root.querySelector('[data-typeahead-suggestions]');
+      var resultsEl = root.querySelector('[data-typeahead-results]');
+      var footerEl = root.querySelector('[data-typeahead-footer]');
+      var allLink = root.querySelector('[data-typeahead-all-link]');
+      var chips = root.querySelectorAll('[data-typeahead-chip]');
+
+      var open = false;
+      var query = '';
+      var debounceTimer = null;
+      var activeIndex = -1;
+      var resultLinks = [];
+
+      function setOpen(next) {
+        if (open === next) return;
+        open = next;
+        trigger.setAttribute('aria-expanded', next ? 'true' : 'false');
+        panel.setAttribute('aria-expanded', next ? 'true' : 'false');
+        if (next) {
+          panel.removeAttribute('hidden');
+          root.classList.add('is-open');
+          document.body.classList.add('typeahead-open');
+          // Lazy-load Pagefind on first open.
+          ensurePagefind();
+          // Focus AFTER render so the panel transition completes first.
+          requestAnimationFrame(function () { input.focus(); });
+        } else {
+          panel.setAttribute('hidden', '');
+          root.classList.remove('is-open');
+          document.body.classList.remove('typeahead-open');
+          input.value = '';
+          query = '';
+          activeIndex = -1;
+          showSuggestions();
+        }
+      }
+
+      function showSuggestions() {
+        if (suggestions) suggestions.removeAttribute('hidden');
+        if (resultsEl) resultsEl.setAttribute('hidden', '');
+        if (footerEl) footerEl.setAttribute('hidden', '');
+        resultLinks = [];
+      }
+
+      function showResultsHint(html) {
+        if (suggestions) suggestions.setAttribute('hidden', '');
+        if (resultsEl) {
+          resultsEl.removeAttribute('hidden');
+          resultsEl.innerHTML = html;
+        }
+        resultLinks = [];
+      }
+
+      function ensurePagefind() {
+        if (state.pagefind || state.loading) return state.loading;
+        state.loading = (async function () {
+          try {
+            state.pagefind = await import(/* @vite-ignore */ '/pagefind/pagefind.js');
+            try { await state.pagefind.options({ basePath: '/pagefind/' }); } catch (_e) {}
+          } catch (err) {
+            console.warn('[typeahead] Pagefind failed to load:', err);
+          }
+        })();
+        return state.loading;
+      }
+
+      function escapeHtml(s) {
+        return String(s == null ? '' : s)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      function kindOf(item) {
+        if (item.meta && item.meta.kind) return item.meta.kind;
+        if (item.filters && item.filters.kind && item.filters.kind[0]) return item.filters.kind[0];
+        return 'Guide';
+      }
+
+      var KIND_ORDER = ['Plans', 'Eat', 'Wine', 'Stay', 'Explore', 'Places', "What's On", 'Journal', 'Guide', 'Home'];
+
+      function groupResults(results) {
+        var groups = {};
+        results.forEach(function (item) {
+          var kind = kindOf(item);
+          if (!groups[kind]) groups[kind] = [];
+          groups[kind].push(item);
+        });
+        return Object.keys(groups)
+          .sort(function (a, b) {
+            var ai = KIND_ORDER.indexOf(a);
+            var bi = KIND_ORDER.indexOf(b);
+            if (ai === -1) ai = 99;
+            if (bi === -1) bi = 99;
+            return ai - bi;
+          })
+          .map(function (k) { return { kind: k, items: groups[k] }; });
+      }
+
+      function renderResults(grouped, q) {
+        if (!grouped.length) {
+          showResultsHint(
+            '<li class="typeahead__empty">' +
+              '<p class="typeahead__empty-title">No instant matches for "' + escapeHtml(q) + '".</p>' +
+              '<p class="typeahead__empty-hint">Hit Enter for the full results page, or ask The Insider directly.</p>' +
+            '</li>'
+          );
+          if (footerEl) footerEl.removeAttribute('hidden');
+          if (allLink) allLink.href = '/search/?q=' + encodeURIComponent(q);
+          return;
+        }
+
+        // Cap at 8 total results across groups.
+        var perGroupCap = 4;
+        var totalCap = 8;
+        var rendered = 0;
+        var html = '';
+        grouped.forEach(function (group) {
+          if (rendered >= totalCap) return;
+          var slice = group.items.slice(0, perGroupCap);
+          html += '<li class="typeahead__group" role="presentation">';
+          html += '<p class="typeahead__group-label">' + escapeHtml(group.kind) + '</p>';
+          html += '<ul class="typeahead__group-items">';
+          for (var i = 0; i < slice.length && rendered < totalCap; i++) {
+            var item = slice[i];
+            var title = (item.meta && item.meta.title) || 'Untitled';
+            var excerpt = item.excerpt || '';
+            var url = item.url || '#';
+            html += ''
+              + '<li class="typeahead__result">'
+              +   '<a href="' + escapeHtml(url) + '" class="typeahead__result-link" role="option" tabindex="-1">'
+              +     '<span class="typeahead__result-title">' + escapeHtml(title) + '</span>'
+              +     (excerpt ? '<span class="typeahead__result-excerpt">' + excerpt + '</span>' : '')
+              +   '</a>'
+              + '</li>';
+            rendered++;
+          }
+          html += '</ul></li>';
+        });
+        if (suggestions) suggestions.setAttribute('hidden', '');
+        if (resultsEl) {
+          resultsEl.removeAttribute('hidden');
+          resultsEl.innerHTML = html;
+        }
+        if (footerEl) footerEl.removeAttribute('hidden');
+        if (allLink) allLink.href = '/search/?q=' + encodeURIComponent(q);
+
+        resultLinks = Array.prototype.slice.call(resultsEl.querySelectorAll('.typeahead__result-link'));
+        activeIndex = -1;
+      }
+
+      async function runQuery(q) {
+        if (!q || q.length < 2) {
+          showSuggestions();
+          if (footerEl) footerEl.setAttribute('hidden', '');
+          return;
+        }
+        await ensurePagefind();
+        if (!state.pagefind) {
+          showResultsHint('<li class="typeahead__empty"><p>Search isn\'t available right now.</p></li>');
+          return;
+        }
+        try {
+          var search = await state.pagefind.search(q);
+          var top = await Promise.all(search.results.slice(0, 12).map(function (r) { return r.data(); }));
+          if (q !== query) return; // user kept typing; this query is stale
+          renderResults(groupResults(top), q);
+        } catch (err) {
+          console.warn('[typeahead] search error:', err);
+          showResultsHint('<li class="typeahead__empty"><p>Search hiccup. Try again.</p></li>');
+        }
+      }
+
+      function setActive(idx) {
+        if (!resultLinks.length) return;
+        if (idx < 0) idx = resultLinks.length - 1;
+        if (idx >= resultLinks.length) idx = 0;
+        if (activeIndex >= 0 && resultLinks[activeIndex]) {
+          resultLinks[activeIndex].classList.remove('is-active');
+        }
+        activeIndex = idx;
+        resultLinks[activeIndex].classList.add('is-active');
+        // Scroll into view if needed.
+        var el = resultLinks[activeIndex];
+        if (el && typeof el.scrollIntoView === 'function') {
+          el.scrollIntoView({ block: 'nearest' });
+        }
+      }
+
+      // Trigger / open
+      trigger.addEventListener('click', function () { setOpen(!open); });
+      if (closeBtn) closeBtn.addEventListener('click', function () { setOpen(false); });
+
+      // Click outside closes
+      document.addEventListener('click', function (e) {
+        if (!open) return;
+        if (root.contains(e.target)) return;
+        setOpen(false);
+      });
+
+      // Slash key opens search from anywhere (unless typing in another input)
+      document.addEventListener('keydown', function (e) {
+        if (e.key === '/' && !open) {
+          var t = e.target;
+          var tag = t && t.tagName ? t.tagName.toLowerCase() : '';
+          if (tag === 'input' || tag === 'textarea' || (t && t.isContentEditable)) return;
+          e.preventDefault();
+          setOpen(true);
+          return;
+        }
+        if (e.key === 'Escape' && open) {
+          setOpen(false);
+          trigger.focus();
+        }
+      });
+
+      // Input handling — debounced query
+      input.addEventListener('input', function () {
+        query = input.value.trim();
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function () { runQuery(query); }, 150);
+      });
+
+      // Form submit → open /search/?q=…
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (query) window.location.href = '/search/?q=' + encodeURIComponent(query);
+      });
+
+      // Keyboard nav within results (input-level)
+      input.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowDown') {
+          if (resultLinks.length) {
+            e.preventDefault();
+            setActive(activeIndex + 1);
+          }
+        } else if (e.key === 'ArrowUp') {
+          if (resultLinks.length) {
+            e.preventDefault();
+            setActive(activeIndex - 1);
+          }
+        } else if (e.key === 'Enter') {
+          if (activeIndex >= 0 && resultLinks[activeIndex]) {
+            e.preventDefault();
+            window.location.href = resultLinks[activeIndex].getAttribute('href');
+          }
+        }
+      });
+
+      // Suggestion chips → run query
+      chips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+          var q = chip.getAttribute('data-typeahead-chip') || '';
+          input.value = q;
+          query = q;
+          runQuery(q);
+        });
+      });
+
+      // Restore on page-swap (Astro view transitions): reset state.
+      showSuggestions();
+    }
+
+    init();
+    document.addEventListener('astro:page-load', function () {
+      // Re-bind on each page load. We allow re-binding because the
+      // typeahead lives in the masthead which is part of every layout.
+      state.bound = false;
+      init();
+    });
+  })();
+</script>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -8945,3 +8945,287 @@ body.menu-open .subscribe-pill {
 .map-popup__cta:hover {
   border-bottom-color: var(--accent);
 }
+
+/* ============================================================================
+   TYPEAHEAD (Phase 3 WS3A)
+   Masthead-mounted instant search. Trigger sits where the old search-icon
+   used to live; click or "/" expands the dropdown panel; results appear
+   grouped by kind. Mobile: dropdown becomes a full-screen sheet.
+   ============================================================================ */
+
+.typeahead {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.typeahead__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.75rem 0.45rem 0.7rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--soft);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.typeahead__trigger:hover,
+.typeahead__trigger:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+.typeahead__trigger-label { margin-right: 0.1rem; }
+.typeahead__trigger-kbd {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.32rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--paper, #fbf7f0);
+  color: var(--soft);
+}
+@media (max-width: 720px) {
+  /* Mobile: keep just the icon to save space; the panel grows full-screen
+     when opened so the absent label doesn't matter. */
+  .typeahead__trigger-label,
+  .typeahead__trigger-kbd { display: none; }
+  .typeahead__trigger { padding: 0.45rem; }
+}
+
+.typeahead__panel {
+  position: absolute;
+  top: calc(100% + 0.55rem);
+  right: 0;
+  z-index: 60;
+  min-width: 26rem;
+  max-width: min(34rem, calc(100vw - 2rem));
+  background: var(--bg, #fff);
+  border: 1px solid var(--border);
+  box-shadow: 0 22px 50px -22px rgba(40, 28, 14, 0.4);
+  /* Same translate-bridge pattern as the More mega-menu so cursor traversal
+     stays inside the hit area. */
+  transform: translateY(0);
+}
+.typeahead__panel[hidden] { display: none; }
+.typeahead__panel-inner {
+  display: flex;
+  flex-direction: column;
+}
+
+.typeahead__form {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+.typeahead__form-icon {
+  display: inline-flex;
+  color: var(--soft);
+  flex-shrink: 0;
+}
+.typeahead__input {
+  flex: 1;
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--text);
+  background: transparent;
+  border: 0;
+  outline: none;
+  min-width: 0;
+}
+.typeahead__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  background: transparent;
+  border: 0;
+  color: var(--soft);
+  cursor: pointer;
+  border-radius: 999px;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.typeahead__close:hover { color: var(--accent); background: rgba(167, 118, 55, 0.08); }
+
+.typeahead__suggestions {
+  padding: 0.85rem 1rem 1rem;
+}
+.typeahead__suggestions-label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin: 0 0 0.55rem;
+}
+.typeahead__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.typeahead__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  background: var(--paper, #fbf7f0);
+  border: 1px solid var(--border);
+  color: var(--dark);
+  cursor: pointer;
+  border-radius: 999px;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.typeahead__chip:hover { border-color: var(--accent); color: var(--accent); }
+.typeahead__chip-bullet {
+  color: var(--accent);
+  font-size: 0.7em;
+}
+
+.typeahead__results {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0;
+  max-height: min(60vh, 28rem);
+  overflow-y: auto;
+}
+.typeahead__group {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.typeahead__group + .typeahead__group {
+  border-top: 1px solid var(--border);
+  margin-top: 0.4rem;
+  padding-top: 0.4rem;
+}
+.typeahead__group-label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--soft);
+  margin: 0;
+  padding: 0.4rem 1rem 0.25rem;
+}
+.typeahead__group-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.typeahead__result { margin: 0; padding: 0; }
+.typeahead__result-link {
+  display: block;
+  padding: 0.55rem 1rem;
+  text-decoration: none;
+  color: var(--dark);
+  border-left: 2px solid transparent;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.typeahead__result-link:hover,
+.typeahead__result-link:focus-visible,
+.typeahead__result-link.is-active {
+  background: rgba(167, 118, 55, 0.08);
+  border-left-color: var(--accent);
+  outline: none;
+}
+.typeahead__result-title {
+  display: block;
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.02rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--text);
+  line-height: 1.2;
+}
+.typeahead__result-excerpt {
+  display: block;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.83rem;
+  line-height: 1.45;
+  color: var(--soft);
+  margin-top: 0.18rem;
+  /* Pagefind excerpts contain <mark> wrappers around matched terms — let
+     them render with brand colour. */
+}
+.typeahead__result-excerpt mark {
+  background: rgba(167, 118, 55, 0.18);
+  color: var(--text);
+  padding: 0 0.1em;
+  border-radius: 2px;
+}
+.typeahead__empty {
+  padding: 1rem 1.1rem 1.2rem;
+  list-style: none;
+}
+.typeahead__empty-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  color: var(--text);
+  margin: 0 0 0.35rem;
+}
+.typeahead__empty-hint {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  color: var(--soft);
+  margin: 0;
+}
+
+.typeahead__footer {
+  border-top: 1px solid var(--border);
+  padding: 0.6rem 1rem 0.7rem;
+}
+.typeahead__footer-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+}
+.typeahead__footer-link:hover { color: var(--text); }
+
+/* Mobile: panel becomes a full-screen sheet, anchored to the top. */
+@media (max-width: 720px) {
+  body.typeahead-open { overflow: hidden; }
+  .typeahead__panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
+    max-width: 100vw;
+    min-width: 0;
+    border: 0;
+    box-shadow: none;
+    transform: none;
+  }
+  .typeahead__panel-inner {
+    height: 100%;
+    overflow-y: auto;
+  }
+  .typeahead__form {
+    padding: 1.1rem 1rem 0.85rem;
+  }
+  .typeahead__results { max-height: none; }
+}


### PR DESCRIPTION
## Summary

First Phase 3 workstream. Replaces the masthead search-icon trigger with an inline typeahead. The pagefind index already exists; this is a UI rebuild over it.

## What ships
- New `Typeahead.astro` mounts in the masthead. Click, focus, or "/" expands a dropdown panel.
- Lazy-loads pagefind on first open (≈80 KB WASM, no cost on pages where search is never used).
- Debounced 150ms; results grouped by kind (Plans / Eat / Wine / Stay / Explore / Places / What's On / Journal / Guide). Capped at 8 across up to 4 per group.
- Keyboard nav: ↑/↓ moves focus ring, Enter opens, Esc closes. "/" focuses input from anywhere on the site (skipped when typing in another input).
- Suggestion chips when input is empty.
- Pagefind excerpt `<mark>` tags styled with brand accent.
- "View all results →" footer routes to `/search/?q=…` for the full pagefind page.
- Mobile: panel becomes a full-screen sheet.

## Rollback path

Per locked decision Q1, the existing `SearchOverlay.astro` is left intact and still mounted by `BaseLayout`. It's no longer the primary affordance — no masthead trigger opens it — but the markup, JS, and styles still ship. Reverting is a one-line swap in `Masthead.astro`: replace `<Typeahead />` with the original search-icon button.

## Test plan
- [ ] Click the masthead "Search /" pill — confirm panel opens, input focuses.
- [ ] Press "/" anywhere on the site — confirm search opens.
- [ ] Type "long lunch" — confirm grouped results appear within ~150ms.
- [ ] Press ↓ then Enter — confirm navigation to highlighted result.
- [ ] Press Esc — confirm panel closes and focus returns to the trigger.
- [ ] Click outside the panel — confirm it closes.
- [ ] Click a suggestion chip with input empty — confirm it runs the search.
- [ ] Hit Enter with a query but nothing highlighted — confirm route to `/search/?q=…`.
- [ ] Mobile: tap the icon — confirm full-screen sheet, full-width input, scrollable results.

## Build
1206 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)