### PR TITLE
feat(discovery-phase-3): itinerary builder (WS3C)

### DIFF
--- a/next/src/components/Masthead.astro
+++ b/next/src/components/Masthead.astro
@@ -53,6 +53,7 @@ const {
           <a href="/saved/" class="masthead__saved-link" data-saved-link hidden>
             Saved <span class="masthead__saved-count" data-saved-count hidden>0</span>
           </a>
+          <a href="/itinerary/" class="masthead__saved-link" data-saved-link hidden>Itinerary</a>
           <a href="/#newsletter" data-auth-anonymous>Subscribe</a>
           <a href="/about/">About</a>
         </div>

--- a/next/src/lib/itinerary.ts
+++ b/next/src/lib/itinerary.ts
@@ -1,0 +1,175 @@
+/**
+ * Itinerary helpers — Phase 3 WS3C.
+ *
+ * Pure functions used by the /itinerary/ page. Kept here rather than
+ * inlined into the page so the same logic can serve a future place-hub
+ * sequencer or an AI-generated payload (WS3D).
+ *
+ * Travel-time approach is deliberately simple per locked decision Q3:
+ * haversine distance multiplied by an empirical Peninsula driving
+ * constant. Not a Distance Matrix API; the rough estimate is good enough
+ * for "is this a 15-minute or 50-minute drive". Revisit if reader
+ * feedback says estimates are misleading.
+ */
+
+/** Haversine great-circle distance in kilometres between two lat/lng points. */
+export function haversineKm(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+): number {
+  const R = 6371; // Earth radius, km
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Convert a haversine distance to an estimated Peninsula driving time.
+ * Empirical multiplier 1.3× crow-flies for the back-road geometry, plus
+ * a 45 km/h average speed (rural, with one or two slowdowns through
+ * villages). Returns minutes.
+ */
+export function drivingMinutes(distanceKm: number): number {
+  const ROAD_MULTIPLIER = 1.3;
+  const AVG_SPEED_KMH = 45;
+  const roadKm = distanceKm * ROAD_MULTIPLIER;
+  return (roadKm / AVG_SPEED_KMH) * 60;
+}
+
+/**
+ * Format a driving-minutes estimate for display ("12 min", "45 min",
+ * "1 h 10"). Snap to the nearest 5 minutes so the precision matches the
+ * estimation method's actual confidence.
+ */
+export function formatTravelMinutes(minutes: number): string {
+  const snapped = Math.max(1, Math.round(minutes / 5) * 5);
+  if (snapped < 60) return `${snapped} min`;
+  const h = Math.floor(snapped / 60);
+  const m = snapped % 60;
+  if (m === 0) return `${h} h`;
+  return `${h} h ${m}`;
+}
+
+/**
+ * Build the Google Maps multi-stop directions URL for a sequence of
+ * waypoints. The first item is treated as the origin, the last as the
+ * destination, anything in between as a waypoint. Falls back to a single
+ * search query if there's only one stop.
+ *
+ * Format reference:
+ *   https://www.google.com/maps/dir/?api=1&origin=lat,lng&destination=lat,lng&waypoints=lat,lng%7Clat,lng
+ */
+export function googleMapsDirectionsUrl(
+  stops: Array<{ lat: number; lng: number; name: string }>,
+): string {
+  if (!stops.length) return 'https://www.google.com/maps';
+  if (stops.length === 1) {
+    const p = stops[0];
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+      `${p.lat},${p.lng} (${p.name})`,
+    )}`;
+  }
+  const origin = stops[0];
+  const destination = stops[stops.length - 1];
+  const waypoints = stops.slice(1, -1);
+  const params = new URLSearchParams({
+    api: '1',
+    origin: `${origin.lat},${origin.lng}`,
+    destination: `${destination.lat},${destination.lng}`,
+    travelmode: 'driving',
+  });
+  if (waypoints.length > 0) {
+    params.set('waypoints', waypoints.map((w) => `${w.lat},${w.lng}`).join('|'));
+  }
+  return `https://www.google.com/maps/dir/?${params.toString()}`;
+}
+
+/**
+ * Itinerary item shape (client-side). Same identity convention as
+ * pi:saved:v1 (kind + slug); adds a `dayId` for optional day grouping
+ * and a `note` for free-text annotations between items.
+ */
+export interface ItineraryItem {
+  kind: 'venue' | 'event';
+  slug: string;
+  /** Day grouping id (e.g. "day-1"). Empty string means ungrouped. */
+  dayId: string;
+  /** Free-text note shown above this item ("Lunch reservation", etc.). */
+  note: string;
+}
+
+export interface ItineraryStore {
+  version: 1;
+  items: ItineraryItem[];
+  /** Day labels ordered by display order. */
+  days: Array<{ id: string; label: string }>;
+}
+
+export const EMPTY_ITINERARY: ItineraryStore = { version: 1, items: [], days: [] };
+
+/**
+ * Encode an itinerary into a URL-safe query string. Items become a
+ * pipe-delimited list of `kind:slug:dayId` triples; days become a
+ * pipe-delimited list of `id:label` pairs. Notes are intentionally not
+ * encoded into the share URL — they stay private to the user's local
+ * store.
+ */
+export function encodeItineraryToUrl(itinerary: ItineraryStore): URLSearchParams {
+  const params = new URLSearchParams();
+  if (itinerary.items.length > 0) {
+    params.set(
+      'i',
+      itinerary.items
+        .map((it) => `${it.kind}:${it.slug}:${it.dayId}`)
+        .join('|'),
+    );
+  }
+  if (itinerary.days.length > 0) {
+    params.set(
+      'd',
+      itinerary.days.map((d) => `${d.id}:${encodeURIComponent(d.label)}`).join('|'),
+    );
+  }
+  return params;
+}
+
+/**
+ * Decode a URL query payload into an itinerary. Used by the /itinerary/
+ * page when arriving from a shared URL.
+ */
+export function decodeItineraryFromUrl(params: URLSearchParams): ItineraryStore | null {
+  const itemsRaw = params.get('i');
+  if (!itemsRaw) return null;
+  const items: ItineraryItem[] = itemsRaw.split('|').filter(Boolean).map((triple) => {
+    const [kind, slug, dayId] = triple.split(':');
+    return {
+      kind: (kind === 'event' ? 'event' : 'venue'),
+      slug: slug ?? '',
+      dayId: dayId ?? '',
+      note: '',
+    };
+  }).filter((it) => it.slug);
+
+  const daysRaw = params.get('d');
+  const days: Array<{ id: string; label: string }> = [];
+  if (daysRaw) {
+    daysRaw.split('|').filter(Boolean).forEach((pair) => {
+      const [id, labelEnc] = pair.split(':');
+      if (!id) return;
+      let label: string;
+      try {
+        label = decodeURIComponent(labelEnc ?? id);
+      } catch {
+        label = labelEnc ?? id;
+      }
+      days.push({ id, label });
+    });
+  }
+  return { version: 1, items, days };
+}

--- a/next/src/pages/itinerary.astro
+++ b/next/src/pages/itinerary.astro
@@ -1,0 +1,619 @@
+---
+/**
+ * /itinerary/ — itinerary builder (Phase 3 WS3C).
+ *
+ * Pulls saved items from window.PISave, lets the user drag-and-drop to
+ * sequence them, optionally group into days, and see haversine-based
+ * driving estimates between consecutive stops. Print-friendly via the
+ * native browser print dialog. Sharable as a URL containing the sequence
+ * (notes stay private to the local store).
+ *
+ * Storage: pi:itinerary:v1 in localStorage. Independent of pi:saved:v1
+ * (the simple shortlist) so the two surfaces don't tangle. The builder
+ * has a "Pull from saved" action that ingests every saved item into the
+ * current itinerary in one click.
+ *
+ * Locked decisions for v1:
+ *   Q3: haversine + Peninsula multiplier; no external API.
+ *   Q4: SortableJS for drag-and-drop.
+ *   Q5: Day groupings optional (flat sequence with optional dividers).
+ *   Q6: New /itinerary/ route, /saved/ stays as the simple shortlist.
+ *   Q8: Native browser print v1.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import SectionHero from '../components/SectionHero.astro';
+import NewsletterBlock from '../components/NewsletterBlock.astro';
+import { routeSlug, venueHrefPrefix } from '../lib/editorial';
+
+const venues = await getCollection('venues');
+const events = await getCollection('events');
+
+/**
+ * Build-time lookup tables. Carry coordinates so the client can compute
+ * haversine estimates without a network call.
+ */
+const venueLookup = Object.fromEntries(
+  venues.map((v) => [
+    routeSlug(v),
+    {
+      slug: routeSlug(v),
+      kind: 'venue' as const,
+      title: v.data.name,
+      href: `${venueHrefPrefix(v.data.type)}/${routeSlug(v)}/`,
+      hero: v.data.heroImage?.src ?? '',
+      lat: v.data.coordinates?.lat ?? null,
+      lng: v.data.coordinates?.lng ?? null,
+      placeId: typeof v.data.place === 'string' ? v.data.place : v.data.place?.id ?? '',
+      type: v.data.type,
+      price: v.data.priceBand ?? '',
+      signature: v.data.signature ?? '',
+    },
+  ]),
+);
+const eventLookup = Object.fromEntries(
+  events.map((e) => [
+    routeSlug(e),
+    {
+      slug: routeSlug(e),
+      kind: 'event' as const,
+      title: e.data.title,
+      href: `/whats-on/${routeSlug(e)}/`,
+      hero: e.data.heroImage?.src ?? '',
+      lat: e.data.coordinates?.lat ?? null,
+      lng: e.data.coordinates?.lng ?? null,
+      placeId: typeof e.data.place === 'string' ? e.data.place : e.data.place?.id ?? '',
+      type: e.data.category,
+      price: '',
+      signature: e.data.summary ?? '',
+    },
+  ]),
+);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'My itinerary' },
+];
+---
+
+<BaseLayout
+  title="My itinerary · Peninsula Insider"
+  description="Sequence your saved Peninsula venues and events into a working day plan, with driving-time estimates between stops."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="My itinerary"
+    subEyebrow="Drag, sequence, plan"
+    title="Build your <em>Peninsula</em> day."
+    dek="Drop saved venues and events into the order you'd actually do them. We estimate the drive between stops so you can tell a 15-minute hop from a 50-minute trek. Print it for the glove box, share the link with a co-traveller, or open the whole route in Google Maps."
+    gradient="journal"
+    visualLabel="Peninsula Insider · itinerary"
+  />
+
+  <section class="itinerary-page">
+    <div class="container">
+
+      <!-- Empty state — visible until the user has at least one item. -->
+      <div class="itinerary-empty" data-itinerary-empty>
+        <p class="itinerary-empty__title">Your itinerary is empty.</p>
+        <p class="itinerary-empty__body">Save venues and events from anywhere on the site, then come back here to sequence them.</p>
+        <p class="itinerary-empty__cta-row">
+          <a href="/saved/" class="itinerary-empty__cta">Open my shortlist</a>
+          <button type="button" class="itinerary-empty__cta itinerary-empty__cta--ghost" data-itinerary-pull>
+            Pull every saved item into the itinerary
+          </button>
+        </p>
+      </div>
+
+      <!-- Mode banner — appears in shared mode only. -->
+      <aside class="itinerary-banner" data-itinerary-banner hidden>
+        <div class="itinerary-banner__inner">
+          <p class="itinerary-banner__label">Shared itinerary</p>
+          <p class="itinerary-banner__body">Someone shared this Peninsula itinerary with you. You can browse it as is, or import it into your own builder on this device.</p>
+          <button type="button" class="itinerary-banner__action" data-itinerary-import>Import this itinerary</button>
+        </div>
+      </aside>
+
+      <!-- Toolbar -->
+      <div class="itinerary-toolbar" data-itinerary-toolbar hidden>
+        <div class="itinerary-toolbar__count">
+          <span data-itinerary-stop-count>0 stops</span>
+          <span class="itinerary-toolbar__sep" aria-hidden="true">·</span>
+          <span data-itinerary-distance-summary>est. 0 min driving</span>
+        </div>
+        <div class="itinerary-toolbar__actions">
+          <button type="button" class="itinerary-toolbar__action" data-itinerary-add-day>+ Add day</button>
+          <button type="button" class="itinerary-toolbar__action" data-itinerary-pull>+ Pull from saved</button>
+          <button type="button" class="itinerary-toolbar__action" data-itinerary-share>Copy share link</button>
+          <a class="itinerary-toolbar__action itinerary-toolbar__action--gmaps" data-itinerary-gmaps target="_blank" rel="noreferrer">Open in Google Maps</a>
+          <button type="button" class="itinerary-toolbar__action" data-itinerary-print>Print</button>
+          <button type="button" class="itinerary-toolbar__action itinerary-toolbar__action--ghost" data-itinerary-clear>Clear</button>
+        </div>
+      </div>
+
+      <!-- The actual builder — populated by the controller below. -->
+      <ol class="itinerary-list" data-itinerary-list></ol>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<!-- SortableJS from CDN; lazy-loaded when the user has at least one item. -->
+<script
+  is:inline
+  define:vars={{ venueLookup, eventLookup }}
+>
+  /* /itinerary/ controller. Owns localStorage (pi:itinerary:v1), wires
+     SortableJS for drag-and-drop, computes haversine estimates between
+     consecutive stops, and supports share/import via URL params. */
+  (function () {
+    var KEY = 'pi:itinerary:v1';
+    var SORTABLE_SRC = 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js';
+
+    function escapeHtml(s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function read() {
+      try {
+        var raw = localStorage.getItem(KEY);
+        if (!raw) return { version: 1, items: [], days: [] };
+        var parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return { version: 1, items: [], days: [] };
+        return {
+          version: 1,
+          items: Array.isArray(parsed.items) ? parsed.items : [],
+          days: Array.isArray(parsed.days) ? parsed.days : [],
+        };
+      } catch (_e) {
+        return { version: 1, items: [], days: [] };
+      }
+    }
+
+    function write(store) {
+      try { localStorage.setItem(KEY, JSON.stringify(store)); } catch (_e) {}
+    }
+
+    function hydrate(item) {
+      var lookup = item.kind === 'event' ? eventLookup : venueLookup;
+      return lookup[item.slug] || { slug: item.slug, kind: item.kind, title: item.slug, href: '#', hero: '', lat: null, lng: null };
+    }
+
+    /* ─── Travel-time helpers (mirror lib/itinerary.ts) ─────────────────── */
+    function haversineKm(a, b) {
+      if (a == null || b == null || a.lat == null || b.lat == null) return null;
+      var R = 6371;
+      var toRad = function (d) { return (d * Math.PI) / 180; };
+      var dLat = toRad(b.lat - a.lat);
+      var dLng = toRad(b.lng - a.lng);
+      var lat1 = toRad(a.lat);
+      var lat2 = toRad(b.lat);
+      var h = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.sin(dLng / 2) * Math.sin(dLng / 2) * Math.cos(lat1) * Math.cos(lat2);
+      return 2 * R * Math.asin(Math.sqrt(h));
+    }
+    function drivingMinutes(km) {
+      var ROAD_MULTIPLIER = 1.3;
+      var AVG_SPEED_KMH = 45;
+      return (km * ROAD_MULTIPLIER) / AVG_SPEED_KMH * 60;
+    }
+    function formatMinutes(minutes) {
+      var snapped = Math.max(1, Math.round(minutes / 5) * 5);
+      if (snapped < 60) return snapped + ' min';
+      var h = Math.floor(snapped / 60);
+      var m = snapped % 60;
+      if (m === 0) return h + ' h';
+      return h + ' h ' + m;
+    }
+
+    /* ─── State ────────────────────────────────────────────────────────── */
+    var state = read();
+
+    function newDayId() {
+      return 'day-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
+    }
+    function dayLabel(idx) { return 'Day ' + (idx + 1); }
+
+    /* ─── Rendering ───────────────────────────────────────────────────── */
+    var listEl = document.querySelector('[data-itinerary-list]');
+    var emptyEl = document.querySelector('[data-itinerary-empty]');
+    var toolbarEl = document.querySelector('[data-itinerary-toolbar]');
+    var bannerEl = document.querySelector('[data-itinerary-banner]');
+    var stopCountEl = document.querySelector('[data-itinerary-stop-count]');
+    var distanceSummaryEl = document.querySelector('[data-itinerary-distance-summary]');
+    var gmapsLink = document.querySelector('[data-itinerary-gmaps]');
+
+    function groupByDay() {
+      // Returns ordered array of { day, items } where day === null for the
+      // ungrouped sequence, then each named day in declared order.
+      var ungrouped = [];
+      var dayBuckets = {};
+      state.days.forEach(function (d) { dayBuckets[d.id] = []; });
+      state.items.forEach(function (it) {
+        if (it.dayId && dayBuckets[it.dayId]) dayBuckets[it.dayId].push(it);
+        else ungrouped.push(it);
+      });
+      var out = [];
+      if (ungrouped.length > 0 || state.days.length === 0) {
+        out.push({ day: null, items: ungrouped });
+      }
+      state.days.forEach(function (d) {
+        out.push({ day: d, items: dayBuckets[d.id] });
+      });
+      return out;
+    }
+
+    function renderItem(item) {
+      var data = hydrate(item);
+      var hero = data.hero
+        ? '<div class="itinerary-item__hero" style="background-image:url(' + escapeHtml(data.hero) + ')"></div>'
+        : '<div class="itinerary-item__hero itinerary-item__hero--empty"></div>';
+      var meta = [data.type, data.price].filter(Boolean).map(escapeHtml).join(' · ');
+      return ''
+        + '<li class="itinerary-item" data-itinerary-id="' + escapeHtml(item.kind + ':' + item.slug) + '">'
+        +   '<span class="itinerary-item__handle" aria-hidden="true">≡</span>'
+        +   '<a class="itinerary-item__link" href="' + escapeHtml(data.href) + '">'
+        +     hero
+        +     '<span class="itinerary-item__body">'
+        +       (meta ? '<span class="itinerary-item__meta">' + meta + '</span>' : '')
+        +       '<span class="itinerary-item__title">' + escapeHtml(data.title) + '</span>'
+        +     '</span>'
+        +   '</a>'
+        +   '<button type="button" class="itinerary-item__remove" data-itinerary-remove aria-label="Remove ' + escapeHtml(data.title) + '">Remove</button>'
+        + '</li>';
+    }
+
+    function renderTravelGap(prev, next) {
+      if (!prev || !next) return '';
+      var prevC = hydrate(prev), nextC = hydrate(next);
+      if (prevC.lat == null || nextC.lat == null) return '';
+      var km = haversineKm(prevC, nextC);
+      if (km == null) return '';
+      var label = formatMinutes(drivingMinutes(km));
+      return ''
+        + '<li class="itinerary-gap" aria-hidden="true">'
+        +   '<span class="itinerary-gap__line"></span>'
+        +   '<span class="itinerary-gap__label">~ ' + escapeHtml(label) + ' drive</span>'
+        + '</li>';
+    }
+
+    function renderDay(day, items, dayIndex) {
+      var head = day
+        ? ''
+          + '<li class="itinerary-day-head" data-itinerary-day-head="' + escapeHtml(day.id) + '">'
+          +   '<span class="itinerary-day-head__label">' + escapeHtml(day.label || dayLabel(dayIndex)) + '</span>'
+          +   '<button type="button" class="itinerary-day-head__rename" data-itinerary-day-rename="' + escapeHtml(day.id) + '">Rename</button>'
+          +   '<button type="button" class="itinerary-day-head__remove" data-itinerary-day-remove="' + escapeHtml(day.id) + '">Remove day</button>'
+          + '</li>'
+        : '';
+      var rows = '';
+      items.forEach(function (item, idx) {
+        if (idx > 0) rows += renderTravelGap(items[idx - 1], item);
+        rows += renderItem(item);
+      });
+      var bucket = ''
+        + head
+        + '<li class="itinerary-day" data-itinerary-day="' + escapeHtml(day ? day.id : '') + '">'
+        +   '<ol class="itinerary-day__list" data-itinerary-day-list="' + escapeHtml(day ? day.id : '') + '">'
+        +     rows
+        +   '</ol>'
+        + '</li>';
+      return bucket;
+    }
+
+    var sortableInstances = [];
+
+    function destroySortables() {
+      sortableInstances.forEach(function (s) { try { s.destroy(); } catch (_e) {} });
+      sortableInstances = [];
+    }
+
+    function ensureSortableLoaded(cb) {
+      if (window.Sortable) return cb();
+      var existing = document.querySelector('script[data-sortable-loader]');
+      if (existing) {
+        existing.addEventListener('load', cb);
+        return;
+      }
+      var s = document.createElement('script');
+      s.setAttribute('data-sortable-loader', '');
+      s.src = SORTABLE_SRC;
+      s.onload = cb;
+      s.onerror = function () { console.warn('[itinerary] Sortable failed to load'); };
+      document.head.appendChild(s);
+    }
+
+    function bindSortables() {
+      destroySortables();
+      if (!window.Sortable) return;
+      var lists = document.querySelectorAll('[data-itinerary-day-list]');
+      lists.forEach(function (listNode) {
+        var s = new window.Sortable(listNode, {
+          group: 'itinerary',
+          animation: 160,
+          handle: '.itinerary-item__handle',
+          ghostClass: 'is-ghost',
+          dragClass: 'is-dragging',
+          onEnd: function () {
+            // Walk the DOM, rebuild state.items so the order matches what
+            // the user just dropped.
+            var newItems = [];
+            document.querySelectorAll('[data-itinerary-day-list]').forEach(function (dayListEl) {
+              var dayId = dayListEl.getAttribute('data-itinerary-day-list') || '';
+              dayListEl.querySelectorAll('[data-itinerary-id]').forEach(function (li) {
+                var key = li.getAttribute('data-itinerary-id') || '';
+                var parts = key.split(':');
+                var kind = parts[0]; var slug = parts.slice(1).join(':');
+                if (!kind || !slug) return;
+                var existing = state.items.find(function (it) { return it.kind === kind && it.slug === slug; });
+                newItems.push({
+                  kind: kind,
+                  slug: slug,
+                  dayId: dayId,
+                  note: existing ? existing.note : '',
+                });
+              });
+            });
+            state.items = newItems;
+            persist();
+            render(); // re-render to refresh the travel gaps
+          },
+        });
+        sortableInstances.push(s);
+      });
+    }
+
+    function render() {
+      var totalCount = state.items.length;
+      if (totalCount === 0) {
+        if (listEl) listEl.innerHTML = '';
+        if (emptyEl) emptyEl.removeAttribute('hidden');
+        if (toolbarEl) toolbarEl.setAttribute('hidden', '');
+        return;
+      }
+      if (emptyEl) emptyEl.setAttribute('hidden', '');
+      if (toolbarEl) toolbarEl.removeAttribute('hidden');
+
+      var grouped = groupByDay();
+      var html = '';
+      grouped.forEach(function (g, idx) {
+        html += renderDay(g.day, g.items, idx);
+      });
+      if (listEl) listEl.innerHTML = html;
+
+      // Stats
+      if (stopCountEl) {
+        stopCountEl.textContent = totalCount + ' stop' + (totalCount === 1 ? '' : 's');
+      }
+      if (distanceSummaryEl) {
+        var totalMinutes = 0;
+        for (var i = 1; i < state.items.length; i++) {
+          var prev = hydrate(state.items[i - 1]);
+          var next = hydrate(state.items[i]);
+          if (prev.lat != null && next.lat != null) {
+            totalMinutes += drivingMinutes(haversineKm(prev, next));
+          }
+        }
+        distanceSummaryEl.textContent = totalMinutes > 0
+          ? '~ ' + formatMinutes(totalMinutes) + ' driving'
+          : 'driving estimate unavailable';
+      }
+      if (gmapsLink) {
+        var stops = state.items
+          .map(hydrate)
+          .filter(function (h) { return h.lat != null && h.lng != null; })
+          .map(function (h) { return { lat: h.lat, lng: h.lng, name: h.title }; });
+        if (stops.length === 0) {
+          gmapsLink.setAttribute('href', 'https://www.google.com/maps');
+        } else if (stops.length === 1) {
+          gmapsLink.setAttribute('href', 'https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent(stops[0].lat + ',' + stops[0].lng + ' (' + stops[0].name + ')'));
+        } else {
+          var origin = stops[0];
+          var dest = stops[stops.length - 1];
+          var waypoints = stops.slice(1, -1).map(function (s) { return s.lat + ',' + s.lng; }).join('|');
+          var p = new URLSearchParams({ api: '1', origin: origin.lat + ',' + origin.lng, destination: dest.lat + ',' + dest.lng, travelmode: 'driving' });
+          if (waypoints) p.set('waypoints', waypoints);
+          gmapsLink.setAttribute('href', 'https://www.google.com/maps/dir/?' + p.toString());
+        }
+      }
+
+      // Bind dynamic actions
+      document.querySelectorAll('[data-itinerary-remove]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var li = btn.closest('[data-itinerary-id]');
+          if (!li) return;
+          var key = li.getAttribute('data-itinerary-id') || '';
+          var parts = key.split(':'); var kind = parts[0]; var slug = parts.slice(1).join(':');
+          state.items = state.items.filter(function (it) { return !(it.kind === kind && it.slug === slug); });
+          persist();
+          render();
+        });
+      });
+      document.querySelectorAll('[data-itinerary-day-rename]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var id = btn.getAttribute('data-itinerary-day-rename') || '';
+          var d = state.days.find(function (x) { return x.id === id; });
+          if (!d) return;
+          var next = window.prompt('Rename day:', d.label);
+          if (next === null) return;
+          d.label = next.trim() || d.label;
+          persist();
+          render();
+        });
+      });
+      document.querySelectorAll('[data-itinerary-day-remove]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var id = btn.getAttribute('data-itinerary-day-remove') || '';
+          state.days = state.days.filter(function (d) { return d.id !== id; });
+          state.items.forEach(function (it) {
+            if (it.dayId === id) it.dayId = '';
+          });
+          persist();
+          render();
+        });
+      });
+
+      bindSortables();
+    }
+
+    function persist() { write(state); }
+
+    /* ─── URL ingest (shared mode) ─────────────────────────────────────── */
+    function readSharedFromUrl() {
+      var p = new URLSearchParams(window.location.search);
+      var raw = p.get('i');
+      if (!raw) return null;
+      var items = raw.split('|').filter(Boolean).map(function (triple) {
+        var parts = triple.split(':');
+        return { kind: parts[0] === 'event' ? 'event' : 'venue', slug: parts[1] || '', dayId: parts[2] || '', note: '' };
+      }).filter(function (it) { return it.slug; });
+      var days = [];
+      var dr = p.get('d');
+      if (dr) {
+        dr.split('|').filter(Boolean).forEach(function (pair) {
+          var parts = pair.split(':');
+          var id = parts[0] || '';
+          var label;
+          try { label = decodeURIComponent(parts[1] || id); } catch (_e) { label = parts[1] || id; }
+          if (id) days.push({ id: id, label: label });
+        });
+      }
+      return { version: 1, items: items, days: days };
+    }
+
+    function buildShareUrl() {
+      var p = new URLSearchParams();
+      if (state.items.length > 0) {
+        p.set('i', state.items.map(function (it) { return it.kind + ':' + it.slug + ':' + (it.dayId || ''); }).join('|'));
+      }
+      if (state.days.length > 0) {
+        p.set('d', state.days.map(function (d) { return d.id + ':' + encodeURIComponent(d.label); }).join('|'));
+      }
+      var qs = p.toString();
+      return window.location.origin + window.location.pathname + (qs ? '?' + qs : '');
+    }
+
+    /* ─── Toolbar bindings ─────────────────────────────────────────────── */
+    var addDayBtn = document.querySelector('[data-itinerary-add-day]');
+    if (addDayBtn) addDayBtn.addEventListener('click', function () {
+      var idx = state.days.length;
+      var label = window.prompt('Name this day:', 'Day ' + (idx + 1));
+      if (label === null) return;
+      state.days.push({ id: newDayId(), label: label.trim() || ('Day ' + (idx + 1)) });
+      persist();
+      render();
+    });
+
+    document.querySelectorAll('[data-itinerary-pull]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var saved = window.PISave ? window.PISave.list() : { venues: [], events: [] };
+        var added = 0;
+        (saved.venues || []).forEach(function (v) {
+          if (state.items.some(function (it) { return it.kind === 'venue' && it.slug === v.slug; })) return;
+          state.items.push({ kind: 'venue', slug: v.slug, dayId: '', note: '' });
+          added++;
+        });
+        (saved.events || []).forEach(function (e) {
+          if (state.items.some(function (it) { return it.kind === 'event' && it.slug === e.slug; })) return;
+          state.items.push({ kind: 'event', slug: e.slug, dayId: '', note: '' });
+          added++;
+        });
+        if (added === 0) {
+          window.alert('Nothing new to pull — your shortlist items are already in this itinerary.');
+        }
+        persist();
+        render();
+      });
+    });
+
+    var shareBtn = document.querySelector('[data-itinerary-share]');
+    if (shareBtn) shareBtn.addEventListener('click', function () {
+      var url = buildShareUrl();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(function () {
+          shareBtn.textContent = 'Copied!';
+          setTimeout(function () { shareBtn.textContent = 'Copy share link'; }, 2000);
+        }, function () {
+          window.prompt('Copy this share link:', url);
+        });
+      } else {
+        window.prompt('Copy this share link:', url);
+      }
+    });
+
+    var printBtn = document.querySelector('[data-itinerary-print]');
+    if (printBtn) printBtn.addEventListener('click', function () { window.print(); });
+
+    var clearBtn = document.querySelector('[data-itinerary-clear]');
+    if (clearBtn) clearBtn.addEventListener('click', function () {
+      if (state.items.length === 0 && state.days.length === 0) return;
+      if (window.confirm('Clear the entire itinerary?')) {
+        state = { version: 1, items: [], days: [] };
+        persist();
+        render();
+      }
+    });
+
+    var importBtn = document.querySelector('[data-itinerary-import]');
+    if (importBtn) importBtn.addEventListener('click', function () {
+      var shared = readSharedFromUrl();
+      if (!shared) return;
+      // Merge incoming days first so existing day ids continue to work.
+      shared.days.forEach(function (d) {
+        if (!state.days.some(function (x) { return x.id === d.id; })) state.days.push(d);
+      });
+      shared.items.forEach(function (it) {
+        if (state.items.some(function (x) { return x.kind === it.kind && x.slug === it.slug; })) return;
+        state.items.push(it);
+      });
+      persist();
+      window.history.replaceState(null, '', window.location.pathname);
+      if (bannerEl) bannerEl.setAttribute('hidden', '');
+      render();
+    });
+
+    /* ─── Boot ─────────────────────────────────────────────────────────── */
+    function boot() {
+      var shared = readSharedFromUrl();
+      if (shared && shared.items.length > 0) {
+        // Show shared mode banner; keep local state separate until import.
+        if (bannerEl) bannerEl.removeAttribute('hidden');
+        state = shared; // render the shared list, but persist on first change
+      }
+      ensureSortableLoaded(function () {
+        render();
+      });
+      // Render once before SortableJS arrives so the page isn't blank.
+      render();
+
+      // Listen for save-changed events from the rest of the site so the
+      // toolbar count etc. stay live if the user saves something while
+      // /itinerary/ is open in another tab.
+      window.addEventListener('storage', function (e) {
+        if (e.key === KEY) {
+          state = read();
+          render();
+        }
+      });
+    }
+
+    boot();
+  })();
+</script>
+
+<style>
+  /* Fallback styles — anything that's purely scoped to the itinerary page
+     and shouldn't leak into the global stylesheet. The bulk lives in
+     global.css so the print rules can also style it. */
+</style>

--- a/next/src/pages/saved.astro
+++ b/next/src/pages/saved.astro
@@ -93,6 +93,7 @@ const breadcrumbItems = [
       <div class="saved-toolbar">
         <p class="saved-toolbar__count" data-saved-toolbar-count></p>
         <div class="saved-toolbar__actions">
+          <a href="/itinerary/" class="saved-toolbar__action saved-toolbar__action--ghost">Sequence into a day plan →</a>
           <button type="button" class="saved-toolbar__action" data-saved-share>Copy share link</button>
           <button type="button" class="saved-toolbar__action saved-toolbar__action--ghost" data-saved-clear>Clear shortlist</button>
         </div>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -9302,3 +9302,354 @@ body.menu-open .subscribe-pill {
   color: var(--soft);
   margin: 0;
 }
+
+/* ============================================================================
+   ITINERARY BUILDER (Phase 3 WS3C)
+   /itinerary/ page. Drag-and-drop sequencer with travel-time gaps, optional
+   day groupings, share URL, native print, and Google Maps multi-stop link.
+   ============================================================================ */
+
+.itinerary-page {
+  padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem);
+}
+
+.itinerary-empty {
+  border: 1px dashed var(--border);
+  padding: clamp(1.5rem, 3vw, 2.5rem) 1.5rem;
+  text-align: center;
+}
+.itinerary-empty__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--text);
+  margin: 0 0 0.5rem;
+}
+.itinerary-empty__body {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  color: var(--soft);
+  margin: 0 0 1.25rem;
+}
+.itinerary-empty__cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+  margin: 0;
+}
+.itinerary-empty__cta {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--bg, #fff);
+  border: 1px solid var(--accent);
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+.itinerary-empty__cta--ghost {
+  background: transparent;
+  color: var(--accent);
+}
+.itinerary-empty__cta:hover { background: var(--text, #1a1a1a); border-color: var(--text, #1a1a1a); color: var(--bg, #fff); }
+.itinerary-empty__cta--ghost:hover { color: var(--bg, #fff); }
+[data-itinerary-empty][hidden] { display: none; }
+
+.itinerary-banner {
+  border: 1px solid var(--accent);
+  background: rgba(167, 118, 55, 0.06);
+  padding: clamp(1rem, 2vw, 1.4rem);
+  margin-bottom: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+.itinerary-banner__label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.55rem;
+}
+.itinerary-banner__body {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--dark);
+  margin: 0 0 0.85rem;
+}
+.itinerary-banner__action {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--bg, #fff);
+  border: 1px solid var(--accent);
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+}
+.itinerary-banner__action:hover { background: var(--text, #1a1a1a); border-color: var(--text, #1a1a1a); }
+
+.itinerary-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 0.95rem 0 1.1rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+.itinerary-toolbar__count {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.92rem;
+  color: var(--soft);
+}
+.itinerary-toolbar__sep { margin: 0 0.5rem; }
+.itinerary-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+.itinerary-toolbar__action {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  background: transparent;
+  color: var(--dark);
+  border: 1px solid var(--border);
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.itinerary-toolbar__action:hover { color: var(--accent); border-color: var(--accent); }
+.itinerary-toolbar__action--ghost { color: var(--soft); }
+.itinerary-toolbar__action--gmaps {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+[data-itinerary-toolbar][hidden] { display: none; }
+
+.itinerary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.itinerary-day {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+}
+.itinerary-day__list {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--paper, #fbf7f0);
+}
+.itinerary-day-head {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.85rem 0 0.55rem;
+  border-top: 1px solid var(--border);
+  margin-top: 1rem;
+}
+.itinerary-day-head:first-child {
+  border-top: 0;
+  margin-top: 0;
+}
+.itinerary-day-head__label {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.01em;
+  flex: 1;
+}
+.itinerary-day-head__rename,
+.itinerary-day-head__remove {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: transparent;
+  border: 0;
+  color: var(--soft);
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+}
+.itinerary-day-head__rename:hover,
+.itinerary-day-head__remove:hover { color: var(--accent); }
+
+.itinerary-item {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border);
+  margin: 0.4rem 0.5rem;
+  list-style: none;
+  transition: box-shadow 0.15s ease;
+}
+.itinerary-item.is-ghost {
+  opacity: 0.4;
+  background: var(--paper, #fbf7f0);
+}
+.itinerary-item.is-dragging {
+  box-shadow: 0 12px 24px -12px rgba(40, 28, 14, 0.4);
+}
+.itinerary-item__handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  font-size: 1.1rem;
+  color: var(--soft);
+  cursor: grab;
+  user-select: none;
+  border-right: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+}
+.itinerary-item__handle:active { cursor: grabbing; }
+.itinerary-item__link {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  text-decoration: none;
+  color: inherit;
+  min-width: 0;
+}
+.itinerary-item__hero {
+  flex-shrink: 0;
+  width: 80px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--paper, #fbf7f0);
+}
+.itinerary-item__hero--empty {
+  background: linear-gradient(135deg, rgba(167, 118, 55, 0.12), rgba(223, 197, 158, 0.08));
+}
+.itinerary-item__body {
+  flex: 1;
+  padding: 0.75rem 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+.itinerary-item__meta {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+}
+.itinerary-item__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.1rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--text);
+}
+.itinerary-item__remove {
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin: 0.65rem 0.65rem 0 0;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+}
+.itinerary-item__remove:hover { color: var(--accent); border-color: var(--accent); }
+
+.itinerary-gap {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0 1rem;
+  margin: 0.15rem 0;
+}
+.itinerary-gap__line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--border), transparent);
+}
+.itinerary-gap__label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--soft);
+  white-space: nowrap;
+}
+
+/* Print rules — strip chrome for a clean glove-box copy. */
+@media print {
+  header.masthead,
+  footer,
+  .breadcrumbs,
+  .section-hero,
+  .newsletter-block,
+  [data-pi-trigger],
+  .typeahead,
+  .save-button,
+  #siteSearchOverlay,
+  .cookie-banner,
+  body > nav.mobile-nav,
+  .itinerary-toolbar,
+  .itinerary-empty,
+  .itinerary-banner,
+  .itinerary-item__handle,
+  .itinerary-item__remove,
+  .itinerary-day-head__rename,
+  .itinerary-day-head__remove {
+    display: none !important;
+  }
+  body, .itinerary-page, main {
+    background: #fff !important;
+    color: #000 !important;
+  }
+  .itinerary-day__list {
+    background: transparent;
+    border: 0;
+    padding: 0;
+  }
+  .itinerary-item {
+    page-break-inside: avoid;
+    border: 0;
+    border-bottom: 1px solid #ddd;
+  }
+  .itinerary-item__hero { display: none; }
+  .itinerary-gap__line { background: #000; }
+  .itinerary-gap__label { color: #000; }
+}


### PR DESCRIPTION
## Summary

Largest single Phase 3 workstream. Turns the saved shortlist into a sequenced, drag-and-drop day plan with travel-time estimates between stops, optional day groupings, share-URL, and a native-print view.

## What ships

- **`/itinerary/` page** — separate from `/saved/` (which stays as the simple shortlist). Independent storage at `pi:itinerary:v1`.
- **Drag-and-drop** via SortableJS (CDN, lazy-loaded when the user has ≥1 item). Single shared group across day buckets so cross-day drag works.
- **Travel-time gaps** between consecutive stops — haversine × 1.3 road multiplier ÷ 45 km/h average, snapped to 5-minute precision. Total drive shown in the toolbar.
- **Optional day groupings** — flat by default, "+ Add day" creates a labelled bucket; rename and remove inline.
- **Toolbar actions:** + Add day, + Pull from saved, Copy share link, Open in Google Maps (multi-stop directions URL), Print, Clear.
- **Share URL** encodes the sequence; notes stay private. Import banner appears when arriving via `?i=…&d=…` and merges into the user's local store on one click.
- **Native browser print** with chrome stripped (masthead, footer, hero, toolbar, handles) and travel-time gaps preserved.
- **Bridges:** `/saved/` gains a "Sequence into a day plan →" toolbar link; masthead utility row gains an Itinerary link.

## Locked decisions implemented

- Q3 — Haversine + Peninsula multiplier (no external API).
- Q4 — SortableJS for drag-and-drop.
- Q5 — Day groupings optional.
- Q6 — `/itinerary/` as a new route; `/saved/` kept as the simple shortlist.
- Q8 — Native browser print v1.

## Test plan

- [ ] Visit `/itinerary/` empty — confirm empty state with "Pull every saved item" CTA.
- [ ] Save 3 venues from across the site, then click "+ Pull from saved" — confirm they appear, with travel-time gaps between consecutive stops.
- [ ] Drag the second item to first position — confirm reorder, travel times update.
- [ ] Click "+ Add day" → name it Day 1 — confirm a day header appears.
- [ ] Drag an item into the day bucket — confirm it nests under Day 1.
- [ ] Click "Copy share link" — confirm clipboard copy, then open the URL in a private window — confirm Import banner appears.
- [ ] Click "Open in Google Maps" — confirm a `dir/?api=1&...` multi-stop URL opens.
- [ ] Click Print — confirm chrome strips and the page is a clean sequence.
- [ ] Click Clear with confirmation — confirm the itinerary empties.

## Build
1207 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)