### PR TITLE
feat(discovery-phase-3): place-hub mini-maps (WS3B)

### DIFF
--- a/next/src/components/PlaceMap.astro
+++ b/next/src/components/PlaceMap.astro
@@ -1,0 +1,383 @@
+---
+/**
+ * PlaceMap — scoped Leaflet map for /places/<slug>/ (Phase 3 WS3B).
+ *
+ * Reuses the /map/ infrastructure: same DivIcon palette, same popup
+ * pattern, same OSM tiles. The two differences from /map/:
+ *   1. Pins are scoped to a single place (≈5–25 pins typical).
+ *   2. Leaflet is lazy-loaded via IntersectionObserver — the page renders
+ *      a placeholder until the user scrolls the map into view, so place
+ *      hubs without scroll-into-view stay light.
+ *
+ * Locked decisions (see Phase 3 plan):
+ *   Q2 — Events on place maps: yes, next-30-day window.
+ *   Map height — fixed 380px desktop, 4:3 aspect on mobile.
+ */
+import { routeSlug, venueHrefPrefix } from '../lib/editorial';
+
+export interface Props {
+  place: any;
+  venues: any[];
+  experiences: any[];
+  events: any[];
+}
+
+const { place, venues, experiences, events } = Astro.props as Props;
+
+type MapPin = {
+  id: string;
+  category: 'place' | 'eat' | 'wine' | 'stay' | 'experience' | 'event';
+  type: string;
+  name: string;
+  href: string;
+  lat: number;
+  lng: number;
+  hero: string;
+  blurb: string;
+};
+
+function venueCategory(t: string): MapPin['category'] {
+  if (['winery', 'brewery', 'distillery', 'producer'].includes(t)) return 'wine';
+  if (['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'].includes(t)) return 'stay';
+  return 'eat';
+}
+
+const pins: MapPin[] = [];
+
+// Anchor pin: the place itself.
+if (place.data.coordinates && Number.isFinite(place.data.coordinates.lat)) {
+  pins.push({
+    id: `place:${place.id ?? place.data.slug}`,
+    category: 'place',
+    type: place.data.kind,
+    name: place.data.name,
+    href: `/places/${place.id ?? place.data.slug}/`,
+    lat: place.data.coordinates.lat,
+    lng: place.data.coordinates.lng,
+    hero: place.data.heroImage?.src ?? '',
+    blurb: (place.data.intro ?? '').slice(0, 140),
+  });
+}
+
+// Venues anchored to this place.
+venues.forEach((v) => {
+  if (!v.data.coordinates || !Number.isFinite(v.data.coordinates.lat)) return;
+  const slug = routeSlug(v);
+  pins.push({
+    id: `venue:${slug}`,
+    category: venueCategory(v.data.type),
+    type: v.data.type,
+    name: v.data.name,
+    href: `${venueHrefPrefix(v.data.type)}/${slug}/`,
+    lat: v.data.coordinates.lat,
+    lng: v.data.coordinates.lng,
+    hero: v.data.heroImage?.src ?? '',
+    blurb: (v.data.signature ?? '').slice(0, 140),
+  });
+});
+
+// Experiences anchored to this place.
+experiences.forEach((e) => {
+  if (!e.data.coordinates || !Number.isFinite(e.data.coordinates.lat)) return;
+  if (e.data.sitemapExclude) return;
+  const slug = routeSlug(e);
+  pins.push({
+    id: `experience:${slug}`,
+    category: 'experience',
+    type: e.data.type,
+    name: e.data.name,
+    href: `/explore/${slug}/`,
+    lat: e.data.coordinates.lat,
+    lng: e.data.coordinates.lng,
+    hero: e.data.heroImage?.src ?? '',
+    blurb: (e.data.editorNote ?? '').slice(0, 140),
+  });
+});
+
+// Events in the next 30-day window (locked decision Q2).
+const now = Date.now();
+const horizon = now + 30 * 24 * 60 * 60 * 1000;
+events.forEach((ev) => {
+  if (!ev.data.coordinates || !Number.isFinite(ev.data.coordinates.lat)) return;
+  const startMs = ev.data.startDate ? new Date(ev.data.startDate).getTime() : 0;
+  const endMs = ev.data.endDate ? new Date(ev.data.endDate).getTime() : startMs;
+  const recurring = ['weekly', 'monthly', 'ongoing'].includes(ev.data.recurrence);
+  // Pass through if recurring; otherwise require overlap with the next 30 days.
+  const inWindow = recurring || (endMs >= now && startMs <= horizon);
+  if (!inWindow) return;
+  const slug = routeSlug(ev);
+  pins.push({
+    id: `event:${slug}`,
+    category: 'event',
+    type: ev.data.category,
+    name: ev.data.title,
+    href: `/whats-on/${slug}/`,
+    lat: ev.data.coordinates.lat,
+    lng: ev.data.coordinates.lng,
+    hero: ev.data.heroImage?.src ?? '',
+    blurb: (ev.data.summary ?? '').slice(0, 140),
+  });
+});
+
+// Counts for the legend / category toggles.
+const counts = pins.reduce<Record<MapPin['category'], number>>((acc, p) => {
+  acc[p.category] = (acc[p.category] ?? 0) + 1;
+  return acc;
+}, { place: 0, eat: 0, wine: 0, stay: 0, experience: 0, event: 0 });
+
+const showEvent = counts.event > 0;
+const legend: Array<{ key: MapPin['category']; label: string; show: boolean }> = [
+  { key: 'place',      label: 'This place', show: counts.place > 0 },
+  { key: 'eat',        label: 'Eat',        show: counts.eat > 0 },
+  { key: 'wine',       label: 'Wine',       show: counts.wine > 0 },
+  { key: 'stay',       label: 'Stay',       show: counts.stay > 0 },
+  { key: 'experience', label: 'Explore',    show: counts.experience > 0 },
+  { key: 'event',      label: 'Events',     show: showEvent },
+];
+
+// Stable id for the map container so multiple PlaceMaps on one page (rare,
+// but possible later) don't collide.
+const placeSlug = place.id ?? place.data.slug ?? 'place';
+const mapId = `placeMap-${placeSlug}`;
+---
+
+{pins.length > 0 && (
+  <section class="place-map" data-place-map-root>
+    <div class="container">
+      <div class="place-map__header">
+        <p class="label label--accent">On the map</p>
+        <h2 class="place-map__title">{place.data.name}, by location</h2>
+        <p class="place-map__sub">Every editorially verified pin in {place.data.name} on one screen — toggle a category, click any marker for the editor's note.</p>
+      </div>
+
+      <div class="place-map__filters">
+        {legend.filter((l) => l.show).map((l) => (
+          <button
+            type="button"
+            class={`map-pin-toggle map-pin-toggle--${l.key}`}
+            data-place-map-toggle={l.key}
+            aria-pressed="true"
+          >
+            <span class="map-pin-toggle__dot" aria-hidden="true"></span>
+            <span class="map-pin-toggle__label">{l.label}</span>
+            <span class="map-pin-toggle__count">{counts[l.key]}</span>
+          </button>
+        ))}
+      </div>
+
+      <div
+        class="place-map__canvas"
+        id={mapId}
+        data-place-map={placeSlug}
+        data-place-map-pins={JSON.stringify(pins)}
+        aria-label={`Map of ${place.data.name}`}
+      >
+        <div class="place-map__placeholder" data-place-map-placeholder>
+          <p class="place-map__placeholder-text">Loading map…</p>
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+
+<script is:inline define:vars={{ mapId }}>
+  /* PlaceMap controller. Lazy-loads Leaflet from CDN via an
+     IntersectionObserver so place hubs that aren't scrolled to don't pay
+     for the library. Once initialised, behaves like a scoped /map/ —
+     category toggles, click-to-popup, list-marker sync via the same
+     DivIcon palette.
+     Multiple instances on a page would share the Leaflet load (the
+     first to enter the viewport triggers it). */
+  (function () {
+    function init() {
+      var canvas = document.getElementById(mapId);
+      if (!canvas || canvas._piPlaceMapBound) return;
+      canvas._piPlaceMapBound = true;
+
+      // Read the build-time pin payload; bail if empty.
+      var raw = canvas.getAttribute('data-place-map-pins');
+      if (!raw) return;
+      var pins;
+      try { pins = JSON.parse(raw); } catch (_e) { pins = []; }
+      if (!pins.length) return;
+
+      var root = canvas.closest('[data-place-map-root]');
+      if (!root) return;
+
+      var initialised = false;
+
+      function loadLeafletAssets() {
+        var head = document.head;
+        function ensure(tag, attrs) {
+          var sel = tag === 'link'
+            ? 'link[href="' + attrs.href + '"]'
+            : 'script[src="' + attrs.src + '"]';
+          if (head.querySelector(sel)) return Promise.resolve();
+          return new Promise(function (resolve, reject) {
+            var el = document.createElement(tag);
+            Object.keys(attrs).forEach(function (k) { el.setAttribute(k, attrs[k]); });
+            el.onload = function () { resolve(); };
+            el.onerror = function () { reject(new Error('Failed to load ' + (attrs.href || attrs.src))); };
+            head.appendChild(el);
+          });
+        }
+
+        return Promise.all([
+          ensure('link', { rel: 'stylesheet', href: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', crossorigin: '' }),
+          ensure('link', { rel: 'stylesheet', href: 'https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css' }),
+          ensure('link', { rel: 'stylesheet', href: 'https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css' }),
+        ]).then(function () {
+          return ensure('script', { src: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', crossorigin: '' });
+        }).then(function () {
+          return ensure('script', { src: 'https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js' });
+        });
+      }
+
+      function escapeHtml(s) {
+        return String(s == null ? '' : s)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      function popupHtml(p) {
+        var hero = p.hero
+          ? '<div class="map-popup__hero" style="background-image:url(' + escapeHtml(p.hero) + ')"></div>'
+          : '';
+        var meta = escapeHtml(p.type || '');
+        return ''
+          + '<div class="map-popup">'
+          +   hero
+          +   '<div class="map-popup__body">'
+          +     (meta ? '<p class="map-popup__meta">' + meta + '</p>' : '')
+          +     '<h3 class="map-popup__title">' + escapeHtml(p.name) + '</h3>'
+          +     (p.blurb ? '<p class="map-popup__blurb">' + escapeHtml(p.blurb) + '</p>' : '')
+          +     '<a class="map-popup__cta" href="' + escapeHtml(p.href) + '">Read the full notes →</a>'
+          +   '</div>'
+          + '</div>';
+      }
+
+      function startMap() {
+        if (initialised) return;
+        if (typeof L === 'undefined') {
+          // Library hasn't finished loading yet; retry shortly.
+          setTimeout(startMap, 80);
+          return;
+        }
+        initialised = true;
+        var placeholder = canvas.querySelector('[data-place-map-placeholder]');
+        if (placeholder) placeholder.remove();
+
+        // Centre on the place pin if present, otherwise the centroid of all pins.
+        var center;
+        var anchor = pins.find(function (p) { return p.category === 'place'; });
+        if (anchor) {
+          center = [anchor.lat, anchor.lng];
+        } else {
+          var sumLat = 0, sumLng = 0;
+          pins.forEach(function (p) { sumLat += p.lat; sumLng += p.lng; });
+          center = [sumLat / pins.length, sumLng / pins.length];
+        }
+
+        var map = L.map(canvas, {
+          attributionControl: true,
+          scrollWheelZoom: false,
+        }).setView(center, 13);
+        canvas.addEventListener('focus', function () { map.scrollWheelZoom.enable(); });
+        canvas.addEventListener('blur', function () { map.scrollWheelZoom.disable(); });
+        map.on('click', function () { map.scrollWheelZoom.enable(); });
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 18,
+          attribution: '© OpenStreetMap contributors',
+        }).addTo(map);
+
+        var iconFor = function (cat) {
+          return L.divIcon({
+            className: 'map-pin map-pin--' + cat,
+            html: '<span class="map-pin__inner" aria-hidden="true"></span>',
+            iconSize: [22, 22],
+            iconAnchor: [11, 11],
+            popupAnchor: [0, -10],
+          });
+        };
+
+        var clusterGroup = L.markerClusterGroup({
+          showCoverageOnHover: false,
+          maxClusterRadius: 35,
+        });
+
+        var markersById = {};
+        pins.forEach(function (p) {
+          if (!Number.isFinite(p.lat) || !Number.isFinite(p.lng)) return;
+          var marker = L.marker([p.lat, p.lng], { icon: iconFor(p.category) });
+          marker.bindPopup(popupHtml(p), { maxWidth: 260, autoPanPadding: [30, 30] });
+          marker._piData = p;
+          clusterGroup.addLayer(marker);
+          markersById[p.id] = marker;
+        });
+        map.addLayer(clusterGroup);
+
+        if (Object.keys(markersById).length > 1) {
+          var group = L.featureGroup(Object.values(markersById));
+          map.fitBounds(group.getBounds(), { padding: [25, 25], maxZoom: 14 });
+        }
+
+        // Category toggles
+        var enabled = { place: true, eat: true, wine: true, stay: true, experience: true, event: true };
+        function applyVisibility() {
+          clusterGroup.clearLayers();
+          pins.forEach(function (p) {
+            if (!enabled[p.category]) return;
+            var m = markersById[p.id];
+            if (m) clusterGroup.addLayer(m);
+          });
+        }
+        root.querySelectorAll('[data-place-map-toggle]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var cat = btn.getAttribute('data-place-map-toggle');
+            enabled[cat] = !enabled[cat];
+            btn.setAttribute('aria-pressed', enabled[cat] ? 'true' : 'false');
+            applyVisibility();
+          });
+        });
+      }
+
+      // Lazy boot via IntersectionObserver: initialise as soon as the map
+      // canvas enters the viewport (with a small rootMargin so we start
+      // loading before the user actually sees it).
+      var booted = false;
+      function boot() {
+        if (booted) return;
+        booted = true;
+        loadLeafletAssets()
+          .then(startMap)
+          .catch(function (err) {
+            console.warn('[place-map] Leaflet load failed:', err);
+            var placeholder = canvas.querySelector('[data-place-map-placeholder]');
+            if (placeholder) placeholder.querySelector('.place-map__placeholder-text').textContent = 'Map unavailable.';
+          });
+      }
+
+      if ('IntersectionObserver' in window) {
+        var io = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              boot();
+              io.disconnect();
+            }
+          });
+        }, { rootMargin: '120px 0px' });
+        io.observe(canvas);
+      } else {
+        // Fallback: just init immediately.
+        boot();
+      }
+    }
+
+    init();
+    document.addEventListener('astro:page-load', init);
+  })();
+</script>

--- a/next/src/pages/places/[slug].astro
+++ b/next/src/pages/places/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PlaceDetailTemplate from '../../components/PlaceDetailTemplate.astro';
+import PlaceMap from '../../components/PlaceMap.astro';
 import EventStrip from '../../components/EventStrip.astro';
 import { routeSlug, stayTypes, wineTypes, isUpcoming } from '../../lib/editorial';
 
@@ -29,7 +30,10 @@ const venuesForPlace = allVenues
 
 // Events at this place: match place ref, OR suburb name (machine-imported
 // events without a clean place ref still surface if the suburb matches).
-const eventsForPlace = allEvents
+// `eventsForMap` keeps the full upcoming list (PlaceMap applies its own
+// 30-day window per locked decision Q2). `eventsForPlace` is the curated
+// top-3 used by the EventStrip below.
+const eventsForMap = allEvents
   .filter((event) => {
     const eventPlace = String(event.data.place?.id ?? event.data.place ?? '');
     if (eventPlace === placeSlug) return true;
@@ -38,7 +42,8 @@ const eventsForPlace = allEvents
   .filter((event) => {
     if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
     return isUpcoming(event.data.endDate ?? event.data.startDate);
-  })
+  });
+const eventsForPlace = [...eventsForMap]
   .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
   .slice(0, 3);
 const venueSlugs = venuesForPlace.map((venue) => routeSlug(venue));
@@ -324,6 +329,16 @@ const placeSchema = {
     articles={articles}
     relatedPlaces={relatedPlaces}
     snapshotCards={snapshotCards}
+  />
+
+  <!-- Phase 3 WS3B — scoped Leaflet map of every editorial pin in this
+       place. Lazy-loaded via IntersectionObserver so the library only
+       downloads when the section is scrolled to. -->
+  <PlaceMap
+    place={place}
+    venues={venuesForPlace}
+    experiences={experiences}
+    events={eventsForMap}
   />
 
   <EventStrip

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -9229,3 +9229,76 @@ body.menu-open .subscribe-pill {
   }
   .typeahead__results { max-height: none; }
 }
+
+/* ============================================================================
+   PLACE MAP (Phase 3 WS3B)
+   Scoped Leaflet map embedded on /places/<slug>/. Reuses the global
+   .map-pin and .map-popup styles from /map/. The block below is just the
+   page chrome around the canvas.
+   ============================================================================ */
+
+.place-map {
+  padding: clamp(1.75rem, 3vw, 2.75rem) 0;
+  border-top: 1px solid var(--border);
+}
+.place-map__header {
+  margin-bottom: clamp(1rem, 2vw, 1.5rem);
+  max-width: 720px;
+}
+.place-map__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(1.55rem, 3vw, 2.1rem);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0.45rem 0 0.65rem;
+  line-height: 1.15;
+}
+.place-map__sub {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--soft);
+  margin: 0;
+}
+
+.place-map__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 clamp(0.85rem, 1.5vw, 1.15rem);
+}
+
+.place-map__canvas {
+  position: relative;
+  width: 100%;
+  height: 380px;
+  border: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+  z-index: 0;
+}
+@media (max-width: 720px) {
+  .place-map__canvas {
+    /* 4:3 aspect on mobile per locked decision; capped to a sensible
+       maximum on tall phones. */
+    height: auto;
+    aspect-ratio: 4 / 3;
+    max-height: 70vh;
+  }
+}
+
+.place-map__placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--paper, #fbf7f0);
+}
+.place-map__placeholder-text {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  color: var(--soft);
+  margin: 0;
+}


### PR DESCRIPTION
## Summary

Second Phase 3 workstream. Every `/places/<slug>/` page now has a scoped Leaflet map showing venues, experiences, and upcoming events anchored to that place. Reuses the `/map/` infrastructure: DivIcon palette, popup pattern, OSM tiles.

## What ships
- `PlaceMap.astro` component keyed off the place's coordinates and the entries already gathered for the page.
- Six categories (place, eat, wine, stay, experience, event) with chip toggles that share the global `.map-pin-toggle` styles.
- Pin payload serialised at build time into a `data-place-map-pins` attribute and parsed at runtime.
- **Lazy-loaded via IntersectionObserver** — Leaflet CSS/JS only download when the canvas enters the viewport (rootMargin 120px). Place hubs that aren't scrolled to stay light.
- 30-day window for non-recurring events (locked decision Q2); recurring (weekly / monthly / ongoing) always pass.
- Map height: fixed 380px desktop, 4:3 aspect ratio on mobile capped at 70vh.

## Data flow
A new `eventsForMap` (full upcoming + recurring list) feeds `PlaceMap`; the existing `eventsForPlace` (top-3 by visitorAppealScore) still feeds the `EventStrip` below. Same source filter, different slice.

## Test plan
- [ ] Visit `/places/red-hill/` — confirm map appears under the detail block, ~38 pins clustered.
- [ ] Scroll the page — confirm Leaflet doesn't download until the map is near-visible.
- [ ] Toggle the "Wine" chip — confirm wine pins disappear.
- [ ] Click a marker — confirm popup with hero, meta, blurb, and "Read full notes →" link.
- [ ] Visit `/places/sorrento/` — confirm 17-ish pins, recentred on Sorrento.
- [ ] Resize to mobile — confirm map switches to 4:3 aspect.
- [ ] Check that scroll-wheel zoom only activates after click/focus.

## Build
1206 pages, clean. Pin counts: Red Hill 38, Mornington 35, Sorrento 17, Flinders 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)