### PR TITLE
feat(discovery-phase-3): AI itinerary ingestion + backend contract (WS3D)

### DIFF
--- a/next/src/components/ConciergeDrawer.astro
+++ b/next/src/components/ConciergeDrawer.astro
@@ -912,6 +912,67 @@
       }
     }
 
+    /**
+     * Phase 3 WS3D — concierge itinerary helpers.
+     *
+     * The backend can optionally include an `itinerary` field in the
+     * meta payload of a response. When present, the drawer renders a
+     * CTA card linking to the /itinerary/ builder with a base64url-
+     * encoded payload. See lib/concierge-itinerary.ts for the contract.
+     *
+     * Permissive parser: accepts and coerces variations since the
+     * producer is an LLM. Invalid payloads return null silently.
+     */
+    function parseConciergeItineraryFromPayload(input) {
+      if (!input || typeof input !== 'object') return null;
+      const itemsRaw = input.items;
+      if (!Array.isArray(itemsRaw) || itemsRaw.length === 0) return null;
+      const items = [];
+      for (const it of itemsRaw) {
+        if (!it || typeof it !== 'object') continue;
+        const kind = String(it.kind || '').toLowerCase();
+        if (kind !== 'venue' && kind !== 'event' && kind !== 'experience') continue;
+        const slug = String(it.slug || '').trim();
+        if (!slug) continue;
+        items.push({
+          kind: kind,
+          slug: slug,
+          dayId: typeof it.dayId === 'string' ? it.dayId : '',
+          note: typeof it.note === 'string' ? it.note : '',
+        });
+      }
+      if (items.length === 0) return null;
+      const days = [];
+      if (Array.isArray(input.days)) {
+        for (const d of input.days) {
+          if (!d || typeof d !== 'object') continue;
+          const id = String(d.id || '').trim();
+          const label = String(d.label || '').trim();
+          if (!id) continue;
+          days.push({ id: id, label: label || id });
+        }
+      }
+      return {
+        title: typeof input.title === 'string' ? input.title : '',
+        framing: typeof input.framing === 'string' ? input.framing : '',
+        items: items,
+        days: days,
+      };
+    }
+
+    function encodeAiPayload(it) {
+      try {
+        const json = JSON.stringify(it);
+        const bytes = new TextEncoder().encode(json);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+        const b64 = btoa(binary);
+        return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      } catch (_e) {
+        return '';
+      }
+    }
+
     function renderTile(rec, rank, idx) {
       const heroSrc = rec.hero_image ? escapeHtml(rec.hero_image) : null;
       const heroStyle = heroSrc ? "background-image: url('" + heroSrc + "')" : '';
@@ -1155,6 +1216,32 @@
           rail.innerHTML = recs.map((rec, i) => renderTile(rec, i + 1, i)).join('');
           // Place the rail OUTSIDE the prose card, like appendPiMessage does.
           proseContainer.insertAdjacentElement('afterend', rail);
+        }
+
+        // Phase 3 WS3D — recognise structured itinerary payloads from the
+        // concierge backend and render a "Sequence in builder" CTA. The
+        // backend doesn't speak this format yet; until it does, the
+        // condition below is silently false and nothing renders.
+        const itineraryPayload = parseConciergeItineraryFromPayload(payload && payload.itinerary);
+        if (itineraryPayload) {
+          const cta = document.createElement('div');
+          cta.className = 'ask-itinerary-cta';
+          const titleHtml = itineraryPayload.title
+            ? '<p class="ask-itinerary-cta__title">' + escapeHtml(itineraryPayload.title) + '</p>'
+            : '';
+          const framingHtml = itineraryPayload.framing
+            ? '<p class="ask-itinerary-cta__framing">' + escapeHtml(itineraryPayload.framing) + '</p>'
+            : '';
+          const aiHref = '/itinerary/?ai=' + encodeAiPayload(itineraryPayload);
+          cta.innerHTML = ''
+            + '<div class="ask-itinerary-cta__inner">'
+            +   '<p class="ask-itinerary-cta__label">Sequenced for you</p>'
+            +   titleHtml
+            +   framingHtml
+            +   '<p class="ask-itinerary-cta__count">' + itineraryPayload.items.length + ' stops</p>'
+            +   '<a class="ask-itinerary-cta__link" href="' + escapeHtml(aiHref) + '">Open in the itinerary builder →</a>'
+            + '</div>';
+          proseContainer.insertAdjacentElement('afterend', cta);
         }
 
         const followOn = Array.isArray(payload.follow_on) ? payload.follow_on : [];

--- a/next/src/lib/concierge-itinerary.ts
+++ b/next/src/lib/concierge-itinerary.ts
@@ -1,0 +1,153 @@
+/**
+ * Concierge → Itinerary contract (Phase 3 WS3D).
+ *
+ * Defines the JSON shape the Ask The Insider backend should emit when a
+ * user prompt looks like an itinerary request ("plan me a Saturday in
+ * Red Hill", "two-night couples weekend", "rainy day with kids"). The
+ * front-end recognises this payload, renders a "Sequence in builder"
+ * CTA, and ingests into pi:itinerary:v1 when the user clicks.
+ *
+ * Until the backend speaks this format, the contract is documented but
+ * unused — the recogniser quietly does nothing on responses that lack
+ * an `itinerary` field.
+ *
+ * BACKEND CONTRACT
+ * ================
+ * The concierge response should optionally include an `itinerary` field
+ * alongside its existing `prose` and `recommendations` (or whatever the
+ * current shape is). When present:
+ *
+ *   {
+ *     "itinerary": {
+ *       "title": "A Red Hill Saturday",      // editorial title; optional
+ *       "framing": "Long lunch...",          // 1–2 sentence dek; optional
+ *       "items": [
+ *         { "kind": "venue",      "slug": "montalto",                "dayId": "",      "note": "" },
+ *         { "kind": "experience", "slug": "arthurs-seat-walk",       "dayId": "",      "note": "" },
+ *         { "kind": "venue",      "slug": "ten-minutes-by-tractor",  "dayId": "day-1", "note": "Lunch reservation 1 pm" },
+ *         { "kind": "event",      "slug": "red-hill-market",         "dayId": "day-1", "note": "" }
+ *       ],
+ *       "days": [
+ *         { "id": "day-1", "label": "Saturday" }
+ *       ]
+ *     }
+ *   }
+ *
+ * RULES
+ *  - `kind` must be 'venue' | 'event' | 'experience'.
+ *  - `slug` must match an existing slug in the corresponding collection;
+ *    items with unknown slugs are dropped silently on the front end.
+ *  - `dayId` is optional. Empty string means ungrouped.
+ *  - `note` is optional free text. Stays in local storage; not encoded
+ *    into share URLs (see `/itinerary/` for the share rule).
+ *  - `days` is optional. If present and an item references an unknown
+ *    dayId, the item lands ungrouped.
+ *  - Titles and framings are surfaced to the user but are not persisted
+ *    to local storage (the user's own itinerary belongs to them, not
+ *    the concierge that suggested it).
+ */
+
+export type ItineraryItemKind = 'venue' | 'event' | 'experience';
+
+export interface ConciergeItineraryItem {
+  kind: ItineraryItemKind;
+  slug: string;
+  dayId?: string;
+  note?: string;
+}
+
+export interface ConciergeItineraryDay {
+  id: string;
+  label: string;
+}
+
+export interface ConciergeItinerary {
+  title?: string;
+  framing?: string;
+  items: ConciergeItineraryItem[];
+  days?: ConciergeItineraryDay[];
+}
+
+/**
+ * Validate an arbitrary value as a ConciergeItinerary. Returns null if
+ * it doesn't conform; this is intentionally permissive (accept and
+ * coerce reasonable variations) since the producer is an LLM.
+ */
+export function parseConciergeItinerary(input: unknown): ConciergeItinerary | null {
+  if (!input || typeof input !== 'object') return null;
+  const raw = input as Record<string, unknown>;
+  const itemsRaw = raw.items;
+  if (!Array.isArray(itemsRaw) || itemsRaw.length === 0) return null;
+  const items: ConciergeItineraryItem[] = [];
+  for (const it of itemsRaw) {
+    if (!it || typeof it !== 'object') continue;
+    const itAny = it as Record<string, unknown>;
+    const kind = String(itAny.kind ?? '').toLowerCase();
+    if (kind !== 'venue' && kind !== 'event' && kind !== 'experience') continue;
+    const slug = String(itAny.slug ?? '').trim();
+    if (!slug) continue;
+    items.push({
+      kind: kind as ItineraryItemKind,
+      slug,
+      dayId: typeof itAny.dayId === 'string' ? itAny.dayId : '',
+      note: typeof itAny.note === 'string' ? itAny.note : '',
+    });
+  }
+  if (items.length === 0) return null;
+
+  const daysRaw = raw.days;
+  const days: ConciergeItineraryDay[] = [];
+  if (Array.isArray(daysRaw)) {
+    for (const d of daysRaw) {
+      if (!d || typeof d !== 'object') continue;
+      const dAny = d as Record<string, unknown>;
+      const id = String(dAny.id ?? '').trim();
+      const label = String(dAny.label ?? '').trim();
+      if (!id) continue;
+      days.push({ id, label: label || id });
+    }
+  }
+
+  return {
+    title: typeof raw.title === 'string' ? raw.title : undefined,
+    framing: typeof raw.framing === 'string' ? raw.framing : undefined,
+    items,
+    days: days.length > 0 ? days : undefined,
+  };
+}
+
+/**
+ * Encode a ConciergeItinerary into a URL fragment usable on
+ * /itinerary/?ai=<encoded>. base64url-encodes the JSON to keep the
+ * URL compact and safe across email/SMS forwarding.
+ */
+export function encodeConciergeItinerary(it: ConciergeItinerary): string {
+  const json = JSON.stringify(it);
+  // btoa requires Latin-1; encode as UTF-8 first.
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  const b64 = (typeof btoa !== 'undefined' ? btoa(binary) : '');
+  // base64url
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Decode a base64url payload back into a ConciergeItinerary. Returns
+ * null on any parse failure — the front end falls back to a plain
+ * empty itinerary in that case.
+ */
+export function decodeConciergeItinerary(encoded: string): ConciergeItinerary | null {
+  try {
+    const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const binary = (typeof atob !== 'undefined' ? atob(padded) : '');
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const json = new TextDecoder().decode(bytes);
+    const parsed = JSON.parse(json);
+    return parseConciergeItinerary(parsed);
+  } catch {
+    return null;
+  }
+}

--- a/next/src/pages/itinerary.astro
+++ b/next/src/pages/itinerary.astro
@@ -29,6 +29,7 @@ import { routeSlug, venueHrefPrefix } from '../lib/editorial';
 
 const venues = await getCollection('venues');
 const events = await getCollection('events');
+const experiences = await getCollection('experiences');
 
 /**
  * Build-time lookup tables. Carry coordinates so the client can compute
@@ -67,6 +68,24 @@ const eventLookup = Object.fromEntries(
       type: e.data.category,
       price: '',
       signature: e.data.summary ?? '',
+    },
+  ]),
+);
+const experienceLookup = Object.fromEntries(
+  experiences.map((x) => [
+    routeSlug(x),
+    {
+      slug: routeSlug(x),
+      kind: 'experience' as const,
+      title: x.data.name,
+      href: `/explore/${routeSlug(x)}/`,
+      hero: x.data.heroImage?.src ?? '',
+      lat: x.data.coordinates?.lat ?? null,
+      lng: x.data.coordinates?.lng ?? null,
+      placeId: typeof x.data.place === 'string' ? x.data.place : x.data.place?.id ?? '',
+      type: x.data.type,
+      price: '',
+      signature: (x.data.editorNote ?? '').slice(0, 160),
     },
   ]),
 );
@@ -110,11 +129,16 @@ const breadcrumbItems = [
         </p>
       </div>
 
-      <!-- Mode banner — appears in shared mode only. -->
+      <!-- Mode banner — appears in shared mode only.
+           Two flavours:
+             - Shared from another user: generic "import" copy.
+             - Suggested by Ask The Insider: title + framing from the
+               concierge payload, "Save as my itinerary" CTA. -->
       <aside class="itinerary-banner" data-itinerary-banner hidden>
         <div class="itinerary-banner__inner">
-          <p class="itinerary-banner__label">Shared itinerary</p>
-          <p class="itinerary-banner__body">Someone shared this Peninsula itinerary with you. You can browse it as is, or import it into your own builder on this device.</p>
+          <p class="itinerary-banner__label" data-itinerary-banner-label>Shared itinerary</p>
+          <p class="itinerary-banner__title" data-itinerary-banner-title hidden></p>
+          <p class="itinerary-banner__body" data-itinerary-banner-body>Someone shared this Peninsula itinerary with you. You can browse it as is, or import it into your own builder on this device.</p>
           <button type="button" class="itinerary-banner__action" data-itinerary-import>Import this itinerary</button>
         </div>
       </aside>
@@ -147,7 +171,7 @@ const breadcrumbItems = [
 <!-- SortableJS from CDN; lazy-loaded when the user has at least one item. -->
 <script
   is:inline
-  define:vars={{ venueLookup, eventLookup }}
+  define:vars={{ venueLookup, eventLookup, experienceLookup }}
 >
   /* /itinerary/ controller. Owns localStorage (pi:itinerary:v1), wires
      SortableJS for drag-and-drop, computes haversine estimates between
@@ -186,7 +210,10 @@ const breadcrumbItems = [
     }
 
     function hydrate(item) {
-      var lookup = item.kind === 'event' ? eventLookup : venueLookup;
+      var lookup;
+      if (item.kind === 'event') lookup = eventLookup;
+      else if (item.kind === 'experience') lookup = experienceLookup;
+      else lookup = venueLookup;
       return lookup[item.slug] || { slug: item.slug, kind: item.kind, title: item.slug, href: '#', hero: '', lat: null, lng: null };
     }
 
@@ -470,13 +497,50 @@ const breadcrumbItems = [
     function persist() { write(state); }
 
     /* ─── URL ingest (shared mode) ─────────────────────────────────────── */
+    function normaliseKind(k) {
+      if (k === 'event') return 'event';
+      if (k === 'experience') return 'experience';
+      return 'venue';
+    }
+
     function readSharedFromUrl() {
       var p = new URLSearchParams(window.location.search);
+
+      // AI-itinerary ingest path: /itinerary/?ai=<base64url-json>.
+      // Lets the concierge (or any external producer) link directly into
+      // the builder with a pre-sequenced list. See lib/concierge-itinerary.ts
+      // for the contract.
+      var aiRaw = p.get('ai');
+      if (aiRaw) {
+        var decoded = decodeAiPayload(aiRaw);
+        if (decoded && decoded.items && decoded.items.length > 0) {
+          var aiItems = decoded.items.map(function (it) {
+            return {
+              kind: normaliseKind(it.kind),
+              slug: String(it.slug || ''),
+              dayId: String(it.dayId || ''),
+              note: String(it.note || ''),
+            };
+          }).filter(function (it) { return it.slug; });
+          var aiDays = Array.isArray(decoded.days) ? decoded.days.map(function (d) {
+            return { id: String(d.id || ''), label: String(d.label || d.id || '') };
+          }).filter(function (d) { return d.id; }) : [];
+          return {
+            version: 1,
+            items: aiItems,
+            days: aiDays,
+            // Carry editorial framing so the banner can show it.
+            _meta: { title: decoded.title || '', framing: decoded.framing || '', source: 'ai' },
+          };
+        }
+      }
+
+      // Personal share-link path: ?i=kind:slug:dayId|... &d=id:label|...
       var raw = p.get('i');
       if (!raw) return null;
       var items = raw.split('|').filter(Boolean).map(function (triple) {
         var parts = triple.split(':');
-        return { kind: parts[0] === 'event' ? 'event' : 'venue', slug: parts[1] || '', dayId: parts[2] || '', note: '' };
+        return { kind: normaliseKind(parts[0]), slug: parts[1] || '', dayId: parts[2] || '', note: '' };
       }).filter(function (it) { return it.slug; });
       var days = [];
       var dr = p.get('d');
@@ -490,6 +554,22 @@ const breadcrumbItems = [
         });
       }
       return { version: 1, items: items, days: days };
+    }
+
+    function decodeAiPayload(encoded) {
+      try {
+        var b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+        var padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+        var binary = atob(padded);
+        var bytes = new Uint8Array(binary.length);
+        for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+        var json = new TextDecoder().decode(bytes);
+        var parsed = JSON.parse(json);
+        if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.items)) return null;
+        return parsed;
+      } catch (_e) {
+        return null;
+      }
     }
 
     function buildShareUrl() {
@@ -584,11 +664,40 @@ const breadcrumbItems = [
     });
 
     /* ─── Boot ─────────────────────────────────────────────────────────── */
+    function applyBannerCopy(meta) {
+      var bannerLabel = document.querySelector('[data-itinerary-banner-label]');
+      var bannerTitle = document.querySelector('[data-itinerary-banner-title]');
+      var bannerBody = document.querySelector('[data-itinerary-banner-body]');
+      var importBtn = document.querySelector('[data-itinerary-import]');
+      if (meta && meta.source === 'ai') {
+        if (bannerLabel) bannerLabel.textContent = 'Ask The Insider · suggested itinerary';
+        if (bannerTitle) {
+          if (meta.title) {
+            bannerTitle.textContent = meta.title;
+            bannerTitle.removeAttribute('hidden');
+          } else {
+            bannerTitle.setAttribute('hidden', '');
+          }
+        }
+        if (bannerBody) {
+          bannerBody.textContent = meta.framing
+            || 'The Insider built this sequence in response to your prompt. Browse it, or save it to your own builder where you can rearrange, add notes, and share.';
+        }
+        if (importBtn) importBtn.textContent = 'Save as my itinerary';
+      } else {
+        if (bannerLabel) bannerLabel.textContent = 'Shared itinerary';
+        if (bannerTitle) bannerTitle.setAttribute('hidden', '');
+        if (bannerBody) bannerBody.textContent = 'Someone shared this Peninsula itinerary with you. You can browse it as is, or import it into your own builder on this device.';
+        if (importBtn) importBtn.textContent = 'Import this itinerary';
+      }
+    }
+
     function boot() {
       var shared = readSharedFromUrl();
       if (shared && shared.items.length > 0) {
         // Show shared mode banner; keep local state separate until import.
         if (bannerEl) bannerEl.removeAttribute('hidden');
+        applyBannerCopy(shared._meta);
         state = shared; // render the shared list, but persist on first change
       }
       ensureSortableLoaded(function () {

--- a/next/src/styles/concierge.css
+++ b/next/src/styles/concierge.css
@@ -963,3 +963,85 @@
     outline: 2px solid #8B4E3B;
     outline-offset: 2px;
   }
+
+
+/* ============================================================================
+   AI ITINERARY CTA (Phase 3 WS3D)
+   Rendered inside the Ask The Insider drawer when the response payload
+   carries an itinerary field. Visually echoes the recommendation tiles
+   but reads as a single decision: "open this in the builder".
+   ============================================================================ */
+
+.ask-itinerary-cta {
+  margin: 0.85rem 0 0.5rem;
+}
+.ask-itinerary-cta__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.95rem 1rem 1rem;
+  background: rgba(167, 118, 55, 0.08);
+  border: 1px solid rgba(167, 118, 55, 0.4);
+  border-left-width: 3px;
+}
+.ask-itinerary-cta__label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8B4E3B;
+  margin: 0;
+}
+.ask-itinerary-cta__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.15rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+  color: #1a1a1a;
+  margin: 0;
+}
+.ask-itinerary-cta__framing {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: #5b4f3f;
+  margin: 0;
+}
+.ask-itinerary-cta__count {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8B4E3B;
+  margin: 0;
+}
+.ask-itinerary-cta__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.4rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: #8B4E3B;
+  align-self: flex-start;
+  border-bottom: 1px solid rgba(139, 78, 59, 0.5);
+  padding-bottom: 0.1rem;
+}
+.ask-itinerary-cta__link:hover {
+  border-bottom-color: #8B4E3B;
+}
+.ask-banner__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 0.4rem;
+}
+[data-itinerary-banner-title][hidden] { display: none; }


### PR DESCRIPTION
## Summary

Front-end-first delivery of WS3D. The concierge backend doesn't yet speak the structured-output format; this PR documents the contract clearly and wires the full front-end ingestion path. Once the backend includes an `itinerary` field in its meta payload, the existing recogniser fires immediately. Zero risk to existing concierge flow until that happens.

## What ships

- **Backend contract** in `next/src/lib/concierge-itinerary.ts` — documented JSON shape, permissive validators, base64url encode/decode helpers.
- **Itinerary page extensions** — new `experience` kind alongside venue/event; build-time `experienceLookup` payload; new `?ai=<base64url-json>` URL ingest path with adapted banner copy ("Ask The Insider · suggested itinerary", title + framing surfaced, "Save as my itinerary" CTA).
- **ConciergeDrawer wiring** — `applyMeta()` now recognises `payload.itinerary` and renders a brand-coloured CTA card inside the message bubble: title + framing + stop count + "Open in the itinerary builder →" link.

## Backend contract for the concierge service

The backend should optionally include an `itinerary` field on the meta payload:

```json
{
  "itinerary": {
    "title": "A Red Hill Saturday",
    "framing": "Long lunch on the ridge, walk on Arthurs Seat, hot springs to close.",
    "items": [
      { "kind": "venue",      "slug": "montalto",                "dayId": "",      "note": "" },
      { "kind": "experience", "slug": "arthurs-seat-walk",       "dayId": "",      "note": "" },
      { "kind": "event",      "slug": "red-hill-market",         "dayId": "day-1", "note": "" }
    ],
    "days": [
      { "id": "day-1", "label": "Saturday" }
    ]
  }
}
```

Rules:
- `kind` must be `'venue' | 'event' | 'experience'`.
- `slug` must match an existing slug in the corresponding collection. Items with unknown slugs are dropped silently.
- `dayId` and `note` are optional. Empty string means ungrouped.
- `days` is optional. Items referencing an unknown dayId land ungrouped.

Backend team can implement against this independently. Front-end is wired and waiting.

## Test plan

- [ ] Hand-craft a base64url payload and visit `/itinerary/?ai=<payload>` — confirm banner shows "Ask The Insider · suggested itinerary" with title and framing, and items render in order.
- [ ] Click "Save as my itinerary" — confirm payload merges into local store and URL params drop.
- [ ] Open ConciergeDrawer and run a regular query — confirm no AI CTA renders (existing flow unchanged).
- [ ] When concierge backend is updated to emit `itinerary`, verify the CTA appears in the response bubble.

## Build
1207 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)