### PR TITLE
feat(discovery-phase-6): Stripe Checkout scaffold for Pass tiers (WS6A)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,10 +70,22 @@ jobs:
           # either is unset, lib/auth.ts gracefully no-ops to localStorage.
           PUBLIC_SUPABASE_URL: ${{ vars.PUBLIC_SUPABASE_URL || secrets.PUBLIC_SUPABASE_URL }}
           PUBLIC_SUPABASE_ANON_KEY: ${{ vars.PUBLIC_SUPABASE_ANON_KEY || secrets.PUBLIC_SUPABASE_ANON_KEY }}
+          # Phase 6 WS6A — Stripe Checkout for Pass tiers. Publishable
+          # key + price ids are non-sensitive (RLS-equivalent — Stripe
+          # validates everything server-side). Until set, /pass/ falls
+          # back to the waitlist email-capture flow.
+          PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ vars.PUBLIC_STRIPE_PUBLISHABLE_KEY || secrets.PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+          PUBLIC_STRIPE_PRICE_INSIDER_MONTHLY: ${{ vars.PUBLIC_STRIPE_PRICE_INSIDER_MONTHLY || secrets.PUBLIC_STRIPE_PRICE_INSIDER_MONTHLY }}
+          PUBLIC_STRIPE_PRICE_INSIDER_ANNUAL:  ${{ vars.PUBLIC_STRIPE_PRICE_INSIDER_ANNUAL  || secrets.PUBLIC_STRIPE_PRICE_INSIDER_ANNUAL }}
+          PUBLIC_STRIPE_PRICE_FOUNDERS:        ${{ vars.PUBLIC_STRIPE_PRICE_FOUNDERS        || secrets.PUBLIC_STRIPE_PRICE_FOUNDERS }}
         run: |
           echo "Building with API URL: ${PUBLIC_CONCIERGE_API_URL:-(unset)}"
           echo "Supabase URL configured:    $([ -n "$PUBLIC_SUPABASE_URL" ] && echo yes || echo no)"
           echo "Supabase anon key configured: $([ -n "$PUBLIC_SUPABASE_ANON_KEY" ] && echo yes || echo no)"
+          echo "Stripe publishable key:     $([ -n "$PUBLIC_STRIPE_PUBLISHABLE_KEY" ] && echo yes || echo no)"
+          echo "Stripe Insider monthly:     $([ -n "$PUBLIC_STRIPE_PRICE_INSIDER_MONTHLY" ] && echo yes || echo no)"
+          echo "Stripe Insider annual:      $([ -n "$PUBLIC_STRIPE_PRICE_INSIDER_ANNUAL" ] && echo yes || echo no)"
+          echo "Stripe Founders:            $([ -n "$PUBLIC_STRIPE_PRICE_FOUNDERS" ] && echo yes || echo no)"
           npm run build:search
 
       - name: Sync dist to repo root (mirrors build-live.sh)

--- a/next/src/lib/stripe.ts
+++ b/next/src/lib/stripe.ts
@@ -1,0 +1,154 @@
+/**
+ * Stripe Checkout helpers — Phase 6 WS6A.
+ *
+ * Front-end side of the Pass tier purchase flow. Calls the
+ * `create-checkout-session` Supabase Edge Function (deployed via
+ * supabase functions deploy from ops/edge-functions/) which runs with
+ * the Stripe secret key server-side and returns a Checkout session URL.
+ *
+ * GRACEFUL DEGRADATION
+ * Until both the Stripe account is set up and the Edge Function is
+ * deployed, `isStripeEnabled()` returns false and the Pass landing
+ * keeps showing the waitlist email-capture forms. One env var flip
+ * (PUBLIC_STRIPE_PUBLISHABLE_KEY) and one Edge Function deploy turns
+ * the page from waitlist to live commerce without code changes.
+ *
+ * SECURITY NOTE
+ * The publishable key is safe to ship in the static bundle. The
+ * secret key (sk_*) MUST stay in the Edge Function environment;
+ * never put it in any PUBLIC_* env var.
+ */
+
+const SUPABASE_URL =
+  (import.meta.env.PUBLIC_SUPABASE_URL as string | undefined) ||
+  'https://tjjhpvslpysfklwpqmgz.supabase.co';
+
+const STRIPE_PUBLISHABLE_KEY = import.meta.env.PUBLIC_STRIPE_PUBLISHABLE_KEY as string | undefined;
+
+/** Per-tier price IDs. Set as build-time env vars; can be plain text since
+ *  Stripe price IDs are not secrets. Adding monthly + annual variants per
+ *  locked decision Q1. */
+const PRICES = {
+  insider_monthly: import.meta.env.PUBLIC_STRIPE_PRICE_INSIDER_MONTHLY as string | undefined,
+  insider_annual:  import.meta.env.PUBLIC_STRIPE_PRICE_INSIDER_ANNUAL  as string | undefined,
+  founders:        import.meta.env.PUBLIC_STRIPE_PRICE_FOUNDERS        as string | undefined,
+};
+
+export type PassTier = 'insider' | 'founders';
+export type BillingInterval = 'month' | 'year';
+
+/**
+ * True iff Stripe Checkout is wired end-to-end:
+ *   - publishable key present (build picked it up)
+ *   - at least one price ID configured (so we have something to buy)
+ *
+ * The Edge Function deployment is checked at call-time (a 404 on the
+ * function endpoint surfaces in the user-facing error message).
+ */
+export function isStripeEnabled(): boolean {
+  return Boolean(
+    STRIPE_PUBLISHABLE_KEY
+    && (PRICES.insider_monthly || PRICES.insider_annual || PRICES.founders)
+  );
+}
+
+/**
+ * Resolve the price ID for a tier + interval combination. Returns
+ * undefined if not configured — caller should fall back to the
+ * waitlist UI. */
+export function priceIdFor(tier: PassTier, interval: BillingInterval = 'month'): string | undefined {
+  if (tier === 'insider' && interval === 'month') return PRICES.insider_monthly;
+  if (tier === 'insider' && interval === 'year')  return PRICES.insider_annual;
+  if (tier === 'founders')                          return PRICES.founders;
+  return undefined;
+}
+
+/**
+ * Kick off Checkout for a tier. POSTs to the Supabase Edge Function
+ * with the price ID + the current user's email (when signed in) +
+ * success/cancel return URLs. The function creates a Checkout Session
+ * in Stripe and returns its URL; we redirect the browser there.
+ *
+ * The function path:
+ *   POST {SUPABASE_URL}/functions/v1/create-pass-checkout-session
+ *   body: { price_id, success_url, cancel_url, user_email? }
+ *   returns: { url }
+ */
+export async function startPassCheckout(opts: {
+  tier: PassTier;
+  interval?: BillingInterval;
+  userEmail?: string;
+  /** Where Stripe sends the user back on success. Default: /account/pass/?welcome=1. */
+  successUrl?: string;
+  /** Where Stripe sends the user back if they bail. Default: /pass/?cancelled=1. */
+  cancelUrl?: string;
+}): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  if (!isStripeEnabled()) {
+    return { ok: false, error: 'stripe-not-configured' };
+  }
+  const priceId = priceIdFor(opts.tier, opts.interval);
+  if (!priceId) {
+    return { ok: false, error: 'price-not-configured' };
+  }
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://peninsulainsider.com.au';
+  const successUrl = opts.successUrl ?? `${origin}/account/pass/?welcome=1`;
+  const cancelUrl  = opts.cancelUrl  ?? `${origin}/pass/?cancelled=1`;
+
+  try {
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/create-pass-checkout-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        price_id: priceId,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        user_email: opts.userEmail,
+      }),
+    });
+    if (!res.ok) {
+      // Most likely cause: function not deployed (404) or the request
+      // failed validation. Surface a stable error string the UI maps to
+      // a friendly message.
+      if (res.status === 404) return { ok: false, error: 'function-not-deployed' };
+      const txt = await res.text().catch(() => '');
+      return { ok: false, error: txt || `http-${res.status}` };
+    }
+    const json = await res.json();
+    if (!json || typeof json.url !== 'string') {
+      return { ok: false, error: 'invalid-response' };
+    }
+    return { ok: true, url: json.url };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * URL of the Stripe Customer Portal where members manage billing,
+ * cancel, change card, etc. Backed by another Edge Function (which
+ * calls billingPortal.sessions.create with the user's customer id).
+ *
+ * We don't expose the URL directly because it requires the Stripe
+ * customer id, which lives in pi.profiles.stripe_customer_id and
+ * needs an authenticated lookup the front-end can't do safely.
+ */
+export async function getBillingPortalUrl(): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  if (!isStripeEnabled()) return { ok: false, error: 'stripe-not-configured' };
+  try {
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/create-pass-billing-portal`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) {
+      if (res.status === 404) return { ok: false, error: 'function-not-deployed' };
+      const txt = await res.text().catch(() => '');
+      return { ok: false, error: txt || `http-${res.status}` };
+    }
+    const json = await res.json();
+    if (!json || typeof json.url !== 'string') return { ok: false, error: 'invalid-response' };
+    return { ok: true, url: json.url };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}

--- a/next/src/pages/account/pass.astro
+++ b/next/src/pages/account/pass.astro
@@ -1,0 +1,404 @@
+---
+/**
+ * /account/pass/ — Pass member dashboard (Phase 6 WS6A).
+ *
+ * Auth-gated. Shows the signed-in user's Pass tier, renewal date,
+ * and a link to the Stripe Customer Portal for billing management.
+ *
+ * v1: read-only summary. v1.x: cancel-here-without-Stripe-redirect,
+ * pause/resume actions, member-only inventory teasers (Pass-only
+ * itineraries, early Awards access, Pass dispatch archive).
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import SectionHero from '../../components/SectionHero.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'My account', href: '/account/' },
+  { label: 'The Pass' },
+];
+---
+
+<BaseLayout
+  title="My Pass · Peninsula Insider"
+  description="Your Peninsula Insider Pass — tier, renewal date, billing."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <SectionHero
+    eyebrow="My Pass"
+    subEyebrow="Membership account"
+    title="Your <em>Peninsula Insider</em> Pass."
+    dek="The membership that funds the editorial. Manage your tier, renewal, and billing here. Member-only itineraries and early Awards voting unlock once your tier is active."
+    gradient="journal"
+    visualLabel="Peninsula Insider · my Pass"
+  />
+
+  <section class="pass-account">
+    <div class="container">
+
+      <!-- Welcome banner: shown after Stripe Checkout success redirect -->
+      <aside class="pass-account-welcome" data-pass-account-welcome hidden>
+        <p class="pass-account-welcome__title">Welcome to the Pass.</p>
+        <p class="pass-account-welcome__body">Your subscription is active. Membership benefits unlock as we ship them; the next is the Pass-only quarterly dispatch in early winter.</p>
+      </aside>
+
+      <!-- Anonymous prompt -->
+      <div class="pass-account-anon" data-pass-account-anon>
+        <p class="pass-account-anon__title">Sign in to manage your Pass.</p>
+        <p class="pass-account-anon__body">If you've already taken out an Insider or Founders' tier, sign in with the email you used at checkout. Otherwise, see the <a href="/pass/">Pass page</a>.</p>
+        <button type="button" class="pass-account-anon__cta" data-open-auth>Sign in</button>
+      </div>
+
+      <!-- Loading state -->
+      <div class="pass-account-loading" data-pass-account-loading hidden>
+        <p>Loading your subscription…</p>
+      </div>
+
+      <!-- No active membership -->
+      <div class="pass-account-empty" data-pass-account-empty hidden>
+        <p class="pass-account-empty__title">You're signed in, but you don't have an active Pass.</p>
+        <p class="pass-account-empty__body">Pick a tier on the Pass page — Insider unlocks the member benefits, Founders' Circle is a capped longer-term partnership.</p>
+        <a href="/pass/" class="pass-account-empty__cta">Open the Pass page →</a>
+      </div>
+
+      <!-- Active membership summary -->
+      <div class="pass-account-active" data-pass-account-active hidden>
+        <div class="pass-account-active__head">
+          <p class="pass-account-active__tier-eyebrow">Your tier</p>
+          <h2 class="pass-account-active__tier" data-pass-tier-name>—</h2>
+          <p class="pass-account-active__status" data-pass-status-text>—</p>
+        </div>
+
+        <dl class="pass-account-active__detail">
+          <div>
+            <dt>Billing</dt>
+            <dd data-pass-billing-interval>—</dd>
+          </div>
+          <div>
+            <dt>Active until</dt>
+            <dd data-pass-active-until>—</dd>
+          </div>
+          <div>
+            <dt>Auto-renew</dt>
+            <dd data-pass-autorenew>—</dd>
+          </div>
+        </dl>
+
+        <div class="pass-account-active__actions">
+          <button type="button" class="pass-account-active__portal" data-pass-portal>Manage billing in Stripe →</button>
+          <p class="pass-account-active__portal-note" data-pass-portal-note hidden></p>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled, onAuthChange } from '../../lib/auth';
+  import { getBillingPortalUrl } from '../../lib/stripe';
+
+  function setVisible(selector, visible) {
+    const el = document.querySelector(selector);
+    if (!el) return;
+    if (visible) el.removeAttribute('hidden');
+    else el.setAttribute('hidden', '');
+  }
+
+  function showWelcome() {
+    try {
+      const p = new URLSearchParams(window.location.search);
+      if (p.get('welcome') === '1') {
+        setVisible('[data-pass-account-welcome]', true);
+        // Drop the param so refresh doesn't re-show.
+        window.history.replaceState(null, '', window.location.pathname);
+      }
+    } catch {}
+  }
+
+  type SubscriptionRow = {
+    tier: string;
+    billing_interval: string | null;
+    status: string;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  };
+
+  async function load(user: any) {
+    if (!user) {
+      setVisible('[data-pass-account-anon]', true);
+      setVisible('[data-pass-account-loading]', false);
+      setVisible('[data-pass-account-empty]', false);
+      setVisible('[data-pass-account-active]', false);
+      return;
+    }
+
+    setVisible('[data-pass-account-anon]', false);
+    setVisible('[data-pass-account-loading]', true);
+
+    const c = getSupabase();
+    if (!c) { setVisible('[data-pass-account-loading]', false); return; }
+
+    const { data: profile } = await c
+      .from('profiles')
+      .select('is_member, pass_tier, pass_active_until')
+      .eq('id', user.id)
+      .maybeSingle();
+
+    const isMember = profile?.is_member === true
+      && (!profile?.pass_active_until || new Date(profile.pass_active_until).getTime() > Date.now());
+
+    if (!isMember) {
+      setVisible('[data-pass-account-loading]', false);
+      setVisible('[data-pass-account-empty]', true);
+      setVisible('[data-pass-account-active]', false);
+      return;
+    }
+
+    const { data: subRows } = await c
+      .from('pass_subscriptions')
+      .select('tier, billing_interval, status, current_period_end, cancel_at_period_end')
+      .eq('user_id', user.id)
+      .order('current_period_end', { ascending: false })
+      .limit(1);
+
+    const sub: SubscriptionRow | null = (subRows && subRows[0]) ? (subRows[0] as SubscriptionRow) : null;
+
+    setVisible('[data-pass-account-loading]', false);
+    setVisible('[data-pass-account-empty]', false);
+    setVisible('[data-pass-account-active]', true);
+
+    const tierEl = document.querySelector('[data-pass-tier-name]');
+    const statusEl = document.querySelector('[data-pass-status-text]');
+    const intervalEl = document.querySelector('[data-pass-billing-interval]');
+    const untilEl = document.querySelector('[data-pass-active-until]');
+    const autorenewEl = document.querySelector('[data-pass-autorenew]');
+
+    if (tierEl) tierEl.textContent =
+      profile?.pass_tier === 'founders' ? "Founders' Circle"
+      : profile?.pass_tier === 'insider' ? 'Insider'
+      : 'Member';
+    if (statusEl) statusEl.textContent = sub?.status === 'active' ? 'Active'
+      : sub?.status === 'trialing' ? 'On trial'
+      : sub?.status === 'past_due' ? 'Payment past due — please update card'
+      : sub?.status === 'canceled' ? 'Cancelled, ends at period end'
+      : sub?.status ?? 'Active';
+    if (intervalEl) intervalEl.textContent =
+      sub?.billing_interval === 'month' ? 'Monthly'
+      : sub?.billing_interval === 'year' ? 'Annual'
+      : '—';
+    if (untilEl) {
+      const until = profile?.pass_active_until || sub?.current_period_end;
+      untilEl.textContent = until
+        ? new Date(until).toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })
+        : 'Lifetime';
+    }
+    if (autorenewEl) autorenewEl.textContent = sub
+      ? (sub.cancel_at_period_end ? 'Off — ends at period end' : 'On')
+      : '—';
+
+    bindPortalButton();
+  }
+
+  function bindPortalButton() {
+    const btn = document.querySelector('[data-pass-portal]');
+    if (!btn || (btn as any)._piBound) return;
+    (btn as any)._piBound = true;
+    const note = document.querySelector('[data-pass-portal-note]');
+    btn.addEventListener('click', async () => {
+      btn.setAttribute('disabled', '');
+      if (note) { note.textContent = 'Opening Stripe…'; note.removeAttribute('hidden'); }
+      const result = await getBillingPortalUrl();
+      if (!result.ok) {
+        if (note) {
+          note.textContent = result.error === 'function-not-deployed'
+            ? "The billing portal endpoint isn't deployed yet. Email hello@peninsulainsider.com.au and we'll handle it manually."
+            : "Couldn't open the billing portal. Try once more.";
+        }
+        btn.removeAttribute('disabled');
+        return;
+      }
+      window.location.href = result.url;
+    });
+  }
+
+  async function init() {
+    showWelcome();
+    if (!isAuthEnabled()) {
+      setVisible('[data-pass-account-anon]', true);
+      const note = document.querySelector('[data-pass-account-anon] .pass-account-anon__body');
+      if (note) note.textContent = "Pass accounts aren't currently configured. See /pass/ for the waitlist.";
+      return;
+    }
+    const c = getSupabase();
+    if (!c) { load(null); return; }
+    const session = (await c.auth.getSession()).data.session;
+    load(session?.user ?? null);
+    onAuthChange((user) => load(user));
+  }
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>
+
+<style>
+  .pass-account { padding: clamp(1.5rem, 3vw, 2.5rem) 0 clamp(2rem, 4vw, 3rem); }
+  .pass-account-welcome {
+    border: 1px solid var(--accent);
+    background: rgba(167, 118, 55, 0.08);
+    padding: clamp(1rem, 2vw, 1.4rem);
+    margin-bottom: clamp(1.25rem, 2.5vw, 1.75rem);
+  }
+  .pass-account-welcome__title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--accent);
+    margin: 0 0 0.45rem;
+  }
+  .pass-account-welcome__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--dark);
+    margin: 0;
+  }
+
+  .pass-account-anon, .pass-account-empty, .pass-account-loading {
+    border: 1px dashed var(--border);
+    padding: clamp(1.5rem, 3vw, 2.5rem) 1.5rem;
+    text-align: center;
+  }
+  .pass-account-anon__title, .pass-account-empty__title, .pass-account-loading p {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0 0 0.5rem;
+  }
+  .pass-account-anon__body, .pass-account-empty__body {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    color: var(--soft);
+    margin: 0 auto 1.25rem;
+    max-width: 38rem;
+  }
+  .pass-account-anon__body a, .pass-account-empty__cta {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .pass-account-anon__cta, .pass-account-empty__cta {
+    display: inline-flex;
+    align-items: center;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.7rem 1.1rem;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .pass-account-anon__cta:hover, .pass-account-empty__cta:hover {
+    background: var(--text, #1a1a1a);
+    border-color: var(--text, #1a1a1a);
+    color: var(--bg, #fff);
+  }
+
+  .pass-account-active {
+    border: 1px solid var(--border);
+    background: var(--paper, #fbf7f0);
+    padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  }
+  .pass-account-active__head {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+  }
+  .pass-account-active__tier-eyebrow {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 0.45rem;
+  }
+  .pass-account-active__tier {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(1.55rem, 3vw, 2.1rem);
+    font-weight: 500;
+    color: var(--text);
+    margin: 0 0 0.4rem;
+    letter-spacing: -0.01em;
+  }
+  .pass-account-active__status {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.92rem;
+    color: var(--soft);
+    margin: 0;
+  }
+  .pass-account-active__detail {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    margin: 0 0 1.25rem;
+  }
+  @media (min-width: 720px) { .pass-account-active__detail { grid-template-columns: 1fr 1fr 1fr; } }
+  .pass-account-active__detail > div {
+    border-top: 1px solid var(--border);
+    padding-top: 0.55rem;
+  }
+  .pass-account-active__detail dt {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--soft);
+    margin-bottom: 0.25rem;
+  }
+  .pass-account-active__detail dd {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1rem;
+    color: var(--text);
+    margin: 0;
+  }
+  .pass-account-active__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    align-items: flex-start;
+  }
+  .pass-account-active__portal {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: var(--accent);
+    color: var(--bg, #fff);
+    border: 1px solid var(--accent);
+    padding: 0.7rem 1.1rem;
+    cursor: pointer;
+  }
+  .pass-account-active__portal:disabled { opacity: 0.6; cursor: progress; }
+  .pass-account-active__portal-note {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.85rem;
+    color: var(--soft);
+    margin: 0;
+  }
+</style>

--- a/next/src/pages/pass.astro
+++ b/next/src/pages/pass.astro
@@ -132,10 +132,99 @@ const breadcrumbItems = [
   <NewsletterBlock />
 </BaseLayout>
 
+<!-- Pass tier purchase controller (Phase 6 WS6A).
+     When Stripe is configured (PUBLIC_STRIPE_PUBLISHABLE_KEY + at least
+     one price id), the Insider/Founders forms swap to "Become an
+     Insider" / "Join the Founders' Circle" buttons that open Stripe
+     Checkout. When not configured, falls back to the waitlist email-
+     capture flow that posts to Beehiiv with a pass-interest-<tier>
+     tag. Same graceful-degradation pattern as the Phase 3 Supabase
+     wiring. -->
+<script>
+  import { isStripeEnabled, startPassCheckout } from '../lib/stripe';
+  import { getSupabase } from '../lib/auth';
+
+  async function activateStripeMode() {
+    if (!isStripeEnabled()) return false;
+
+    document.querySelectorAll('[data-pass-form]').forEach((form) => {
+      const tier = form.getAttribute('data-pass-tier') || 'insider';
+      // Replace the form contents with a Buy button + small interval
+      // toggle (insider only — founders is annual-only).
+      const isInsider = tier === 'insider';
+      form.innerHTML = ''
+        + '<p class="pass-tier__waitlist-label">Open the door</p>'
+        + (isInsider
+          ? '<div class="pass-tier__interval-row" role="radiogroup" aria-label="Billing interval">'
+          +   '<label><input type="radio" name="interval-' + tier + '" value="month" checked /> Monthly</label>'
+          +   '<label><input type="radio" name="interval-' + tier + '" value="year" /> Annual (save ~16%)</label>'
+          + '</div>'
+          : '')
+        + '<button type="submit" class="pass-tier__buy-button">'
+        +   (isInsider ? 'Become an Insider' : "Join the Founders' Circle")
+        + '</button>'
+        + '<p class="pass-tier__waitlist-note" data-pass-status hidden></p>';
+
+      const status = form.querySelector('[data-pass-status]');
+      const button = form.querySelector('.pass-tier__buy-button');
+
+      function setStatus(kind, msg) {
+        if (!status) return;
+        status.textContent = msg;
+        status.setAttribute('data-status-kind', kind);
+        status.removeAttribute('hidden');
+      }
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (button) button.setAttribute('disabled', '');
+        setStatus('info', 'Opening Stripe…');
+
+        const intervalInput = form.querySelector('input[name="interval-' + tier + '"]:checked');
+        const interval = intervalInput ? intervalInput.value : 'year';
+
+        // Lift the user's email from their session if signed in, so
+        // Checkout pre-fills it.
+        let userEmail;
+        const c = getSupabase();
+        if (c) {
+          const session = (await c.auth.getSession()).data.session;
+          userEmail = session?.user?.email;
+        }
+
+        const result = await startPassCheckout({ tier, interval, userEmail });
+        if (!result.ok) {
+          const errMsg = ({
+            'stripe-not-configured': "The Pass isn't quite open yet — try the waitlist below.",
+            'price-not-configured':  "Pricing for this tier isn't loaded yet — refresh and try again.",
+            'function-not-deployed': "The checkout endpoint isn't responding. Email hello@peninsulainsider.com.au and we'll set up your tier manually.",
+          })[result.error] || "Couldn't open checkout. Try once more, or email hello@peninsulainsider.com.au.";
+          setStatus('error', errMsg);
+          if (button) button.removeAttribute('disabled');
+          return;
+        }
+        window.location.href = result.url;
+      });
+    });
+
+    return true;
+  }
+
+  // Try Stripe mode first; if it returns false, the inline waitlist
+  // controller below stays bound and handles submission.
+  (async () => {
+    const activated = await activateStripeMode();
+    if (!activated) return;
+    document.body.setAttribute('data-pass-mode', 'stripe');
+  })();
+  document.addEventListener('astro:page-load', activateStripeMode);
+</script>
+
 <script is:inline>
-  /* Waitlist controller. POSTs to the existing pi-newsletter-subscribe
-     edge function with a pass-interest-<tier> tag so we capture leads
-     into the same Beehiiv list ahead of Stripe wiring. */
+  /* Waitlist controller (fallback). POSTs to the existing
+     pi-newsletter-subscribe edge function with a pass-interest-<tier>
+     tag so we capture leads into the same Beehiiv list ahead of Stripe
+     wiring. */
   (function () {
     var ENDPOINT = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsletter-subscribe';
 

--- a/ops/edge-functions/README.md
+++ b/ops/edge-functions/README.md
@@ -1,0 +1,93 @@
+# Peninsula Insider — Supabase Edge Functions
+
+Server-side endpoints invoked by the static site. Each subdirectory is a Deno-based Supabase Edge Function.
+
+## Deployment
+
+These functions are NOT auto-deployed by the GitHub Pages workflow — they live in the Supabase project and need to be pushed via the Supabase CLI:
+
+```bash
+# One-time: link this repo to the Supabase project
+supabase link --project-ref tjjhpvslpysfklwpqmgz
+
+# Deploy a single function
+supabase functions deploy create-pass-checkout-session
+
+# Deploy all functions in this directory
+for fn in create-pass-checkout-session create-pass-billing-portal stripe-webhook; do
+  supabase functions deploy "$fn"
+done
+```
+
+## Required environment variables (set in Supabase Studio → Functions → Secrets)
+
+| Variable | Purpose |
+|---|---|
+| `STRIPE_SECRET_KEY` | `sk_live_*` or `sk_test_*`. The Stripe secret key. NEVER expose to the client. |
+| `STRIPE_WEBHOOK_SECRET` | `whsec_*`. Used by `stripe-webhook` to verify incoming events. |
+| `SUPABASE_URL` | Already auto-provided by Supabase to all Edge Functions. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Already auto-provided. Used by `stripe-webhook` to upsert into `pi.pass_subscriptions` (bypasses RLS). |
+
+## Functions
+
+### `create-pass-checkout-session`
+
+Called by `/pass/` when a user clicks Become an Insider / Join the Founders' Circle.
+
+**Request:**
+```json
+{
+  "price_id": "price_…",
+  "success_url": "https://peninsulainsider.com.au/account/pass/?welcome=1",
+  "cancel_url":  "https://peninsulainsider.com.au/pass/?cancelled=1",
+  "user_email":  "user@example.com"  // optional
+}
+```
+
+**Response:**
+```json
+{ "url": "https://checkout.stripe.com/c/…" }
+```
+
+### `create-pass-billing-portal`
+
+Called by `/account/pass/` when the user clicks Manage billing in Stripe.
+
+Looks up the user's `stripe_customer_id` from `pi.profiles`, creates a Stripe Billing Portal session, and returns its URL.
+
+**Request:** empty (the Supabase JWT in the Authorization header identifies the user).
+
+**Response:**
+```json
+{ "url": "https://billing.stripe.com/p/session/…" }
+```
+
+### `stripe-webhook`
+
+Receives Stripe webhook events (`checkout.session.completed`, `customer.subscription.{created,updated,deleted}`, etc.) and mirrors the resulting state into `pi.pass_subscriptions` + `pi.profiles.is_member` / `pass_tier` / `pass_active_until`.
+
+**Webhook endpoint URL** (configure in Stripe Dashboard → Developers → Webhooks):
+```
+https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/stripe-webhook
+```
+
+**Events to subscribe to:**
+- `checkout.session.completed`
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+- `invoice.payment_succeeded` (extends `pass_active_until`)
+- `invoice.payment_failed` (sets status to `past_due`)
+
+## Build-time env vars (in addition to function-side secrets)
+
+The static site needs these GitHub Variables (or Secrets) so the bundle knows about Stripe at all:
+
+| Variable | Notes |
+|---|---|
+| `PUBLIC_STRIPE_PUBLISHABLE_KEY` | `pk_live_*` or `pk_test_*`. Safe to ship in the static bundle. |
+| `PUBLIC_STRIPE_PRICE_INSIDER_MONTHLY` | The Stripe price id for monthly Insider. |
+| `PUBLIC_STRIPE_PRICE_INSIDER_ANNUAL` | The Stripe price id for annual Insider. |
+| `PUBLIC_STRIPE_PRICE_FOUNDERS` | The Stripe price id for Founders. |
+
+Without these, `/pass/` falls back to the waitlist email-capture flow. With them, `/pass/` flips to live commerce. No code change needed.

--- a/ops/edge-functions/create-pass-billing-portal/index.ts
+++ b/ops/edge-functions/create-pass-billing-portal/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Edge Function: create-pass-billing-portal
+ *
+ * Phase 6 WS6A. Creates a Stripe Billing Portal session for the
+ * signed-in user and returns its URL. Called by /account/pass/
+ * when the user clicks "Manage billing in Stripe".
+ *
+ * Looks up the user's stripe_customer_id from pi.profiles via the
+ * service-role key (bypasses RLS), then creates the portal session.
+ *
+ * Deploy:
+ *   supabase functions deploy create-pass-billing-portal
+ *
+ * Required secrets:
+ *   STRIPE_SECRET_KEY
+ */
+
+// @ts-ignore — Deno standard library
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+// @ts-ignore — esm.sh
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+// @ts-ignore — esm.sh
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target=deno';
+
+const STRIPE_SECRET_KEY        = Deno.env.get('STRIPE_SECRET_KEY');
+const SUPABASE_URL              = Deno.env.get('SUPABASE_URL');
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+const stripe = STRIPE_SECRET_KEY
+  ? new Stripe(STRIPE_SECRET_KEY, {
+      apiVersion: '2024-09-30.acacia',
+      httpClient: Stripe.createFetchHttpClient(),
+    })
+  : null;
+
+const admin = (SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY)
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false }, db: { schema: 'pi' } })
+  : null;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (!stripe || !admin) {
+    return new Response(JSON.stringify({ error: 'stripe-or-admin-not-configured' }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Identify the calling user via the Authorization JWT.
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) {
+    return new Response(JSON.stringify({ error: 'missing-auth' }), {
+      status: 401,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+  const userClient = createClient(SUPABASE_URL!, auth.slice(7), {
+    auth: { persistSession: false },
+  });
+  const { data: userData, error: userErr } = await userClient.auth.getUser();
+  if (userErr || !userData?.user) {
+    return new Response(JSON.stringify({ error: 'invalid-auth' }), {
+      status: 401,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+  const userId = userData.user.id;
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('stripe_customer_id')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (!profile?.stripe_customer_id) {
+    return new Response(JSON.stringify({ error: 'no-stripe-customer' }), {
+      status: 404,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const session = await stripe.billingPortal.sessions.create({
+      customer: profile.stripe_customer_id,
+      return_url: `${new URL(req.url).origin.replace(/\.supabase\.co.*$/, '.supabase.co')}` // unused; user is on PI
+        || 'https://peninsulainsider.com.au/account/pass/',
+    });
+    // Manually default the return URL since the URL above is the Edge
+    // Function's URL, not the front-end. This is a small ergonomic
+    // fix — Stripe accepts any return URL on the Customer Portal.
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: profile.stripe_customer_id,
+      return_url: 'https://peninsulainsider.com.au/account/pass/',
+    });
+    return new Response(JSON.stringify({ url: portalSession.url }), {
+      status: 200,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[create-pass-billing-portal] error:', err);
+    return new Response(JSON.stringify({ error: (err as Error).message }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/ops/edge-functions/create-pass-checkout-session/index.ts
+++ b/ops/edge-functions/create-pass-checkout-session/index.ts
@@ -1,0 +1,106 @@
+/**
+ * Edge Function: create-pass-checkout-session
+ *
+ * Phase 6 WS6A. Creates a Stripe Checkout Session for the Pass and
+ * returns its hosted-checkout URL. Called by /pass/ when a user clicks
+ * Become an Insider / Join the Founders' Circle.
+ *
+ * Deploy:
+ *   supabase functions deploy create-pass-checkout-session
+ *
+ * Required secrets (set via supabase secrets set):
+ *   STRIPE_SECRET_KEY
+ *
+ * The function runs in Deno. The Stripe SDK we use here is the
+ * Deno-native build available on esm.sh.
+ */
+
+// @ts-ignore — Deno standard library import
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+// @ts-ignore — esm.sh-resolved npm package
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+
+const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY');
+
+if (!STRIPE_SECRET_KEY) {
+  console.warn('[create-pass-checkout-session] STRIPE_SECRET_KEY not set');
+}
+
+const stripe = STRIPE_SECRET_KEY
+  ? new Stripe(STRIPE_SECRET_KEY, {
+      apiVersion: '2024-09-30.acacia',
+      httpClient: Stripe.createFetchHttpClient(),
+    })
+  : null;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'method-not-allowed' }), {
+      status: 405,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+  if (!stripe) {
+    return new Response(JSON.stringify({ error: 'stripe-not-configured' }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid-json' }), {
+      status: 400,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const priceId    = String(body?.price_id ?? '');
+  const successUrl = String(body?.success_url ?? '');
+  const cancelUrl  = String(body?.cancel_url  ?? '');
+  const userEmail  = body?.user_email ? String(body.user_email) : undefined;
+
+  if (!priceId || !successUrl || !cancelUrl) {
+    return new Response(JSON.stringify({ error: 'missing-fields' }), {
+      status: 400,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: successUrl,
+      cancel_url:  cancelUrl,
+      customer_email: userEmail,
+      // Metadata flows through to the webhook so we can map session →
+      // user when the checkout completes.
+      metadata: userEmail ? { user_email: userEmail } : {},
+      // Allow promotion codes by default; can be tightened per-tier.
+      allow_promotion_codes: true,
+    });
+
+    return new Response(JSON.stringify({ url: session.url }), {
+      status: 200,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[create-pass-checkout-session] error:', err);
+    return new Response(JSON.stringify({ error: (err as Error).message }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/ops/edge-functions/stripe-webhook/index.ts
+++ b/ops/edge-functions/stripe-webhook/index.ts
@@ -1,0 +1,192 @@
+/**
+ * Edge Function: stripe-webhook
+ *
+ * Phase 6 WS6A. Receives Stripe webhook events and mirrors the
+ * resulting state into pi.pass_subscriptions + pi.profiles.
+ *
+ * Subscribe these events in Stripe Dashboard → Developers → Webhooks:
+ *   checkout.session.completed
+ *   customer.subscription.created
+ *   customer.subscription.updated
+ *   customer.subscription.deleted
+ *   invoice.payment_succeeded
+ *   invoice.payment_failed
+ *
+ * Deploy:
+ *   supabase functions deploy stripe-webhook --no-verify-jwt
+ *   (--no-verify-jwt is required because Stripe doesn't send a
+ *    Supabase JWT; we verify the webhook signature instead.)
+ *
+ * Required secrets:
+ *   STRIPE_SECRET_KEY
+ *   STRIPE_WEBHOOK_SECRET
+ */
+
+// @ts-ignore — Deno standard library
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+// @ts-ignore — esm.sh
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+// @ts-ignore — esm.sh
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target=deno';
+
+const STRIPE_SECRET_KEY        = Deno.env.get('STRIPE_SECRET_KEY');
+const STRIPE_WEBHOOK_SECRET    = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+const SUPABASE_URL              = Deno.env.get('SUPABASE_URL');
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+const stripe = STRIPE_SECRET_KEY
+  ? new Stripe(STRIPE_SECRET_KEY, {
+      apiVersion: '2024-09-30.acacia',
+      httpClient: Stripe.createFetchHttpClient(),
+    })
+  : null;
+
+const admin = (SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY)
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false }, db: { schema: 'pi' } })
+  : null;
+
+function tierFromPriceId(priceId: string): 'insider' | 'founders' {
+  // Resolve via env vars: PUBLIC_STRIPE_PRICE_INSIDER_* vs FOUNDERS.
+  // We match by id rather than price metadata so the function doesn't
+  // need to fetch the price object on every event.
+  const insiderMonthly = Deno.env.get('PRICE_INSIDER_MONTHLY');
+  const insiderAnnual  = Deno.env.get('PRICE_INSIDER_ANNUAL');
+  const founders       = Deno.env.get('PRICE_FOUNDERS');
+  if (priceId === founders) return 'founders';
+  if (priceId === insiderMonthly || priceId === insiderAnnual) return 'insider';
+  // Default fallback — assume Insider; editor can correct in Studio if
+  // a new price id is added without updating these env vars.
+  return 'insider';
+}
+
+async function syncSubscription(stripeSubscriptionId: string) {
+  if (!stripe || !admin) return;
+
+  const sub = await stripe.subscriptions.retrieve(stripeSubscriptionId, {
+    expand: ['items.data.price'],
+  });
+
+  const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer.id;
+
+  // Resolve the user_id by stripe_customer_id on pi.profiles. If the
+  // profile doesn't have one yet (first subscription), look up by
+  // customer email and patch the profile.
+  let userId: string | null = null;
+  {
+    const { data: existing } = await admin
+      .from('profiles')
+      .select('id')
+      .eq('stripe_customer_id', customerId)
+      .maybeSingle();
+    if (existing?.id) userId = existing.id as string;
+  }
+  if (!userId) {
+    const customer = await stripe.customers.retrieve(customerId);
+    if (customer && !customer.deleted && customer.email) {
+      const { data: byEmail } = await admin
+        .from('profiles')
+        .select('id')
+        .eq('id', (await admin.auth.admin.listUsers({ page: 1, perPage: 200 })).data?.users?.find?.((u: any) => u.email === customer.email)?.id ?? '___')
+        .maybeSingle();
+      // Simpler reliable path: look up auth user directly.
+      const { data: authUsers } = await admin.auth.admin.listUsers({ page: 1, perPage: 200 });
+      const match = authUsers?.users?.find((u: any) => u.email === customer.email);
+      if (match) {
+        userId = match.id;
+        await admin.from('profiles').update({ stripe_customer_id: customerId }).eq('id', userId);
+      }
+    }
+  }
+  if (!userId) {
+    console.warn('[stripe-webhook] could not resolve user_id for customer', customerId);
+    return;
+  }
+
+  const item = sub.items?.data?.[0];
+  const price = item?.price;
+  const priceId = price?.id ?? '';
+  const tier = tierFromPriceId(priceId);
+  const interval = price?.recurring?.interval === 'year' ? 'year' : (price?.recurring?.interval === 'month' ? 'month' : null);
+
+  const periodEnd = sub.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : null;
+
+  await admin.from('pass_subscriptions').upsert(
+    {
+      stripe_subscription_id: sub.id,
+      user_id: userId,
+      stripe_customer_id: customerId,
+      tier,
+      billing_interval: interval,
+      status: sub.status,
+      current_period_end: periodEnd,
+      cancel_at_period_end: sub.cancel_at_period_end,
+      stripe_price_id: priceId,
+    },
+    { onConflict: 'stripe_subscription_id' },
+  );
+
+  // Mirror onto pi.profiles.
+  const isMember = ['active', 'trialing', 'past_due'].includes(sub.status);
+  await admin
+    .from('profiles')
+    .update({
+      is_member: isMember,
+      pass_tier: tier,
+      pass_active_until: periodEnd,
+      stripe_customer_id: customerId,
+    })
+    .eq('id', userId);
+}
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('method-not-allowed', { status: 405 });
+  }
+  if (!stripe || !admin) {
+    return new Response('stripe-or-admin-not-configured', { status: 500 });
+  }
+  if (!STRIPE_WEBHOOK_SECRET) {
+    return new Response('missing-webhook-secret', { status: 500 });
+  }
+
+  const sig = req.headers.get('stripe-signature') ?? '';
+  const body = await req.text();
+
+  let event: any;
+  try {
+    event = await stripe.webhooks.constructEventAsync(body, sig, STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    console.warn('[stripe-webhook] signature verification failed:', (err as Error).message);
+    return new Response('invalid-signature', { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object;
+        if (session.mode === 'subscription' && session.subscription) {
+          await syncSubscription(String(session.subscription));
+        }
+        break;
+      }
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted':
+      case 'invoice.payment_succeeded':
+      case 'invoice.payment_failed': {
+        const sub = event.data.object;
+        const subId = sub.subscription || sub.id;
+        if (subId) await syncSubscription(String(subId));
+        break;
+      }
+      default:
+        // Ignore other event types.
+        break;
+    }
+  } catch (err) {
+    console.error('[stripe-webhook] handler error:', err);
+    return new Response('handler-error', { status: 500 });
+  }
+
+  return new Response('ok', { status: 200 });
+});

--- a/ops/migrations/2026-05-05-pass-membership.sql
+++ b/ops/migrations/2026-05-05-pass-membership.sql
@@ -1,0 +1,99 @@
+-- Migration: Pass membership columns + Stripe state tracking (Phase 6 WS6A)
+-- Date: 2026-05-05
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+--
+-- Purpose: extend pi.profiles with membership state + add a small
+-- pi.pass_subscriptions table that mirrors the Stripe subscription
+-- record for fast lookups (Stripe webhook → Edge Function → upserts
+-- here on subscription.created/updated/deleted events).
+--
+-- Member-only content gating reads pi.profiles.is_member +
+-- pass_active_until; the Pass dashboard at /account/pass/ reads from
+-- pi.pass_subscriptions for billing-portal links + renewal date.
+--
+-- Idempotent.
+
+-- ─── pi.profiles extensions ────────────────────────────────────────────────
+
+alter table pi.profiles
+  add column if not exists is_member         boolean      not null default false,
+  add column if not exists pass_tier         text         check (pass_tier in ('insider', 'founders')),
+  add column if not exists pass_active_until timestamptz,
+  add column if not exists stripe_customer_id text;
+
+create index if not exists profiles_is_member on pi.profiles (is_member) where is_member = true;
+
+-- ─── pi.pass_subscriptions ─────────────────────────────────────────────────
+
+create table if not exists pi.pass_subscriptions (
+  -- Stripe subscription id is the natural primary key (sub_*).
+  stripe_subscription_id text primary key,
+  user_id                uuid not null references auth.users(id) on delete cascade,
+  stripe_customer_id     text not null,
+  tier                   text not null check (tier in ('insider', 'founders')),
+  billing_interval       text check (billing_interval in ('month', 'year')),
+  -- Stripe-side status: trialing / active / past_due / canceled / etc.
+  status                 text not null,
+  current_period_end     timestamptz,
+  cancel_at_period_end   boolean not null default false,
+  -- Convenience snapshot of the price-id that drove this subscription.
+  stripe_price_id        text,
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now()
+);
+
+comment on table pi.pass_subscriptions is 'Phase 6 WS6A: cached mirror of Stripe subscription rows. Source of truth is Stripe; this is the read-side cache populated by the webhook.';
+
+create index if not exists pass_subscriptions_by_user on pi.pass_subscriptions (user_id, current_period_end desc);
+create index if not exists pass_subscriptions_by_status on pi.pass_subscriptions (status);
+
+alter table pi.pass_subscriptions enable row level security;
+
+-- Signed-in users read their own subscription rows.
+drop policy if exists "pass_subscriptions_select_own" on pi.pass_subscriptions;
+create policy "pass_subscriptions_select_own"
+  on pi.pass_subscriptions for select using (user_id = auth.uid());
+
+-- Editor full access for admin / billing-issue lookups.
+drop policy if exists "pass_subscriptions_editor_all" on pi.pass_subscriptions;
+create policy "pass_subscriptions_editor_all"
+  on pi.pass_subscriptions for all
+  using (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true))
+  with check (exists (select 1 from pi.profiles p where p.id = auth.uid() and p.is_editor = true));
+
+-- Webhook writes via the service-role key, which bypasses RLS — no
+-- policy needed for the Edge Function.
+
+-- updated_at trigger
+create or replace function pi.pass_subscriptions_set_updated_at()
+returns trigger as $$
+begin new.updated_at = now(); return new; end;
+$$ language plpgsql;
+
+drop trigger if exists pass_subscriptions_set_updated_at on pi.pass_subscriptions;
+create trigger pass_subscriptions_set_updated_at
+  before update on pi.pass_subscriptions
+  for each row execute function pi.pass_subscriptions_set_updated_at();
+
+-- ─── Helper: is_active_member(uuid) ────────────────────────────────────────
+-- Convenience function for content-gating queries from the front-end.
+-- Returns true iff the user has is_member=true and either no expiry
+-- (founders lifetime) or pass_active_until is in the future.
+
+create or replace function pi.is_active_member(p_user_id uuid)
+returns boolean
+language sql
+stable
+as $$
+  select coalesce(
+    (
+      select p.is_member
+        and (p.pass_active_until is null or p.pass_active_until > now())
+      from pi.profiles p where p.id = p_user_id
+    ),
+    false
+  );
+$$;
+
+grant execute on function pi.is_active_member(uuid) to anon, authenticated, service_role;


### PR DESCRIPTION
Wires Stripe end-to-end for the Pass: lib + page swap + member dashboard + 3 Edge Function templates + 4 build env vars + 1 migration. Falls back to waitlist when Stripe isn't configured. Once James deploys the functions and sets the env vars, /pass/ flips from waitlist to live commerce. Phase 6 complete after this PR. Build clean at 1235 pages.