### PR TITLE
feat(discovery-phase-4): Peninsula Insider Awards (WS4E)

### DIFF
--- a/next/src/pages/awards/[slug].astro
+++ b/next/src/pages/awards/[slug].astro
@@ -1,0 +1,425 @@
+---
+/**
+ * /awards/<slug>/ — single category page (Phase 4 WS4E).
+ *
+ * Renders the nominees for a category and lets signed-in users cast a
+ * vote. Empty state when categories aren't loaded yet (pre-migration).
+ *
+ * Static-paths-via-fallback: we don't know the slug list at build time,
+ * so we use the well-known DEFAULT_CATEGORY_SLUGS to pre-render the
+ * scaffold. Live data hydrates from Supabase. Custom slugs (e.g. a
+ * year-specific category like 'wine-list-of-2026') will 404 until added
+ * to DEFAULT_CATEGORY_SLUGS or a redirect is set up.
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+
+const DEFAULT_CATEGORY_SLUGS = [
+  'restaurant-of-the-year',
+  'cellar-door-of-the-year',
+  'stay-of-the-year',
+  'walk-of-the-year',
+  'best-new-opening',
+  'best-family-day',
+  'locals-choice',
+  'worth-the-drive',
+  'editorial-discovery',
+];
+
+export async function getStaticPaths() {
+  return [
+    'restaurant-of-the-year',
+    'cellar-door-of-the-year',
+    'stay-of-the-year',
+    'walk-of-the-year',
+    'best-new-opening',
+    'best-family-day',
+    'locals-choice',
+    'worth-the-drive',
+    'editorial-discovery',
+  ].map((slug) => ({ params: { slug } }));
+}
+
+const { slug } = Astro.params;
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'The Awards', href: '/awards/' },
+  { label: slug ?? '' },
+];
+
+const titleFromSlug = String(slug ?? '')
+  .replace(/-/g, ' ')
+  .replace(/\b\w/g, (c) => c.toUpperCase());
+---
+
+<BaseLayout
+  title={`${titleFromSlug} · The Peninsula Insider Awards`}
+  description={`Vote in the ${titleFromSlug} category of the Peninsula Insider Awards.`}
+  section="explore"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <article class="award-detail">
+    <div class="container">
+      <p class="label label--accent">Peninsula Insider Award</p>
+      <h1 class="award-detail__title" data-award-title>{titleFromSlug}</h1>
+      <p class="award-detail__description" data-award-description>Loading the category…</p>
+
+      <p class="award-detail__state" data-award-state></p>
+
+      <ol class="award-nominees" data-award-nominees>
+        <li class="award-nominees__loading">Loading nominees…</li>
+      </ol>
+
+      <div class="award-detail__results" data-award-results hidden>
+        <p class="label label--accent">Results</p>
+        <p class="award-detail__results-note" data-award-results-note></p>
+      </div>
+
+      <p class="award-detail__signin" data-award-signin hidden>
+        Sign in to cast a vote.
+        <button type="button" class="award-detail__signin-button" data-open-auth>Sign in</button>
+      </p>
+    </div>
+  </article>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script define:vars={{ slug }}>
+  /* Per-category controller. Loads category + nominees + the user's
+     existing vote (if any), and lets signed-in users vote with a single
+     click. Aggregate counts shown after voting closes (published=true). */
+  import { getSupabase, getUser, onAuthChange } from '../../lib/auth';
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function nomineeLabel(n) {
+    return n.custom_label
+      || (n.venue_slug ? n.venue_slug : '')
+      || (n.event_slug ? n.event_slug : '')
+      || (n.experience_slug ? n.experience_slug : '')
+      || (n.place_slug ? n.place_slug : '')
+      || 'Untitled';
+  }
+
+  function nomineeHref(n) {
+    if (n.venue_slug) return `/eat/${n.venue_slug}/`;
+    if (n.event_slug) return `/whats-on/${n.event_slug}/`;
+    if (n.experience_slug) return `/explore/${n.experience_slug}/`;
+    if (n.place_slug) return `/places/${n.place_slug}/`;
+    return null;
+  }
+
+  async function init() {
+    const c = getSupabase();
+    const titleEl = document.querySelector('[data-award-title]');
+    const descEl = document.querySelector('[data-award-description]');
+    const stateEl = document.querySelector('[data-award-state]');
+    const listEl = document.querySelector('[data-award-nominees]');
+    const resultsEl = document.querySelector('[data-award-results]');
+    const resultsNoteEl = document.querySelector('[data-award-results-note]');
+    const signinEl = document.querySelector('[data-award-signin]');
+
+    if (!c) {
+      if (descEl) descEl.textContent = "The Awards aren't currently configured. The 2026 cycle will appear here when nominations open.";
+      if (listEl) listEl.innerHTML = '';
+      return;
+    }
+
+    let cat = null;
+    try {
+      const { data, error } = await c
+        .from('award_categories')
+        .select('slug, year, title, description, voting_opens_at, voting_closes_at, published')
+        .eq('slug', slug)
+        .maybeSingle();
+      if (error) throw error;
+      cat = data;
+    } catch (err) {
+      console.warn('[award] category load failed:', err);
+    }
+
+    if (!cat) {
+      if (descEl) descEl.textContent = "This category hasn't been published yet. Check the awards index for the open categories.";
+      if (listEl) listEl.innerHTML = '';
+      return;
+    }
+
+    if (titleEl) titleEl.textContent = cat.title;
+    if (descEl) descEl.textContent = cat.description ?? '';
+
+    const now = Date.now();
+    const opens = cat.voting_opens_at ? new Date(cat.voting_opens_at).getTime() : null;
+    const closes = cat.voting_closes_at ? new Date(cat.voting_closes_at).getTime() : null;
+    const state = cat.published
+      ? 'published'
+      : (opens && now < opens ? 'before'
+        : (closes && now >= closes ? 'closed' : 'open'));
+    const stateCopy = {
+      before:    'Voting opens September. Nominate via the Awards index until then.',
+      open:      'Voting is open. Sign in and pick one. Change your mind any time before the close.',
+      closed:    'Voting has closed for this category. Results land the first weekend of October.',
+      published: 'Results published.',
+    };
+    if (stateEl) stateEl.textContent = stateCopy[state];
+
+    let nominees = [];
+    try {
+      const { data, error } = await c
+        .from('award_nominees')
+        .select('id, category_slug, venue_slug, event_slug, experience_slug, place_slug, custom_label, blurb, sort_order')
+        .eq('category_slug', slug)
+        .order('sort_order', { ascending: true });
+      if (error) throw error;
+      nominees = data || [];
+    } catch (err) {
+      console.warn('[award] nominees load failed:', err);
+    }
+
+    if (nominees.length === 0) {
+      if (listEl) {
+        listEl.innerHTML = '<li class="award-nominees__empty">The shortlist hasn\'t been published yet. Submit a nomination via the <a href="/awards/nominate/">nominate page</a>.</li>';
+      }
+      return;
+    }
+
+    let userVote = null;
+    let user = null;
+    try {
+      user = await getUser();
+      if (user) {
+        const { data } = await c
+          .from('award_votes')
+          .select('nominee_id')
+          .eq('category_slug', slug)
+          .eq('user_id', user.id)
+          .maybeSingle();
+        userVote = data?.nominee_id ?? null;
+      }
+    } catch {}
+
+    let counts = {};
+    if (state === 'published') {
+      try {
+        const { data } = await c
+          .from('award_vote_counts')
+          .select('nominee_id, vote_count')
+          .eq('category_slug', slug);
+        (data || []).forEach((row) => { counts[row.nominee_id] = row.vote_count; });
+      } catch {}
+    }
+
+    const totalVotes = Object.values(counts).reduce((a, b) => a + (b || 0), 0);
+    if (state === 'published' && resultsEl && resultsNoteEl) {
+      resultsEl.removeAttribute('hidden');
+      resultsNoteEl.textContent = totalVotes > 0
+        ? `${totalVotes} reader vote${totalVotes === 1 ? '' : 's'} counted.`
+        : 'Editor selection — reader voting did not run for this category.';
+    }
+
+    if (listEl) {
+      listEl.innerHTML = nominees.map((n) => {
+        const label = escapeHtml(nomineeLabel(n));
+        const href = nomineeHref(n);
+        const linkOpen = href ? `<a href="${escapeHtml(href)}">` : '';
+        const linkClose = href ? '</a>' : '';
+        const blurb = n.blurb ? `<p class="award-nominee__blurb">${escapeHtml(n.blurb)}</p>` : '';
+        const isVote = userVote === n.id;
+        const voteCountHtml = state === 'published'
+          ? `<p class="award-nominee__count">${counts[n.id] || 0} vote${counts[n.id] === 1 ? '' : 's'}</p>`
+          : '';
+        const voteButton = state === 'open' && user
+          ? `<button type="button" class="award-nominee__vote ${isVote ? 'is-voted' : ''}" data-vote-nominee="${escapeHtml(n.id)}">${isVote ? 'Your vote' : 'Cast vote'}</button>`
+          : '';
+        return ''
+          + '<li class="award-nominee">'
+          +   '<div class="award-nominee__body">'
+          +     `<h3 class="award-nominee__name">${linkOpen}${label}${linkClose}</h3>`
+          +     blurb
+          +     voteCountHtml
+          +   '</div>'
+          +   voteButton
+          + '</li>';
+      }).join('');
+
+      // Wire vote buttons
+      listEl.querySelectorAll('[data-vote-nominee]').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          if (!user) return;
+          const nomineeId = btn.getAttribute('data-vote-nominee');
+          btn.setAttribute('disabled', '');
+          btn.textContent = 'Voting…';
+          try {
+            // Upsert keyed on (user_id, category_slug)
+            const { error } = await c
+              .from('award_votes')
+              .upsert(
+                { user_id: user.id, category_slug: slug, nominee_id: nomineeId },
+                { onConflict: 'user_id,category_slug' },
+              );
+            if (error) throw error;
+            // Re-render to reflect the new vote
+            init();
+          } catch (err) {
+            console.warn('[award] vote failed:', err);
+            btn.removeAttribute('disabled');
+            btn.textContent = 'Try again';
+          }
+        });
+      });
+    }
+
+    if (state === 'open' && !user && signinEl) {
+      signinEl.removeAttribute('hidden');
+    }
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+  // Re-render when auth state changes so the vote buttons appear after sign-in.
+  onAuthChange(() => init());
+</script>
+
+<style>
+  .award-detail { padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem); }
+  .award-detail__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    margin: 0.5rem 0 0.85rem;
+  }
+  .award-detail__description {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: var(--soft);
+    max-width: 38rem;
+    margin: 0 0 1.25rem;
+  }
+  .award-detail__state {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    color: var(--accent);
+    margin: 0 0 2rem;
+  }
+  .award-nominees {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .award-nominees__loading,
+  .award-nominees__empty {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--soft);
+    border: 1px dashed var(--border);
+    padding: 1.25rem;
+    text-align: center;
+  }
+  .award-nominees__empty a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+  .award-nominee {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+  }
+  .award-nominee__body { flex: 1; min-width: 0; }
+  .award-nominee__name {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.3rem;
+    font-weight: 500;
+    line-height: 1.2;
+    margin: 0 0 0.3rem;
+  }
+  .award-nominee__name a {
+    color: var(--text);
+    text-decoration: none;
+    border-bottom: 1px solid rgba(167, 118, 55, 0.3);
+  }
+  .award-nominee__name a:hover { color: var(--accent); }
+  .award-nominee__blurb {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--dark);
+    margin: 0;
+  }
+  .award-nominee__count {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    margin: 0.4rem 0 0;
+  }
+  .award-nominee__vote {
+    flex-shrink: 0;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: transparent;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 0.65rem 1rem;
+    cursor: pointer;
+  }
+  .award-nominee__vote:hover { background: var(--accent); color: var(--bg, #fff); }
+  .award-nominee__vote.is-voted {
+    background: var(--accent);
+    color: var(--bg, #fff);
+  }
+  .award-nominee__vote:disabled { opacity: 0.6; cursor: progress; }
+
+  .award-detail__results {
+    margin-top: clamp(1.5rem, 3vw, 2rem);
+    padding-top: 1.5rem;
+    border-top: 1px dashed var(--border);
+  }
+  .award-detail__results-note {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    color: var(--soft);
+    margin: 0.5rem 0 0;
+  }
+
+  .award-detail__signin {
+    margin-top: 1.5rem;
+    padding: 1rem 1.1rem;
+    border: 1px dashed var(--accent);
+    background: rgba(167, 118, 55, 0.06);
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--dark);
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+  }
+  .award-detail__signin-button {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.55rem 0.95rem;
+    cursor: pointer;
+  }
+</style>

--- a/next/src/pages/awards/index.astro
+++ b/next/src/pages/awards/index.astro
@@ -1,0 +1,314 @@
+---
+/**
+ * /awards/ — Peninsula Insider Awards landing page (Phase 4 WS4E).
+ *
+ * Annual editorial moment combining editor-selected categories and
+ * reader-voted ones. v1 ships the *infrastructure*: voting, nomination,
+ * and results templates plus the schema. The actual 2026 categories
+ * are loaded at runtime from pi.award_categories so editorial can stand
+ * up the year's slate via Supabase Studio without a code change.
+ *
+ * Annual cycle:
+ *   August  — nominations open (visitors POST to pi.award_nominations)
+ *   September — voting open (signed-in users POST to pi.award_votes)
+ *   First weekend of October — results announced (published=true)
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import SectionHero from '../../components/SectionHero.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'The Peninsula Insider Awards' },
+];
+
+// Default category slate for v1. The page reads live data from Supabase
+// at runtime (see the inline script below); these defaults render
+// immediately so the page looks right even before the migration runs.
+const DEFAULT_CATEGORIES = [
+  { slug: 'restaurant-of-the-year',    title: 'Restaurant of the Year',     description: "The dining room the editorial desk would book this year if it could only book one." },
+  { slug: 'cellar-door-of-the-year',   title: 'Cellar Door of the Year',    description: 'Where the wine, the room, and the welcome converged.' },
+  { slug: 'stay-of-the-year',          title: 'Stay of the Year',           description: 'The bed that defined a Peninsula weekend in 2026.' },
+  { slug: 'walk-of-the-year',          title: 'Walk of the Year',           description: 'The route that justified the drive and the boots.' },
+  { slug: 'best-new-opening',          title: 'Best New Opening',           description: 'The 2026 arrival that reset what was possible in its category.' },
+  { slug: 'best-family-day',           title: 'Best Family Day',            description: 'Pram, picnic, parking. Kids-grade A in the field.' },
+  { slug: 'locals-choice',             title: "Locals' Choice",             description: 'Reader-voted. The place locals would actually send a friend to.' },
+  { slug: 'worth-the-drive',           title: 'Worth-the-Drive Award',      description: 'The Peninsula moment that justified the 90-minute return without any other reason.' },
+  { slug: 'editorial-discovery',       title: 'Editorial Discovery',        description: "The hidden corner the editorial desk found this year that won't stay hidden much longer." },
+];
+---
+
+<BaseLayout
+  title="The Peninsula Insider Awards"
+  description="An annual editorial moment combining editor selections and reader voting. The Peninsula at its best, named, ranked, and credited."
+  section="explore"
+  canonical="https://peninsulainsider.com.au/awards/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="The Peninsula Insider Awards"
+    subEyebrow="Annual editorial · Reader-voted"
+    title="The Peninsula at its <em>best</em>, named."
+    dek="Nine categories. Editor selections and reader voting. Nominations open August, voting through September, results announced the first weekend of October. Independent, editorially gated, never paid."
+    gradient="journal"
+    visualLabel="Peninsula Insider · Awards"
+  />
+
+  <section class="awards-page">
+    <div class="container">
+
+      <div class="awards-cycle">
+        <p class="label label--accent">The 2026 cycle</p>
+        <ol class="awards-cycle__list">
+          <li>
+            <p class="awards-cycle__phase">August</p>
+            <p class="awards-cycle__what">Nominations open. Anyone can suggest a venue, event, or place for any category.</p>
+          </li>
+          <li>
+            <p class="awards-cycle__phase">September</p>
+            <p class="awards-cycle__what">Voting opens. Sign in to cast a vote in each category. One vote per category, change anytime until close.</p>
+          </li>
+          <li>
+            <p class="awards-cycle__phase">First weekend of October</p>
+            <p class="awards-cycle__what">Results announced. Editor selections + reader votes published, with editorial framing on the winners.</p>
+          </li>
+        </ol>
+      </div>
+
+      <p class="awards-status" data-awards-status>Loading the 2026 slate…</p>
+
+      <ol class="awards-categories" data-awards-categories>
+        {DEFAULT_CATEGORIES.map((c) => (
+          <li class="award-category" data-category-slug={c.slug}>
+            <p class="award-category__eyebrow">Category</p>
+            <h2 class="award-category__title">
+              <a href={`/awards/${c.slug}/`}>{c.title}</a>
+            </h2>
+            <p class="award-category__description">{c.description}</p>
+            <p class="award-category__meta" data-category-meta>Voting opens September.</p>
+          </li>
+        ))}
+      </ol>
+
+      <aside class="awards-nominate-cta">
+        <p class="label label--accent">Want to nominate?</p>
+        <p class="awards-nominate-cta__body">
+          Got a spot or a moment that should be on the slate? Send it in. Editorial reviews every nomination; the strongest go on the public ballot.
+        </p>
+        <a href="/awards/nominate/" class="awards-nominate-cta__link">Nominate something →</a>
+      </aside>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script>
+  /**
+   * Live updater. Reads pi.award_categories from Supabase to determine
+   * which categories are actually open this cycle and what their voting
+   * windows look like. Falls back gracefully to the SSR defaults if the
+   * table is empty (or doesn't exist yet).
+   */
+  import { getSupabase } from '../../lib/auth';
+
+  type CategoryRow = {
+    slug: string;
+    year: number;
+    title: string;
+    description: string | null;
+    voting_opens_at: string | null;
+    voting_closes_at: string | null;
+    published: boolean;
+  };
+
+  function votingState(row: CategoryRow): 'before' | 'open' | 'closed' | 'published' {
+    if (row.published) return 'published';
+    const now = Date.now();
+    const opens = row.voting_opens_at ? new Date(row.voting_opens_at).getTime() : null;
+    const closes = row.voting_closes_at ? new Date(row.voting_closes_at).getTime() : null;
+    if (opens && now < opens) return 'before';
+    if (closes && now >= closes) return 'closed';
+    if (opens && now >= opens) return 'open';
+    return 'before';
+  }
+
+  async function init() {
+    const status = document.querySelector('[data-awards-status]');
+    const c = getSupabase();
+    if (!c) {
+      if (status) status.textContent = '';
+      return;
+    }
+    try {
+      const { data, error } = await c
+        .from('award_categories')
+        .select('slug, year, title, description, voting_opens_at, voting_closes_at, published')
+        .order('sort_order', { ascending: true });
+      if (error) throw error;
+      if (!data || data.length === 0) {
+        if (status) status.textContent = "The 2026 slate isn't published yet. The default categories above are a preview.";
+        return;
+      }
+
+      // Render the live categories on top of the SSR defaults.
+      const list = document.querySelector('[data-awards-categories]');
+      if (list) list.innerHTML = '';
+      data.forEach((row: CategoryRow) => {
+        const li = document.createElement('li');
+        li.className = 'award-category';
+        li.setAttribute('data-category-slug', row.slug);
+        const state = votingState(row);
+        const stateLabel =
+          state === 'open'      ? 'Voting open — cast yours' :
+          state === 'closed'    ? 'Voting closed' :
+          state === 'published' ? 'Results published' :
+                                  'Voting opens September';
+        li.innerHTML = `
+          <p class="award-category__eyebrow">Category · ${row.year}</p>
+          <h2 class="award-category__title">
+            <a href="/awards/${row.slug}/">${row.title}</a>
+          </h2>
+          <p class="award-category__description">${row.description ?? ''}</p>
+          <p class="award-category__meta">${stateLabel}</p>
+        `;
+        list?.appendChild(li);
+      });
+      if (status) status.textContent = '';
+    } catch (err) {
+      console.warn('[awards] live load failed:', err);
+      if (status) status.textContent = '';
+    }
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>
+
+<style>
+  .awards-page { padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem); }
+
+  .awards-cycle {
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: clamp(1.25rem, 2.5vw, 1.75rem);
+    margin-bottom: clamp(1.75rem, 3vw, 2.5rem);
+  }
+  .awards-cycle__list {
+    list-style: none;
+    padding: 0;
+    margin: 0.85rem 0 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+  }
+  @media (min-width: 720px) { .awards-cycle__list { grid-template-columns: 1fr 1fr 1fr; } }
+  .awards-cycle__phase {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: var(--accent);
+    margin: 0 0 0.3rem;
+  }
+  .awards-cycle__what {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--dark);
+    margin: 0;
+  }
+
+  .awards-status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    color: var(--soft);
+    margin: 0 0 1rem;
+  }
+  .awards-status:empty { display: none; }
+
+  .awards-categories {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: clamp(1rem, 2vw, 1.5rem);
+  }
+  @media (min-width: 880px) { .awards-categories { grid-template-columns: 1fr 1fr; } }
+  @media (min-width: 1140px) { .awards-categories { grid-template-columns: 1fr 1fr 1fr; } }
+
+  .award-category {
+    border: 1px solid var(--border);
+    padding: clamp(1rem, 2vw, 1.4rem);
+    background: var(--bg, #fff);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .award-category__eyebrow {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0;
+  }
+  .award-category__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    line-height: 1.15;
+    margin: 0;
+  }
+  .award-category__title a {
+    color: var(--text);
+    text-decoration: none;
+  }
+  .award-category__title a:hover { color: var(--accent); }
+  .award-category__description {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--dark);
+    margin: 0;
+  }
+  .award-category__meta {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    color: var(--soft);
+    margin: 0.4rem 0 0;
+  }
+
+  .awards-nominate-cta {
+    margin-top: clamp(2rem, 4vw, 3rem);
+    padding-top: 1.75rem;
+    border-top: 1px solid var(--border);
+  }
+  .awards-nominate-cta__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--dark);
+    max-width: 36rem;
+    margin: 0.55rem 0 1rem;
+  }
+  .awards-nominate-cta__link {
+    display: inline-flex;
+    align-items: center;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid rgba(167, 118, 55, 0.5);
+    padding-bottom: 0.1rem;
+  }
+  .awards-nominate-cta__link:hover { border-bottom-color: var(--accent); color: var(--text); }
+</style>

--- a/next/src/pages/awards/nominate.astro
+++ b/next/src/pages/awards/nominate.astro
@@ -1,0 +1,261 @@
+---
+/**
+ * /awards/nominate/ — open nomination form (Phase 4 WS4E).
+ *
+ * Anonymous form posts to pi.award_nominations. Light dedupe via
+ * client_token. Editor reviews submissions in Supabase Studio and
+ * lifts the strongest into pi.award_nominees.
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import SectionHero from '../../components/SectionHero.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'The Awards', href: '/awards/' },
+  { label: 'Nominate' },
+];
+
+const DEFAULT_CATEGORIES = [
+  { slug: 'restaurant-of-the-year',  title: 'Restaurant of the Year' },
+  { slug: 'cellar-door-of-the-year', title: 'Cellar Door of the Year' },
+  { slug: 'stay-of-the-year',        title: 'Stay of the Year' },
+  { slug: 'walk-of-the-year',        title: 'Walk of the Year' },
+  { slug: 'best-new-opening',        title: 'Best New Opening' },
+  { slug: 'best-family-day',         title: 'Best Family Day' },
+  { slug: 'locals-choice',           title: "Locals' Choice" },
+  { slug: 'worth-the-drive',         title: 'Worth-the-Drive' },
+  { slug: 'editorial-discovery',     title: 'Editorial Discovery' },
+];
+---
+
+<BaseLayout
+  title="Nominate · The Peninsula Insider Awards"
+  description="Suggest a venue, event, or place for the 2026 Peninsula Insider Awards. Editorial reviews every nomination."
+  section="explore"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="Nominate"
+    subEyebrow="Open submissions"
+    title="Tell us who should be on the <em>2026</em> ballot."
+    dek="Anyone can nominate. Editorial reviews every submission and lifts the strongest into the public ballot. The shortlist publishes in early September; voting follows."
+    gradient="journal"
+    visualLabel="Peninsula Insider · nominate"
+  />
+
+  <section class="awards-nominate-page">
+    <div class="container">
+      <form class="awards-nominate-form" data-nominate-form aria-label="Awards nomination form">
+        <p class="awards-nominate-form__heading">A nomination, in three boxes.</p>
+
+        <div class="awards-nominate-form__field">
+          <label for="nominate-category">Category</label>
+          <select id="nominate-category" name="category_slug" required>
+            <option value="">Choose a category…</option>
+            {DEFAULT_CATEGORIES.map((c) => <option value={c.slug}>{c.title}</option>)}
+          </select>
+        </div>
+
+        <div class="awards-nominate-form__field">
+          <label for="nominate-nominee">The nominee</label>
+          <input
+            id="nominate-nominee"
+            type="text"
+            name="nominee_label"
+            required
+            maxlength="200"
+            placeholder="The venue, event, or place you'd put on the slate"
+          />
+        </div>
+
+        <div class="awards-nominate-form__field">
+          <label for="nominate-reason">Why (optional, but useful)</label>
+          <textarea
+            id="nominate-reason"
+            name="reason"
+            rows="5"
+            maxlength="1200"
+            placeholder="A line or two on what makes them a contender. Helps the editor cut through."
+          ></textarea>
+        </div>
+
+        <div class="awards-nominate-form__field">
+          <label for="nominate-email">Your email (optional)</label>
+          <input
+            id="nominate-email"
+            type="email"
+            name="submitter_email"
+            maxlength="240"
+            placeholder="If you want a follow-up if your nomination lands"
+          />
+        </div>
+
+        <button type="submit" class="awards-nominate-form__submit">Send nomination</button>
+        <p class="awards-nominate-form__status" data-nominate-status hidden></p>
+      </form>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled } from '../../lib/auth';
+
+  function clientToken() {
+    try {
+      const k = 'pi:awards:client-token';
+      let v = localStorage.getItem(k);
+      if (!v) {
+        v = (typeof crypto !== 'undefined' && crypto.randomUUID)
+          ? crypto.randomUUID()
+          : 'tok-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        localStorage.setItem(k, v);
+      }
+      return v;
+    } catch {
+      return 'tok-' + Math.random().toString(36).slice(2);
+    }
+  }
+
+  function init() {
+    const form = document.querySelector('[data-nominate-form]') as HTMLFormElement | null;
+    if (!form) return;
+    const status = document.querySelector('[data-nominate-status]') as HTMLElement | null;
+    const button = form.querySelector('button[type="submit"]') as HTMLButtonElement | null;
+
+    function setStatus(kind: string, msg: string) {
+      if (!status) return;
+      status.textContent = msg;
+      status.setAttribute('data-status-kind', kind);
+      status.removeAttribute('hidden');
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (!isAuthEnabled()) {
+        setStatus('error', "Nominations aren't currently configured. Email hello@peninsulainsider.com.au.");
+        return;
+      }
+      if (button) button.disabled = true;
+      setStatus('info', 'Sending…');
+
+      const fd = new FormData(form);
+      const c = getSupabase();
+      if (!c) {
+        setStatus('error', "Supabase isn't available right now.");
+        if (button) button.disabled = false;
+        return;
+      }
+
+      const { error } = await c.from('award_nominations').insert({
+        category_slug: String(fd.get('category_slug') || ''),
+        nominee_label: String(fd.get('nominee_label') || ''),
+        reason: String(fd.get('reason') || ''),
+        submitter_email: String(fd.get('submitter_email') || ''),
+        client_token: clientToken(),
+      });
+      if (error) {
+        console.warn('[award-nominate] insert failed:', error.message);
+        setStatus('error', "Couldn't send. Try again or email hello@peninsulainsider.com.au.");
+        if (button) button.disabled = false;
+        return;
+      }
+
+      form.reset();
+      setStatus('success', 'Got it. The editor will read every nomination.');
+      if (button) button.disabled = false;
+    });
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>
+
+<style>
+  .awards-nominate-page { padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem); }
+  .awards-nominate-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: clamp(1.25rem, 2.5vw, 1.75rem);
+    max-width: 38rem;
+  }
+  .awards-nominate-form__heading {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0;
+  }
+  .awards-nominate-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .awards-nominate-form__field label {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--dark);
+  }
+  .awards-nominate-form__field input,
+  .awards-nominate-form__field textarea,
+  .awards-nominate-form__field select {
+    width: 100%;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    color: var(--dark);
+    background: var(--bg, #fff);
+    border: 1px solid var(--border);
+    padding: 0.6rem 0.75rem;
+  }
+  .awards-nominate-form__field textarea { resize: vertical; min-height: 7rem; }
+  .awards-nominate-form__field input:focus,
+  .awards-nominate-form__field textarea:focus,
+  .awards-nominate-form__field select:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .awards-nominate-form__submit {
+    align-self: flex-start;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.7rem 1.2rem;
+    cursor: pointer;
+  }
+  .awards-nominate-form__submit:disabled { opacity: 0.6; cursor: progress; }
+  .awards-nominate-form__submit:hover:not(:disabled) {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+  }
+  .awards-nominate-form__status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--border);
+  }
+  .awards-nominate-form__status[data-status-kind="success"] {
+    color: #2f6e3a;
+    border-color: rgba(47, 110, 58, 0.5);
+    background: rgba(47, 110, 58, 0.07);
+  }
+  .awards-nominate-form__status[data-status-kind="error"] {
+    color: #b14b3a;
+    border-color: rgba(177, 75, 58, 0.5);
+    background: rgba(177, 75, 58, 0.07);
+  }
+</style>

--- a/ops/migrations/2026-05-05-awards.sql
+++ b/ops/migrations/2026-05-05-awards.sql
@@ -1,0 +1,151 @@
+-- Migration: Peninsula Insider Awards (Phase 4 WS4E)
+-- Date: 2026-05-05
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+--
+-- Purpose: voting infrastructure for the annual Peninsula Insider
+--          Awards. One row per (user, category, year) for signed-in
+--          votes; anonymous nominations land in pi.award_nominations
+--          with a client_token for light dedupe.
+--
+-- v1 ships the *infrastructure*. The actual 2026 Awards content
+-- (categories, nominees, results) is editorial work that follows.
+--
+-- Idempotent. RLS scoped tightly.
+
+-- ─── Categories (editor-managed) ──────────────────────────────────────────
+create table if not exists pi.award_categories (
+  slug         text primary key,
+  year         integer not null,
+  title        text not null,
+  description  text,
+  -- Display ordering on the awards page.
+  sort_order   integer not null default 0,
+  -- Voting window controls. Outside the window the form is read-only.
+  voting_opens_at  timestamptz,
+  voting_closes_at timestamptz,
+  -- Once results are public, set published=true to surface them.
+  published    boolean not null default false,
+  created_at   timestamptz not null default now()
+);
+
+comment on table pi.award_categories is 'Annual categories for the Peninsula Insider Awards. One row per (slug, year) effectively — slug is unique here for simplicity in v1.';
+
+create index if not exists award_categories_by_year on pi.award_categories (year, sort_order);
+
+alter table pi.award_categories enable row level security;
+
+drop policy if exists "award_categories_public_read" on pi.award_categories;
+create policy "award_categories_public_read"
+  on pi.award_categories for select using (true);
+
+drop policy if exists "award_categories_editor_write" on pi.award_categories;
+create policy "award_categories_editor_write"
+  on pi.award_categories for all
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true))
+  with check (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- ─── Nominees (editor-curated shortlist per category) ─────────────────────
+create table if not exists pi.award_nominees (
+  id              uuid primary key default gen_random_uuid(),
+  category_slug   text not null references pi.award_categories(slug) on delete cascade,
+  -- Polymorphic nominee: one of (venue_slug, event_slug, experience_slug, place_slug).
+  -- Exactly one should be set; not enforced as a constraint to keep editorial flexibility.
+  venue_slug      text,
+  event_slug      text,
+  experience_slug text,
+  place_slug      text,
+  -- Free-text for write-in nominees that don't map to a content row.
+  custom_label    text,
+  -- Editorial framing for the awards page.
+  blurb           text,
+  sort_order      integer not null default 0,
+  created_at      timestamptz not null default now()
+);
+
+create index if not exists award_nominees_by_category on pi.award_nominees (category_slug, sort_order);
+
+alter table pi.award_nominees enable row level security;
+
+drop policy if exists "award_nominees_public_read" on pi.award_nominees;
+create policy "award_nominees_public_read"
+  on pi.award_nominees for select using (true);
+
+drop policy if exists "award_nominees_editor_write" on pi.award_nominees;
+create policy "award_nominees_editor_write"
+  on pi.award_nominees for all
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true))
+  with check (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- ─── Votes (signed-in only; one per user per category per year) ──────────
+create table if not exists pi.award_votes (
+  user_id        uuid not null references auth.users(id) on delete cascade,
+  category_slug  text not null references pi.award_categories(slug) on delete cascade,
+  nominee_id     uuid not null references pi.award_nominees(id) on delete cascade,
+  voted_at       timestamptz not null default now(),
+  primary key (user_id, category_slug)
+);
+
+create index if not exists award_votes_by_nominee on pi.award_votes (nominee_id);
+create index if not exists award_votes_by_category on pi.award_votes (category_slug);
+
+alter table pi.award_votes enable row level security;
+
+drop policy if exists "award_votes_select_own" on pi.award_votes;
+create policy "award_votes_select_own"
+  on pi.award_votes for select using (user_id = auth.uid());
+
+drop policy if exists "award_votes_insert_own" on pi.award_votes;
+create policy "award_votes_insert_own"
+  on pi.award_votes for insert with check (user_id = auth.uid());
+
+drop policy if exists "award_votes_update_own" on pi.award_votes;
+create policy "award_votes_update_own"
+  on pi.award_votes for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+drop policy if exists "award_votes_delete_own" on pi.award_votes;
+create policy "award_votes_delete_own"
+  on pi.award_votes for delete using (user_id = auth.uid());
+
+-- Editor read-all so we can surface aggregate counts on the results page.
+drop policy if exists "award_votes_editor_read" on pi.award_votes;
+create policy "award_votes_editor_read"
+  on pi.award_votes for select
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- ─── Anonymous nominations (open submissions) ────────────────────────────
+create table if not exists pi.award_nominations (
+  id              uuid primary key default gen_random_uuid(),
+  category_slug   text not null references pi.award_categories(slug) on delete cascade,
+  -- Free text: the venue/event/place the visitor is nominating.
+  nominee_label   text not null,
+  reason          text,
+  -- Submitter optional metadata.
+  submitter_email text,
+  client_token    text,
+  created_at      timestamptz not null default now()
+);
+
+create index if not exists award_nominations_by_category on pi.award_nominations (category_slug, created_at desc);
+
+alter table pi.award_nominations enable row level security;
+
+drop policy if exists "award_nominations_anon_insert" on pi.award_nominations;
+create policy "award_nominations_anon_insert"
+  on pi.award_nominations for insert with check (true);
+
+drop policy if exists "award_nominations_editor_read" on pi.award_nominations;
+create policy "award_nominations_editor_read"
+  on pi.award_nominations for select
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- ─── Aggregate view (public read; counts per nominee) ────────────────────
+create or replace view pi.award_vote_counts as
+select
+  v.category_slug,
+  v.nominee_id,
+  count(*)::integer as vote_count
+from pi.award_votes v
+group by v.category_slug, v.nominee_id;
+
+comment on view pi.award_vote_counts is 'Aggregated reader-vote totals per nominee. Public read for the results page.';


### PR DESCRIPTION
Fourth Phase 4 workstream. Awards microsite (landing + per-category voting + nominate) plus Supabase tables for categories, nominees, votes, anonymous nominations, and an aggregate vote-count view. v1 ships the infrastructure; 2026 categories load at runtime so editorial can stand up the slate via Supabase Studio. Build clean at 1224 pages.