### PR TITLE
seo(sitemap): drop noindex /golf/, add /explore/golf/ canonical

### DIFF
--- a/next/src/pages/sitemap.xml.ts
+++ b/next/src/pages/sitemap.xml.ts
@@ -67,18 +67,26 @@ export const GET: APIRoute = async () => {
   // Section index pages. /spa/ and /walks/ are intentionally omitted because
   // astro.config.mjs redirects them to canonical homes (/explore/spas-and-wellness/
   // and /explore/walks/); listing redirect URLs in the sitemap creates noise
-  // for crawlers. /whats-on/, /golf/, and /dog-friendly/ are real lanes and
-  // were missing from this list previously.
+  // for crawlers. /whats-on/ and /dog-friendly/ are real lanes and were
+  // missing from this list previously.
+  // /golf/ removed 2026-05-05 (post-deploy of experiment 2026-05-05-01) after
+  // GSC live-test on the manual reindex submission revealed /golf/ is itself
+  // a noindex redirect-stub pointing to /explore/golf/. Sitemap should advertise
+  // the canonical destination, not the redirect. /explore/golf/ added below
+  // alongside the other explicit hub entries.
   // Promoted to priority 1.0 (alongside the homepage) on 2026-05-05 because
-  // GSC inspection showed dog-friendly, whats-on, corporate-events, and golf
+  // GSC inspection showed dog-friendly, whats-on, corporate-events, and ask
   // had never been crawled despite being internally linked from 500+ pages.
   // The site-wide nav links were not winning crawl priority. Bumping these to
   // 1.0 alongside the canonical-home homepage signals "treat as top-tier hubs".
   // See ops/reports/seo/experiments.md experiment 2026-05-05-01.
-  const TOP_HUBS = new Set(['dog-friendly', 'whats-on', 'corporate-events', 'fishing', 'golf', 'ask']);
-  for (const section of ['eat', 'stay', 'wine', 'explore', 'escape', 'journal', 'places', 'whats-on', 'golf', 'dog-friendly', 'weddings', 'corporate-events', 'fishing', 'boating']) {
+  const TOP_HUBS = new Set(['dog-friendly', 'whats-on', 'corporate-events', 'fishing', 'ask']);
+  for (const section of ['eat', 'stay', 'wine', 'explore', 'escape', 'journal', 'places', 'whats-on', 'dog-friendly', 'weddings', 'corporate-events', 'fishing', 'boating']) {
     entries.push(url(`/${section}`, TOP_HUBS.has(section) ? 1.0 : 0.9, 'weekly'));
   }
+  // /explore/golf/ — the canonical golf hub. /golf/ is a noindex redirect stub
+  // that points here, so sitemap-list this destination directly.
+  entries.push(url('/explore/golf', 1.0, 'weekly'));
   // /fishing/ and /boating/ sub-hubs — emit unconditionally so crawlers find
   // them once Phase 1 ships, even before all leaf entities are populated.
   for (const subhub of ['fishing/species', 'fishing/locations', 'fishing/charters', 'boating/ramps', 'boating/hire']) {

--- a/ops/reports/seo/daily-log.md
+++ b/ops/reports/seo/daily-log.md
@@ -661,10 +661,12 @@ Reverse-engineered the GSC Page Indexing report by inspecting all 418 known URLs
    https://peninsulainsider.com.au/whats-on/
    https://peninsulainsider.com.au/corporate-events/
    https://peninsulainsider.com.au/ask/
-   https://peninsulainsider.com.au/golf/
+   https://peninsulainsider.com.au/explore/golf/
    ```
 
    Five URLs, well within the 10/day quota.
+
+   **Note (correction 2026-05-05 evening)**: original list had `/golf/` which is a noindex redirect-stub pointing to `/explore/golf/`. GSC live test correctly returned "Excluded by noindex tag". Submit `/explore/golf/` instead — that's the canonical golf hub. Sitemap also corrected (PR #78) to remove `/golf/` and add `/explore/golf/`.
 
 ### Tomorrow's queue
 


### PR DESCRIPTION
Small follow-up to PR #77 after GSC live-test surfaced an issue.

## Problem

When James ran GSC URL Inspection → Request Indexing on \`/golf/\` (one of the 5 hub URLs from PR #77's reindex list), GSC returned:

> Page cannot be indexed: Excluded by 'noindex' tag

That's because \`/golf/\` is intentionally a noindex redirect-stub pointing to \`/explore/golf/\` (the real golf hub). The sitemap was wrong to advertise the redirect — it should advertise the canonical destination.

## Fix

- Remove 'golf' from the section loop in \`next/src/pages/sitemap.xml.ts\` (so \`/golf/\` is no longer in the sitemap)
- Add explicit entry for \`/explore/golf/\` at priority 1.0
- Update daily-log manual reindex list to use \`/explore/golf/\`

The \`/golf/\` redirect page itself stays — it's needed for legacy inbound links. It just shouldn't be in the sitemap.

## Verified

\`npm run build\` → 1235 pages, no errors. Sitemap now lists \`/explore/golf/\` and not \`/golf/\`.

## After deploy

Re-submit \`https://peninsulainsider.com.au/explore/golf/\` (instead of \`/golf/\`) via GSC URL Inspection → Request Indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)