### PR TITLE
docs(mobile-app): Sprint 0 paperwork pack — Expo + Supabase + EAS stack locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ For each meaningful change, include:
 
 ---
 
+## 2026-05-05 — Remy (mobile app — Sprint 0 paperwork pack)
+
+### Summary
+Kicked off the Peninsula Insider iOS app project. Locked the stack (Expo SDK 53 + Supabase + EAS Build + Sign in with Apple + Apple Wallet for Pass), reframed the April pocket-concierge thesis from "PWA-first / Capacitor-later" to "Expo native first" based on 2026 vibe-coding research, and produced the Sprint 0 Apple paperwork checklist. Sprint 1 handover doc is queued to execute as soon as Apple Developer enrolment lands.
+
+### Files changed
+- `docs/mobile-app/README.md` (new) — workspace overview and strategic shift note
+- `docs/mobile-app/decisions-2026-05-05.md` (new) — locked decisions + 2 awaiting James (enrolment type, repo layout)
+- `docs/mobile-app/sprint-0-apple-paperwork-2026-05-05.md` (new) — step-by-step Apple Developer Program / App Store Connect / APNs / API Key checklist
+- `docs/mobile-app/sprint-1-handover-2026-05-05.md` (new) — day-by-day TestFlight plan + IAP decision tree for Insider Pass
+
+### Pages affected
+None — docs-only. Site build is unaffected.
+
+### Why it matters
+The April thesis treated the app as a future R&D bet. Conditions in 2026 (Claude Code's Expo proficiency, EAS auto-credentials, Apple's stable native review path, the existing Supabase + `/ask` + saves backend) make the iOS app a near-term ship rather than an experiment. Sprint 0 is the gating paperwork; Sprint 1 reaches TestFlight in 5 working days once Apple enrolment is approved.
+
+### Follow-up
+- James: confirm enrolment type (Individual recommended for speed) and repo layout (monorepo recommended) — both flagged in `decisions-2026-05-05.md`
+- James: run the Sprint 0 checklist; populate `~/.apple-keys/peninsula-insider.env`
+- Remy (next session): execute Sprint 1 day-by-day plan once preconditions are met
+
+---
+
 ## 2026-05-04 — Claude (SEO experiment 2026-05-04-01)
 
 ### CTR snippet rewrite on dog-friendly journal page

--- a/docs/mobile-app/README.md
+++ b/docs/mobile-app/README.md
@@ -1,0 +1,35 @@
+# Peninsula Insider — Mobile App Workspace
+
+This folder holds planning, decisions, and handover docs for the **Peninsula Insider iOS app** — the native concierge product proposed in [`docs/peninsula-insider-pocket-concierge-app-strategy-2026-04-14.md`](../peninsula-insider-pocket-concierge-app-strategy-2026-04-14.md).
+
+## Strategic shift from the April thesis
+
+The 14 April strategy doc concluded "PWA first, Capacitor iOS later." On 5 May 2026, after fresh research into 2026 vibe-coding tooling and App Store dynamics, the decision flipped to **Expo (React Native) first** for iOS. Reasons in one paragraph:
+
+- LLM codegen quality on TypeScript + Expo Router is materially better than on Capacitor or pure Swift, and Claude Code's strengths line up with Expo's conventions.
+- Apple's "thin wrapper" review bots are stricter on Capacitor (ITMS-90338 history); Expo + native chat + push + Wallet + offline saves clears the bar comfortably.
+- EAS Build / Submit / Update collapse the build–TestFlight–OTA surface area to a handful of CLI calls.
+- The differentiated features that make this app worth shipping (push, Apple Wallet Pass, Sign in with Apple, offline saves, location) need real native APIs anyway.
+
+The April thesis on **what** the product is — opinionated concierge, taste-led, focused, context-aware — stands. Only the **how** has changed.
+
+## Documents in this folder
+
+| File | What it is |
+|------|-----------|
+| [`decisions-2026-05-05.md`](decisions-2026-05-05.md) | Locked decisions (bundle ID, app name, repo layout, stack). Two require James's call. |
+| [`sprint-0-apple-paperwork-2026-05-05.md`](sprint-0-apple-paperwork-2026-05-05.md) | Step-by-step checklist for Apple Developer enrolment + identifiers + keys. |
+| [`sprint-1-handover-2026-05-05.md`](sprint-1-handover-2026-05-05.md) | What needs to be in place before scaffolding the Expo app, and the day-by-day Sprint 1 plan. |
+
+## Sprint 0 status
+
+| Item | Status | Owner |
+|------|--------|-------|
+| Strategic shift documented | Done | Remy |
+| Decisions drafted | Done — 2 awaiting James | Remy |
+| Apple Developer enrolment | Pending | James |
+| App Store Connect record | Pending Apple approval | James |
+| APNs Auth Key | Pending Step 4 | James |
+| App Store Connect API Key | Pending Step 6 | James |
+| Bundle ID registered | Pending Step 3 | James |
+| Repo scaffold | Sprint 1 | Remy |

--- a/docs/mobile-app/decisions-2026-05-05.md
+++ b/docs/mobile-app/decisions-2026-05-05.md
@@ -1,0 +1,98 @@
+# Peninsula Insider iOS App — Locked Decisions
+
+**Date:** 5 May 2026
+**Author:** Remy
+**Status:** Sprint 0 — 2 items need James's call (flagged ⚠️ below). Everything else is locked.
+
+## Product framing
+Lifted directly from [`docs/peninsula-insider-pocket-concierge-app-strategy-2026-04-14.md`](../peninsula-insider-pocket-concierge-app-strategy-2026-04-14.md). Not re-derived here. The app is **PI in Your Pocket** — the curated, opinionated, context-aware Peninsula concierge. Editorial site stays separate as the SEO / authority engine.
+
+## ⚠️ Decision 1 — Apple Developer Program enrolment type
+
+| Option | Pros | Cons | Cost | Time |
+|--------|------|------|------|------|
+| **Individual** (recommended for speed) | Fastest enrolment; no D-U-N-S; can transfer to Org later | Seller name on App Store reads "James Richmond" not "Peninsula Insider" | $99 USD/yr | 24–72 hours |
+| **Organisation** | Seller name reads "Peninsula Insider Pty Ltd" or your trading entity; cleaner for partnerships, advertising, Pass billing | Needs D-U-N-S Number (free, 5–10 business days for Australian entities); tax + legal entity verification | $99 USD/yr | 1–2 weeks total |
+
+**Remy's recommendation:** **Enrol as Individual today** to unblock Sprint 1, then start the D-U-N-S process in parallel and transfer the account to the company entity once approved (Apple supports this and James doesn't lose anything in the transition). The seller name visibility cost is small relative to the time-to-launch cost.
+
+**Override path:** If James wants the App Store seller name to read "Peninsula Insider" from day one, go straight to Organisation. Sprint 1 still proceeds locally; only TestFlight submission is gated on Apple approval.
+
+→ **James, please confirm: Individual (default) or Organisation?**
+
+## ⚠️ Decision 2 — Repo layout
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Monorepo: `mobile/` directory in this repo (recommended)** | Shared types with `next/`, single CI, single source of truth for backend contract, easier for Claude Code to work across | Larger repo; build outputs need clearer separation |
+| **Separate repo `peninsula-insider-app`** | Cleaner isolation; smaller clones | Duplicates type definitions; cross-repo refactors are painful; backend contract drift risk |
+
+**Remy's recommendation:** **Monorepo with `mobile/` at repo root.** The web (`next/`) and the app share Supabase tables, types, the `/ask` endpoint contract, and the brand persona doc. Keeping them in one repo means a schema change is one PR, not two coordinated PRs.
+
+→ **James, please confirm: Monorepo (default) or separate repo?**
+
+## Decisions locked (no input needed)
+
+### Bundle ID
+**`au.com.peninsulainsider.app`**
+
+Reverse-DNS form of `peninsulainsider.com.au`. Australian convention for AU-domain apps. Globally unique within Apple's namespace.
+
+### App display name
+**Peninsula Insider** (30-char limit, we use 17)
+
+### Subtitle (30-char limit) — three candidates
+1. **"Mornington Peninsula concierge"** (30) — most descriptive, exact category match
+2. **"Your Peninsula concierge"** (24) — branded, less SEO
+3. **"The Peninsula, with taste"** (25) — voice-led, on-brand for PI
+
+**Default:** option 1 for App Store discoverability; revisit at submission if voice wins out.
+
+### App SKU (internal)
+**`pi-app-001`**
+
+### Categories
+- Primary: **Travel**
+- Secondary: **Food & Drink**
+
+### Age rating
+**4+** (no objectionable content; concierge content is general audience)
+
+### Capabilities to enable on App ID
+- Sign in with Apple (mandatory once we offer Google OAuth, which we do)
+- Push Notifications
+- Associated Domains (Universal Links — `peninsulainsider.com.au` deep-links into the app)
+- Wallet (for Insider Pass v1 PassKit integration; safe to enable up front)
+
+### Stack (locked from research, 5 May)
+| Layer | Choice |
+|-------|--------|
+| Frontend | Expo SDK 53+ with Expo Router, TypeScript |
+| Editor | Cursor for inline + Claude Code in terminal for multi-file |
+| Backend | Existing Supabase project (no new infra) |
+| Build/CI | EAS Build + EAS Submit |
+| OTA | EAS Update (JS-only fixes without re-review) |
+| Auth | Supabase Auth — Google + magic link (already wired) + **add Sign in with Apple** |
+| Push | Expo Push Service from Supabase Edge Function |
+| Storage | Supabase Storage (already used) |
+| Analytics/crash | PostHog or Sentry (TBD; both ship privacy manifests) |
+
+### App Store seller / privacy contacts
+- **Support URL:** `https://peninsulainsider.com.au/contact`
+- **Marketing URL:** `https://peninsulainsider.com.au`
+- **Privacy Policy URL:** `https://peninsulainsider.com.au/privacy`
+
+### Privacy practices declaration draft (refined at submission)
+- **Data linked to user:** email, user ID, content (saves, likes, lists, alerts preferences)
+- **Data not linked:** none currently
+- **Data not collected (initially):** location (added when Now-tab v0.5 ships), health, financial, browsing history, contacts, photos, audio
+- **Tracking:** none
+
+### Encryption export compliance
+**`ITSAppUsesNonExemptEncryption = false`** in Info.plist — only standard HTTPS/TLS used.
+
+### What's deferred (decided NOT now)
+- Android via React Native — possible later from same Expo codebase; out of scope for v1
+- Native Swift/SwiftUI — secondary path if the Expo build hits a wall on a specific feature
+- Operator dashboard as a separate app target — feature flag inside the same app for v1
+- IAP for Insider Pass — needs Apple guidance call before submission; v1 may launch Pass-free or with physical-only perks. See sprint-1-handover for the decision tree.

--- a/docs/mobile-app/sprint-0-apple-paperwork-2026-05-05.md
+++ b/docs/mobile-app/sprint-0-apple-paperwork-2026-05-05.md
@@ -1,0 +1,138 @@
+# Sprint 0 — Apple Paperwork Checklist
+
+**Date:** 5 May 2026
+**Owner:** James
+**Outcome:** A registered bundle ID, an App Store Connect record, an APNs Auth Key, and an App Store Connect API Key — i.e. everything Sprint 1 needs to ship to TestFlight.
+**Time:** ~30 min of clicking, then 24 h–2 weeks of Apple-side approval (depending on Decision 1).
+
+> Read [`decisions-2026-05-05.md`](decisions-2026-05-05.md) first if you haven't. The two ⚠️ decisions there gate Step 2 and the repo work.
+
+## Pre-flight (5 min)
+
+- [ ] Decide on Apple ID. Use a stable one — account transfers are painful. Recommended: a dedicated apple-id like `apple@peninsulainsider.com.au` rather than a personal account, but if you're going Individual a personal Apple ID is fine.
+- [ ] Confirm two-factor auth is enabled on that Apple ID. Apple Developer Program enrolment requires 2FA.
+- [ ] Have a physical iOS device on hand for testing later (any iPhone running iOS 17+).
+- [ ] Have Xcode installed (latest stable, currently Xcode 16). Command Line Tools also need to be installed: `xcode-select --install` in Terminal.
+- [ ] Have a payment method ready ($99 USD).
+
+## Step 1 — D-U-N-S Number (only if going Organisation)
+
+Skip this step if enrolling as Individual.
+
+1. Open <https://developer.apple.com/enroll/duns-lookup/>.
+2. Select country **Australia**.
+3. Search by your legal company name (e.g. "Optiflows Pty Ltd" or whatever entity owns Peninsula Insider).
+4. **If a number is found** — note it down, move to Step 2.
+5. **If not found** — request a new D-U-N-S number through that same page. Free for App Store Connect enrolment. Apple's intake form forwards to Dun & Bradstreet; takes 5–10 business days.
+
+While waiting for D-U-N-S, you can still do everything in Sprint 1 that doesn't require a registered bundle ID — but you can't push to TestFlight until enrolled.
+
+## Step 2 — Apple Developer Program enrolment
+
+1. Open <https://developer.apple.com/programs/enroll/>.
+2. Sign in with the Apple ID from Pre-flight.
+3. Choose **Individual** or **Organisation** per Decision 1.
+4. Pay $99 USD.
+5. Wait for approval email.
+   - Individual: typically 24–72 hours.
+   - Organisation: typically 1–2 weeks (after D-U-N-S is in hand).
+
+Do not start Step 3 until you receive "Welcome to the Apple Developer Program" email.
+
+## Step 3 — Register the bundle ID
+
+Once enrolled:
+
+1. Open <https://developer.apple.com/account/resources/identifiers/list>.
+2. Click **+** (top-left of identifiers list).
+3. Choose **App IDs** → **Continue** → **App** → **Continue**.
+4. Fill in:
+   - **Description:** `Peninsula Insider`
+   - **Bundle ID:** `Explicit` → `au.com.peninsulainsider.app`
+5. Scroll the **Capabilities** list. Tick:
+   - [x] **Sign In with Apple** (required — we already offer Google OAuth on the web)
+   - [x] **Push Notifications**
+   - [x] **Associated Domains** (for Universal Links)
+   - [x] **Wallet** (Insider Pass)
+6. Click **Continue**, then **Register**.
+
+## Step 4 — APNs Auth Key
+
+1. Open <https://developer.apple.com/account/resources/authkeys/list>.
+2. Click **+**.
+3. Name: `PI APNs Production`.
+4. Tick **Apple Push Notifications service (APNs)**.
+5. Click **Configure** next to APNs → leave the dropdown on `Sandbox & Production` (single key works for both) → **Save**.
+6. Click **Continue** → **Register** → **Download**.
+7. **Save the `.p8` file outside this repo.** Recommended path: `~/.apple-keys/AuthKey_<KEYID>.p8`.
+8. Note these for later (you'll paste them into Supabase + EAS):
+   - **Key ID** (10 chars, on the page after download)
+   - **Team ID** (10 chars — find at <https://developer.apple.com/account#MembershipDetailsCard>)
+   - The **bundle ID** you registered
+
+Apple only lets you download the .p8 once. If you lose it, revoke the key and create a new one.
+
+## Step 5 — App Store Connect record
+
+1. Open <https://appstoreconnect.apple.com/apps>.
+2. Click **+** → **New App**.
+3. Fill in:
+   - **Platforms:** iOS (tick only iOS for now)
+   - **Name:** `Peninsula Insider`
+   - **Primary Language:** English (Australia)
+   - **Bundle ID:** `au.com.peninsulainsider.app` (the one from Step 3)
+   - **SKU:** `pi-app-001`
+   - **User Access:** Full Access
+4. Click **Create**.
+5. Inside the new app record → **App Information**:
+   - **Subtitle:** `Mornington Peninsula concierge`
+   - **Category:** Primary `Travel`, Secondary `Food & Drink`
+   - **Content Rights:** tick "I have the rights" (we own the editorial corpus)
+6. **Pricing and Availability** → set price tier `Free` for now (Pass purchases happen via Stripe or future IAP).
+
+Don't worry about screenshots, description, keywords, or App Privacy details yet — those land in Sprint 3, before submission.
+
+## Step 6 — App Store Connect API Key (for EAS)
+
+1. In App Store Connect, go to **Users and Access** → **Integrations** tab → **Team Keys** → **Generate API Key**.
+2. **Name:** `EAS Submit`.
+3. **Access:** `App Manager` (sufficient for EAS).
+4. Click **Generate**.
+5. **Download the `.p8` file** (one-time only).
+6. Save outside this repo: `~/.apple-keys/AuthKey_API_<KEYID>.p8`.
+7. Note these for the EAS configuration:
+   - **Issuer ID** (UUID at the top of the page)
+   - **Key ID** (10 chars, next to the row you just generated)
+
+## Step 7 — Hand the keys to Sprint 1
+
+Once Steps 1–6 are done, fill in the values below into a local file at `~/.apple-keys/peninsula-insider.env` (DO NOT commit). Sprint 1 will read these.
+
+```
+# Peninsula Insider iOS — Apple credentials, do not commit
+APPLE_TEAM_ID=
+APPLE_BUNDLE_ID=au.com.peninsulainsider.app
+
+# APNs key (Step 4)
+APPLE_APNS_KEY_ID=
+APPLE_APNS_KEY_PATH=~/.apple-keys/AuthKey_<KEYID>.p8
+
+# App Store Connect API key (Step 6)
+APPLE_ASC_ISSUER_ID=
+APPLE_ASC_KEY_ID=
+APPLE_ASC_KEY_PATH=~/.apple-keys/AuthKey_API_<KEYID>.p8
+
+# Apple ID (used by EAS for some interactive flows)
+APPLE_ID=
+```
+
+Once that file exists, ping Remy in the next session and we kick off Sprint 1 immediately.
+
+## Common gotchas
+
+- **Two-factor auth not enabled** → enrolment fails silently. Set it up before Step 2.
+- **Wrong Apple ID associated with Org enrolment** → you can't change it later without a support ticket. Decide carefully.
+- **D-U-N-S requested through a third-party paid service** → Apple's free portal is fine; don't pay anyone.
+- **Bundle ID mismatch** → if you typo the bundle ID in Step 3 vs Step 5, App Store Connect will reject the App record. The bundle ID is case-sensitive.
+- **APNs key revocation cascade** → deleting an APNs key kills push for any app using it. We have only one app, so safe — but be aware.
+- **Lost .p8** → both Apple .p8 keys can only be downloaded once. Revoke and regenerate if lost.

--- a/docs/mobile-app/sprint-1-handover-2026-05-05.md
+++ b/docs/mobile-app/sprint-1-handover-2026-05-05.md
@@ -1,0 +1,154 @@
+# Sprint 1 Handover — From Sprint 0 to TestFlight
+
+**Date:** 5 May 2026
+**Author:** Remy
+**Status:** Draft, ready to execute once Sprint 0 is complete
+
+This document tells future-Remy (or future-James) exactly how to start Sprint 1 the moment Apple approval lands.
+
+## Preconditions (all from Sprint 0)
+
+- [ ] Apple Developer Program: enrolled and approved
+- [ ] Bundle ID registered: `au.com.peninsulainsider.app` with capabilities (SIWA, Push, Associated Domains, Wallet)
+- [ ] App Store Connect record created with name "Peninsula Insider"
+- [ ] APNs Auth Key downloaded; Key ID + Team ID noted
+- [ ] App Store Connect API Key downloaded; Issuer ID + Key ID noted
+- [ ] `~/.apple-keys/peninsula-insider.env` populated
+- [ ] Decision 1 (Individual vs Org) and Decision 2 (monorepo vs separate repo) confirmed by James in [`decisions-2026-05-05.md`](decisions-2026-05-05.md)
+
+## Sprint 1 goal
+
+A signed-in Peninsula Insider app installed on James's iPhone via TestFlight, rendering Saved articles from the existing Supabase, with the Ask tab calling the existing `/ask` endpoint. Five working days, four if approval lands fast.
+
+## Day-by-day plan
+
+### Day 1 — Scaffold and auth
+
+**Outcomes:** Expo project compiling locally, signed in via Supabase magic link.
+
+1. From repo root: `npx create-expo-app@latest mobile --template default` — TypeScript + Expo Router default.
+2. Add `mobile/` to repo's existing `.gitignore` for build outputs (`.expo`, `dist`, `ios/`, `android/`).
+3. `cd mobile && npx expo install @supabase/supabase-js expo-secure-store expo-crypto react-native-url-polyfill`.
+4. Create `mobile/lib/supabase.ts` mirroring `next/src/lib/auth.ts`. Use `expo-secure-store` for `auth.storage` so the session lives in iOS Keychain not AsyncStorage.
+5. Wire magic-link sign-in screen: paste email → Supabase sends OTP → app handles redirect via deep link (custom scheme `peninsulainsider://`).
+6. Add `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY` to `mobile/.env.local` (use the same values as `next/.env`).
+
+### Day 2 — Sign in with Apple, Saved tab
+
+**Outcomes:** Apple sign-in works; Saved tab lists `article_saves` for the current user.
+
+1. `npx expo install expo-apple-authentication`.
+2. Configure Sign in with Apple in Supabase Auth dashboard: Services ID + key (from Step 4 of Sprint 0).
+3. Add a "Continue with Apple" button on the auth screen (mandatory for App Store now that we offer Google).
+4. Build `app/(tabs)/saved.tsx` that calls `c.from('article_saves').select('*')` exactly as `next/src/lib/auth.ts:listSaves` does. RLS already protects the data.
+5. Each row renders a `SavedCard` — title, dek, image, link out to `https://peninsulainsider.com.au/<section>/<slug>`. Tap = open in in-app `expo-web-browser`.
+6. Add a "Sign out" button that calls `supabase.auth.signOut()`.
+
+### Day 3 — Ask tab + tab navigator
+
+**Outcomes:** Ask tab posts to `/ask` and renders streaming response.
+
+1. Identify the deployed `/ask` endpoint (Vercel function, Supabase Edge Function, or wherever — confirm with James). Copy its URL into an env var.
+2. Build `app/(tabs)/ask.tsx`: chat thread UI, text input at the bottom, `fetch(askUrl, { method: 'POST', body: { question } })`.
+3. Render messages using a `MessageBubble` component — style consistent with `BRAND-PI.md` voice rules (no em-dashes in any UI copy).
+4. Add tab navigator: `app/(tabs)/_layout.tsx` with four tabs — Ask, Now, Saved, Pass. Now and Pass are placeholders for Sprint 1.
+5. Splash screen + app icon: use the existing `pi-mark.svg` from `next/public/images/`. Generate iOS icon set via `npx expo-cli icon` or manual export. App icon must be 1024×1024 PNG, no transparency, no rounded corners (Apple adds those).
+
+### Day 4 — Privacy manifest, EAS, first build
+
+**Outcomes:** EAS Build completes; app installs on James's phone via QR code.
+
+1. Add `mobile/ios/PrivacyInfo.xcprivacy` declaring required reasons for `UserDefaults` (CA92.1) and any other Required Reasons APIs Expo modules pull in.
+2. `npx eas init` from `mobile/`. Choose existing project or create new — this links it to your EAS account.
+3. Configure `eas.json`:
+   - `preview` profile: internal distribution, simulator + ad-hoc.
+   - `production` profile: store distribution.
+4. Run `eas credentials --platform ios`. Paste API Key path + Issuer ID + Key ID from Sprint 0 Step 6. EAS auto-generates the distribution cert and provisioning profile.
+5. `eas build --profile preview --platform ios`. Wait ~15 min. EAS sends a QR code; scan with iPhone camera; install.
+6. Verify: open app, sign in with Apple, see Saved tab.
+
+### Day 5 — TestFlight + EAS Update wired
+
+**Outcomes:** Production build live on TestFlight internal; OTA update path tested.
+
+1. Tag a release: `git tag -a v0.1.0 -m "Sprint 1 — TestFlight first build"`.
+2. `eas build --profile production --platform ios`.
+3. `eas submit --profile production --platform ios --latest`. EAS uploads to App Store Connect.
+4. App Store Connect → Peninsula Insider → TestFlight → wait 10–15 min for build processing → "Manage" the build → choose `ITSAppUsesNonExemptEncryption: No`.
+5. Add yourself to the **Internal Testing** group (instant; no beta review needed for internal).
+6. Install via TestFlight app on iPhone.
+7. Test the OTA path: change a string in Ask tab, `eas update --channel production --message "test ota"`. Verify it lands on the device after relaunch.
+8. Update `CHANGELOG.md` with the v0.1.0 entry per `HANDOVER-CLAUDE.md` convention.
+
+## Risk register for Sprint 1
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Apple approval slips beyond 72h | Medium | Decision 1 default is Individual; if delayed, scaffold locally without TestFlight push. |
+| `/ask` endpoint isn't ready for cross-origin mobile calls | Medium | Confirm endpoint URL + CORS up front; add device ID header so concierge can rate-limit. |
+| Sign in with Apple service ID misconfigured | Medium | Test on physical device, not simulator (SIWA needs a real Apple ID). |
+| Privacy manifest missing for an Expo module | Medium | Run `npx expo-doctor` before EAS Build; it now flags missing manifests. |
+| EAS Build queue is slow on free tier | Low | Pay $19/mo for priority builds during launch sprint; cancel after. |
+| App Store Connect rejects "thin wrapper" | Low — Sprint 1 only ships internal testing, not external review | Ask + Saved are real native; no review until Sprint 3. |
+
+## What Sprint 1 deliberately does NOT do
+
+- Push notifications (Sprint 2)
+- Universal Links / deep linking (Sprint 2)
+- Now tab content (Sprint 2)
+- Pass / Wallet (Sprint 3)
+- Offline support (Sprint 3)
+- App Store external review submission (Sprint 3)
+
+## IAP decision tree for Insider Pass
+
+This is the one strategic question Sprint 3 needs answered. Document the decision before then.
+
+```
+Is Insider Pass purchased and consumed entirely inside the iOS app?
+├── Yes → Apple's IAP rules apply. 15–30% Apple cut. Use StoreKit 2.
+└── No → can the Pass be purchased on the website (peninsulainsider.com.au) only?
+    ├── Yes, web-only purchase, app just authenticates an existing pass → Reader Rule applies.
+    │     The app can show Pass status without offering in-app purchase.
+    │     This is the path App Store accepts most cleanly. Recommended.
+    └── No, app needs to offer purchase → IAP only.
+
+Are Pass perks digital (concierge access, premium content) or physical (event entry, vouchers, partner discounts)?
+├── Mostly digital → Apple insists on IAP for digital subscription.
+├── Mostly physical → Apple's "physical goods and services" exemption may allow Stripe, but get an explicit confirmation from Apple Review or a TRC ticket before submission.
+└── Mixed → safest is web-purchase + app-authentication (Reader Rule) until product is settled.
+```
+
+**Recommendation:** Sprint 1 ships with no Pass-related screens. Sprint 2 adds a "View on web" link to the Pass tab. Sprint 3 makes the call based on where the Pass product lands commercially. This is a strategic decision James owns; Remy will surface it for review at start of Sprint 3.
+
+## Files Sprint 1 will create or modify
+
+```
+mobile/                          (new, scaffolded by create-expo-app)
+├── app/
+│   ├── _layout.tsx              (root)
+│   ├── (auth)/
+│   │   └── sign-in.tsx
+│   └── (tabs)/
+│       ├── _layout.tsx
+│       ├── ask.tsx
+│       ├── now.tsx              (placeholder)
+│       ├── saved.tsx
+│       └── pass.tsx             (placeholder)
+├── components/
+│   ├── MessageBubble.tsx
+│   ├── SavedCard.tsx
+│   └── SignInWithApple.tsx
+├── lib/
+│   └── supabase.ts
+├── ios/PrivacyInfo.xcprivacy
+├── app.json                     (Expo config — bundle ID, capabilities)
+├── eas.json
+├── package.json
+└── .env.local                   (gitignored)
+
+CHANGELOG.md                     (append v0.1.0 entry)
+.gitignore                       (add mobile/ build artefacts)
+```
+
+That is Sprint 1 in full.


### PR DESCRIPTION
## Summary

- Kicks off the Peninsula Insider iOS app project. Backend is already built (Supabase auth, saves, lists, alerts, `/ask`, Pass Stripe scaffold), so the app is a thin native client over a thick existing backend.
- Reframes the April pocket-concierge thesis from "PWA-first / Capacitor-later" to **Expo-native-first**, based on fresh 2026 vibe-coding research. Strategic thesis (curated, opinionated, taste-led concierge) is unchanged; only the packaging flipped.
- Locks the stack: **Expo SDK 53 + Supabase + EAS Build/Submit/Update + Sign in with Apple + Apple Wallet PassKit**. Bundle ID `au.com.peninsulainsider.app`.
- Ships four planning docs in `docs/mobile-app/` plus a `CHANGELOG.md` entry. No site/code changes; build is unaffected.

## Files

- `docs/mobile-app/README.md` — workspace overview + the strategic shift note
- `docs/mobile-app/decisions-2026-05-05.md` — locked decisions; **2 awaiting James's call**
- `docs/mobile-app/sprint-0-apple-paperwork-2026-05-05.md` — 7-step Apple Developer / App Store Connect / APNs / API Key checklist
- `docs/mobile-app/sprint-1-handover-2026-05-05.md` — day-by-day plan to TestFlight in 5 working days, plus IAP decision tree for Insider Pass

## Decisions awaiting James

1. **Apple Developer enrolment** — Individual (recommended, 24-72h) vs Organisation (1-2w, needs D-U-N-S). Documented trade-offs in `decisions-2026-05-05.md`.
2. **Repo layout** — monorepo with `mobile/` (recommended) vs separate repo. Both rationales documented.

## Test plan

- [ ] Read `docs/mobile-app/README.md` — confirm strategic shift framing reads correctly
- [ ] Read `decisions-2026-05-05.md` — confirm or override the two open decisions
- [ ] Spot-check the Sprint 0 checklist against current Apple Developer portal flows (URLs, capability names) before running it
- [ ] Confirm `CHANGELOG.md` entry follows house format

## Out of scope (deliberate)

- No `mobile/` scaffold yet — that's Sprint 1, gated on Apple Developer enrolment approval.
- No PR to update the original April strategy doc — preserved as the canonical product thesis; the README in `docs/mobile-app/` references it and notes the packaging shift.
- IAP decision for Insider Pass deferred to Sprint 3 with a decision tree documented now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)