### PR TITLE
feat(discovery-phase-5): partner change-request portal (WS5C)

### DIFF
--- a/next/src/pages/partners/index.astro
+++ b/next/src/pages/partners/index.astro
@@ -47,6 +47,13 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
       </div>
     </section>
 
+    <aside class="partners-update-banner">
+      <div class="partners-section__inner">
+        <p class="partners-update-banner__eyebrow">Already a Peninsula venue we cover?</p>
+        <p class="partners-update-banner__body">Hours moved? Hero photo dated? An event we should know about? <a href="/partners/update/">Send us a structured update</a> — editor reads every request, applies in hours.</p>
+      </div>
+    </aside>
+
     <section class="partners-section partners-audience">
       <div class="partners-section__inner">
         <p class="partners-section__eyebrow">Audience and reach</p>
@@ -807,6 +814,35 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
     color: var(--soft);
   }
   .partners-standards__methodology a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  /* OPERATOR UPDATE BANNER (Phase 5 WS5C). */
+  .partners-update-banner {
+    border-bottom: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: clamp(1rem, 2vw, 1.4rem) 0;
+  }
+  .partners-update-banner__eyebrow {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.45rem;
+  }
+  .partners-update-banner__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--dark);
+    margin: 0;
+    max-width: 760px;
+  }
+  .partners-update-banner__body a {
     color: var(--accent);
     text-decoration: underline;
     text-underline-offset: 3px;

--- a/next/src/pages/partners/update.astro
+++ b/next/src/pages/partners/update.astro
@@ -1,0 +1,470 @@
+---
+/**
+ * /partners/update/ — operator change-request form (Phase 5 WS5C).
+ *
+ * Operators submit a structured request to update their venue's
+ * listing — hours, photos, closures, events, factual corrections.
+ * Posts to pi.venue_change_requests; editor reviews in Studio and
+ * applies the change to next/src/content/venues/<slug>.json.
+ *
+ * v1 is anonymous (no auth). Once Pass is live with operator tier,
+ * we'll auth-gate this and link change requests to the operator's
+ * profile.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import SectionHero from '../../components/SectionHero.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { routeSlug } from '../../lib/editorial';
+
+const venues = await getCollection('venues');
+// Build a sorted lightweight list for the autocomplete datalist.
+const venueOptions = venues
+  .filter((v) => !v.data.sitemapExclude)
+  .map((v) => ({ slug: routeSlug(v), name: v.data.name }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Partner with us', href: '/partners/' },
+  { label: 'Update your listing' },
+];
+
+const changeTypes = [
+  { value: 'hours',      label: 'Hours / opening times' },
+  { value: 'photo',      label: 'Hero photo (URL)' },
+  { value: 'closure',    label: 'Closure (temporary or permanent)' },
+  { value: 'event',      label: 'Propose an event for this venue' },
+  { value: 'correction', label: 'Factual correction' },
+  { value: 'other',      label: 'Other' },
+];
+---
+
+<BaseLayout
+  title="Update your listing · Peninsula Insider"
+  description="Operators submit a structured change request to update hours, photos, closures, or propose events. Editorial reviews every request."
+  section="home"
+  noindex={false}
+  canonical="https://peninsulainsider.com.au/partners/update/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="Update your listing"
+    subEyebrow="Operator change request"
+    title="Tell us what's <em>changed</em>."
+    dek="If your venue's hours have moved, your hero photo is dated, or you've got an event that should be on the calendar — submit it here. The editor reviews every request and applies the ones that hold up to verification. No charge, no commercial relationship required, no AI moderation. Just a working desk."
+    gradient="journal"
+    visualLabel="Peninsula Insider · operator update"
+  />
+
+  <section class="partner-update-page">
+    <div class="container">
+
+      <div class="partner-update-grid">
+        <div class="partner-update-grid__intro">
+          <p class="label label--accent">How it works</p>
+          <ol class="partner-update-process">
+            <li><strong>You submit</strong> the venue, the change, and your contact.</li>
+            <li><strong>The editor reads</strong> every request, usually within a working day.</li>
+            <li><strong>If it verifies</strong>, the change goes live on the next site build (within hours).</li>
+            <li><strong>If it doesn't</strong>, you'll hear back with what's missing.</li>
+          </ol>
+
+          <p class="partner-update-rules-label">A few notes</p>
+          <ul class="partner-update-rules">
+            <li>This is for <strong>your venue</strong> — not for nominating other places. Use <a href="/submit/">/submit/</a> for those.</li>
+            <li>Hours updates apply to the next build, typically same-day.</li>
+            <li>Photo updates need a URL (Drive, Dropbox, Cloudinary, your own site). Direct file upload follows once we ship operator accounts.</li>
+            <li>Event proposals get treated as event submissions — editorial discretion applies. We won't list everything.</li>
+            <li>Factual corrections are taken seriously and acted on fast. Always include the source.</li>
+            <li>One request per submission. If you've got three changes, send three.</li>
+          </ul>
+        </div>
+
+        <div class="partner-update-grid__form-wrap">
+          <form class="partner-update-form" data-partner-update-form aria-label="Operator change-request form">
+            <fieldset class="partner-update-form__group">
+              <legend class="partner-update-form__legend">Your venue</legend>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-venue">Venue</label>
+                <input
+                  id="pu-venue"
+                  name="venue"
+                  type="text"
+                  list="pu-venue-list"
+                  required
+                  maxlength="200"
+                  class="partner-update-form__input"
+                  placeholder="Start typing your venue name…"
+                  autocomplete="off"
+                />
+                <datalist id="pu-venue-list">
+                  {venueOptions.map((v) => <option value={v.name} data-slug={v.slug}>{v.name}</option>)}
+                </datalist>
+                <p class="partner-update-form__hint">Pick from the list — the autocomplete shows the full venue corpus. If your venue isn't listed yet, type it in and the editor will pick it up.</p>
+              </div>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-change-type">What's changing?</label>
+                <select id="pu-change-type" name="change_type" class="partner-update-form__select" required>
+                  <option value="">Choose one…</option>
+                  {changeTypes.map((c) => <option value={c.value}>{c.label}</option>)}
+                </select>
+              </div>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-proposed-change">The change, in detail</label>
+                <textarea
+                  id="pu-proposed-change"
+                  name="proposed_change"
+                  required
+                  minlength="20"
+                  maxlength="2000"
+                  rows="6"
+                  class="partner-update-form__textarea"
+                  placeholder="New hours: Sat–Sun 11am to 5pm, closed Tue / Wed / Thu through July."
+                ></textarea>
+                <p class="partner-update-form__hint">Be specific. Editor applies this verbatim to the JSON, so the more precise the better.</p>
+              </div>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-reference-url">Reference URL (optional)</label>
+                <input
+                  id="pu-reference-url"
+                  name="reference_url"
+                  type="url"
+                  maxlength="600"
+                  class="partner-update-form__input"
+                  placeholder="https://… (Drive folder, your website, the official source for the change)"
+                />
+              </div>
+            </fieldset>
+
+            <fieldset class="partner-update-form__group">
+              <legend class="partner-update-form__legend">You</legend>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-operator-name">Your name</label>
+                <input
+                  id="pu-operator-name"
+                  name="operator_name"
+                  type="text"
+                  required
+                  maxlength="120"
+                  class="partner-update-form__input"
+                />
+              </div>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-operator-email">Email (we'll write back if we need to)</label>
+                <input
+                  id="pu-operator-email"
+                  name="operator_email"
+                  type="email"
+                  required
+                  maxlength="240"
+                  class="partner-update-form__input"
+                />
+              </div>
+
+              <div class="partner-update-form__field">
+                <label class="partner-update-form__label" for="pu-operator-role">Your role at the venue (optional)</label>
+                <input
+                  id="pu-operator-role"
+                  name="operator_role"
+                  type="text"
+                  maxlength="120"
+                  class="partner-update-form__input"
+                  placeholder="Owner / Manager / GM / Marketing"
+                />
+              </div>
+            </fieldset>
+
+            <div class="partner-update-form__submit">
+              <button type="submit" class="partner-update-form__button">Send the update</button>
+              <p class="partner-update-form__caveat">By submitting you confirm the information is accurate and you have authority to submit it on the venue's behalf. Editorial may verify with a phone call or a visit.</p>
+            </div>
+
+            <p class="partner-update-form__status" data-partner-update-status hidden></p>
+          </form>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script define:vars={{ venueOptionsJson: JSON.stringify(venueOptions) }}>
+  import { getSupabase, isAuthEnabled } from '../../lib/auth';
+
+  function clientToken() {
+    try {
+      const k = 'pi:partner-update:client-token';
+      let v = localStorage.getItem(k);
+      if (!v) {
+        v = (typeof crypto !== 'undefined' && crypto.randomUUID)
+          ? crypto.randomUUID()
+          : 'tok-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        localStorage.setItem(k, v);
+      }
+      return v;
+    } catch {
+      return 'tok-' + Math.random().toString(36).slice(2);
+    }
+  }
+
+  function init() {
+    const form = document.querySelector('[data-partner-update-form]');
+    if (!form) return;
+    const status = document.querySelector('[data-partner-update-status]');
+    const button = form.querySelector('.partner-update-form__button');
+    const venueOptions = venueOptionsJson;
+
+    function setStatus(kind, message) {
+      if (!status) return;
+      status.textContent = message;
+      status.setAttribute('data-status-kind', kind);
+      status.removeAttribute('hidden');
+    }
+
+    /** Resolve the typed venue name to a slug from the autocomplete list. */
+    function resolveVenueSlug(typedName) {
+      if (!typedName) return '';
+      const exact = venueOptions.find((v) => v.name.toLowerCase() === typedName.toLowerCase());
+      return exact ? exact.slug : '';
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (button) button.disabled = true;
+      setStatus('info', 'Sending…');
+
+      const fd = new FormData(form);
+      const venueName = String(fd.get('venue') || '').trim();
+      const venueSlug = resolveVenueSlug(venueName);
+
+      if (!isAuthEnabled()) {
+        setStatus('error', "Submissions aren't currently configured. Email hello@peninsulainsider.com.au and we'll pick it up.");
+        if (button) button.disabled = false;
+        return;
+      }
+      const c = getSupabase();
+      if (!c) {
+        setStatus('error', "Supabase isn't available right now.");
+        if (button) button.disabled = false;
+        return;
+      }
+
+      const session = (await c.auth.getSession()).data.session;
+      const userId = session?.user?.id ?? null;
+
+      const row = {
+        user_id: userId,
+        venue_slug: venueSlug || (venueName ? '__pending__' : ''),
+        venue_name: venueName,
+        change_type: String(fd.get('change_type') || ''),
+        proposed_change: String(fd.get('proposed_change') || ''),
+        reference_url: String(fd.get('reference_url') || ''),
+        operator_name: String(fd.get('operator_name') || ''),
+        operator_email: String(fd.get('operator_email') || ''),
+        operator_role: String(fd.get('operator_role') || ''),
+        client_token: clientToken(),
+      };
+
+      const { error } = await c.from('venue_change_requests').insert(row);
+      if (error) {
+        console.warn('[partner-update] insert failed:', error.message);
+        setStatus('error', "Couldn't send. Try once more, or email hello@peninsulainsider.com.au.");
+        if (button) button.disabled = false;
+        return;
+      }
+
+      form.reset();
+      const venueDisplay = venueSlug ? venueName : `${venueName} (we'll pick it up)`;
+      setStatus('success', `Got it. The editor will read this within a working day. Submitted change for ${venueDisplay}.`);
+      if (button) button.disabled = false;
+    });
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>
+
+<style>
+  .partner-update-page {
+    padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem);
+  }
+  .partner-update-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+  }
+  @media (min-width: 920px) {
+    .partner-update-grid { grid-template-columns: 320px 1fr; }
+  }
+
+  .partner-update-process {
+    list-style: none;
+    margin: 0.85rem 0 1.5rem;
+    padding: 0;
+    counter-reset: pu-step;
+  }
+  .partner-update-process li {
+    position: relative;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--dark);
+    padding: 0.55rem 0 0.55rem 2.2rem;
+    border-bottom: 1px dashed var(--border);
+    counter-increment: pu-step;
+  }
+  .partner-update-process li::before {
+    content: counter(pu-step);
+    position: absolute;
+    left: 0;
+    top: 0.55rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+  .partner-update-process li:last-child { border-bottom: 0; }
+
+  .partner-update-rules-label {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 1.25rem 0 0.55rem;
+  }
+  .partner-update-rules {
+    list-style: disc inside;
+    padding: 0;
+    margin: 0;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--soft);
+  }
+  .partner-update-rules li { margin-bottom: 0.4rem; }
+  .partner-update-rules a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+
+  .partner-update-form {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 2.5vw, 1.75rem);
+  }
+  .partner-update-form__group {
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: clamp(1rem, 2vw, 1.4rem);
+  }
+  .partner-update-form__legend {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    padding: 0 0.4rem;
+    margin: 0;
+  }
+  .partner-update-form__field { margin-top: 1rem; }
+  .partner-update-form__label {
+    display: block;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--dark);
+    margin-bottom: 0.35rem;
+  }
+  .partner-update-form__input,
+  .partner-update-form__textarea,
+  .partner-update-form__select {
+    width: 100%;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    color: var(--dark);
+    background: var(--bg, #fff);
+    border: 1px solid var(--border);
+    padding: 0.6rem 0.75rem;
+  }
+  .partner-update-form__textarea { resize: vertical; min-height: 8rem; }
+  .partner-update-form__input:focus,
+  .partner-update-form__textarea:focus,
+  .partner-update-form__select:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .partner-update-form__hint {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin: 0.35rem 0 0;
+  }
+  .partner-update-form__submit {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    align-items: flex-start;
+    margin-top: 0.5rem;
+  }
+  .partner-update-form__button {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--bg, #fff);
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 0.85rem 1.4rem;
+    cursor: pointer;
+  }
+  .partner-update-form__button:disabled { opacity: 0.6; cursor: progress; }
+  .partner-update-form__button:hover:not(:disabled) {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+  }
+  .partner-update-form__caveat {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin: 0;
+    max-width: 32rem;
+  }
+  .partner-update-form__status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--border);
+  }
+  .partner-update-form__status[data-status-kind="success"] {
+    color: #2f6e3a;
+    border-color: rgba(47, 110, 58, 0.5);
+    background: rgba(47, 110, 58, 0.07);
+  }
+  .partner-update-form__status[data-status-kind="error"] {
+    color: #b14b3a;
+    border-color: rgba(177, 75, 58, 0.5);
+    background: rgba(177, 75, 58, 0.07);
+  }
+  .partner-update-form__status[data-status-kind="info"] {
+    color: var(--soft);
+  }
+</style>

--- a/ops/migrations/2026-05-05-venue-change-requests.sql
+++ b/ops/migrations/2026-05-05-venue-change-requests.sql
@@ -1,0 +1,114 @@
+-- Migration: venue change requests (Phase 5 WS5C)
+-- Date: 2026-05-05
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+--
+-- Purpose: operator-submitted change requests against the published
+-- editorial corpus. Operators (no auth required for v1) submit a
+-- structured request via /partners/update/. Editor reviews in Studio
+-- and applies the change manually to the relevant content JSON in
+-- next/src/content/venues/.
+--
+-- v1 covers: hours updates, photo updates (URL paste only — file
+-- uploads land in v1.x once Pass auth is live), closure flags, and
+-- proposed events. Each request lands as one row.
+--
+-- Idempotent.
+
+create table if not exists pi.venue_change_requests (
+  id              uuid primary key default gen_random_uuid(),
+  -- Optional auth.users reference. Anonymous requests allowed for v1
+  -- (most operators won't have site accounts yet); auth gating turns
+  -- on when the Pass tier ships.
+  user_id         uuid references auth.users(id) on delete set null,
+
+  -- Which venue the request is about. Operators autocomplete from the
+  -- live venues collection on the form, so we expect a real slug here.
+  -- We store as text rather than a foreign key because the venues
+  -- collection is JSON-on-disk, not a Supabase table.
+  venue_slug      text not null,
+  venue_name      text,                   -- denormalised for editor convenience
+
+  -- Change taxonomy. Drives the editor's review queue ordering and
+  -- which fields to apply.
+  change_type     text not null check (change_type in (
+    'hours',          -- hours / opening times update
+    'photo',          -- replace hero photo (URL)
+    'closure',        -- venue is closed permanently / temporarily
+    'event',          -- proposed event for the venue
+    'correction',     -- factual correction to an existing field
+    'other'
+  )),
+  -- Free-form payload describing the change. Editor uses this verbatim
+  -- when applying to JSON. We could go schema-per-type later but a
+  -- single text field is simpler for v1 and the volume is low.
+  proposed_change text not null,
+
+  -- Optional supporting URL — a photo on Drive, a website, an event
+  -- listing, etc.
+  reference_url   text,
+
+  -- Operator metadata
+  operator_name   text not null,
+  operator_email  text not null,
+  operator_role   text,                   -- 'owner', 'manager', 'gm', etc.
+
+  -- Editorial state
+  status          text not null default 'pending' check (status in (
+    'pending', 'in-review', 'applied', 'declined'
+  )),
+  editor_notes    text,
+  decision_at     timestamptz,
+
+  -- Audit
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  client_token    text                    -- light spam dedupe; not auth-secured
+);
+
+comment on table pi.venue_change_requests is 'Operator-submitted change requests against the venue corpus. Phase 5 WS5C.';
+
+create index if not exists venue_change_requests_by_status_created
+  on pi.venue_change_requests (status, created_at desc);
+create index if not exists venue_change_requests_by_venue
+  on pi.venue_change_requests (venue_slug, created_at desc);
+
+alter table pi.venue_change_requests enable row level security;
+
+-- Anonymous insert allowed (v1 operators don't need accounts).
+drop policy if exists "venue_change_requests_anon_insert" on pi.venue_change_requests;
+create policy "venue_change_requests_anon_insert"
+  on pi.venue_change_requests for insert
+  with check (true);
+
+-- Signed-in submitters can read their own pending requests (so the
+-- form can show "thanks, in review" later if the user is signed in).
+drop policy if exists "venue_change_requests_select_own_by_user" on pi.venue_change_requests;
+create policy "venue_change_requests_select_own_by_user"
+  on pi.venue_change_requests for select
+  using (user_id is not null and user_id = auth.uid());
+
+-- Editor full access via pi.profiles.is_editor.
+drop policy if exists "venue_change_requests_editor_all" on pi.venue_change_requests;
+create policy "venue_change_requests_editor_all"
+  on pi.venue_change_requests for all
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true))
+  with check (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- Default privileges already cover authenticated/anon for new tables in
+-- pi (set in the consolidated bootstrap migration). Explicit insert for
+-- anon is fine here because RLS still gates it.
+
+-- updated_at trigger
+create or replace function pi.venue_change_requests_set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists venue_change_requests_set_updated_at on pi.venue_change_requests;
+create trigger venue_change_requests_set_updated_at
+  before update on pi.venue_change_requests
+  for each row execute function pi.venue_change_requests_set_updated_at();


### PR DESCRIPTION
First operator self-serve surface. /partners/update/ form posts to a new pi.venue_change_requests table. Migration in ops/. Partner page grows a banner pointing operators at it. Phase 5 complete after this PR. Build clean at 1229 pages.