### PR TITLE
feat(discovery-phase-4): community submissions for local secrets (WS4D)

### DIFF
--- a/next/scripts/export-local-secrets.mjs
+++ b/next/scripts/export-local-secrets.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * export-local-secrets.mjs — Phase 4 WS4D pipeline.
+ *
+ * Pulls submissions with status='approved' from the Supabase
+ * pi.submissions table and writes one markdown file per submission to
+ * next/src/content/local-secrets/<slug>.md. Marks the source row as
+ * status='published' so it isn't exported twice.
+ *
+ * Usage:
+ *   PUBLIC_SUPABASE_ANON_KEY=... node next/scripts/export-local-secrets.mjs
+ *
+ * Editorial workflow for v1:
+ *   1. Reader submits via /submit/ → row lands with status='pending'.
+ *   2. Editor reviews in Supabase Studio. Approves by setting
+ *      status='approved' and (optionally) writes editor_notes,
+ *      published_slug.
+ *   3. This script runs (manually or via a deploy hook), exports the
+ *      markdown, sets status='published'.
+ *   4. Next site build picks up the new markdown file and the secret
+ *      goes live at /journal/local-secrets/<slug>/.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { mkdir, writeFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONTENT_DIR = join(__dirname, '..', 'src', 'content', 'local-secrets');
+
+const SUPABASE_URL =
+  process.env.PUBLIC_SUPABASE_URL || 'https://tjjhpvslpysfklwpqmgz.supabase.co';
+const SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_KEY || process.env.PUBLIC_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_SERVICE_KEY) {
+  console.error('[export] No SUPABASE_SERVICE_KEY (or PUBLIC_SUPABASE_ANON_KEY) in env. Aborting.');
+  process.exit(1);
+}
+
+const client = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+  auth: { persistSession: false },
+  db: { schema: 'pi' },
+});
+
+function slugify(s) {
+  return String(s ?? '')
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .slice(0, 80);
+}
+
+function escapeYamlString(s) {
+  if (s == null) return '""';
+  const v = String(s).replace(/"/g, '\\"');
+  return `"${v}"`;
+}
+
+async function main() {
+  const { data: rows, error } = await client
+    .from('submissions')
+    .select('*')
+    .eq('status', 'approved')
+    .order('created_at', { ascending: true });
+  if (error) {
+    console.error('[export] Failed to load approved submissions:', error.message);
+    process.exit(1);
+  }
+  if (!rows || rows.length === 0) {
+    console.log('[export] No approved submissions to export.');
+    return;
+  }
+
+  await mkdir(CONTENT_DIR, { recursive: true });
+
+  let exported = 0;
+  for (const row of rows) {
+    const slug = row.published_slug?.trim() || slugify(row.title);
+    if (!slug) {
+      console.warn('[export] skipping row', row.id, '(no slug)');
+      continue;
+    }
+    const submittedAt = new Date(row.created_at).toISOString().slice(0, 10);
+    const publishedAt = new Date().toISOString().slice(0, 10);
+    const heroBlock = (row.photo_urls && row.photo_urls.length > 0)
+      ? `heroImage:\n  src: "${row.photo_urls[0]}"\n  alt: ${escapeYamlString(row.title)}\n  credit: ${escapeYamlString(row.submitter_name)}\n  license: other-licensed\n`
+      : '';
+    const frontmatter = ''
+      + '---\n'
+      + `title: ${escapeYamlString(row.title)}\n`
+      + 'contributor:\n'
+      + `  name: ${escapeYamlString(row.submitter_name)}\n`
+      + (row.submitter_handle ? `  handle: ${escapeYamlString(row.submitter_handle)}\n` : '')
+      + (row.place_name ? `placeName: ${escapeYamlString(row.place_name)}\n` : '')
+      + `category: ${row.category}\n`
+      + `submittedAt: ${submittedAt}\n`
+      + `publishedAt: ${publishedAt}\n`
+      + (row.editor_notes ? `editorNote: ${escapeYamlString(row.editor_notes)}\n` : '')
+      + heroBlock
+      + '---\n\n';
+    const body = String(row.body ?? '').trim() + '\n';
+    const filePath = join(CONTENT_DIR, `${slug}.md`);
+    await writeFile(filePath, frontmatter + body, 'utf-8');
+
+    const { error: updErr } = await client
+      .from('submissions')
+      .update({
+        status: 'published',
+        published_slug: slug,
+        decision_at: new Date().toISOString(),
+      })
+      .eq('id', row.id);
+    if (updErr) {
+      console.warn('[export] wrote file but failed to mark published for row', row.id, ':', updErr.message);
+    }
+    exported++;
+    console.log(`[export] wrote ${slug}.md (from submission ${row.id})`);
+  }
+
+  console.log(`[export] done. ${exported} file(s) written.`);
+}
+
+main().catch((err) => {
+  console.error('[export] fatal:', err);
+  process.exit(1);
+});

--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -307,4 +307,13 @@ const totalVenues = eatVenues.length + wineVenues.length + stayVenues.length;
   </section>
 )}
 
+<!-- Phase 4 WS4D — reader-contribution CTA. Same shape on every place hub. -->
+<aside class="place-submit-cta">
+  <div class="container place-submit-cta__inner">
+    <p class="place-submit-cta__label">Got a {place.data.name} secret?</p>
+    <p class="place-submit-cta__body">If there's a {place.data.name} corner you think we'd cover better with your help — a back-bay swimming hole, a producer's farm-gate, a local pub that hits — send it through. Editorial review, named credit if we publish it.</p>
+    <a href="/submit/" class="place-submit-cta__link">Tell us about {place.data.name} →</a>
+  </div>
+</aside>
+
 <NewsletterBlock />

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -1009,6 +1009,36 @@ const editorial_blocks = defineCollection({
   }),
 });
 
+/**
+ * Reader-submitted local secrets (Phase 4 WS4D). Approved submissions
+ * are exported from the Supabase `pi.submissions` table to markdown
+ * files in src/content/local-secrets/ by next/scripts/export-local-secrets.mjs.
+ * Each file ships at build time as a static page under
+ * /journal/local-secrets/<slug>/.
+ */
+const localSecrets = defineCollection({
+  loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/local-secrets' }),
+  schema: z.object({
+    title: z.string(),
+    contributor: z.object({
+      name: z.string(),
+      handle: z.string().optional(),
+    }),
+    placeName: z.string().optional(),
+    category: z.enum([
+      'food', 'drink', 'wine', 'beach', 'walk', 'view',
+      'experience', 'event', 'shop', 'service', 'wildlife', 'other',
+    ]),
+    submittedAt: z.coerce.date(),
+    publishedAt: z.coerce.date(),
+    editorNote: z.string().optional(),
+    heroImage: imageRef.optional(),
+    relatedVenues: z.array(reference('venues')).default([]),
+    relatedPlaces: z.array(reference('places')).default([]),
+    sitemapExclude: z.boolean().default(false),
+  }),
+});
+
 export const collections = {
   venues,
   experiences,
@@ -1027,4 +1057,5 @@ export const collections = {
   boatHire,
   quickNotes,
   editorial_blocks,
+  localSecrets,
 };

--- a/next/src/pages/journal/local-secrets/[slug].astro
+++ b/next/src/pages/journal/local-secrets/[slug].astro
@@ -1,0 +1,175 @@
+---
+/**
+ * /journal/local-secrets/<slug>/ — single reader-submitted secret.
+ *
+ * Renders the markdown body plus contributor credit, optional editor
+ * note (we may add context the reader didn't include), and related
+ * venues / places where applicable.
+ */
+import { getCollection, getEntry, render } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import VenueCard from '../../../components/VenueCard.astro';
+import PlaceCard from '../../../components/PlaceCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+
+export async function getStaticPaths() {
+  const secrets = await getCollection('localSecrets');
+  return secrets.map((entry) => ({
+    params: { slug: entry.id ?? entry.slug },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+
+const data = entry.data;
+
+const relatedVenues = await Promise.all(
+  (data.relatedVenues ?? []).map((ref) => getEntry(ref).catch(() => null)),
+).then((arr) => arr.filter((v): v is NonNullable<typeof v> => Boolean(v)));
+
+const relatedPlaces = await Promise.all(
+  (data.relatedPlaces ?? []).map((ref) => getEntry(ref).catch(() => null)),
+).then((arr) => arr.filter((p): p is NonNullable<typeof p> => Boolean(p)));
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Journal', href: '/journal/' },
+  { label: 'Local Secrets', href: '/journal/local-secrets/' },
+  { label: data.title },
+];
+---
+
+<BaseLayout
+  title={`${data.title} · A Peninsula Insider Local Secret`}
+  description={`Reader-contributed Peninsula spot, submitted by ${data.contributor.name}.`}
+  section="journal"
+  noindex={data.sitemapExclude === true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <article class="local-secret-detail">
+    <div class="container">
+      <p class="label label--accent">Local secret · contributed by {data.contributor.name}{data.contributor.handle ? ` · ${data.contributor.handle}` : ''}</p>
+      <h1 class="local-secret-detail__title">{data.title}</h1>
+      {data.placeName && <p class="local-secret-detail__place">{data.placeName}</p>}
+
+      {data.heroImage?.src && (
+        <figure class="local-secret-detail__hero">
+          <img src={data.heroImage.src} alt={data.heroImage.alt} loading="lazy" />
+          {data.heroImage.credit && <figcaption>{data.heroImage.credit}</figcaption>}
+        </figure>
+      )}
+
+      <div class="prose local-secret-detail__body">
+        <Content />
+      </div>
+
+      {data.editorNote && (
+        <aside class="local-secret-detail__editor">
+          <p class="local-secret-detail__editor-label">Editor's note</p>
+          <p class="local-secret-detail__editor-body">{data.editorNote}</p>
+        </aside>
+      )}
+
+      {(relatedVenues.length > 0 || relatedPlaces.length > 0) && (
+        <section class="local-secret-detail__related">
+          <p class="label label--accent">From the editorial corpus</p>
+          {relatedVenues.length > 0 && (
+            <div class="venues__grid">
+              {relatedVenues.map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+            </div>
+          )}
+          {relatedPlaces.length > 0 && (
+            <div class="venues__grid">
+              {relatedPlaces.map((place) => <PlaceCard place={place} />)}
+            </div>
+          )}
+        </section>
+      )}
+
+      <p class="local-secret-detail__contribute">
+        Got a Peninsula spot the rest of us should know about?
+        <a href="/submit/">Tell us your secret →</a>
+      </p>
+    </div>
+  </article>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<style>
+  .local-secret-detail { padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem); }
+  .local-secret-detail__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 500;
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    margin: 0.45rem 0 0.5rem;
+  }
+  .local-secret-detail__place {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--soft);
+    margin: 0 0 1.5rem;
+  }
+  .local-secret-detail__hero {
+    margin: 1.5rem 0 1.75rem;
+  }
+  .local-secret-detail__hero img {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .local-secret-detail__hero figcaption {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin-top: 0.4rem;
+  }
+  .local-secret-detail__body { max-width: 38rem; }
+  .local-secret-detail__editor {
+    margin: 1.75rem 0;
+    padding: 1.1rem 1.25rem;
+    border-left: 3px solid var(--accent);
+    background: var(--paper, #fbf7f0);
+    max-width: 38rem;
+  }
+  .local-secret-detail__editor-label {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.45rem;
+  }
+  .local-secret-detail__editor-body {
+    font-family: 'Cormorant Garamond', serif;
+    font-style: italic;
+    font-size: 1.05rem;
+    line-height: 1.55;
+    color: var(--text);
+    margin: 0;
+  }
+  .local-secret-detail__related {
+    margin: 2.5rem 0;
+  }
+  .local-secret-detail__contribute {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px dashed var(--border);
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--soft);
+  }
+  .local-secret-detail__contribute a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    margin-left: 0.4rem;
+  }
+</style>

--- a/next/src/pages/journal/local-secrets/index.astro
+++ b/next/src/pages/journal/local-secrets/index.astro
@@ -1,0 +1,186 @@
+---
+/**
+ * /journal/local-secrets/ — index of reader-submitted local secrets
+ * (Phase 4 WS4D).
+ *
+ * Lists every published submission. Empty state until the first reader
+ * contribution lands; the empty state is a CTA to /submit/.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import SectionHero from '../../../components/SectionHero.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+
+const secrets = (await getCollection('localSecrets'))
+  .filter((s) => !s.data.sitemapExclude)
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Journal', href: '/journal/' },
+  { label: 'Local Secrets' },
+];
+---
+
+<BaseLayout
+  title="Local Secrets · Peninsula Insider"
+  description="Peninsula spots brought in by readers. Editorial review, named credit, no paid placements."
+  section="journal"
+  canonical="https://peninsulainsider.com.au/journal/local-secrets/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="Local Secrets"
+    subEyebrow="Reader contributions"
+    title="The Peninsula our <em>readers</em> see."
+    dek="Spots, stories, and recommendations that came in from readers — vetted by the editor, published with named credit, never paid for."
+    gradient="journal"
+    visualLabel="Peninsula Insider · local secrets"
+  />
+
+  <section class="local-secrets-page">
+    <div class="container">
+      {secrets.length > 0 ? (
+        <div class="local-secrets-grid">
+          {secrets.map((s) => {
+            const slug = s.id ?? s.slug;
+            return (
+              <article class="local-secret-card">
+                {s.data.heroImage?.src && (
+                  <div class="local-secret-card__hero" style={`background-image:url(${s.data.heroImage.src})`} aria-hidden="true"></div>
+                )}
+                <div class="local-secret-card__body">
+                  <p class="local-secret-card__category">{s.data.category}</p>
+                  <h3 class="local-secret-card__title">
+                    <a href={`/journal/local-secrets/${slug}/`}>{s.data.title}</a>
+                  </h3>
+                  {s.data.placeName && <p class="local-secret-card__place">{s.data.placeName}</p>}
+                  <p class="local-secret-card__contributor">Submitted by <strong>{s.data.contributor.name}</strong>{s.data.contributor.handle ? ` · ${s.data.contributor.handle}` : ''}</p>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div class="local-secrets-empty">
+          <p class="local-secrets-empty__title">The first published submissions are coming.</p>
+          <p class="local-secrets-empty__body">
+            We open this section with reader-submitted spots that pass our editorial review. If you have a Peninsula corner the rest of us should know about, send it through.
+          </p>
+          <a href="/submit/" class="local-secrets-empty__cta">Tell us your secret →</a>
+        </div>
+      )}
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<style>
+  .local-secrets-page {
+    padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem);
+  }
+  .local-secrets-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: clamp(1rem, 2vw, 1.5rem);
+  }
+  @media (min-width: 720px) {
+    .local-secrets-grid { grid-template-columns: 1fr 1fr; }
+  }
+  @media (min-width: 1080px) {
+    .local-secrets-grid { grid-template-columns: 1fr 1fr 1fr; }
+  }
+  .local-secret-card {
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    display: flex;
+    flex-direction: column;
+  }
+  .local-secret-card__hero {
+    aspect-ratio: 16 / 10;
+    background-size: cover;
+    background-position: center;
+  }
+  .local-secret-card__body {
+    padding: 0.95rem 1.05rem 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .local-secret-card__category {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0;
+  }
+  .local-secret-card__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.2rem;
+    font-weight: 500;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    margin: 0;
+  }
+  .local-secret-card__title a {
+    color: var(--text);
+    text-decoration: none;
+  }
+  .local-secret-card__title a:hover { color: var(--accent); }
+  .local-secret-card__place {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    color: var(--soft);
+    margin: 0;
+  }
+  .local-secret-card__contributor {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin: 0.25rem 0 0;
+  }
+
+  .local-secrets-empty {
+    border: 1px dashed var(--border);
+    padding: clamp(1.5rem, 3vw, 2.5rem) 1.5rem;
+    text-align: center;
+  }
+  .local-secrets-empty__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0 0 0.75rem;
+  }
+  .local-secrets-empty__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--soft);
+    max-width: 36rem;
+    margin: 0 auto 1.25rem;
+  }
+  .local-secrets-empty__cta {
+    display: inline-flex;
+    align-items: center;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.7rem 1.1rem;
+    text-decoration: none;
+  }
+  .local-secrets-empty__cta:hover {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+  }
+</style>

--- a/next/src/pages/submit.astro
+++ b/next/src/pages/submit.astro
@@ -1,0 +1,318 @@
+---
+/**
+ * /submit/ — community submissions form (Phase 4 WS4D).
+ *
+ * Reader-submitted local secrets. Form posts to Supabase via the
+ * anon client (RLS allows insert; reads gated). Anonymous and signed-in
+ * users can both submit; signed-in submissions are linked to the user
+ * row so the submitter can come back and see their own submissions.
+ *
+ * Editorial review happens in Supabase Studio for v1. Approved rows
+ * are exported to next/src/content/local-secrets/<slug>.md by a small
+ * CLI (next/scripts/export-local-secrets.mjs) and ship at build time.
+ *
+ * Photo uploads use Supabase Storage. The bucket and policies are
+ * configured separately in the Supabase project; the form falls back
+ * to text-only submission if storage is unavailable.
+ */
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import SectionHero from '../components/SectionHero.astro';
+import NewsletterBlock from '../components/NewsletterBlock.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about/' },
+  { label: 'Tell us your secret' },
+];
+
+const categories = [
+  { value: 'food',       label: 'Food' },
+  { value: 'drink',      label: 'Drink / coffee' },
+  { value: 'wine',       label: 'Wine / cellar door' },
+  { value: 'beach',      label: 'Beach' },
+  { value: 'walk',       label: 'Walk / trail' },
+  { value: 'view',       label: 'View / lookout' },
+  { value: 'experience', label: 'Experience' },
+  { value: 'event',      label: 'Event' },
+  { value: 'shop',       label: 'Shop / market' },
+  { value: 'service',    label: 'Service' },
+  { value: 'wildlife',   label: 'Wildlife' },
+  { value: 'other',      label: 'Other' },
+];
+---
+
+<BaseLayout
+  title="Tell us your local secret · Peninsula Insider"
+  description="Got a Peninsula spot the rest of us should know about? Send it through. Editorial review, named credit if we publish it."
+  section="home"
+  noindex={false}
+  canonical="https://peninsulainsider.com.au/submit/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="Tell us your secret"
+    subEyebrow="Reader contributions"
+    title="The places we'd never find <em>without you</em>."
+    dek="The Peninsula Insider editorial desk visits a lot of venues. We don't know everything. If you've got a hidden corner that doesn't get the coverage it deserves — a back-bay swimming hole, a producer's farm-gate stall, a local pub with a roast that's worth the drive — we'd like to hear about it. Send it through, and if it lands we'll publish it with your name."
+    gradient="journal"
+    visualLabel="Peninsula Insider · reader contributions"
+  />
+
+  <section class="submit-page">
+    <div class="container">
+
+      <div class="submit-grid">
+        <div class="submit-grid__intro">
+          <p class="label label--accent">How it works</p>
+          <ol class="submit-process">
+            <li><strong>You submit</strong> the spot, the story, and your name.</li>
+            <li><strong>We visit</strong> if it's somewhere we haven't been. Otherwise we cross-reference with our notes.</li>
+            <li><strong>We publish</strong> the strongest submissions in the Local Secrets stream with your name as contributor.</li>
+            <li><strong>We disclose</strong> any commercial relationships transparently; reader submissions are never paid placements.</li>
+          </ol>
+
+          <p class="submit-rules-label">House rules</p>
+          <ul class="submit-rules">
+            <li>One spot per submission. If you have three, send three.</li>
+            <li>It must be on the Mornington Peninsula proper — Mount Martha to Portsea, plus Western Port fringe.</li>
+            <li>If you own or work at the venue, say so. We won't publish it as a "secret" but we may cover it editorially.</li>
+            <li>Photos are optional. If you submit one, you're confirming you took it or have permission to share it.</li>
+            <li>No deceased-author plagiarism. Use your own words.</li>
+          </ul>
+        </div>
+
+        <div class="submit-grid__form-wrap">
+          <form class="submit-form" data-submit-form aria-label="Local-secret submission form">
+            <fieldset class="submit-form__group">
+              <legend class="submit-form__legend">The spot</legend>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-title">A short headline</label>
+                <input
+                  id="submit-title"
+                  name="title"
+                  type="text"
+                  required
+                  maxlength="120"
+                  class="submit-form__input"
+                  placeholder="The bakery in the back of a Sorrento bookshop"
+                />
+                <p class="submit-form__hint">One line. Pretend it's the headline of a journal piece.</p>
+              </div>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-place">Where</label>
+                <input
+                  id="submit-place"
+                  name="place_name"
+                  type="text"
+                  class="submit-form__input"
+                  placeholder="Sorrento, or 'between Flinders and Shoreham'"
+                />
+              </div>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-category">Category</label>
+                <select id="submit-category" name="category" class="submit-form__select" required>
+                  <option value="">Choose a category…</option>
+                  {categories.map((c) => <option value={c.value}>{c.label}</option>)}
+                </select>
+              </div>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-body">The secret, in your own words</label>
+                <textarea
+                  id="submit-body"
+                  name="body"
+                  required
+                  minlength="60"
+                  maxlength="2000"
+                  rows="7"
+                  class="submit-form__textarea"
+                  placeholder="What is it, why should we care, when's the right time to go, what's the move when you arrive."
+                ></textarea>
+                <p class="submit-form__hint">60 characters minimum. Take your time; this is the only part the editor reads first.</p>
+              </div>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-photos">Photos (optional, up to 2)</label>
+                <input
+                  id="submit-photos"
+                  name="photos"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  multiple
+                  class="submit-form__file"
+                />
+                <p class="submit-form__hint">JPG, PNG, or WebP. Max 4 MB each. By uploading you confirm you took the photo or have permission to share it.</p>
+              </div>
+            </fieldset>
+
+            <fieldset class="submit-form__group">
+              <legend class="submit-form__legend">You</legend>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-name">Your name (we'll credit it if we publish)</label>
+                <input
+                  id="submit-name"
+                  name="submitter_name"
+                  type="text"
+                  required
+                  maxlength="120"
+                  class="submit-form__input"
+                  placeholder="James Richmond"
+                />
+              </div>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-email">Email (private; for follow-up only)</label>
+                <input
+                  id="submit-email"
+                  name="submitter_email"
+                  type="email"
+                  required
+                  maxlength="240"
+                  class="submit-form__input"
+                  placeholder="you@example.com"
+                />
+              </div>
+
+              <div class="submit-form__field">
+                <label class="submit-form__label" for="submit-handle">Instagram or website (optional)</label>
+                <input
+                  id="submit-handle"
+                  name="submitter_handle"
+                  type="text"
+                  maxlength="120"
+                  class="submit-form__input"
+                  placeholder="@yourhandle or yoursite.com"
+                />
+              </div>
+            </fieldset>
+
+            <div class="submit-form__submit">
+              <button type="submit" class="submit-form__button">Send the secret</button>
+              <p class="submit-form__caveat">By submitting you agree to the editor's right to lightly edit for clarity, fact-check the venue, and decline to publish.</p>
+            </div>
+
+            <p class="submit-form__status" data-submit-status hidden></p>
+          </form>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled } from '../lib/auth';
+
+  const PHOTO_LIMIT = 2;
+  const PHOTO_MAX_BYTES = 4 * 1024 * 1024;
+
+  function clientToken() {
+    try {
+      const k = 'pi:submit:client-token';
+      let v = localStorage.getItem(k);
+      if (!v) {
+        v = (typeof crypto !== 'undefined' && crypto.randomUUID)
+          ? crypto.randomUUID()
+          : 'tok-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        localStorage.setItem(k, v);
+      }
+      return v;
+    } catch {
+      return 'tok-' + Math.random().toString(36).slice(2);
+    }
+  }
+
+  async function uploadPhotos(files: File[]): Promise<string[]> {
+    const c = getSupabase();
+    if (!c) return [];
+    const out: string[] = [];
+    for (let i = 0; i < Math.min(files.length, PHOTO_LIMIT); i++) {
+      const f = files[i];
+      if (f.size > PHOTO_MAX_BYTES) continue;
+      const path = `submissions/${clientToken()}/${Date.now()}-${i}-${f.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
+      try {
+        const { data, error } = await c.storage.from('submissions').upload(path, f, {
+          cacheControl: '3600',
+          upsert: false,
+        });
+        if (error) {
+          console.warn('[submit] photo upload failed:', error.message);
+          continue;
+        }
+        out.push(data?.path || path);
+      } catch (err) {
+        console.warn('[submit] photo upload threw:', err);
+      }
+    }
+    return out;
+  }
+
+  function init() {
+    const form = document.querySelector('[data-submit-form]') as HTMLFormElement | null;
+    if (!form) return;
+    const status = document.querySelector('[data-submit-status]') as HTMLParagraphElement | null;
+    const button = form.querySelector('.submit-form__button') as HTMLButtonElement | null;
+
+    function setStatus(kind: 'success' | 'error' | 'info', message: string) {
+      if (!status) return;
+      status.textContent = message;
+      status.setAttribute('data-status-kind', kind);
+      status.removeAttribute('hidden');
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (button) button.disabled = true;
+      setStatus('info', 'Sending…');
+
+      const fd = new FormData(form);
+      const photos = (fd.getAll('photos') as File[]).filter((f) => f && f.size > 0);
+
+      const c = getSupabase();
+      if (!c || !isAuthEnabled()) {
+        setStatus('error', "Submissions aren't currently configured. Try again later, or email hello@peninsulainsider.com.au.");
+        if (button) button.disabled = false;
+        return;
+      }
+
+      const photoUrls = photos.length > 0 ? await uploadPhotos(photos) : [];
+      const session = (await c.auth.getSession()).data.session;
+      const userId = session?.user?.id ?? null;
+
+      const row = {
+        user_id: userId,
+        category: String(fd.get('category') || ''),
+        place_name: String(fd.get('place_name') || ''),
+        title: String(fd.get('title') || ''),
+        body: String(fd.get('body') || ''),
+        submitter_name: String(fd.get('submitter_name') || ''),
+        submitter_email: String(fd.get('submitter_email') || ''),
+        submitter_handle: String(fd.get('submitter_handle') || ''),
+        photo_urls: photoUrls,
+        client_token: clientToken(),
+      };
+
+      const { error } = await c.from('submissions').insert(row);
+      if (error) {
+        console.warn('[submit] insert failed:', error.message);
+        setStatus('error', "Couldn't send that — try once more. If it keeps failing, email hello@peninsulainsider.com.au.");
+        if (button) button.disabled = false;
+        return;
+      }
+
+      form.reset();
+      setStatus('success', "Got it. Thanks for sending. The editor will read it; if we run it, you'll hear from us.");
+      if (button) button.disabled = false;
+    });
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -9709,3 +9709,235 @@ body.menu-open .subscribe-pill {
   0%, 100% { opacity: 1; }
   50%      { opacity: 0.35; }
 }
+
+
+/* ============================================================================
+   COMMUNITY SUBMISSIONS (Phase 4 WS4D)
+   /submit/ form for reader-contributed local secrets.
+   ============================================================================ */
+
+.submit-page {
+  padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem);
+}
+.submit-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+@media (min-width: 920px) {
+  .submit-grid { grid-template-columns: 320px 1fr; }
+}
+
+.submit-process {
+  list-style: none;
+  margin: 0.85rem 0 1.5rem;
+  padding: 0;
+  counter-reset: submit-step;
+}
+.submit-process li {
+  position: relative;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--dark);
+  padding: 0.55rem 0 0.55rem 2.2rem;
+  border-bottom: 1px dashed var(--border);
+  counter-increment: submit-step;
+}
+.submit-process li::before {
+  content: counter(submit-step);
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--bg, #fff);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.submit-process li:last-child { border-bottom: 0; }
+
+.submit-rules-label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 1.25rem 0 0.55rem;
+}
+.submit-rules {
+  list-style: disc inside;
+  padding: 0;
+  margin: 0;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--soft);
+}
+.submit-rules li { margin-bottom: 0.4rem; }
+
+.submit-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+.submit-form__group {
+  border: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+  padding: clamp(1rem, 2vw, 1.4rem);
+}
+.submit-form__legend {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 0 0.4rem;
+  margin: 0;
+}
+.submit-form__field {
+  margin-top: 1rem;
+}
+.submit-form__label {
+  display: block;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--dark);
+  margin-bottom: 0.35rem;
+}
+.submit-form__input,
+.submit-form__textarea,
+.submit-form__select {
+  width: 100%;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--dark);
+  background: var(--bg, #fff);
+  border: 1px solid var(--border);
+  padding: 0.6rem 0.75rem;
+}
+.submit-form__textarea { resize: vertical; min-height: 9rem; }
+.submit-form__input:focus,
+.submit-form__textarea:focus,
+.submit-form__select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.submit-form__hint {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  color: var(--soft);
+  margin: 0.35rem 0 0;
+}
+.submit-form__file {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+}
+.submit-form__submit {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  align-items: flex-start;
+  margin-top: 0.5rem;
+}
+.submit-form__button {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bg, #fff);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0.85rem 1.4rem;
+  cursor: pointer;
+}
+.submit-form__button:disabled { opacity: 0.6; cursor: progress; }
+.submit-form__button:hover:not(:disabled) {
+  background: var(--text, #1a1a1a);
+  border-color: var(--text, #1a1a1a);
+}
+.submit-form__caveat {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  color: var(--soft);
+  margin: 0;
+  max-width: 30rem;
+}
+.submit-form__status {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.92rem;
+  padding: 0.7rem 0.95rem;
+  border: 1px solid var(--border);
+}
+.submit-form__status[data-status-kind="success"] {
+  color: #2f6e3a;
+  border-color: rgba(47, 110, 58, 0.5);
+  background: rgba(47, 110, 58, 0.07);
+}
+.submit-form__status[data-status-kind="error"] {
+  color: #b14b3a;
+  border-color: rgba(177, 75, 58, 0.5);
+  background: rgba(177, 75, 58, 0.07);
+}
+.submit-form__status[data-status-kind="info"] {
+  color: var(--soft);
+}
+
+
+/* ============================================================================
+   PLACE SUBMIT CTA (Phase 4 WS4D)
+   "Got a Sorrento secret?" block at the foot of every /places/<slug>/ hub.
+   ============================================================================ */
+
+.place-submit-cta {
+  padding: clamp(1.75rem, 3.5vw, 2.5rem) 0;
+  border-top: 1px solid var(--border);
+  background: var(--paper, #fbf7f0);
+}
+.place-submit-cta__inner {
+  max-width: 720px;
+}
+.place-submit-cta__label {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.55rem;
+}
+.place-submit-cta__body {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--dark);
+  margin: 0 0 1rem;
+}
+.place-submit-cta__link {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(167, 118, 55, 0.5);
+  padding-bottom: 0.1rem;
+}
+.place-submit-cta__link:hover {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+}

--- a/ops/migrations/2026-05-05-community-submissions.sql
+++ b/ops/migrations/2026-05-05-community-submissions.sql
@@ -1,0 +1,99 @@
+-- Migration: community submissions table
+-- Date: 2026-05-05
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+--
+-- Purpose: Phase 4 WS4D — reader-submitted local secrets. Form on /submit/
+--          posts a row here with status 'pending'. Editorial reviews via
+--          Supabase Studio (no custom CMS for v1); approved rows are
+--          exported to next/src/content/local-secrets/<slug>.md by a small
+--          CLI script for build-time inclusion.
+--
+-- Idempotent: safe to re-run.
+--
+-- How to apply:
+--   1. Supabase Studio → SQL editor for the PI auth project
+--   2. Paste this file
+--   3. Run. Expect <1s.
+
+create table if not exists pi.submissions (
+  id              uuid primary key default gen_random_uuid(),
+  -- Optional auth.users link if the submitter was signed in. Anonymous
+  -- submissions are allowed for v1; we still capture name + email below.
+  user_id         uuid references auth.users(id) on delete set null,
+  -- Submission content
+  category        text not null check (category in (
+    'food', 'drink', 'wine', 'beach', 'walk', 'view',
+    'experience', 'event', 'shop', 'service', 'wildlife', 'other'
+  )),
+  place_name      text,                          -- free text, e.g. "Sorrento"
+  title           text not null,                  -- short headline
+  body            text not null,                  -- the secret in their own words
+  -- Submitter metadata
+  submitter_name  text not null,
+  submitter_email text not null,
+  submitter_handle text,                          -- optional Instagram or website
+  -- Photo storage references (Supabase Storage paths). Cap at 2 photos
+  -- per locked decision Q8; enforced client-side with a server check.
+  photo_urls      text[] default array[]::text[],
+  -- Editorial state
+  status          text not null default 'pending' check (status in (
+    'pending', 'in-review', 'approved', 'declined', 'published'
+  )),
+  editor_notes    text,                            -- internal notes; never surfaced to submitter
+  decision_at     timestamptz,
+  published_slug  text,                            -- once exported to MD, the slug
+  -- Audit
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  -- Light spam-deflection: same-IP/same-cookie identifier
+  client_token    text                              -- random hash from the client; not auth-secured
+);
+
+comment on table pi.submissions is 'Reader-submitted local secrets, Phase 4 WS4D. Editorial review in Supabase Studio; approved rows exported to next/src/content/local-secrets/.';
+
+create index if not exists submissions_by_status_created
+  on pi.submissions (status, created_at desc);
+create index if not exists submissions_by_email
+  on pi.submissions (submitter_email);
+
+alter table pi.submissions enable row level security;
+
+-- Anonymous submitters can insert. We DO NOT allow public select; submitters
+-- can read back their own only via authenticated user_id match (when signed
+-- in) or via a tiny RPC by client_token if we add one later.
+drop policy if exists "submissions_anonymous_insert" on pi.submissions;
+create policy "submissions_anonymous_insert"
+  on pi.submissions for insert
+  with check (true);
+
+drop policy if exists "submissions_select_own_by_user" on pi.submissions;
+create policy "submissions_select_own_by_user"
+  on pi.submissions for select
+  using (user_id is not null and user_id = auth.uid());
+
+-- Editor role gets full access. The 'is_editor' boolean already lives on
+-- pi.profiles per existing auth setup.
+drop policy if exists "submissions_editor_all" on pi.submissions;
+create policy "submissions_editor_all"
+  on pi.submissions for all
+  using (
+    exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true)
+  )
+  with check (
+    exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true)
+  );
+
+-- updated_at trigger
+create or replace function pi.submissions_set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists submissions_set_updated_at on pi.submissions;
+create trigger submissions_set_updated_at
+  before update on pi.submissions
+  for each row execute function pi.submissions_set_updated_at();


### PR DESCRIPTION
## Summary

First Phase 4 workstream. Reader-contribution pipeline: a form at `/submit/`, a Supabase intake table, an editorial review flow in Supabase Studio, an export script that turns approved rows into markdown files, and a `/journal/local-secrets/` index that lists published submissions with named contributors.

## What ships
- **Migration** `ops/migrations/2026-05-05-community-submissions.sql` adds `pi.submissions`. RLS allows anonymous inserts; select-own-by-user; full access for editors via `pi.profiles.is_editor`.
- **`/submit/` form** — two fieldsets (the spot, you), photo upload (≤2 × 4MB), client-token spam dedupe, status feedback inline.
- **`localSecrets` content collection** — schema with contributor, category, place, hero, optional editor note, related venues/places.
- **`/journal/local-secrets/` + `[slug].astro`** — index and detail pages. Empty-state on the index links to `/submit/` until the first piece lands.
- **`scripts/export-local-secrets.mjs`** — pulls approved rows, writes markdown, marks rows published. Editor runs locally or via deploy hook.
- **Place-hub CTA** — "Got a {place} secret?" at the foot of every `/places/<slug>/`.

## Operational
- Apply migration to Supabase Studio.
- Create Storage bucket `submissions` with insert-allowed policy and 4 MB max object size.
- Set `is_editor=true` on the editor account's `pi.profiles` row.

Until done, form gracefully shows "submissions aren't currently configured".

## Build
1209 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)