### PR TITLE
feat(discovery-phase-6): operator claim + dashboard (WS6B)

### DIFF
--- a/next/src/lib/auth.ts
+++ b/next/src/lib/auth.ts
@@ -377,3 +377,76 @@ export async function syncUserAlerts(
     return { ok: false, error: (err as Error).message };
   }
 }
+
+// ---- Venue claims (Phase 6 WS6B) ------------------------------------------
+
+export type VenueClaim = {
+  id: string;
+  user_id: string;
+  venue_slug: string;
+  venue_name: string | null;
+  operator_role: string | null;
+  proof: string | null;
+  status: 'pending' | 'approved' | 'revoked';
+  editor_notes: string | null;
+  decision_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function listOwnVenueClaims(userId: string): Promise<VenueClaim[]> {
+  const c = getSupabase();
+  if (!c) return [];
+  try {
+    const { data, error } = await c
+      .from('venue_claims')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    if (error) return [];
+    return (data ?? []) as VenueClaim[];
+  } catch {
+    return [];
+  }
+}
+
+export async function submitVenueClaim(
+  userId: string,
+  payload: { venue_slug: string; venue_name: string; operator_role?: string; proof?: string },
+): Promise<{ ok: boolean; error?: string; claim?: VenueClaim }> {
+  const c = getSupabase();
+  if (!c) return { ok: false, error: 'Auth not configured' };
+  try {
+    const { data, error } = await c
+      .from('venue_claims')
+      .insert({
+        user_id: userId,
+        venue_slug: payload.venue_slug,
+        venue_name: payload.venue_name,
+        operator_role: payload.operator_role ?? null,
+        proof: payload.proof ?? null,
+      })
+      .select()
+      .single();
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, claim: data as VenueClaim };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+export async function listChangeRequestsForUser(userId: string): Promise<Array<Record<string, any>>> {
+  const c = getSupabase();
+  if (!c) return [];
+  try {
+    const { data, error } = await c
+      .from('venue_change_requests')
+      .select('id, venue_slug, venue_name, change_type, proposed_change, status, created_at, decision_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    if (error) return [];
+    return data ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/next/src/pages/partners/claim.astro
+++ b/next/src/pages/partners/claim.astro
@@ -1,0 +1,384 @@
+---
+/**
+ * /partners/claim/ — operator claim form (Phase 6 WS6B).
+ *
+ * Auth-gated. Lets a signed-in operator submit a "this is my venue"
+ * claim against a slug from the venues collection. Editor approves
+ * manually in Studio (v1); automated email-domain match follows later.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import SectionHero from '../../components/SectionHero.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { routeSlug } from '../../lib/editorial';
+
+const venues = await getCollection('venues');
+const venueOptions = venues
+  .filter((v) => !v.data.sitemapExclude)
+  .map((v) => ({ slug: routeSlug(v), name: v.data.name }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Partner with us', href: '/partners/' },
+  { label: 'Claim your venue' },
+];
+---
+
+<BaseLayout
+  title="Claim your venue · Peninsula Insider"
+  description="Operators sign in and claim their venue listing on Peninsula Insider. Editor verifies; once approved, the operator dashboard unlocks."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="Claim your venue"
+    subEyebrow="Verified-operator surface"
+    title="Tell us this is <em>your</em> venue."
+    dek="Sign in, point us at the listing, and tell us how to verify you. Editorial approves claims manually in v1 — typically within a working day. Once approved, you can manage hours, photos, and event proposals from the operator dashboard."
+    gradient="journal"
+    visualLabel="Peninsula Insider · operator claim"
+  />
+
+  <section class="claim-page">
+    <div class="container">
+
+      <div class="claim-anonymous" data-claim-anonymous>
+        <p class="claim-anonymous__title">Sign in to submit a claim.</p>
+        <p class="claim-anonymous__body">Claims are linked to your account so the editor can write back about verification status. Sign in (or create an account, free) to continue.</p>
+        <button type="button" class="claim-anonymous__cta" data-open-auth>Sign in</button>
+      </div>
+
+      <form class="claim-form" data-claim-form aria-label="Operator claim form" hidden>
+        <fieldset class="claim-form__group">
+          <legend class="claim-form__legend">Your venue</legend>
+
+          <div class="claim-form__field">
+            <label class="claim-form__label" for="cl-venue">Venue</label>
+            <input
+              id="cl-venue"
+              name="venue"
+              type="text"
+              list="cl-venue-list"
+              required
+              maxlength="200"
+              class="claim-form__input"
+              placeholder="Start typing your venue name…"
+              autocomplete="off"
+            />
+            <datalist id="cl-venue-list">
+              {venueOptions.map((v) => <option value={v.name} data-slug={v.slug}>{v.name}</option>)}
+            </datalist>
+            <p class="claim-form__hint">Pick from the list. If your venue isn't on PI yet, see <a href="/partners/">/partners</a> first.</p>
+          </div>
+
+          <div class="claim-form__field">
+            <label class="claim-form__label" for="cl-role">Your role at the venue</label>
+            <input
+              id="cl-role"
+              name="role"
+              type="text"
+              required
+              maxlength="120"
+              class="claim-form__input"
+              placeholder="Owner / Manager / GM / Marketing"
+            />
+          </div>
+
+          <div class="claim-form__field">
+            <label class="claim-form__label" for="cl-proof">Proof of association</label>
+            <textarea
+              id="cl-proof"
+              name="proof"
+              required
+              minlength="20"
+              maxlength="1500"
+              rows="5"
+              class="claim-form__textarea"
+              placeholder="A line or two on how to verify you. Best: an email address on the venue's domain we can write to. Also fine: a phone number on the venue's website. The editor verifies before approving."
+            ></textarea>
+          </div>
+        </fieldset>
+
+        <div class="claim-form__submit">
+          <button type="submit" class="claim-form__button">Submit claim</button>
+          <p class="claim-form__caveat">Claims are reviewed manually. You'll hear back via your account email — usually within a working day.</p>
+        </div>
+
+        <p class="claim-form__status" data-claim-status hidden></p>
+      </form>
+
+      <p class="claim-existing" data-claim-existing hidden>
+        You already have a claim on file for this account. <a href="/partners/dashboard/">Open the dashboard →</a>
+      </p>
+
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script define:vars={{ venueOptionsJson: JSON.stringify(venueOptions) }}>
+  import { getSupabase, isAuthEnabled, onAuthChange, listOwnVenueClaims, submitVenueClaim } from '../../lib/auth';
+
+  function setVisible(selector, visible) {
+    const el = document.querySelector(selector);
+    if (!el) return;
+    if (visible) el.removeAttribute('hidden');
+    else el.setAttribute('hidden', '');
+  }
+
+  async function init() {
+    if (!isAuthEnabled()) {
+      setVisible('[data-claim-anonymous]', true);
+      const note = document.querySelector('[data-claim-anonymous] .claim-anonymous__body');
+      if (note) note.textContent = "Operator accounts aren't currently configured. Use the anonymous /partners/update/ form for ad-hoc updates.";
+      return;
+    }
+
+    const c = getSupabase();
+    if (!c) return;
+
+    const session = (await c.auth.getSession()).data.session;
+    const user = session?.user ?? null;
+
+    if (!user) {
+      setVisible('[data-claim-anonymous]', true);
+      setVisible('[data-claim-form]', false);
+      setVisible('[data-claim-existing]', false);
+      onAuthChange(() => init());
+      return;
+    }
+
+    setVisible('[data-claim-anonymous]', false);
+
+    const claims = await listOwnVenueClaims(user.id);
+    if (claims.some((c) => c.status === 'pending' || c.status === 'approved')) {
+      setVisible('[data-claim-existing]', true);
+      setVisible('[data-claim-form]', false);
+    } else {
+      setVisible('[data-claim-existing]', false);
+      setVisible('[data-claim-form]', true);
+    }
+
+    bindForm(user);
+  }
+
+  function bindForm(user) {
+    const form = document.querySelector('[data-claim-form]');
+    if (!form || form._piBound) return;
+    form._piBound = true;
+    const status = document.querySelector('[data-claim-status]');
+    const button = form.querySelector('.claim-form__button');
+    const venueOptions = venueOptionsJson;
+
+    function setStatus(kind, message) {
+      if (!status) return;
+      status.textContent = message;
+      status.setAttribute('data-status-kind', kind);
+      status.removeAttribute('hidden');
+    }
+
+    function resolveSlug(name) {
+      if (!name) return '';
+      const exact = venueOptions.find((v) => v.name.toLowerCase() === name.toLowerCase());
+      return exact ? exact.slug : '';
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      const venueName = String(fd.get('venue') || '').trim();
+      const venueSlug = resolveSlug(venueName);
+      if (!venueSlug) {
+        setStatus('error', "We couldn't match that venue to one we cover. Pick from the dropdown, or email hello@peninsulainsider.com.au if your venue isn't listed yet.");
+        return;
+      }
+
+      if (button) button.disabled = true;
+      setStatus('info', 'Submitting…');
+
+      const result = await submitVenueClaim(user.id, {
+        venue_slug: venueSlug,
+        venue_name: venueName,
+        operator_role: String(fd.get('role') || ''),
+        proof: String(fd.get('proof') || ''),
+      });
+
+      if (!result.ok) {
+        // Most likely cause: unique constraint (already claimed).
+        const msg = result.error && result.error.includes('duplicate')
+          ? "You've already submitted a claim for this venue. Open the dashboard to see its status."
+          : "Couldn't send. Try once more, or email hello@peninsulainsider.com.au.";
+        setStatus('error', msg);
+        if (button) button.disabled = false;
+        return;
+      }
+
+      form.reset();
+      setStatus('success', "Claim received. The editor will verify and write back via your account email — usually within a working day.");
+      if (button) button.disabled = false;
+      // Re-load the page state so the existing-claims path takes over.
+      setTimeout(init, 500);
+    });
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>
+
+<style>
+  .claim-page { padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem); max-width: 720px; }
+  .claim-anonymous,
+  .claim-existing {
+    border: 1px dashed var(--border);
+    padding: clamp(1.5rem, 3vw, 2.5rem) 1.5rem;
+    text-align: center;
+  }
+  .claim-anonymous__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0 0 0.5rem;
+  }
+  .claim-anonymous__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--soft);
+    margin: 0 auto 1.25rem;
+    max-width: 32rem;
+  }
+  .claim-anonymous__cta {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.7rem 1.1rem;
+    cursor: pointer;
+  }
+  .claim-anonymous__cta:hover {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+  }
+  .claim-existing {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--dark);
+  }
+  .claim-existing a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .claim-form {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 2.5vw, 1.75rem);
+  }
+  .claim-form__group {
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: clamp(1rem, 2vw, 1.4rem);
+  }
+  .claim-form__legend {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    padding: 0 0.4rem;
+    margin: 0;
+  }
+  .claim-form__field { margin-top: 1rem; }
+  .claim-form__label {
+    display: block;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--dark);
+    margin-bottom: 0.35rem;
+  }
+  .claim-form__input,
+  .claim-form__textarea {
+    width: 100%;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    color: var(--dark);
+    background: var(--bg, #fff);
+    border: 1px solid var(--border);
+    padding: 0.6rem 0.75rem;
+  }
+  .claim-form__textarea { resize: vertical; min-height: 7rem; }
+  .claim-form__input:focus,
+  .claim-form__textarea:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .claim-form__hint {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin: 0.35rem 0 0;
+  }
+  .claim-form__hint a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+  .claim-form__submit {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    align-items: flex-start;
+  }
+  .claim-form__button {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--bg, #fff);
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 0.85rem 1.4rem;
+    cursor: pointer;
+  }
+  .claim-form__button:disabled { opacity: 0.6; cursor: progress; }
+  .claim-form__button:hover:not(:disabled) {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+  }
+  .claim-form__caveat {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    color: var(--soft);
+    margin: 0;
+    max-width: 28rem;
+  }
+  .claim-form__status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--border);
+  }
+  .claim-form__status[data-status-kind="success"] {
+    color: #2f6e3a;
+    border-color: rgba(47, 110, 58, 0.5);
+    background: rgba(47, 110, 58, 0.07);
+  }
+  .claim-form__status[data-status-kind="error"] {
+    color: #b14b3a;
+    border-color: rgba(177, 75, 58, 0.5);
+    background: rgba(177, 75, 58, 0.07);
+  }
+  .claim-form__status[data-status-kind="info"] {
+    color: var(--soft);
+  }
+</style>

--- a/next/src/pages/partners/dashboard.astro
+++ b/next/src/pages/partners/dashboard.astro
@@ -1,0 +1,539 @@
+---
+/**
+ * /partners/dashboard/ — operator dashboard (Phase 6 WS6B).
+ *
+ * Auth-gated. When signed in, shows:
+ *   - Each claimed venue as a card with the live listing summary,
+ *     a "Submit a change" CTA pre-filled to that venue, and recent
+ *     change-request history.
+ *   - When no claims, a CTA leading to /partners/claim/.
+ *   - When claims pending, an "in verification" status panel.
+ *
+ * v1: editor approves claims manually in Supabase Studio. v1.x:
+ * automated email-domain match against the venue's website.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import SectionHero from '../../components/SectionHero.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { routeSlug, venueHrefPrefix } from '../../lib/editorial';
+
+const venuesAll = await getCollection('venues');
+// Build a slug → summary lookup that the client controller uses to
+// hydrate claimed venues without an extra round trip.
+const venueIndex = Object.fromEntries(
+  venuesAll.map((v) => {
+    const slug = routeSlug(v);
+    const placeId = typeof v.data.place === 'string' ? v.data.place : v.data.place?.id ?? '';
+    return [
+      slug,
+      {
+        slug,
+        name: v.data.name,
+        href: `${venueHrefPrefix(v.data.type)}/${slug}/`,
+        type: v.data.type,
+        priceBand: v.data.priceBand ?? '',
+        placeName: String(placeId).replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase()),
+        signature: v.data.signature ?? '',
+        hero: v.data.heroImage?.src ?? '',
+      },
+    ];
+  }),
+);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Partner with us', href: '/partners/' },
+  { label: 'Operator dashboard' },
+];
+---
+
+<BaseLayout
+  title="Operator Dashboard · Peninsula Insider"
+  description="Manage your Peninsula Insider venue listing — submit hours / photo / event changes, see recent change-request history, claim a new venue."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="Operator dashboard"
+    subEyebrow="Verified-operator surface"
+    title="Manage your <em>Peninsula Insider</em> listing."
+    dek="Submit hours updates, swap a hero photo, propose an event, or flag a closure. The editor reviews every request, applies the ones that hold up to verification, writes back if it doesn't. Claims approved manually in v1; automated email-domain verification follows."
+    gradient="journal"
+    visualLabel="Peninsula Insider · operator dashboard"
+  />
+
+  <section class="dashboard-page">
+    <div class="container">
+
+      <!-- Auth state — anonymous user prompt -->
+      <div class="dashboard-anonymous" data-dashboard-anonymous>
+        <p class="dashboard-anonymous__title">Sign in to your operator account.</p>
+        <p class="dashboard-anonymous__body">The dashboard is auth-gated. Sign in (or create an account, free) to claim your venue and start managing your listing.</p>
+        <button type="button" class="dashboard-anonymous__cta" data-open-auth>Sign in</button>
+        <p class="dashboard-anonymous__alt">
+          Just want to send a quick update without signing in? You can still <a href="/partners/update/">submit anonymously</a> — that path stays open.
+        </p>
+      </div>
+
+      <!-- Loading state -->
+      <div class="dashboard-loading" data-dashboard-loading hidden>
+        <p>Loading your dashboard…</p>
+      </div>
+
+      <!-- Empty state — signed in, no claims -->
+      <div class="dashboard-empty" data-dashboard-empty hidden>
+        <p class="dashboard-empty__title">No venues claimed yet.</p>
+        <p class="dashboard-empty__body">Claim your venue to manage hours, photos, and events from one place. Editor approves the claim manually — usually within a working day.</p>
+        <a href="/partners/claim/" class="dashboard-empty__cta">Claim your venue →</a>
+      </div>
+
+      <!-- Claims grid -->
+      <div class="dashboard-claims" data-dashboard-claims hidden>
+        <div class="dashboard-claims__head">
+          <p class="dashboard-claims__count" data-dashboard-claims-count></p>
+          <a href="/partners/claim/" class="dashboard-claims__add">+ Claim another venue</a>
+        </div>
+        <ul class="dashboard-claims__list" data-dashboard-claims-list></ul>
+      </div>
+
+      <!-- Recent change requests -->
+      <div class="dashboard-history" data-dashboard-history hidden>
+        <h2 class="dashboard-history__title">Recent change requests</h2>
+        <ul class="dashboard-history__list" data-dashboard-history-list></ul>
+        <p class="dashboard-history__empty" data-dashboard-history-empty hidden>No change requests yet. <a href="/partners/update/">Submit one →</a></p>
+      </div>
+
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script define:vars={{ venueIndex }}>
+  import { getSupabase, isAuthEnabled, onAuthChange, listOwnVenueClaims, listChangeRequestsForUser } from '../../lib/auth';
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function setVisible(selector, visible) {
+    const el = document.querySelector(selector);
+    if (!el) return;
+    if (visible) el.removeAttribute('hidden');
+    else el.setAttribute('hidden', '');
+  }
+
+  function renderClaim(claim) {
+    const v = venueIndex[claim.venue_slug];
+    const fallbackName = claim.venue_name || claim.venue_slug;
+    const heroBlock = v && v.hero
+      ? '<div class="dashboard-claim__hero" style="background-image:url(' + escapeHtml(v.hero) + ')"></div>'
+      : '<div class="dashboard-claim__hero dashboard-claim__hero--empty"></div>';
+    const meta = v
+      ? [v.priceBand, v.placeName, v.type].filter(Boolean).map(escapeHtml).join(' · ')
+      : escapeHtml(claim.venue_slug);
+    const statusLabel = ({
+      pending: 'Verification pending',
+      approved: 'Active',
+      revoked: 'Revoked',
+    })[claim.status] || claim.status;
+    const updateLink = v
+      ? '<a class="dashboard-claim__action" href="/partners/update/?venue=' + encodeURIComponent(claim.venue_slug) + '">Submit a change →</a>'
+      : '<a class="dashboard-claim__action" href="/partners/update/">Submit a change →</a>';
+    const viewLink = v
+      ? '<a class="dashboard-claim__action dashboard-claim__action--ghost" href="' + escapeHtml(v.href) + '" target="_blank" rel="noreferrer">View live listing →</a>'
+      : '';
+    return ''
+      + '<li class="dashboard-claim dashboard-claim--' + escapeHtml(claim.status) + '">'
+      +   heroBlock
+      +   '<div class="dashboard-claim__body">'
+      +     '<p class="dashboard-claim__status">' + escapeHtml(statusLabel) + '</p>'
+      +     '<h3 class="dashboard-claim__name">' + escapeHtml((v && v.name) || fallbackName) + '</h3>'
+      +     '<p class="dashboard-claim__meta">' + meta + '</p>'
+      +     (v && v.signature ? '<p class="dashboard-claim__signature">' + escapeHtml(v.signature) + '</p>' : '')
+      +     '<div class="dashboard-claim__actions">'
+      +       (claim.status === 'approved' ? updateLink : '')
+      +       viewLink
+      +     '</div>'
+      +   '</div>'
+      + '</li>';
+  }
+
+  function renderHistoryItem(req) {
+    const venueLabel = req.venue_name || req.venue_slug;
+    const date = req.created_at ? new Date(req.created_at).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' }) : '';
+    const statusLabel = ({
+      pending: 'Pending',
+      'in-review': 'In review',
+      applied: 'Applied',
+      declined: 'Declined',
+    })[req.status] || req.status;
+    return ''
+      + '<li class="dashboard-history-item dashboard-history-item--' + escapeHtml(req.status) + '">'
+      +   '<div class="dashboard-history-item__head">'
+      +     '<p class="dashboard-history-item__type">' + escapeHtml(req.change_type) + '</p>'
+      +     '<p class="dashboard-history-item__status">' + escapeHtml(statusLabel) + '</p>'
+      +   '</div>'
+      +   '<p class="dashboard-history-item__venue"><strong>' + escapeHtml(venueLabel) + '</strong> · ' + escapeHtml(date) + '</p>'
+      +   '<p class="dashboard-history-item__body">' + escapeHtml(req.proposed_change || '').slice(0, 280) + (req.proposed_change && req.proposed_change.length > 280 ? '…' : '') + '</p>'
+      + '</li>';
+  }
+
+  async function load(user) {
+    if (!user) {
+      setVisible('[data-dashboard-anonymous]', true);
+      setVisible('[data-dashboard-loading]', false);
+      setVisible('[data-dashboard-empty]', false);
+      setVisible('[data-dashboard-claims]', false);
+      setVisible('[data-dashboard-history]', false);
+      return;
+    }
+
+    setVisible('[data-dashboard-anonymous]', false);
+    setVisible('[data-dashboard-loading]', true);
+
+    const [claims, history] = await Promise.all([
+      listOwnVenueClaims(user.id),
+      listChangeRequestsForUser(user.id),
+    ]);
+
+    setVisible('[data-dashboard-loading]', false);
+
+    if (claims.length === 0) {
+      setVisible('[data-dashboard-empty]', true);
+      setVisible('[data-dashboard-claims]', false);
+    } else {
+      setVisible('[data-dashboard-empty]', false);
+      setVisible('[data-dashboard-claims]', true);
+      const list = document.querySelector('[data-dashboard-claims-list]');
+      const count = document.querySelector('[data-dashboard-claims-count]');
+      if (list) list.innerHTML = claims.map(renderClaim).join('');
+      if (count) {
+        const approved = claims.filter((c) => c.status === 'approved').length;
+        const pending = claims.filter((c) => c.status === 'pending').length;
+        const bits = [];
+        if (approved > 0) bits.push(approved + ' active');
+        if (pending > 0) bits.push(pending + ' pending');
+        count.textContent = (bits.length ? bits.join(' · ') : claims.length + ' total');
+      }
+    }
+
+    // History panel — show always when signed in (lets the operator
+    // confirm that anonymous-then-claimed change requests still attach).
+    setVisible('[data-dashboard-history]', true);
+    const histList = document.querySelector('[data-dashboard-history-list]');
+    const histEmpty = document.querySelector('[data-dashboard-history-empty]');
+    if (history.length === 0) {
+      if (histList) histList.innerHTML = '';
+      if (histEmpty) histEmpty.removeAttribute('hidden');
+    } else {
+      if (histEmpty) histEmpty.setAttribute('hidden', '');
+      if (histList) histList.innerHTML = history.slice(0, 12).map(renderHistoryItem).join('');
+    }
+  }
+
+  async function init() {
+    if (!isAuthEnabled()) {
+      // Auth not configured — show the anonymous prompt with a note.
+      setVisible('[data-dashboard-anonymous]', true);
+      const anon = document.querySelector('[data-dashboard-anonymous] .dashboard-anonymous__body');
+      if (anon) anon.textContent = "Operator accounts aren't currently configured. The anonymous /partners/update/ form still works for ad-hoc updates.";
+      return;
+    }
+
+    const c = getSupabase();
+    if (!c) { load(null); return; }
+
+    const session = (await c.auth.getSession()).data.session;
+    load(session?.user ?? null);
+
+    // React to sign-in / sign-out without a page reload.
+    onAuthChange((user) => load(user));
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>
+
+<style>
+  .dashboard-page {
+    padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem);
+  }
+
+  .dashboard-anonymous,
+  .dashboard-empty,
+  .dashboard-loading {
+    border: 1px dashed var(--border);
+    padding: clamp(1.5rem, 3vw, 2.5rem) 1.5rem;
+    text-align: center;
+    margin-bottom: clamp(1.25rem, 2.5vw, 1.75rem);
+  }
+  .dashboard-loading p,
+  .dashboard-anonymous__title,
+  .dashboard-empty__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0 0 0.5rem;
+  }
+  .dashboard-anonymous__body,
+  .dashboard-empty__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--soft);
+    margin: 0 auto 1.25rem;
+    max-width: 38rem;
+  }
+  .dashboard-anonymous__cta,
+  .dashboard-empty__cta {
+    display: inline-flex;
+    align-items: center;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.7rem 1.1rem;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .dashboard-anonymous__cta:hover,
+  .dashboard-empty__cta:hover {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+  }
+  .dashboard-anonymous__alt {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    color: var(--soft);
+    margin: 1rem 0 0;
+  }
+  .dashboard-anonymous__alt a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .dashboard-claims__head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.85rem;
+    padding: 0 0 1rem;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: clamp(1rem, 2vw, 1.5rem);
+  }
+  .dashboard-claims__count {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--soft);
+    margin: 0;
+  }
+  .dashboard-claims__add {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid rgba(167, 118, 55, 0.5);
+  }
+  .dashboard-claims__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: clamp(0.85rem, 1.5vw, 1.25rem);
+  }
+  @media (min-width: 880px) {
+    .dashboard-claims__list { grid-template-columns: 1fr 1fr; }
+  }
+
+  .dashboard-claim {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border);
+    background: var(--bg, #fff);
+    overflow: hidden;
+  }
+  .dashboard-claim--pending { border-color: rgba(167, 118, 55, 0.5); }
+  .dashboard-claim--approved { border-color: var(--border); }
+  .dashboard-claim--revoked { opacity: 0.55; }
+
+  .dashboard-claim__hero {
+    aspect-ratio: 16 / 9;
+    background-size: cover;
+    background-position: center;
+    background-color: var(--paper, #fbf7f0);
+  }
+  .dashboard-claim__hero--empty {
+    background: linear-gradient(135deg, rgba(167, 118, 55, 0.12), rgba(223, 197, 158, 0.08));
+  }
+  .dashboard-claim__body {
+    padding: clamp(0.85rem, 1.5vw, 1.2rem);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .dashboard-claim__status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0;
+  }
+  .dashboard-claim--pending .dashboard-claim__status { color: #b3592a; }
+  .dashboard-claim--approved .dashboard-claim__status { color: #2f6e3a; }
+  .dashboard-claim--revoked .dashboard-claim__status { color: var(--soft); }
+
+  .dashboard-claim__name {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    line-height: 1.2;
+    color: var(--text);
+    margin: 0;
+  }
+  .dashboard-claim__meta {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    color: var(--soft);
+    margin: 0;
+  }
+  .dashboard-claim__signature {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--dark);
+    margin: 0.2rem 0 0;
+  }
+  .dashboard-claim__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+  }
+  .dashboard-claim__action {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    text-decoration: none;
+    border: 1px solid var(--accent);
+    padding: 0.45rem 0.7rem;
+    border-radius: 999px;
+  }
+  .dashboard-claim__action:hover {
+    background: var(--accent);
+    color: var(--bg, #fff);
+  }
+  .dashboard-claim__action--ghost {
+    color: var(--soft);
+    border-color: var(--border);
+  }
+  .dashboard-claim__action--ghost:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: transparent;
+  }
+
+  .dashboard-history {
+    margin-top: clamp(1.75rem, 3vw, 2.5rem);
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+  }
+  .dashboard-history__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.55rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0 0 1rem;
+  }
+  .dashboard-history__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+  }
+  .dashboard-history-item {
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: 0.85rem 1rem;
+  }
+  .dashboard-history-item__head {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.85rem;
+  }
+  .dashboard-history-item__type {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0;
+  }
+  .dashboard-history-item__status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--soft);
+    margin: 0;
+  }
+  .dashboard-history-item--applied .dashboard-history-item__status { color: #2f6e3a; }
+  .dashboard-history-item--declined .dashboard-history-item__status { color: #b14b3a; }
+  .dashboard-history-item__venue {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    color: var(--soft);
+    margin: 0.35rem 0 0.2rem;
+  }
+  .dashboard-history-item__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: var(--dark);
+    margin: 0;
+  }
+  .dashboard-history__empty {
+    margin: 1rem 0 0;
+    padding: 1rem;
+    border: 1px dashed var(--border);
+    text-align: center;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    color: var(--soft);
+  }
+  .dashboard-history__empty a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+</style>

--- a/next/src/pages/partners/index.astro
+++ b/next/src/pages/partners/index.astro
@@ -50,7 +50,7 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
     <aside class="partners-update-banner">
       <div class="partners-section__inner">
         <p class="partners-update-banner__eyebrow">Already a Peninsula venue we cover?</p>
-        <p class="partners-update-banner__body">Hours moved? Hero photo dated? An event we should know about? <a href="/partners/update/">Send us a structured update</a> — editor reads every request, applies in hours.</p>
+        <p class="partners-update-banner__body">Hours moved? Hero photo dated? An event we should know about? <a href="/partners/dashboard/">Open the operator dashboard</a> to manage your listing, or send a one-off via the <a href="/partners/update/">anonymous update form</a> — editor reads every request, applies in hours.</p>
       </div>
     </aside>
 

--- a/next/src/pages/partners/update.astro
+++ b/next/src/pages/partners/update.astro
@@ -217,9 +217,30 @@ const changeTypes = [
     }
   }
 
+  /**
+   * Pre-fill the venue field from a ?venue=<slug> query param. The
+   * operator dashboard sends users here with this hint when they click
+   * "Submit a change" on a claimed venue card. Falls back to manual
+   * entry if the slug doesn't resolve.
+   */
+  function applyVenueQueryParam() {
+    try {
+      const p = new URLSearchParams(window.location.search);
+      const slug = p.get('venue');
+      if (!slug) return;
+      const venueOptions = (typeof venueOptionsJson !== 'undefined') ? venueOptionsJson : null;
+      if (!venueOptions) return;
+      const match = venueOptions.find((v) => v.slug === slug);
+      if (!match) return;
+      const input = document.querySelector('#pu-venue');
+      if (input && !input.value) input.value = match.name;
+    } catch {}
+  }
+
   function init() {
     const form = document.querySelector('[data-partner-update-form]');
     if (!form) return;
+    applyVenueQueryParam();
     const status = document.querySelector('[data-partner-update-status]');
     const button = form.querySelector('.partner-update-form__button');
     const venueOptions = venueOptionsJson;

--- a/ops/migrations/2026-05-05-venue-claims.sql
+++ b/ops/migrations/2026-05-05-venue-claims.sql
@@ -1,0 +1,88 @@
+-- Migration: venue claims (Phase 6 WS6B)
+-- Date: 2026-05-05
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+--
+-- Purpose: link a signed-in operator (auth.users.id) to a venue slug
+-- with editor-approved status. Lets the operator dashboard at
+-- /partners/dashboard/ show their venues and the change-request
+-- history scoped to those.
+--
+-- v1: anonymous insert allowed (the claim form is the entry point);
+-- editor approves manually in Studio. v1.x: automated email-domain
+-- match against the venue's official website.
+--
+-- Idempotent.
+
+create table if not exists pi.venue_claims (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id) on delete cascade,
+  venue_slug      text not null,
+  venue_name      text,
+  -- The operator's stated relationship to the venue.
+  operator_role   text,
+  -- Free-text proof of association (URL, role description, contact
+  -- the editor can verify by phone, etc.). Editor reads this when
+  -- approving.
+  proof           text,
+  status          text not null default 'pending' check (status in (
+    'pending', 'approved', 'revoked'
+  )),
+  editor_notes    text,
+  decision_at     timestamptz,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  -- Composite uniqueness: a user can only have one active claim per
+  -- venue. We allow re-submission after a revoked claim by setting
+  -- status back to 'pending'; the unique constraint catches duplicates.
+  unique (user_id, venue_slug)
+);
+
+comment on table pi.venue_claims is 'Phase 6 WS6B: links an operator (auth.users) to a venue slug. Editor approves in Studio.';
+
+create index if not exists venue_claims_by_user
+  on pi.venue_claims (user_id, created_at desc);
+create index if not exists venue_claims_by_venue
+  on pi.venue_claims (venue_slug);
+create index if not exists venue_claims_by_status
+  on pi.venue_claims (status, created_at desc);
+
+alter table pi.venue_claims enable row level security;
+
+-- Signed-in users can insert claims for themselves.
+drop policy if exists "venue_claims_insert_own" on pi.venue_claims;
+create policy "venue_claims_insert_own"
+  on pi.venue_claims for insert
+  with check (user_id = auth.uid());
+
+-- Signed-in users can read their own claims (any status).
+drop policy if exists "venue_claims_select_own" on pi.venue_claims;
+create policy "venue_claims_select_own"
+  on pi.venue_claims for select
+  using (user_id = auth.uid());
+
+-- Signed-in users can withdraw their own claims by setting status to
+-- 'revoked'. Editor still has full access.
+drop policy if exists "venue_claims_update_own" on pi.venue_claims;
+create policy "venue_claims_update_own"
+  on pi.venue_claims for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+-- Editor full access via pi.profiles.is_editor.
+drop policy if exists "venue_claims_editor_all" on pi.venue_claims;
+create policy "venue_claims_editor_all"
+  on pi.venue_claims for all
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true))
+  with check (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- updated_at trigger
+create or replace function pi.venue_claims_set_updated_at()
+returns trigger as $$
+begin new.updated_at = now(); return new; end;
+$$ language plpgsql;
+
+drop trigger if exists venue_claims_set_updated_at on pi.venue_claims;
+create trigger venue_claims_set_updated_at
+  before update on pi.venue_claims
+  for each row execute function pi.venue_claims_set_updated_at();


### PR DESCRIPTION
Extends Phase 5's anonymous change-request form into a verified-operator surface. New pi.venue_claims table, /partners/dashboard/ auth-gated dashboard, /partners/claim/ form, ?venue=slug pre-fill on /partners/update/. Migration in ops/. Build clean at 1234 pages.