### PR TITLE
feat(menu): promote V4 mega-menu to live site

### DIFF
--- a/docs/v3/STAGING-V3.md
+++ b/docs/v3/STAGING-V3.md
@@ -1,0 +1,151 @@
+# V3 Staging — Release 1 + Release 2
+
+**Branch:** `claude/optimistic-chatelet-c6e355`
+**Route:** `/v3/` (noindex, isolated from production)
+**Build status:** ✅ 1201 pages, no errors against the V3 surface
+
+---
+
+## What you're looking at
+
+A complete fork of the Peninsula Insider homepage, masthead, and IA running at `/v3/`, built against the V3 strategy doc. Production `/index.astro`, masthead, footer, and the live nav lib (`lib/nav.ts`) are **untouched**. Run `npm run dev` and visit `http://localhost:4321/v3/` to review.
+
+This stages **Release 1 (homepage rebuild)** and the structural half of **Release 2 (nav, IA, card system)** in a single, reviewable surface so you can decide what to promote.
+
+---
+
+## File map
+
+```
+next/src/
+├── styles/
+│   └── v3.css                            # NEW — V3 design tokens + all V3 component styles
+├── lib/
+│   └── v3-nav.ts                         # NEW — 5-pillar nav, mega-panel data, footer cols
+├── layouts/v3/
+│   └── V3BaseLayout.astro                # NEW — fork of BaseLayout, mounts V3 chrome
+├── components/v3/
+│   ├── V3Masthead.astro                  # NEW — utility + brand + 5-pillar nav + mega-panel
+│   ├── V3Footer.astro                    # NEW — colophon footer
+│   ├── V3HomeCover.astro                 # NEW — cinematic full-bleed cover with poster + loop
+│   ├── V3AskBlock.astro                  # NEW — homepage Ask PI front-door
+│   ├── V3PillarGrid.astro                # NEW — Stay/Explore/Plans/Tours, 4 cards w/ line icons
+│   ├── V3WeekendHero.astro               # NEW — combined dispatch + 3-event strip
+│   ├── V3EventCard.astro                 # NEW — compact event card w/ flags
+│   ├── V3IntentGrid.astro                # NEW — 8 voice-led intent cards (chips upgraded)
+│   ├── V3EditorialCard.astro             # NEW — unified editorial card (replaces ArticleCard)
+│   ├── V3EntityCard.astro                # NEW — unified entity card (replaces 7 V2 card types)
+│   ├── V3LateralSurfaces.astro           # NEW — 3-up: eat-now / stay-now / place-by-place
+│   ├── V3EditorsLetter.astro             # NEW — drop-cap letter with 4:5 image
+│   ├── V3Shortlist.astro                 # NEW — five picks with italic numerals
+│   ├── V3InsiderStripe.astro             # NEW — vine-coloured Pass commercial moment
+│   ├── V3Newsletter.astro                # NEW — compact dispatch sign-up
+│   └── V3ConciergeDock.astro             # NEW — bottom-right Ask PI affordance, breathes
+└── pages/v3/
+    └── index.astro                       # NEW — V3 homepage, all 10 blocks wired
+
+docs/v3/
+└── STAGING-V3.md                         # this file (lives outside pages so it doesn't render as a route)
+```
+
+The production homepage at `next/src/pages/index.astro` is **byte-for-byte unchanged**.
+
+---
+
+## What was built (vs the strategy doc)
+
+### Release 1 — Homepage rebuild ✅
+
+| Block (per strategy doc) | Component | Status |
+|---|---|---|
+| 1. Cinematic Cover with poster + silent loop, dual CTA | `V3HomeCover` | ✅ uses `/videos/hero.mp4` + `/images/sourced/home-cover-bay-umbrella-01.webp`. Honours `prefers-reduced-motion` and `Save-Data`. Two CTAs: *Read the cover* and *Ask PI instead*. |
+| 2. Ask PI block | `V3AskBlock` | ✅ Input + 3 voice-chip suggestions, posts to `/ask/?q=…`. Avatar with status dot. |
+| 3. Pillar grid (Stay / Explore / Plans / Tours) | `V3PillarGrid` | ✅ 4 cards, line icons, hover lift. Copy in PI voice. |
+| 4. Weekend hero | `V3WeekendHero` | ✅ Two-column: dispatch story + 3 weekend events. Date prominence. Pulls from real content collection. |
+| 5. Intent grid (chips → cards) | `V3IntentGrid` | ✅ 8 cells, anchor image per cell, hover micro-affordance. Routes to existing journal pieces. |
+| 6. Shortlist | `V3Shortlist` | ✅ Italic numerals, hairline rows, 12px slide on hover. Reads as a collectible artefact. |
+| 7. Editor's Letter | `V3EditorsLetter` | ✅ 4:5 image left + drop-cap body right + pull quote. Image carries an italic caption overlay. |
+| 8. Insider Stripe (Pass) | `V3InsiderStripe` | ✅ The single vine-coloured block on the page. Dual CTAs. |
+| 9. Three lateral surfaces | `V3LateralSurfaces` | ✅ 3-up Eat / Stay / Places, each with one anchor entity card. |
+| 10. Newsletter | `V3Newsletter` | ✅ Compact two-column. Form action stub points at Mailchimp. |
+| Voice on chrome | masthead, CTAs, dock | ✅ "Get the dispatch", "Ask PI", "Open the rooms", "Open the moves", "Open the plans", "Open the operators", "Sign in / Save trip". No tourism adjectives. No em-dashes. |
+
+### Release 2 — Nav, IA, card system ✅ (the structural half)
+
+| Item | Implementation | Status |
+|---|---|---|
+| Collapse 10+ pillars to 5 | `lib/v3-nav.ts` exports `v3Pillars` with five: Eat & Drink, Stay, Explore, Plans, Journal | ✅ |
+| Mega-panel nav (3-column editorial layout) | `V3Masthead.astro` renders mega-panel per pillar with intent / place / format / image rail | ✅ Hover, focus, and Esc-to-close all wired |
+| Concierge in masthead | "Ask PI" pill in utility actions, plus mobile-row pill | ✅ |
+| Three-card system | `V3EditorialCard` (articles/dispatches/shortlist) + `V3EntityCard` (any verdict-bearing thing) + `V3EventCard` (events) | ✅ Replaces 9 V2 card types with 3 |
+| Concierge dock | `V3ConciergeDock` — appears after first scroll, breathes when idle | ✅ |
+| Sticky-on-scroll masthead | V3BaseLayout adds `is-scrolled` class after 80px | ✅ Brand row condenses |
+| Footer reorganised by V3 pillar | `V3Footer` w/ Departments + About + Read more cols | ✅ |
+
+### What is **not** in this release (deliberate)
+
+These are still in the Release 2 / Release 3 backlog and were excluded so V3 stays cleanly reviewable as a staged proposal:
+
+- **No URL migrations.** No redirects from `/wine`, `/walks`, `/golf`, `/fishing`, `/boating`, `/spa`, `/dog-friendly`, `/corporate-events`, `/weddings`, `/tour-packages` into the new pillar pages. The mega-panel links land on existing live pages and querystring-filtered indexes that **already 200**.
+- **No production page rebuilds.** `/eat/`, `/stay/`, `/explore/`, `/escape/`, `/journal/` are still V2. V3 only ships the homepage and chrome (masthead + footer) so far.
+- **No save-to-trip wiring.** Designed in the spec, not yet implemented in V3 — the existing V2 `Shortlist` save flow needs separate wiring once the V3 EntityCard becomes the canonical type.
+- **No Mailchimp credentials.** `V3Newsletter` form action carries a `PLACEHOLDER` you'll need to swap when promoting.
+- **No new search index.** V3 page is `noindex` by default and excluded from the Pagefind body.
+
+---
+
+## How to review
+
+```bash
+cd next
+npm run dev
+# open http://localhost:4321/v3/
+```
+
+A full build (run already): `npx astro build` — succeeds, builds 1201 pages including `/v3/`.
+
+### What to look at first
+
+1. **The cover** at the top of `/v3/`. Does the silent loop play smoothly on your wifi? Does the poster carry the moment if it doesn't? Are the two CTAs (*Read the cover* / *Ask PI instead*) the right framing?
+2. **Hover the masthead pillars** to open the mega-panels. Three columns each: by intent, by place, in voice. Does the curation feel right?
+3. **Scroll past the cover.** The Ask block is the new front door. Type something or tap a chip — it should land on `/ask/?q=…`.
+4. **Compare the rhythm** to live `/`. Same content, fewer competing sections, sharper sequencing.
+
+---
+
+## Known follow-ups before promoting
+
+- [ ] Wire `V3Newsletter` form action to real Mailchimp endpoint (V2 has the credentials).
+- [ ] Swap the cover loop for a 4–8 second silent loop authored specifically for the cover (current `hero.mp4` is the V2 hero, will work but is generic).
+- [ ] Decide whether to honour the mobile burger overlay or rebuild it as `V3MobileNav` (currently V3 mobile shows the brand + Ask pill, no full menu).
+- [ ] Add the V3 mega-panel keyboard navigation (currently mouse + focus + Esc; arrow-key navigation between columns is not wired).
+- [ ] Decide whether `/v3/eat/`, `/v3/stay/`, `/v3/explore/`, `/v3/escape/`, `/v3/journal/` should ship next as Release 2.5 to stage the inside pages, or whether to promote V3 home + chrome over V2 first.
+- [ ] Hook `V3ConciergeDock` `data-pi-trigger` into the existing `ConciergeDrawer` — currently the trigger fires the V2 drawer (which is mounted by V3BaseLayout), so the wiring works but should be smoke-tested.
+- [ ] Image optimisation pass on the intent-card thumbnails (using existing `/images/sourced/article-*-01.webp` — fine for staging, want srcset variants for production).
+
+---
+
+## What changed in production
+
+Nothing. Zero V2 files were modified. The only writes:
+
+```
+next/src/styles/v3.css
+next/src/lib/v3-nav.ts
+next/src/layouts/v3/V3BaseLayout.astro
+next/src/components/v3/*.astro  (15 new files)
+next/src/pages/v3/index.astro
+next/src/pages/v3/STAGING-V3.md
+```
+
+Promotion plan when V3 is approved:
+
+1. Move/rename `pages/v3/index.astro` → `pages/index.astro` (or set `pages/index.astro` to import the V3 layout).
+2. Switch `Masthead`/`Footer` defaults in `BaseLayout.astro` to V3 components, **or** keep both and gate by section flag.
+3. Migrate URL redirects from collapsed pillars (`/wine`, `/walks`, etc.) into the new structure.
+4. Promote V3 nav lib to be the single source of truth (delete or alias the V2 `lib/nav.ts` exports).
+5. Drop `noindex` from `V3BaseLayout`.
+
+---
+
+*Built against `BRAND-PI.md` voice rules: no em-dashes, no tourism-board adjectives, specific over generic, dry over effusive. Everything that ships text in PI's name follows the rule.*

--- a/docs/v4/DESIGN-SYSTEM-V4.md
+++ b/docs/v4/DESIGN-SYSTEM-V4.md
@@ -1,0 +1,273 @@
+# V4 Design System
+
+The mega-menu lift, applied natively to the V2 design language. Cream paper stays. Ochre, gold, sage stay. Cormorant + Outfit stay. Only chrome and behaviour change.
+
+Built around four principles:
+
+1. **Curation over coverage.** Every column capped at six items. The mega menu reads as edited, not exhaustive.
+2. **The framing is the feature.** Every panel teaches the reader its three-axis structure (intent, place, voice) via a one-line intro and small-caps eyebrows. First-time readers don't have to guess.
+3. **The rail is the editor's pin.** Each pillar's image rail is the *one thing* PI is sending you to right now. Refreshes when the issue refreshes.
+4. **The Ask is the safety net.** Every panel ends with an "Ask PI" line in voice. The menu admits its limits and routes around them.
+
+---
+
+## 1. Tokens
+
+V4 inherits V2's `:root`. New tokens are additive, scoped under `--v4-` so V2 components are unaffected.
+
+```css
+/* added to next/src/styles/v4.css */
+:root {
+  --v4-mega-w:           1240px;     /* mega panel max width */
+  --v4-mega-rail-w:      280px;      /* image rail width */
+  --v4-mega-col-gap:     40px;
+  --v4-mega-row-h:       56px;       /* nav row height */
+  --v4-mega-pad-y:       40px;       /* mega panel vertical padding */
+  --v4-mega-open-delay:  70ms;
+  --v4-mega-close-delay: 220ms;
+  --v4-shadow-mega:      0 16px 40px -16px rgba(30, 27, 24, 0.18);
+  --v4-shadow-mega-soft: 0 8px 24px -12px rgba(30, 27, 24, 0.12);
+
+  --v4-link-underline:   1px solid rgba(139, 78, 59, 0.35);  /* matches V2 ochre */
+  --v4-focus-ring:       0 0 0 3px rgba(139, 78, 59, 0.22);
+  --v4-hairline-mega:    rgba(30, 27, 24, 0.10);
+}
+```
+
+V2 colour tokens used by V4 components, unchanged:
+
+| Token | Value | Used for |
+|---|---|---|
+| `--bg` | `#FFFFFF` | masthead surface |
+| `--bg-alt` | `#F6F2EA` | mega panel surface (subtle warmth vs nav row) |
+| `--text` | `#2B2520` | menu link colour |
+| `--soft` | `#7A726A` | meta + intro line colour |
+| `--accent` | `#8B4E3B` | ochre — eyebrows, link hover, focus |
+| `--gold` | `#B69A6B` | image rail caption underline |
+| `--sage` | `#7A8B6D` | "live data" indicator dot on What's On |
+| `--border` | `#E5E0D6` | hairline dividers |
+
+---
+
+## 2. Component anatomy
+
+### V4Masthead
+
+Three rows. Sticky on scroll. Matches V2 layout exactly — only the third row's structure changes.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Vol 04 · Autumn 2026 · Updated weekly        Pass · Sign in / Save    │  Row 1: Utility (V2 black)
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│              Peninsula Insider · An editorial guide                     │  Row 2: Brand (V2 paper)
+│                                                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│  Eat & Drink  Wine  Stay  Explore  Plans  What's On  Journal   🔍 Ask PI  Subscribe  │  Row 3: V4 nav
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Notes:
+- Row 1 + Row 2 are V2 unchanged (utility + brand reuse `Masthead.astro` markup).
+- Row 3 is wholly new — 7 pillars + 3 utility actions (search, Ask PI, Subscribe).
+- Subscribe is the only ochre-coloured pill (V2 already does this).
+- Ask PI is the only **dark-ink** pill, paired with the PI mark in a small disc — different colour treatment from Subscribe so the eye reads them as two different actions.
+- Journal sits last in the row and stays italic Cormorant — magazine signature, kept from V2.
+- On scroll, the brand row collapses to half-height and Row 1 hides; nav row stays visible.
+
+### V4MegaPanel
+
+Anchored to the nav row, full-width. Opens on hover (70 ms delay), closes on leave (220 ms delay), or on focus / keyboard / click-outside / Escape.
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Three ways into Eat & Drink — pick the meal, the place, or the route. │  Intro line
+├──────────────┬──────────────────┬──────────────────┬───────────────────┤
+│              │                  │                  │                   │
+│   IMAGE      │  BY THE MEAL     │  BY THE PLACE    │  IN VOICE         │
+│   (rail,     │                  │                  │                   │
+│   280px,     │  Long lunch      │  Red Hill        │  Editor's Table   │
+│   4:5 ratio) │  Hatted dinner   │  Sorrento        │  The Shortlist    │
+│              │  Breakfast       │  Flinders        │  Pantry & produce │
+│  Italic      │  Cellar door     │  Mornington      │  Every venue      │
+│  verdict     │  Cafe & bakery   │  Main Ridge      │                   │
+│  line        │  Pantry & produce│  Merricks        │                   │
+│  ↓ Open      │                  │                  │                   │
+│              │                  │                  │                   │
+├──────────────┴──────────────────┴──────────────────┴───────────────────┤
+│        Looking for the back-roads version? Ask PI →                     │  Ask line
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+Spacing:
+- Vertical padding: `var(--v4-mega-pad-y)` (40 px) top and bottom.
+- Column gap: `var(--v4-mega-col-gap)` (40 px).
+- Image rail: 280 px fixed, aspect 4:5.
+- Intro line: serif italic, 16 px, `--soft` colour, max 80 ch.
+- Bottom Ask line: serif italic, 18 px, ochre on hover, full width centred.
+
+Backdrop:
+- Surface: `var(--bg-alt)` so the panel reads as a *paper page* below the nav row's white surface.
+- Shadow: `var(--v4-shadow-mega)` for separation.
+- Top hairline: 1 px `var(--border)` — no second hairline at bottom.
+
+### V4MegaColumn
+
+```html
+<div class="v4-mega-col">
+  <h3 class="v4-mega-col__eyebrow">By the meal</h3>
+  <ul class="v4-mega-col__list">
+    <li><a href="/journal/the-long-lunch/">Long lunch</a></li>
+    ...
+  </ul>
+</div>
+```
+
+Eyebrow: Outfit, 11 px, 0.16 em letter-spacing, uppercase, ochre.
+Items: Cormorant Garamond, 19 px, dark ink. Hover: ochre + 1 px underline lift. Focus: ochre + focus ring.
+
+### V4MegaRail
+
+The editor's pin per pillar. Different from a plain category tile — it's an editorial recommendation.
+
+```html
+<a class="v4-mega-rail" href="/eat/laura/">
+  <img src="/images/sourced/eat-laura-01.webp" alt="Laura, Pt Leo Estate">
+  <div class="v4-mega-rail__body">
+    <p class="v4-mega-rail__eyebrow">Editor's pick · Autumn '26</p>
+    <h3 class="v4-mega-rail__title">Laura</h3>
+    <p class="v4-mega-rail__verdict">Sit at the bar, not the dining room. Better view, faster service. The kingfish is the order.</p>
+    <span class="v4-mega-rail__cta">Open the verdict →</span>
+  </div>
+</a>
+```
+
+The rail's verdict line is the only place sentences live inside the menu, and it follows BRAND-PI.md voice rules to the letter.
+
+### V4PillarTopBanner (used inside What's On)
+
+Surfaces temporal context above the three columns:
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  📅  This weekend, Sat 10 – Sun 11 May          Read the dispatch →   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+Sage indicator dot + bold dateline + ochre CTA. Applies only to What's On's mega panel.
+
+### V4MobileDrawer
+
+Replaces the V2 mobile-nav overlay when V4 is mounted. Each pillar is an accordion row:
+
+```
+┌──────────────────────────────────────────────┐
+│  Eat & Drink                            ↓   │  ← tap to expand
+├──────────────────────────────────────────────┤
+│    BY THE MEAL                              │
+│    Long lunch                               │
+│    Hatted dinner                            │
+│    ...                                      │
+│                                             │
+│    BY THE PLACE                             │
+│    ...                                      │
+│                                             │
+│    IN VOICE                                 │
+│    ...                                      │
+│                                             │
+│    Looking for the back-roads version?      │
+│    Ask PI →                                 │
+├──────────────────────────────────────────────┤
+│  Wine                                   →   │
+├──────────────────────────────────────────────┤
+│  Stay                                   →   │
+└──────────────────────────────────────────────┘
+```
+
+One pillar expanded at a time. Smooth-collapse animation honours `prefers-reduced-motion`.
+The image rail is hidden on mobile (no room) — replaced by a single "Editor's pick →" line that links to the rail's URL.
+
+---
+
+## 3. Behaviour contract
+
+| Trigger | Behaviour |
+|---|---|
+| Mouse enters pillar | Panel opens after 70 ms |
+| Mouse leaves pillar AND panel | Panel closes after 220 ms |
+| Mouse moves between two pillars | Old panel closes, new opens — same delays |
+| Pillar receives focus (Tab) | Panel opens immediately |
+| Tab inside open panel | Cycles through links, then exits to next utility action |
+| Escape inside open panel | Closes panel, returns focus to its pillar trigger |
+| Click outside open panel | Closes panel |
+| Click pillar link itself | Navigates to pillar root URL |
+| `prefers-reduced-motion: reduce` | Open/close = instant, no transition |
+| Touch (mobile) | Mega panel never shown — V4MobileDrawer handles it |
+| Browser back from a sub-page | Pillar matching `data-section` is `aria-current="page"` |
+
+ARIA:
+- Each pillar `<a>` has `aria-haspopup="true"`, `aria-expanded="false|true"` flipped by JS.
+- Each mega panel has `role="menu"` with `aria-labelledby` pointing at the pillar.
+- Each mega column link has `role="menuitem"`.
+- Image rail link is the first focusable inside the panel.
+
+---
+
+## 4. Voice rules for menu copy
+
+Inherits BRAND-PI.md. Tightened for nav:
+
+- **Pillar labels**: noun phrase, max two words. *Eat & Drink, Wine, Stay, Explore, Plans, What's On, Journal*.
+- **Column eyebrows**: prepositional phrase, "By the X" or "In voice". Title case, set as small caps via CSS.
+- **Column items**: noun phrase, max three words. *Long lunch, Cellar door, Sunset moves, Group of six+*.
+- **Intro line** (top of panel): one sentence, present tense, in PI voice. *Three ways into Wine — by the venue, by the place, or by the call.*
+- **Image rail verdict**: 1–2 sentences, BRAND-PI.md rules to the letter (no em-dashes, no tourism adjectives, specific over generic).
+- **Ask line** (bottom of panel): one sentence, ends in *"Ask PI →"*. Asks a real question PI could answer.
+
+Forbidden:
+- Em-dashes (use commas, periods, colons, parentheses).
+- Tourism-board adjectives (no *stunning, must-visit, hidden gem, perfect for, breathtaking, idyllic*).
+- Sentence-form column items ("Find the best long lunch" ✗ → "Long lunch" ✓).
+- Generic catch-alls ("More" ✗ → "Every venue we cover" ✓).
+
+---
+
+## 5. Mobile pattern
+
+V4MobileDrawer replaces V2's full-screen mobile-nav overlay when V4 chrome is mounted.
+Burger icon stays top-right of the brand row.
+Drawer opens from the top, full-screen, paper surface.
+Pillars listed as accordion rows.
+Tap to expand inline; one open at a time; smooth collapse animation.
+Inside an expanded pillar:
+- Three columns stack vertically with eyebrow + 6 items each.
+- Image rail collapses to a single "Editor's pick →" line at the top.
+- Ask PI line at the bottom of the expanded pillar.
+
+Footer of the drawer (always visible):
+- Search input.
+- Sign in / Save trip.
+- Subscribe pill.
+
+---
+
+## 6. Documentation deliverables
+
+1. **PILLAR-MAP.md** — every URL accounted for, every panel content listed.
+2. **DESIGN-SYSTEM-V4.md** — this file.
+3. **STAGING-V4.md** — what's staged, how to review, promotion plan.
+4. **MENU-VOICE.md** — voice rules, distilled. Lives inside DESIGN-SYSTEM-V4.md section 4 — no separate file unless we add to it.
+
+---
+
+## 7. Promotion checklist (when V4 is approved to go live)
+
+1. Swap `Masthead.astro` import in `BaseLayout.astro` → `V4Masthead.astro`. Or:
+2. Promote the V4 home: `pages/v4/index.astro` → `pages/index.astro` (with V2 home archived).
+3. Verify all V4 mega-menu links 200 against live URLs — no redirect work needed because they already point at live V2 pages.
+4. Remove `noindex` from `V4BaseLayout`.
+5. Update `Footer.astro` to V4 layout (or fork to `V4Footer`).
+6. Swap mobile nav script binding to `V4MobileDrawer`.
+7. Delete V2 nav data from `lib/nav.ts` once nothing imports it.
+
+Estimated promotion effort: **30 minutes**, because nothing in the data layer changes.

--- a/docs/v4/DESIGN-SYSTEM-V4.md
+++ b/docs/v4/DESIGN-SYSTEM-V4.md
@@ -63,7 +63,7 @@ Three rows. Sticky on scroll. Matches V2 layout exactly — only the third row's
 │              Peninsula Insider · An editorial guide                     │  Row 2: Brand (V2 paper)
 │                                                                         │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  Eat & Drink  Wine  Stay  Explore  Plans  What's On  Journal   🔍 Ask PI  Subscribe  │  Row 3: V4 nav
+│  What's On  Plans  Eat & Drink  Wine  Stay  Explore  Journal   🔍 Ask PI  Subscribe  │  Row 3: V4 nav
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/v4/PILLAR-MAP.md
+++ b/docs/v4/PILLAR-MAP.md
@@ -8,13 +8,15 @@ The seven-pillar collapse, with every current top-level URL accounted for.
 
 ## Top row (7 pillars, in order)
 
-1. **Eat & Drink**
-2. **Wine**
-3. **Stay**
-4. **Explore**
-5. **Plans**
-6. **What's On**
+1. **What's On**
+2. **Plans**
+3. **Eat & Drink**
+4. **Wine**
+5. **Stay**
+6. **Explore**
 7. **Journal** *(italic in masthead, magazine signature)*
+
+Order rationale: the highest-intent question on a Peninsula weekend is "what's happening this Saturday?" — the live calendar wins the first slot. Plans follows because pre-shaped weekends are the next step. Editorial pillars come after intent.
 
 Plus utility actions on the right of the row: search icon, Ask PI pill, Subscribe pill.
 

--- a/docs/v4/PILLAR-MAP.md
+++ b/docs/v4/PILLAR-MAP.md
@@ -1,0 +1,194 @@
+# V4 Pillar Map
+
+The seven-pillar collapse, with every current top-level URL accounted for.
+
+**Status:** approved 2026-05-06.
+
+---
+
+## Top row (7 pillars, in order)
+
+1. **Eat & Drink**
+2. **Wine**
+3. **Stay**
+4. **Explore**
+5. **Plans**
+6. **What's On**
+7. **Journal** *(italic in masthead, magazine signature)*
+
+Plus utility actions on the right of the row: search icon, Ask PI pill, Subscribe pill.
+
+---
+
+## Where every current URL lands
+
+| Live URL | New home | Mega-menu surface |
+|---|---|---|
+| `/eat/` | Eat & Drink | Pillar root |
+| `/wine/` | Wine | Pillar root |
+| `/stay/` | Stay | Pillar root |
+| `/explore/` | Explore | Pillar root |
+| `/walks/` | Explore | Col 1 "By the move" → Walks |
+| `/places/` | every pillar | Col 2 "By the place" + own footer link |
+| `/escape/` | Plans | Pillar root (renamed from Escape to Plans in label only) |
+| `/tour/` | Plans | Col 2 "Hand it to a guide" → Operator tours |
+| `/tour-packages/` | Plans | Col 2 → Multi-day packages |
+| `/whats-on/` | What's On | Pillar root |
+| `/journal/` | Journal | Pillar root |
+| `/golf/` | Plans + footer | Col 2 → Wine-tour day / sport day; footer hub link |
+| `/spa/` | Stay + footer | Col 1 → Wellness weekend; footer hub link |
+| `/fishing/` | Explore + footer | Col 1 → On the water; footer hub link |
+| `/boating/` | Explore + footer | Col 1 → On the water; footer hub link |
+| `/dog-friendly/` | Stay + cross-tag | Col 1 → Dog friendly |
+| `/weddings/` | Plans + footer | Col 3 "By the occasion" → Weddings |
+| `/corporate-events/` | Plans + footer | Col 3 → Corporate offsites |
+
+No URLs orphaned. No URLs deprecated yet — the V4 mega menu links straight at the live V2 pages, so promotion can be a chrome swap without redirect work on day one.
+
+---
+
+## Mega panel content (final)
+
+Every panel: image rail (left, 280 px) + 3 columns + bottom Ask-PI line.
+Every column capped at 6 items.
+Eyebrow lines establish the framing for first-time readers.
+
+### Pillar 1 — Eat & Drink
+**Rail:** Editor's pick this issue (e.g. *Laura, Ten Minutes by Tractor*). Image, italic verdict line, "Open the verdict →".
+**Intro line:** *Three ways into Eat & Drink — pick the meal, the place, or the editorial route.*
+
+| Col 1 — By the meal | Col 2 — By the place | Col 3 — In voice |
+|---|---|---|
+| Long lunch | Red Hill | Editor's Table |
+| Hatted dinner | Sorrento | The Shortlist |
+| Breakfast | Flinders | Pantry & produce |
+| Cellar door | Mornington | Every venue we cover |
+| Cafe & bakery | Main Ridge | — |
+| Pantry & produce | Merricks | — |
+
+**Ask line:** *Looking for the back-roads version? Ask PI →*
+
+---
+
+### Pillar 2 — Wine
+**Rail:** Editor's pick (e.g. *Ten Minutes by Tractor* in autumn).
+**Intro line:** *The Peninsula's strongest editorial authority — by venue type, by place, or by the call.*
+
+| Col 1 — By the venue | Col 2 — By the place | Col 3 — In voice |
+|---|---|---|
+| Cellar door | Red Hill | The cellar-door shortlist |
+| Producer (no door) | Main Ridge | The Chardonnay case |
+| Brewery | Merricks | The Pinot benchmark |
+| Distillery | Mornington | The producer trail |
+| Cidery | Balnarring | Every winery we cover |
+| Pop-up tasting | Flinders | — |
+
+**Ask line:** *After the ones not on the booking apps? Ask PI →*
+
+---
+
+### Pillar 3 — Stay
+**Rail:** Editor's pick (e.g. *Jackalope*).
+**Intro line:** *Rooms by what the trip needs, by what kind of bed, or by editorial pick.*
+
+| Col 1 — By the trip | Col 2 — By the room | Col 3 — In voice |
+|---|---|---|
+| One night | Hotels | Editor's stays |
+| A weekend | Villas & houses | Every room we cover |
+| With kids | B&Bs & cottages | — |
+| Two of you | Glamping | — |
+| Wellness weekend | Spa retreats | — |
+| Dog friendly | — | — |
+
+**Ask line:** *Want the room that opens up on the cancellation list? Ask PI →*
+
+---
+
+### Pillar 4 — Explore
+**Rail:** Editor's pick (e.g. *Bushrangers Bay walk*).
+**Intro line:** *Every move on the Peninsula that isn't a meal or a bed.*
+
+| Col 1 — By the move | Col 2 — By the place | Col 3 — In voice |
+|---|---|---|
+| Walks | Red Hill & ridge | First-visit drive |
+| Beaches | Sorrento & cape | Rainy-day plans |
+| Lookouts & drives | Mornington & bay | Sunset moves |
+| Markets | Point Nepean | On the water guide |
+| Galleries | Flinders & coast | — |
+| On the water | Every town we cover | — |
+
+**Ask line:** *Want the walk only locals know? Ask PI →*
+
+---
+
+### Pillar 5 — Plans
+**Rail:** Editor's current featured itinerary (e.g. *The Thermal Springs Weekend*).
+**Intro line:** *Pre-shaped Peninsula days — by length, by guide, or by occasion.*
+
+| Col 1 — By the shape | Col 2 — Hand it to a guide | Col 3 — By the occasion |
+|---|---|---|
+| One night | Operator tours | Weddings |
+| Two-day weekend | Multi-day packages | Corporate offsites |
+| Long weekend | Wine-tour day | Anniversaries & birthdays |
+| With kids | Hot-springs day | Group of six+ |
+| Wellness weekend | Golf day | End-of-year offsite |
+| Romantic two | Dolphin swim day | — |
+
+**Ask line:** *Need the plan shaped around six adults on a Saturday? Ask PI →*
+
+---
+
+### Pillar 6 — What's On
+**Rail:** This weekend's editor's pick event (live data).
+**Intro line:** *The events calendar with an opinion attached — kids-graded, weather-flagged, worth-the-drive labelled.*
+**Top banner above columns:** *This weekend, Sat–Sun [date range] — read the full dispatch →*
+
+| Col 1 — This weekend (live) | Col 2 — Coming up | Col 3 — By the mood |
+|---|---|---|
+| Pick 1 (live) | Next weekend | Worth the drive |
+| Pick 2 (live) | Markets | Weather-proof |
+| Pick 3 (live) | Festivals | Kids welcome |
+| All this weekend → | Long weekends | After dark |
+| — | Seasonal events | Long-lunch events |
+| — | All upcoming → | All moods → |
+
+**Ask line:** *Need a Saturday plan that punishes nobody? Ask PI →*
+
+---
+
+### Pillar 7 — Journal
+**Rail:** The current cover feature.
+**Intro line:** *Long reads, dispatches, and the Shortlist — every issue, every piece.*
+
+| Col 1 — By the format | Col 2 — By the read | Col 3 (smaller — extra rail width) |
+|---|---|---|
+| The Cover | Every issue | — |
+| Long reads | How we work | — |
+| The Shortlist | About PI | — |
+| Weekend dispatch | — | — |
+| Editor's Table | — | — |
+| Cellar-door dispatch | — | — |
+
+**Ask line:** *Looking for a piece you read three issues ago? Ask PI →*
+
+---
+
+## Footer reorganisation (V4)
+
+Footer columns realign to the 7 pillars + a niche surfaces column for the corners primary nav doesn't reach.
+
+- **Departments** — the 7 pillars
+- **Niche surfaces** — Golf, Spa, Fishing, Boating, Dog-friendly, Weddings, Corporate
+- **About** — About, Methodology, Partners, The Pass, Newsletter, Contact, Privacy
+- **Read more** — Instagram, This weekend, Ask PI, Awards, Insider's 30
+
+---
+
+## Decisions captured
+
+- **Wine** kept as its own pillar (D1 ✓).
+- **Wine column 1** ordered by venue type, not grape variety (D3 ✓).
+- **Weddings + Corporate** placed in Plans column 3 "By the occasion", not footer-only (D2 ✓).
+- **What's On** elevated to its own seventh pillar (D4 ✓).
+- **Sub-page hover-test surface** — V4 masthead mounted on the 7 pillar index pages so the menu is reviewable from each section (D5 ✓).
+- **Image rail picks** chosen by me, autumn 2026 issue (D6 ✓). Listed in `lib/v4-nav.ts` and easy to swap.

--- a/docs/v4/STAGING-V4.md
+++ b/docs/v4/STAGING-V4.md
@@ -1,0 +1,108 @@
+# V4 Staging — Mega-menu lift on V2 chrome
+
+**Branch:** `claude/optimistic-chatelet-c6e355`
+**Routes:** `/v4/`, `/v4/eat/`, `/v4/wine/`, `/v4/stay/`, `/v4/explore/`, `/v4/escape/`, `/v4/whats-on/`, `/v4/journal/`
+**All:** `noindex`, isolated from production. V2 production routes untouched.
+
+---
+
+## What this is
+
+V4 takes the V3 mega-menu strategy and applies it to the **existing V2 visual language** — same paper, ochre, gold, sage, same Cormorant + Outfit type, same restraint. No design-language reset.
+
+The lift is two things:
+
+1. The **7-pillar IA** (Eat & Drink, Wine, Stay, Explore, Plans, What's On, Journal), replacing the current 8-item nav row + chevron-More menu.
+2. A **proper editorial mega-panel system** (image rail + 3 columns + intro line + Ask-PI footer), with documented tokens, components, voice rules, and behaviour contract.
+
+V4 is mounted on the home plus the seven pillar index pages so the menu can be hover-tested from any section. Sub-page deep links inside the mega menu still point at live V2 URLs — V4 is a chrome lift, not a content rebuild.
+
+---
+
+## How to review
+
+```bash
+cd next
+npm run dev
+# open http://localhost:4321/v4/
+```
+
+Hover the seven pillars in the masthead. Each opens an editorial mega panel:
+- 280 px image rail (editor's pick this issue, with verdict line)
+- One-line intro explaining the panel's framing
+- Three columns (intent / place / voice — or pillar-specific variants)
+- Ask-PI line at the bottom
+
+Click any pillar label → goes to the pillar root.
+Click any column item → goes to the live URL on V2.
+Tab through the masthead → panel opens on focus, Escape closes it.
+Resize to mobile → burger replaces the nav row, drawer opens with accordion pillars.
+
+### Key things to look at
+
+1. **Does the mega panel feel native to V2's voice?** Same paper, same hairlines, same Cormorant — but with editorial discipline the V2 More menu never had.
+2. **The 7th pillar.** What's On is now a peer to the others, with a temporal banner inside its panel. Worth checking on `/v4/whats-on/`.
+3. **The Wine pillar.** Wine kept its own pillar (vs being folded into Eat & Drink). Column 1 is by venue type per the brief.
+4. **Plans column 3.** Weddings + corporate live there now, not in the footer.
+5. **The image rail.** Each pillar's rail is the *issue's current pick*, not a generic hub image.
+6. **Hover-test from a sub-page.** Visit `/v4/eat/` and hover Wine — make sure the menu pops, the rail loads, the columns are editorial-tight.
+
+---
+
+## File map
+
+```
+next/src/
+├── styles/v4.css                         # NEW — additive tokens + V4 component styles
+├── lib/v4-nav.ts                         # NEW — 7-pillar data, mega-panel content, image-rail picks
+├── layouts/v4/V4BaseLayout.astro         # NEW — fork of BaseLayout, mounts V4 chrome
+├── components/v4/
+│   ├── V4Masthead.astro                  # NEW — 7 pillars, mega-panel parent, search/Ask/Subscribe
+│   ├── V4MegaPanel.astro                 # NEW — panel container with intro + columns + Ask-PI line
+│   ├── V4MegaColumn.astro                # NEW — eyebrow + ≤6 items
+│   ├── V4MegaRail.astro                  # NEW — image rail (editor's pick per pillar)
+│   ├── V4PillarLink.astro                # NEW — top-row pillar trigger
+│   ├── V4PillarTopBanner.astro           # NEW — temporal banner inside What's On panel
+│   └── V4MobileDrawer.astro              # NEW — accordion mobile menu
+└── pages/v4/
+    ├── index.astro                       # NEW — V2 home content under V4 chrome
+    ├── eat/index.astro                   # NEW
+    ├── wine/index.astro                  # NEW
+    ├── stay/index.astro                  # NEW
+    ├── explore/index.astro               # NEW
+    ├── escape/index.astro                # NEW
+    ├── whats-on/index.astro              # NEW
+    └── journal/index.astro               # NEW
+
+docs/v4/
+├── PILLAR-MAP.md                         # every current URL accounted for
+├── DESIGN-SYSTEM-V4.md                   # tokens, components, behaviour, voice
+└── STAGING-V4.md                         # this file
+```
+
+V2 production files: untouched.
+V3 staging at `/v3/`: untouched, still reviewable.
+
+---
+
+## Decisions captured
+
+- **Wine** kept as its own pillar (D1 ✓).
+- **Wine column 1** by venue type, not grape variety (D3 ✓).
+- **Weddings + Corporate** in Plans column 3 "By the occasion", not footer-only (D2 ✓).
+- **What's On** elevated to its own seventh pillar (D4 ✓).
+- **Sub-page hover-test surface** — V4 masthead on the 7 pillar index pages (D5 ✓).
+- **Image rail picks** — chosen by me, autumn 2026 issue (D6 ✓).
+
+---
+
+## Out of scope (not in this release)
+
+- No homepage block resequencing (V3 covers that).
+- No card-system collapse (the 9 V2 card types stay — V4 only changes chrome).
+- No URL migrations.
+- No production promotion. V4 is `noindex` until you say go.
+- No save-to-trip wiring.
+- No deep sub-page coverage (e.g. `/eat/laura/` still uses V2 chrome — only the 7 pillar index pages get V4 masthead in this release).
+
+If V4 is approved, promotion is documented in `DESIGN-SYSTEM-V4.md` section 7 — estimated 30-minute chrome swap with no data-layer changes.

--- a/next/src/components/v3/V3AskBlock.astro
+++ b/next/src/components/v3/V3AskBlock.astro
@@ -1,0 +1,74 @@
+---
+/**
+ * V3 AskBlock — homepage front-door for the concierge.
+ *
+ * Lives directly under the cover. Replaces the persona-quiz pattern with
+ * a single input box and three voice-chip suggestions written in PI voice.
+ * The chips submit to /ask/?q=... so the existing concierge backend
+ * carries the conversation forward.
+ */
+export interface AskChip {
+  label: string;
+}
+
+export interface Props {
+  eyebrow?: string;
+  title?: string;            // <em> renders italic
+  body?: string;
+  chips?: AskChip[];
+  placeholder?: string;
+  hint?: string;
+}
+
+const {
+  eyebrow = 'Ask PI',
+  title = 'Tell me what <em>you’re</em> after.',
+  body = 'A long lunch, a hatted dinner, a dog-friendly cafe, a rainy Sunday with kids. The more specific you are, the sharper my answer.',
+  chips = [
+    { label: 'Sunday with kids and rain' },
+    { label: 'One night, no driving' },
+    { label: 'Where the locals eat at 8 am' },
+  ],
+  placeholder = 'e.g. long lunch, six adults, Saturday',
+  hint = 'PI answers from the editorial corpus, never invented venues.',
+} = Astro.props;
+
+const askForm = (label: string) => `/ask/?q=${encodeURIComponent(label)}`;
+---
+
+<section class="v3-ask v3-reveal" aria-labelledby="v3-ask-title">
+  <div class="v3-container">
+    <div class="v3-ask__inner">
+
+      <div class="v3-ask__intro">
+        <p class="v3-eyebrow">{eyebrow}</p>
+        <h2 id="v3-ask-title" set:html={title} />
+        <p>{body}</p>
+      </div>
+
+      <form class="v3-ask__form" method="get" action="/ask/" role="search">
+        <label class="v3-ask__field">
+          <span class="v3-ask__avatar" aria-hidden="true"></span>
+          <input
+            class="v3-ask__input"
+            type="text"
+            name="q"
+            placeholder={placeholder}
+            aria-label="Ask PI a question"
+            autocomplete="off"
+          />
+          <button class="v3-ask__submit" type="submit">Ask</button>
+        </label>
+
+        <p class="v3-ask__hint">Try one of these</p>
+        <div class="v3-ask__chips">
+          {chips.map((chip) => (
+            <a class="v3-ask__chip" href={askForm(chip.label)}>{chip.label}</a>
+          ))}
+        </div>
+        <p class="v3-ask__hint" style="margin-top: 4px;">{hint}</p>
+      </form>
+
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3ConciergeDock.astro
+++ b/next/src/components/v3/V3ConciergeDock.astro
@@ -1,0 +1,37 @@
+---
+/**
+ * V3 ConciergeDock — bottom-right floating Ask PI affordance.
+ *
+ * Shows once visitor scrolls past the cover. Triggers the same drawer
+ * the V2 site uses (data-pi-trigger). Has a subtle 4s breathing pulse
+ * when idle, paused when reduced-motion is preferred.
+ */
+---
+
+<button class="v3-dock" data-pi-trigger="true" aria-label="Ask PI a question">
+  <span class="v3-dock__avatar" aria-hidden="true"></span>
+  <span class="v3-dock__label">Ask PI</span>
+</button>
+
+<style>
+  .v3-dock { opacity: 0; transform: translateY(8px); transition: opacity 280ms ease, transform 280ms ease; pointer-events: none; }
+  body.v3-dock-shown .v3-dock { opacity: 1; transform: translateY(0); pointer-events: auto; }
+</style>
+
+<script is:inline>
+  (function () {
+    function initDock() {
+      var dock = document.querySelector('.v3-dock');
+      if (!dock || dock._v3DockBound) return;
+      dock._v3DockBound = true;
+      function check() {
+        var show = window.scrollY > Math.min(window.innerHeight * 0.6, 600);
+        document.body.classList.toggle('v3-dock-shown', show);
+      }
+      window.addEventListener('scroll', check, { passive: true });
+      check();
+    }
+    initDock();
+    document.addEventListener('astro:page-load', initDock);
+  })();
+</script>

--- a/next/src/components/v3/V3EditorialCard.astro
+++ b/next/src/components/v3/V3EditorialCard.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * V3 EditorialCard — the unified card for editorial content.
+ *
+ * Replaces V2's ArticleCard usage. Shape: media (4:3) → meta eyebrow →
+ * headline → optional dek. Used for journal entries, dispatches, and
+ * Editor's Table picks in the V3 home and journal index.
+ */
+export interface Props {
+  href: string;
+  image?: string;
+  imageAlt?: string;
+  meta?: string;
+  title: string;
+  dek?: string;
+}
+
+const { href, image, imageAlt = '', meta, title, dek } = Astro.props;
+---
+
+<a href={href} class="v3-editorial-card">
+  {image && (
+    <div class="v3-editorial-card__media">
+      <img src={image} alt={imageAlt} loading="lazy" />
+    </div>
+  )}
+  {meta && <span class="v3-editorial-card__meta">{meta}</span>}
+  <h3 class="v3-editorial-card__title" set:html={title} />
+  {dek && <p class="v3-editorial-card__dek">{dek}</p>}
+</a>

--- a/next/src/components/v3/V3EditorsLetter.astro
+++ b/next/src/components/v3/V3EditorsLetter.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * V3 Editor's Letter — second cinematic moment on the homepage.
+ *
+ * Image left (4:5), serif body right with drop-cap on the first paragraph,
+ * pull-quote, sign-off. The image gets the second full-bleed treatment of
+ * the page (cover being the first).
+ */
+export interface Props {
+  eyebrow?: string;
+  title: string;          // <em> renders italic
+  paragraphs: string[];   // paragraph HTML strings (use <em> as needed)
+  pullQuote?: string;
+  signoff?: string;
+  image: string;
+  imageAlt: string;
+  imageCaption?: string;
+}
+
+const {
+  eyebrow = "Editor's Letter",
+  title,
+  paragraphs,
+  pullQuote,
+  signoff = 'The Editors · Peninsula Insider',
+  image,
+  imageAlt,
+  imageCaption,
+} = Astro.props;
+---
+
+<section class="v3-letter v3-reveal" aria-labelledby="v3-letter-title">
+  <div class="v3-container">
+    <div class="v3-letter__inner">
+
+      <div class="v3-letter__media">
+        <img src={image} alt={imageAlt} loading="lazy" />
+        {imageCaption && <span class="v3-letter__caption" set:html={imageCaption} />}
+      </div>
+
+      <div>
+        <p class="v3-eyebrow">{eyebrow}</p>
+        <h2 id="v3-letter-title" set:html={title} />
+        <div class="v3-letter__body">
+          {paragraphs.map((p) => <p set:html={p} />)}
+        </div>
+        {pullQuote && <p class="v3-letter__pullquote">{pullQuote}</p>}
+        <p class="v3-letter__signoff">{signoff}</p>
+      </div>
+
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3EntityCard.astro
+++ b/next/src/components/v3/V3EntityCard.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * V3 EntityCard — the unified card for any "thing with a verdict" in the
+ * corpus: venue, place, experience, itinerary, tour, package, operator.
+ *
+ * Replaces V2's VenueCard, PlaceCard, ExperienceCard, ItineraryCard,
+ * TourCard, TourPackageCard, TourOperatorCard. Nine cards collapse to
+ * one via the `kind` overlay label and a flexible meta row.
+ *
+ * Shape: media (5:4) with optional kind badge → name → italic verdict
+ * → meta row (place, type, length, etc).
+ */
+export interface Props {
+  href: string;
+  image?: string;
+  imageAlt?: string;
+  /** Small badge top-left of the image, e.g. "Restaurant", "Itinerary", "Town". */
+  kind?: string;
+  name: string;
+  /** Editorial verdict, italic. Renders <em> as italic-within-italic if needed. */
+  verdict?: string;
+  /** Inline meta tags, e.g. ["Red Hill", "Long lunch"]. */
+  meta?: string[];
+}
+
+const { href, image, imageAlt = '', kind, name, verdict, meta = [] } = Astro.props;
+---
+
+<a href={href} class="v3-entity-card">
+  {image && (
+    <div class="v3-entity-card__media">
+      <img src={image} alt={imageAlt} loading="lazy" />
+      {kind && <span class="v3-entity-card__overlay">{kind}</span>}
+    </div>
+  )}
+  <h3 class="v3-entity-card__name">{name}</h3>
+  {verdict && <p class="v3-entity-card__verdict" set:html={verdict} />}
+  {meta.length > 0 && (
+    <div class="v3-entity-card__meta">
+      {meta.map((m) => <span>{m}</span>)}
+    </div>
+  )}
+</a>

--- a/next/src/components/v3/V3EventCard.astro
+++ b/next/src/components/v3/V3EventCard.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * V3 EventCard — compact, used in WeekendHero strip and any /whats-on rail.
+ * Shows date prominently, with kids/weather/worth-the-drive flags as chips.
+ */
+export interface EventLike {
+  href: string;
+  date: string;
+  title: string;
+  venue?: string;
+  flags?: { label: string; tone?: 'default' | 'ridge' | 'vine' }[];
+}
+
+export interface Props { event: EventLike }
+const { event } = Astro.props;
+---
+
+<a href={event.href} class="v3-eventcard">
+  <span class="v3-eventcard__date">{event.date}</span>
+  <h3 class="v3-eventcard__title">{event.title}</h3>
+  {event.venue && <span class="v3-eventcard__venue">{event.venue}</span>}
+  {event.flags && event.flags.length > 0 && (
+    <div class="v3-eventcard__flags">
+      {event.flags.map((f) => (
+        <span class={`v3-flag${f.tone === 'ridge' ? ' v3-flag--ridge' : ''}${f.tone === 'vine' ? ' v3-flag--vine' : ''}`}>{f.label}</span>
+      ))}
+    </div>
+  )}
+</a>

--- a/next/src/components/v3/V3Footer.astro
+++ b/next/src/components/v3/V3Footer.astro
@@ -1,0 +1,59 @@
+---
+/**
+ * V3 Footer.
+ *
+ * Magazine colophon. Three columns of editorial nav + about + contact, ink
+ * background with paper text, italic tagline, social row, copyright base.
+ */
+import { v3FooterDepartments, v3FooterAbout } from '../../lib/v3-nav';
+
+const year = new Date().getFullYear();
+---
+
+<footer class="v3-footer">
+  <div class="v3-container">
+    <div class="v3-footer__grid">
+
+      <div class="v3-footer__brand">
+        <a href="/v3/" class="v3-masthead__logo" aria-label="Peninsula Insider, home">
+          Peninsula <span>Insider</span>
+        </a>
+        <p>The independent guide to the Mornington Peninsula. Every venue visited, every opinion earned, every weekend judged on what it actually felt like.</p>
+      </div>
+
+      <div class="v3-footer__col">
+        <h4>Departments</h4>
+        <ul>
+          {v3FooterDepartments.map((link) => (
+            <li><a href={link.href}>{link.label}</a></li>
+          ))}
+        </ul>
+      </div>
+
+      <div class="v3-footer__col">
+        <h4>About</h4>
+        <ul>
+          {v3FooterAbout.map((link) => (
+            <li><a href={link.href}>{link.label}</a></li>
+          ))}
+        </ul>
+      </div>
+
+      <div class="v3-footer__col">
+        <h4>Read more</h4>
+        <ul>
+          <li><a href="https://www.instagram.com/peninsula_insider/" target="_blank" rel="noopener">Instagram</a></li>
+          <li><a href="/whats-on/">This weekend</a></li>
+          <li><a href="/ask/">Ask PI a question</a></li>
+          <li><a href="/preview-insider-plans/">The Pass</a></li>
+          <li><a href="/partners/">Operators &amp; partners</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="v3-footer__base">
+      <span>© {year} Peninsula Insider · Published in Victoria, Australia</span>
+      <span>An editorial guide, not a directory.</span>
+    </div>
+  </div>
+</footer>

--- a/next/src/components/v3/V3HomeCover.astro
+++ b/next/src/components/v3/V3HomeCover.astro
@@ -1,0 +1,114 @@
+---
+/**
+ * V3 HomeCover — cinematic full-bleed cover.
+ *
+ * Renders a poster image immediately, with an optional silent looped video
+ * layered on top. Video is muted, plays inline, autoplays on capable
+ * connections, honours `prefers-reduced-motion` (poster-only fallback).
+ *
+ * Eyebrow → title (with italic em emphasis) → meta → two CTAs.
+ *
+ * The two CTAs are intentional: read the cover (editorial route), or ask PI
+ * (concierge route). This is the V3 strategy in one component.
+ */
+export interface Props {
+  eyebrow?: string;            // e.g. "The Cover Feature · Vol 04"
+  vineTag?: string;            // e.g. "AUTUMN 2026"
+  title: string;               // <em> tags render italic
+  meta?: string;               // e.g. "The Long Read · 9 min · The Editors"
+  poster: string;
+  posterAlt: string;
+  video?: string;              // path to silent loop, optional
+  primaryHref: string;
+  primaryLabel: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+}
+
+const {
+  eyebrow = 'The Cover Feature',
+  vineTag,
+  title,
+  meta,
+  poster,
+  posterAlt,
+  video,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+} = Astro.props;
+---
+
+<section class="v3-cover" aria-label="Cover feature">
+  <div class="v3-cover__media" aria-hidden="true">
+    <img src={poster} alt={posterAlt} loading="eager" fetchpriority="high" />
+    {video && (
+      <video
+        src={video}
+        poster={poster}
+        autoplay
+        muted
+        loop
+        playsinline
+        preload="metadata"
+        data-v3-cover-video
+        aria-hidden="true"
+      ></video>
+    )}
+  </div>
+
+  <div class="v3-container v3-cover__inner">
+    <p class="v3-cover__eyebrow">
+      {vineTag && <strong>{vineTag}</strong>}
+      {eyebrow}
+    </p>
+    <h1 class="v3-cover__title" set:html={title} />
+    {meta && <p class="v3-cover__meta">{meta}</p>}
+    <div class="v3-cover__cta-row">
+      <a href={primaryHref} class="v3-btn v3-btn--solid">
+        {primaryLabel}
+        <span aria-hidden="true">→</span>
+      </a>
+      {secondaryHref && secondaryLabel && (
+        <a href={secondaryHref} class="v3-btn v3-btn--ghost">
+          {secondaryLabel}
+          <span aria-hidden="true">→</span>
+        </a>
+      )}
+    </div>
+  </div>
+</section>
+
+<script is:inline>
+  (function () {
+    function initCoverVideo() {
+      var v = document.querySelector('[data-v3-cover-video]');
+      if (!v || v._v3VideoBound) return;
+      v._v3VideoBound = true;
+      // Honour reduced motion: keep poster, drop the video element entirely.
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        v.pause(); v.removeAttribute('autoplay'); v.style.display = 'none';
+        return;
+      }
+      // Throttle on slow connections — poster only.
+      var conn = navigator.connection;
+      if (conn && (conn.saveData || (conn.effectiveType && /(^|-)2g$|3g/.test(conn.effectiveType)))) {
+        v.pause(); v.removeAttribute('autoplay'); v.style.display = 'none';
+        return;
+      }
+      // Pause when scrolled out of view.
+      if ('IntersectionObserver' in window) {
+        var io = new IntersectionObserver(function (entries) {
+          entries.forEach(function (e) {
+            if (e.isIntersecting) v.play().catch(function(){});
+            else v.pause();
+          });
+        }, { threshold: 0.25 });
+        io.observe(v);
+      }
+    }
+    initCoverVideo();
+    document.addEventListener('astro:page-load', initCoverVideo);
+  })();
+</script>

--- a/next/src/components/v3/V3HomeCover.astro
+++ b/next/src/components/v3/V3HomeCover.astro
@@ -86,25 +86,28 @@ const {
       var v = document.querySelector('[data-v3-cover-video]');
       if (!v || v._v3VideoBound) return;
       v._v3VideoBound = true;
-      // Honour reduced motion: keep poster, drop the video element entirely.
+      // Honour reduced motion: keep poster, hide the video element.
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
         v.pause(); v.removeAttribute('autoplay'); v.style.display = 'none';
         return;
       }
-      // Throttle on slow connections — poster only.
+      // Honour explicit Save-Data only (don't second-guess connection type —
+      // Chrome reports lots of wifi as '3g' which was killing the video).
       var conn = navigator.connection;
-      if (conn && (conn.saveData || (conn.effectiveType && /(^|-)2g$|3g/.test(conn.effectiveType)))) {
+      if (conn && conn.saveData === true) {
         v.pause(); v.removeAttribute('autoplay'); v.style.display = 'none';
         return;
       }
-      // Pause when scrolled out of view.
+      // Try to play (some browsers need a kick even with autoplay).
+      v.play().catch(function () { /* autoplay blocked — poster carries it */ });
+      // Pause when scrolled out of view to save battery.
       if ('IntersectionObserver' in window) {
         var io = new IntersectionObserver(function (entries) {
           entries.forEach(function (e) {
             if (e.isIntersecting) v.play().catch(function(){});
             else v.pause();
           });
-        }, { threshold: 0.25 });
+        }, { threshold: 0.1 });
         io.observe(v);
       }
     }

--- a/next/src/components/v3/V3InsiderStripe.astro
+++ b/next/src/components/v3/V3InsiderStripe.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * V3 InsiderStripe — the Pass commercial moment.
+ *
+ * The single vine-coloured block on the homepage. Earns the colour through
+ * scarcity. Always has a single primary CTA, single secondary link.
+ */
+export interface Props {
+  eyebrow?: string;
+  title?: string;            // <em> renders italic
+  body?: string;
+  primaryHref?: string;
+  primaryLabel?: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+}
+
+const {
+  eyebrow = 'The Pass',
+  title = 'A members’ Peninsula, with the <em>names</em> attached.',
+  body = 'Tables held back from the booking apps, the cellar door fed direct, the room that opens up on the cancellation list. The Pass is the version of Peninsula Insider with the doors quietly opened.',
+  primaryHref = '/preview-insider-plans/',
+  primaryLabel = 'See what the Pass unlocks',
+  secondaryHref = '/about/',
+  secondaryLabel = 'Why we built it',
+} = Astro.props;
+---
+
+<section class="v3-stripe v3-reveal" aria-labelledby="v3-stripe-title">
+  <div class="v3-container">
+    <p class="v3-stripe__eyebrow">{eyebrow}</p>
+    <h2 id="v3-stripe-title" class="v3-stripe__title" set:html={title} />
+    <p class="v3-stripe__body">{body}</p>
+    <div style="display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center;">
+      <a href={primaryHref} class="v3-btn v3-btn--solid">
+        {primaryLabel} <span aria-hidden="true">→</span>
+      </a>
+      {secondaryHref && (
+        <a href={secondaryHref} class="v3-btn v3-btn--ghost" style="color: #fff; border-color: rgba(255,255,255,0.5);">
+          {secondaryLabel}
+        </a>
+      )}
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3IntentGrid.astro
+++ b/next/src/components/v3/V3IntentGrid.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * V3 IntentGrid — start from what you actually want the weekend to do.
+ *
+ * Upgrades the V2 intent-chip strip from anchors-in-a-row into 8 cells
+ * with optional anchor imagery and hover micro-affordance. Each cell
+ * routes to a long-form journal piece written for that exact intent.
+ */
+export interface IntentItem {
+  href: string;
+  label: string;
+  note: string;
+  image?: string;
+}
+
+export interface Props {
+  eyebrow?: string;
+  title?: string;
+  body?: string;
+  items: IntentItem[];
+}
+
+const {
+  eyebrow = 'Start from what you need',
+  title = 'Start from what you <em>actually</em> want the weekend to do',
+  body = 'Each one opens a guide built around the question, with real names, real opinions, and a plan you can act on this weekend.',
+  items,
+} = Astro.props;
+---
+
+<section class="v3-intent v3-reveal" aria-labelledby="v3-intent-title">
+  <div class="v3-container">
+    <div class="v3-intent__intro">
+      <div>
+        <p class="v3-eyebrow">{eyebrow}</p>
+        <h2 id="v3-intent-title" set:html={title} />
+      </div>
+      <p>{body}</p>
+    </div>
+    <div class="v3-intent__grid">
+      {items.map((item) => (
+        <a href={item.href} class="v3-intentcard">
+          <div>
+            <span class="v3-intentcard__label">{item.label}</span>
+            <span class="v3-intentcard__note">{item.note}</span>
+          </div>
+          {item.image && (
+            <div class="v3-intentcard__img" style={`background-image:url(${item.image});`} aria-hidden="true"></div>
+          )}
+          <span class="v3-intentcard__arrow" aria-hidden="true">Open the guide →</span>
+        </a>
+      ))}
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3LateralSurfaces.astro
+++ b/next/src/components/v3/V3LateralSurfaces.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * V3 LateralSurfaces — three lateral entry points.
+ *
+ * Replaces the long stack of "Editor's Table / Seasonal / Experiences /
+ * Escape Plans / Places / Stays / Journal" in the V2 home with three
+ * tall columns, each anchoring an EntityCard. Cuts the second half of
+ * the page in half.
+ */
+import V3EntityCard from './V3EntityCard.astro';
+
+export interface LateralCol {
+  eyebrow: string;
+  title: string;       // <em> renders italic
+  href: string;
+  hrefLabel: string;
+  card: {
+    href: string;
+    image?: string;
+    imageAlt?: string;
+    kind?: string;
+    name: string;
+    verdict?: string;
+    meta?: string[];
+  };
+}
+
+export interface Props {
+  eyebrow?: string;
+  title?: string;
+  body?: string;
+  columns: LateralCol[];
+}
+
+const {
+  eyebrow = 'Three lateral moves',
+  title = 'Three more rooms in the house, take whichever <em>fits</em>',
+  body = 'Each opens into the relevant index. The card under it is the one we’d send a close friend to first.',
+  columns,
+} = Astro.props;
+---
+
+<section class="v3-lateral v3-reveal" aria-labelledby="v3-lateral-title">
+  <div class="v3-container">
+    <div class="v3-lateral__intro">
+      <div>
+        <p class="v3-eyebrow">{eyebrow}</p>
+        <h2 id="v3-lateral-title" set:html={title} />
+      </div>
+      <p>{body}</p>
+    </div>
+    <div class="v3-lateral__grid">
+      {columns.map((col) => (
+        <div class="v3-lateral__col">
+          <div class="v3-lateral__col-head">
+            <a href={col.href}>
+              <p class="v3-lateral__col-eyebrow">{col.eyebrow}</p>
+              <h3 class="v3-lateral__col-title" set:html={col.title} />
+            </a>
+          </div>
+          <V3EntityCard
+            href={col.card.href}
+            image={col.card.image}
+            imageAlt={col.card.imageAlt}
+            kind={col.card.kind}
+            name={col.card.name}
+            verdict={col.card.verdict}
+            meta={col.card.meta}
+          />
+          <a href={col.href} class="v3-pillarcard__cta">{col.hrefLabel} →</a>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3Masthead.astro
+++ b/next/src/components/v3/V3Masthead.astro
@@ -1,0 +1,145 @@
+---
+/**
+ * V3 Masthead.
+ *
+ * Three rows: utility (issue stamp + sign-in), brand (wordmark, fades to compact
+ * on scroll), nav (5 pillars + Ask PI pill + What's On + Subscribe). Mega-panel
+ * opens on hover/focus and reveals three-column editorial menu.
+ *
+ * Mobile: utility + brand + bottom row (burger / wordmark / Ask).
+ */
+import { v3Pillars, v3Utility } from '../../lib/v3-nav';
+
+export interface Props {
+  section?: string;
+  issueMark?: string;
+  issueLabel?: string;
+}
+
+const {
+  section = 'home',
+  issueMark = 'Vol 04',
+  issueLabel = 'Autumn 2026 · Updated weekly',
+} = Astro.props;
+---
+
+<header class="v3-masthead">
+
+  <!-- Row 1: Utility -->
+  <div class="v3-utility">
+    <div class="v3-container">
+      <div class="v3-utility__inner">
+        <span class="v3-utility__edition">
+          <strong>{issueMark}</strong>
+          <span>{issueLabel}</span>
+        </span>
+        <div class="v3-utility__links">
+          <a href={v3Utility.pass.href}>The Pass</a>
+          <a href={v3Utility.account.href}>Sign in / Save trip</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Row 2: Brand -->
+  <div class="v3-masthead__brand">
+    <div class="v3-container">
+      <a href="/v3/" class="v3-masthead__logo" aria-label="Peninsula Insider, home">
+        Peninsula <span>Insider</span>
+      </a>
+      <span class="v3-masthead__tagline">An editorial guide, not a directory · Mornington Peninsula</span>
+    </div>
+  </div>
+
+  <!-- Row 3: Pillars + utility actions (desktop) -->
+  <div class="v3-masthead__nav-row">
+    <div class="v3-container">
+      <div class="v3-masthead__nav-inner">
+
+        <nav aria-label="Primary">
+          <ul class="v3-nav">
+            {v3Pillars.map((p) => (
+              <li
+                class={`v3-nav__item${section === p.key ? ' is-current' : ''}`}
+                aria-current={section === p.key ? 'true' : undefined}
+                data-mega
+              >
+                <a
+                  href={p.href}
+                  class={`v3-nav__link${p.key === 'journal' ? ' v3-nav__link--journal' : ''}`}
+                  aria-haspopup="true"
+                >
+                  {p.label}
+                  {p.key !== 'journal' && (
+                    <svg class="v3-nav__chev" viewBox="0 0 12 8" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <polyline points="2,2 6,6 10,2"/>
+                    </svg>
+                  )}
+                </a>
+
+                <!-- Mega panel -->
+                <div class="v3-mega" role="menu" aria-label={`${p.label} sub-navigation`}>
+                  <div class="v3-container">
+                    <div class="v3-mega__grid">
+                      {p.panelImage && (
+                        <a href={p.href} class="v3-mega__rail" aria-label={`${p.label} hub`}>
+                          <img src={p.panelImage.src} alt={p.panelImage.alt} loading="lazy" />
+                          <span class="v3-mega__rail-caption">{p.dek}</span>
+                        </a>
+                      )}
+                      {p.columns.map((col) => (
+                        <div class="v3-mega__col">
+                          <h3>{col.eyebrow}</h3>
+                          <ul>
+                            {col.items.map((item) => (
+                              <li><a href={item.href}>{item.label}</a></li>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div class="v3-masthead__utility-actions">
+          <a href={v3Utility.search.href} class="v3-iconbtn" aria-label="Search Peninsula Insider">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"/>
+              <line x1="21" y1="21" x2="16.5" y2="16.5"/>
+            </svg>
+          </a>
+          <a href={v3Utility.whatsOn.href} class="v3-iconbtn" aria-label={`What's on this weekend`} title="What's on this weekend">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3" y="5" width="18" height="16" rx="1.5"/>
+              <line x1="3" y1="10" x2="21" y2="10"/>
+              <line x1="8" y1="3" x2="8" y2="7"/>
+              <line x1="16" y1="3" x2="16" y2="7"/>
+            </svg>
+          </a>
+          <a href={v3Utility.ask.href} class="v3-ask-pill" aria-label="Ask PI">
+            <span class="v3-ask-pill__dot">PI</span>
+            Ask PI
+          </a>
+          <a href={v3Utility.subscribe.href} class="v3-subscribe-cta">Get the dispatch</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile-only secondary row -->
+  <div class="v3-container">
+    <div class="v3-masthead__mobile">
+      <button class="v3-burger" aria-label="Open menu" aria-expanded="false" aria-controls="v3MobileNav">
+        <span></span><span></span><span></span>
+      </button>
+      <a href={v3Utility.ask.href} class="v3-ask-pill">
+        <span class="v3-ask-pill__dot">PI</span>
+        Ask PI
+      </a>
+    </div>
+  </div>
+</header>

--- a/next/src/components/v3/V3Newsletter.astro
+++ b/next/src/components/v3/V3Newsletter.astro
@@ -1,0 +1,38 @@
+---
+/**
+ * V3 Newsletter — compact dispatch sign-up.
+ *
+ * Reduced footprint vs V2's full NewsletterBlock. Posts to the same
+ * Mailchimp action as V2 (form is enhanced by /assets/subscribe-form.js
+ * when present, falls back to GET). The third commercial moment on the
+ * page; restraint matters.
+ */
+export interface Props {
+  title?: string;        // <em> renders italic
+  body?: string;
+}
+
+const {
+  title = 'The dispatch lands <em>Sunday</em>, before the bookings close.',
+  body = 'Picks for next weekend, weather call, who to call, and the table to ask for. One email, no filler.',
+} = Astro.props;
+---
+
+<section class="v3-newsletter v3-reveal" aria-labelledby="v3-newsletter-title">
+  <div class="v3-container">
+    <div class="v3-newsletter__inner">
+
+      <div>
+        <p class="v3-eyebrow v3-eyebrow--vine">Peninsula This Weekend</p>
+        <h3 id="v3-newsletter-title" set:html={title} />
+        <p>{body}</p>
+      </div>
+
+      <form class="v3-newsletter__form" action="https://peninsulainsider.us9.list-manage.com/subscribe/post?u=PLACEHOLDER&id=PLACEHOLDER" method="post" data-pi-subscribe>
+        <input class="v3-newsletter__input" type="email" name="EMAIL" placeholder="your@email.com" required aria-label="Email address" />
+        <button type="submit" class="v3-btn v3-btn--vine">Subscribe</button>
+      </form>
+
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3PillarGrid.astro
+++ b/next/src/components/v3/V3PillarGrid.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * V3 PillarGrid — "Shape the weekend".
+ *
+ * Four cards: Stay / Explore / Plans / Tours. Editorial copy is the same
+ * lineage as the existing zone-intro block, restaged as four icon-led
+ * cards with hover lift, in PI voice, no tourism-board adjectives.
+ */
+export interface PillarItem {
+  href: string;
+  label: string;        // small label e.g. "Stay"
+  title: string;        // headline question
+  body: string;         // one-line body
+  cta: string;          // CTA line
+  icon: string;         // SVG path body
+}
+
+export interface Props {
+  eyebrow?: string;
+  title?: string;
+  body?: string;
+  items?: PillarItem[];
+}
+
+const defaultItems: PillarItem[] = [
+  {
+    href: '/stay/',
+    label: 'Stay',
+    title: 'Choose the bed before the booking list',
+    body: 'Red Hill stays, Sorrento hotels, the rooms that change the whole weekend.',
+    cta: 'Open the rooms',
+    icon: '<path d="M3 11 L12 3 L21 11 M5 10 L5 20 L19 20 L19 10 M10 20 L10 14 L14 14 L14 20" stroke-linecap="round" stroke-linejoin="round"/>',
+  },
+  {
+    href: '/explore/',
+    label: 'Explore',
+    title: 'Use coast, weather, and timing properly',
+    body: 'Late-afternoon walks, market starts, the non-restaurant moves.',
+    cta: 'Open the moves',
+    icon: '<circle cx="12" cy="12" r="9"/><path d="M14 10 L10 14 M10 10 L14 14" stroke-linecap="round"/>',
+  },
+  {
+    href: '/escape/',
+    label: 'Plans',
+    title: 'Follow a complete weekend, not a list',
+    body: 'Shaped escapes that sequence lunch, landscape, and bed in the right order.',
+    cta: 'Open the plans',
+    icon: '<path d="M2 20 L8 10 L12 15 L16 7 L22 20 Z" stroke-linecap="round" stroke-linejoin="round"/>',
+  },
+  {
+    href: '/tour/',
+    label: 'Tours',
+    title: 'Hand the day to a guide who knows the back roads',
+    body: 'Operator-led wine tours, hot-springs days, dolphin swims, with editorial notes on who each suits.',
+    cta: 'Open the operators',
+    icon: '<path d="M4 18 L20 18 L20 12 L16 12 L14 8 L10 8 L8 12 L4 12 Z" stroke-linecap="round" stroke-linejoin="round"/><circle cx="8" cy="18" r="1.4"/><circle cx="16" cy="18" r="1.4"/>',
+  },
+];
+
+const {
+  eyebrow = 'Build the weekend',
+  title = 'Four ways into the Peninsula, depending on what the trip <em>needs</em>',
+  body = 'Start with the bed if you want the trip to soften, the walk if you want the afternoon to open up, the itinerary if you want the whole weekend pre-shaped, or hand the wheel to a guide if the day should run itself.',
+  items = defaultItems,
+} = Astro.props;
+---
+
+<section class="v3-pillargrid v3-reveal" aria-labelledby="v3-pillar-title">
+  <div class="v3-container">
+    <div class="v3-pillargrid__intro">
+      <div>
+        <p class="v3-eyebrow">{eyebrow}</p>
+        <h2 id="v3-pillar-title" set:html={title} />
+      </div>
+      <p>{body}</p>
+    </div>
+    <div class="v3-pillargrid__grid">
+      {items.map((item) => (
+        <a href={item.href} class="v3-pillarcard">
+          <svg class="v3-pillarcard__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" set:html={item.icon} />
+          <span class="v3-pillarcard__label">{item.label}</span>
+          <h3 class="v3-pillarcard__title">{item.title}</h3>
+          <p class="v3-pillarcard__body">{item.body}</p>
+          <span class="v3-pillarcard__cta">{item.cta} →</span>
+        </a>
+      ))}
+    </div>
+  </div>
+</section>

--- a/next/src/components/v3/V3Shortlist.astro
+++ b/next/src/components/v3/V3Shortlist.astro
@@ -1,0 +1,61 @@
+---
+/**
+ * V3 Shortlist — the issue's five picks.
+ *
+ * Editorial ranking. Hairline-divided rows, italic numerals, headline +
+ * dek + arrow. Hover slides the row right by 12px (the only motion in
+ * the block, kept restrained).
+ */
+export interface ShortlistItem {
+  href: string;
+  name: string;
+  why?: string;
+  meta?: string;
+}
+
+export interface Props {
+  badge?: string;
+  title?: string;          // <em> renders italic
+  body?: string;
+  items: ShortlistItem[];
+}
+
+const {
+  badge = 'The Five Picks · Vol 04',
+  title = 'Five pieces worth the <em>appointment</em>',
+  body = 'The handful we’d send a close friend to this issue, picked for the ratio of payoff to effort, not the view from the tasting room.',
+  items,
+} = Astro.props;
+---
+
+<section class="v3-shortlist v3-reveal" aria-labelledby="v3-shortlist-title">
+  <div class="v3-container">
+    <div class="v3-shortlist__intro">
+      <div>
+        <span class="v3-shortlist__badge">{badge}</span>
+        <h2 id="v3-shortlist-title" class="v3-shortlist__title" set:html={title} />
+      </div>
+      <p>{body}</p>
+    </div>
+    <ol class="v3-shortlist__list">
+      {items.map((item, i) => (
+        <li class="v3-shortlist__item">
+          <a href={item.href}>
+            <span class="v3-shortlist__num">{String(i + 1).padStart(2, '0')}</span>
+            <span>
+              <span class="v3-shortlist__name">{item.name}</span>
+              {(item.meta || item.why) && (
+                <span class="v3-shortlist__why">
+                  {item.meta && <strong>{item.meta}</strong>}
+                  {item.meta && item.why && ' · '}
+                  {item.why}
+                </span>
+              )}
+            </span>
+            <span class="v3-shortlist__arrow" aria-hidden="true">Read →</span>
+          </a>
+        </li>
+      ))}
+    </ol>
+  </div>
+</section>

--- a/next/src/components/v3/V3WeekendHero.astro
+++ b/next/src/components/v3/V3WeekendHero.astro
@@ -1,0 +1,72 @@
+---
+/**
+ * V3 WeekendHero — combined dispatch + events.
+ *
+ * Two-column block: left tells the dispatch story (date + lede + CTA),
+ * right surfaces the three weekend events in compact V3EventCard form.
+ *
+ * Dates are the unique value here, surfaced prominently because nobody
+ * else on the Peninsula event web is brave enough to publish them.
+ */
+import V3EventCard from './V3EventCard.astro';
+
+export interface DispatchInfo {
+  href: string;
+  date: string;       // e.g. "10–11 May" (en-dashes for date ranges, never em-dashes)
+  title: string;      // <em> renders italic
+  lede: string;
+  ctaLabel?: string;
+}
+
+export interface WeekendEvent {
+  href: string;
+  date: string;
+  title: string;
+  venue?: string;
+  flags?: { label: string; tone?: 'default' | 'ridge' | 'vine' }[];
+}
+
+export interface Props {
+  dispatch?: DispatchInfo | null;
+  events?: WeekendEvent[];
+}
+
+const { dispatch = null, events = [] } = Astro.props;
+---
+
+{(dispatch || events.length > 0) && (
+  <section class="v3-weekend v3-reveal" aria-label="Peninsula this weekend">
+    <div class="v3-container">
+      <div class="v3-weekend__grid">
+
+        <div>
+          <p class="v3-eyebrow v3-eyebrow--vine">Peninsula This Weekend</p>
+          {dispatch ? (
+            <>
+              <p class="v3-weekend__date">{dispatch.date}</p>
+              <h2 class="v3-weekend__title" set:html={dispatch.title} />
+              <p class="v3-weekend__lede">{dispatch.lede}</p>
+              <a href={dispatch.href} class="v3-btn v3-btn--vine v3-weekend__cta">
+                {dispatch.ctaLabel ?? 'Read the dispatch'}
+                <span aria-hidden="true">→</span>
+              </a>
+            </>
+          ) : (
+            <>
+              <h2 class="v3-weekend__title">The dispatch lands <em>Sunday</em>.</h2>
+              <p class="v3-weekend__lede">Picks for next weekend, weather, who to call, and the table to ask for. Sent before the bookings close.</p>
+              <a href="/newsletter/" class="v3-btn v3-btn--vine v3-weekend__cta">Get the dispatch <span aria-hidden="true">→</span></a>
+            </>
+          )}
+        </div>
+
+        {events.length > 0 && (
+          <div class="v3-weekend__events">
+            {events.slice(0, 3).map((ev) => <V3EventCard event={ev} />)}
+          </div>
+        )}
+
+      </div>
+    </div>
+  </section>
+)}

--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -1,0 +1,113 @@
+---
+/**
+ * V4 Masthead.
+ *
+ * Reuses V2's first two masthead rows (utility + brand) for visual continuity.
+ * Replaces only the third row with the 7-pillar mega-menu nav + utility actions.
+ *
+ * Mobile: nav row hides; the existing V2 burger fires the V4 mobile drawer
+ * (V4MobileDrawer mounted in V4BaseLayout).
+ */
+import { v4Pillars, v4Utility } from '../../lib/v4-nav';
+import V4PillarLink from './V4PillarLink.astro';
+import V4MegaPanel from './V4MegaPanel.astro';
+
+export interface Props {
+  section?: string;
+  issueMark?: string;
+  issueLabel?: string;
+}
+
+const {
+  section = 'home',
+  issueMark = 'Vol 04',
+  issueLabel = "The May Issue · May 2026",
+} = Astro.props;
+---
+
+<header class="masthead" data-v4-masthead>
+
+  <!-- Row 1 — Utility (V2 carry-over) -->
+  <div class="masthead__utility">
+    <div class="container">
+      <div class="masthead__utility-inner">
+        <span class="masthead__edition">
+          <span class="masthead__edition-mark">{issueMark}</span>
+          <span class="masthead__edition-label">{issueLabel}</span>
+        </span>
+        <div class="masthead__utility-links v2-util__links">
+          <a href={v4Utility.pass.href}>The Pass</a>
+          <a href={v4Utility.account.href}>{v4Utility.account.label}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Row 2 — Brand (V2 carry-over) -->
+  <div class="masthead__brand">
+    <div class="container">
+      <div class="masthead__brand-inner">
+        <a href="/v4/" class="masthead__logo" aria-label="Peninsula Insider, home">
+          Peninsula <span>Insider</span>
+        </a>
+        <p class="masthead__tagline">An editorial guide, not a directory · Mornington Peninsula</p>
+      </div>
+    </div>
+
+    <!-- Mobile burger lives here in the brand row, on mobile only.
+         V4 chrome rebinds it to open V4MobileDrawer (see V4BaseLayout script). -->
+    <button
+      class="masthead__burger v4-burger"
+      aria-label="Open menu"
+      aria-expanded="false"
+      aria-controls="v4Drawer"
+    >
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+
+  <!-- Row 3 — V4 nav row -->
+  <div class="v4-masthead-nav">
+    <div class="container">
+      <div class="v4-masthead-nav__inner">
+
+        <nav aria-label="Primary">
+          <ul class="v4-pillars">
+            {v4Pillars.map((pillar) => {
+              const triggerId = `v4-pillar-${pillar.key}`;
+              const isCurrent = section === pillar.key;
+              return (
+                <li
+                  class={`v4-pillars__item${isCurrent ? ' is-current' : ''}`}
+                  data-v4-pillar
+                  data-pillar-key={pillar.key}
+                >
+                  <V4PillarLink pillar={pillar} current={isCurrent} triggerId={triggerId} />
+                  <V4MegaPanel pillar={pillar} triggerId={triggerId} />
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+
+        <div class="v4-actions">
+          <a href={v4Utility.search.href} class="v4-iconbtn" aria-label="Search Peninsula Insider" data-open-search>
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7" />
+              <line x1="21" y1="21" x2="16.5" y2="16.5" />
+            </svg>
+          </a>
+          <a href={v4Utility.ask.href} class="v4-ask-pill" aria-label="Ask PI">
+            <span class="v4-ask-pill__dot">PI</span>
+            Ask PI
+          </a>
+          <a href={v4Utility.subscribe.href} class="v4-subscribe-cta">
+            {v4Utility.subscribe.label}
+          </a>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+</header>

--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -43,7 +43,11 @@ const {
     </div>
   </div>
 
-  <!-- Row 2 — Brand (V2 carry-over) -->
+  <!-- Row 2 — Brand (V2 carry-over).
+       On desktop, .masthead__brand is centred and the burger is hidden by V2
+       global.css. On mobile, V4's mobile CSS re-shows the brand row as a
+       flex bar with logo left, burger right (.container becomes the flex
+       parent for both children). -->
   <div class="masthead__brand">
     <div class="container">
       <div class="masthead__brand-inner">
@@ -52,18 +56,19 @@ const {
         </a>
         <p class="masthead__tagline">An editorial guide, not a directory · Mornington Peninsula</p>
       </div>
-    </div>
 
-    <!-- Mobile burger lives here in the brand row, on mobile only.
-         V4 chrome rebinds it to open V4MobileDrawer (see V4BaseLayout script). -->
-    <button
-      class="masthead__burger v4-burger"
-      aria-label="Open menu"
-      aria-expanded="false"
-      aria-controls="v4Drawer"
-    >
-      <span></span><span></span><span></span>
-    </button>
+      <!-- Mobile burger lives inside the container so it respects page padding.
+           V4 chrome rebinds it to open V4MobileDrawer (see BaseLayout script).
+           Hidden on desktop by V2's global.css `.masthead__burger { display: none }`. -->
+      <button
+        class="masthead__burger v4-burger"
+        aria-label="Open menu"
+        aria-expanded="false"
+        aria-controls="v4Drawer"
+      >
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 
   <!-- Row 3 — V4 nav row -->

--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -47,7 +47,7 @@ const {
   <div class="masthead__brand">
     <div class="container">
       <div class="masthead__brand-inner">
-        <a href="/v4/" class="masthead__logo" aria-label="Peninsula Insider, home">
+        <a href="/" class="masthead__logo" aria-label="Peninsula Insider, home">
           Peninsula <span>Insider</span>
         </a>
         <p class="masthead__tagline">An editorial guide, not a directory · Mornington Peninsula</p>

--- a/next/src/components/v4/V4MegaColumn.astro
+++ b/next/src/components/v4/V4MegaColumn.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * V4 MegaColumn — single editorial column inside a mega panel.
+ *
+ * Eyebrow (small caps, ochre) over a list of ≤6 noun-phrase items.
+ * Items can carry a `live: true` flag to render a sage indicator dot
+ * (used by What's On column 1 for "this weekend, live data" picks).
+ */
+import type { V4MegaColumn, V4NavItem } from '../../lib/v4-nav';
+
+export interface Props { column: V4MegaColumn }
+
+const { column } = Astro.props;
+const renderItem = (item: V4NavItem) => ({ ...item });
+---
+
+<div class="v4-mega__col">
+  <h3 class="v4-mega__col-eyebrow">{column.eyebrow}</h3>
+  <ul class="v4-mega__col-list">
+    {column.items.map((item) => {
+      const it = renderItem(item);
+      return (
+        <li>
+          <a href={it.href} role="menuitem" data-live={it.live ? 'true' : undefined}>{it.label}</a>
+        </li>
+      );
+    })}
+  </ul>
+</div>

--- a/next/src/components/v4/V4MegaPanel.astro
+++ b/next/src/components/v4/V4MegaPanel.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * V4 MegaPanel — full-width editorial panel anchored to the nav row.
+ *
+ * Anatomy:
+ *   1. Intro line (italic Cormorant, soft colour)
+ *   2. Optional top banner (used by What's On)
+ *   3. Grid: image rail (280px) + 2 or 3 columns
+ *   4. Ask-PI footer line (centred, italic, hairline-bordered)
+ *
+ * Shown only when the parent .v4-pillars__item has .is-open. Animation
+ * honours prefers-reduced-motion.
+ */
+import type { V4Pillar } from '../../lib/v4-nav';
+import V4MegaColumn from './V4MegaColumn.astro';
+import V4MegaRail from './V4MegaRail.astro';
+import V4PillarTopBanner from './V4PillarTopBanner.astro';
+
+export interface Props {
+  pillar: V4Pillar;
+  /** id used to wire aria-labelledby to the trigger. */
+  triggerId: string;
+}
+
+const { pillar, triggerId } = Astro.props;
+const cols = pillar.columns.length;          // 2 or 3
+const wideRail = cols === 2;                 // Journal pattern, give the rail extra width
+const panelClass = [
+  'v4-mega',
+  cols === 2 ? 'v4-mega--cols-2' : 'v4-mega--cols-3',
+  wideRail ? 'v4-mega--rail-wide' : '',
+].filter(Boolean).join(' ');
+---
+
+<div
+  class={panelClass}
+  role="menu"
+  aria-labelledby={triggerId}
+  data-v4-mega
+>
+  <div class="v4-mega__container">
+
+    <p class="v4-mega__intro">{pillar.intro}</p>
+
+    {pillar.topBanner && <V4PillarTopBanner banner={pillar.topBanner} />}
+
+    <div class="v4-mega__grid">
+      <V4MegaRail rail={pillar.rail} />
+      {pillar.columns.map((col) => <V4MegaColumn column={col} />)}
+    </div>
+
+    <p class="v4-mega__ask">
+      <a href="/ask/" data-pi-trigger="true">{pillar.askLine}</a>
+    </p>
+
+  </div>
+</div>

--- a/next/src/components/v4/V4MegaRail.astro
+++ b/next/src/components/v4/V4MegaRail.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * V4 MegaRail — image rail on the left of every mega panel.
+ *
+ * The "editor's pin" — the *one thing* PI is sending you to right now in
+ * this pillar. Anatomy: image, eyebrow, name, italic verdict line, CTA.
+ *
+ * Verdict line carries BRAND-PI.md voice rules to the letter.
+ */
+import type { V4MegaRail } from '../../lib/v4-nav';
+
+export interface Props { rail: V4MegaRail }
+const { rail } = Astro.props;
+---
+
+<a class="v4-mega__rail" href={rail.href}>
+  <div class="v4-mega__rail-image">
+    <img src={rail.image} alt={rail.imageAlt} loading="lazy" />
+  </div>
+  <div class="v4-mega__rail-body">
+    <p class="v4-mega__rail-eyebrow">{rail.eyebrow}</p>
+    <h3 class="v4-mega__rail-title">{rail.title}</h3>
+    <p class="v4-mega__rail-verdict">{rail.verdict}</p>
+    <span class="v4-mega__rail-cta">{rail.cta ?? 'Open the verdict →'}</span>
+  </div>
+</a>

--- a/next/src/components/v4/V4MobileDrawer.astro
+++ b/next/src/components/v4/V4MobileDrawer.astro
@@ -15,7 +15,7 @@ import { v4Pillars, v4Utility } from '../../lib/v4-nav';
 <div class="v4-drawer" id="v4Drawer" role="dialog" aria-modal="true" aria-label="Peninsula Insider menu">
 
   <div class="v4-drawer__head">
-    <a href="/v4/" class="v4-drawer__brand">Peninsula <span>Insider</span></a>
+    <a href="/" class="v4-drawer__brand">Peninsula <span>Insider</span></a>
     <button type="button" class="v4-drawer__close" aria-label="Close menu" data-v4-drawer-close>
       <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <line x1="6" y1="6" x2="18" y2="18"/>

--- a/next/src/components/v4/V4MobileDrawer.astro
+++ b/next/src/components/v4/V4MobileDrawer.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * V4 MobileDrawer.
+ *
+ * Accordion mobile menu. Each pillar is a row; tap to expand inline and
+ * reveal the same three columns (stacked) plus the editor's pick rail
+ * collapsed to a single "Editor's pick →" line plus the Ask-PI line.
+ *
+ * One pillar expanded at a time. Footer carries search input, sign-in,
+ * subscribe pill. Bound by V4BaseLayout's inline script.
+ */
+import { v4Pillars, v4Utility } from '../../lib/v4-nav';
+---
+
+<div class="v4-drawer" id="v4Drawer" role="dialog" aria-modal="true" aria-label="Peninsula Insider menu">
+
+  <div class="v4-drawer__head">
+    <a href="/v4/" class="v4-drawer__brand">Peninsula <span>Insider</span></a>
+    <button type="button" class="v4-drawer__close" aria-label="Close menu" data-v4-drawer-close>
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="6" y1="6" x2="18" y2="18"/>
+        <line x1="18" y1="6" x2="6" y2="18"/>
+      </svg>
+    </button>
+  </div>
+
+  <ul class="v4-drawer__pillars">
+    {v4Pillars.map((pillar) => (
+      <li class="v4-drawer__pillar" data-pillar-key={pillar.key}>
+        <button
+          type="button"
+          class="v4-drawer__pillar-trigger"
+          aria-expanded="false"
+          aria-controls={`v4-drawer-${pillar.key}`}
+          data-v4-drawer-pillar
+        >
+          <span>{pillar.label}</span>
+          <svg class="v4-drawer__pillar-trigger-arrow" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="4,2 8,6 4,10"/>
+          </svg>
+        </button>
+
+        <div class="v4-drawer__pillar-body" id={`v4-drawer-${pillar.key}`}>
+          <a class="v4-drawer__pillar-rail" href={pillar.rail.href}>
+            Editor's pick: {pillar.rail.title} →
+          </a>
+
+          {pillar.columns.map((col) => (
+            <div class="v4-drawer__pillar-col">
+              <p class="v4-drawer__pillar-col-eyebrow">{col.eyebrow}</p>
+              <ul class="v4-drawer__pillar-col-list">
+                {col.items.map((item) => (
+                  <li><a href={item.href}>{item.label}</a></li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          <p class="v4-drawer__pillar-ask">
+            <a href="/ask/" data-pi-trigger="true">{pillar.askLine}</a>
+          </p>
+        </div>
+      </li>
+    ))}
+  </ul>
+
+  <div class="v4-drawer__foot">
+    <a href={v4Utility.search.href}>Search Peninsula Insider</a>
+    <a href={v4Utility.account.href}>{v4Utility.account.label}</a>
+    <a href={v4Utility.ask.href}>Ask PI</a>
+    <a href={v4Utility.subscribe.href}>{v4Utility.subscribe.label}</a>
+  </div>
+</div>

--- a/next/src/components/v4/V4PillarLink.astro
+++ b/next/src/components/v4/V4PillarLink.astro
@@ -1,0 +1,40 @@
+---
+/**
+ * V4 PillarLink — top-row pillar trigger.
+ *
+ * Renders the pillar label, optional chevron, with aria-haspopup wired up
+ * for the mega panel. Journal gets italic Cormorant; the others get
+ * Outfit upper-row. Active section gets aria-current via the parent.
+ */
+import type { V4Pillar } from '../../lib/v4-nav';
+
+export interface Props {
+  pillar: V4Pillar;
+  current?: boolean;
+  triggerId: string;
+}
+
+const { pillar, current = false, triggerId } = Astro.props;
+const isJournal = pillar.key === 'journal';
+const linkClass = [
+  'v4-pillars__link',
+  isJournal ? 'v4-pillars__link--journal' : '',
+].filter(Boolean).join(' ');
+---
+
+<a
+  id={triggerId}
+  href={pillar.href}
+  class={linkClass}
+  aria-haspopup="true"
+  aria-expanded="false"
+  aria-current={current ? 'page' : undefined}
+  data-v4-pillar-link
+>
+  {pillar.label}
+  {!isJournal && (
+    <svg class="v4-pillars__chev" viewBox="0 0 12 8" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <polyline points="2,2 6,6 10,2" />
+    </svg>
+  )}
+</a>

--- a/next/src/components/v4/V4PillarTopBanner.astro
+++ b/next/src/components/v4/V4PillarTopBanner.astro
@@ -1,0 +1,19 @@
+---
+/**
+ * V4 PillarTopBanner — temporal banner inside a mega panel.
+ *
+ * Used by What's On to surface the current date range. Sage indicator dot
+ * + Cormorant text + ochre CTA. Sits between intro line and grid.
+ */
+import type { V4MegaTopBanner } from '../../lib/v4-nav';
+
+export interface Props { banner: V4MegaTopBanner }
+const { banner } = Astro.props;
+---
+
+<div class="v4-mega__top-banner" role="status">
+  <span class="v4-mega__top-banner-text">{banner.text}</span>
+  {banner.ctaLabel && banner.ctaHref && (
+    <a class="v4-mega__top-banner-cta" href={banner.ctaHref}>{banner.ctaLabel}</a>
+  )}
+</div>

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -10,10 +10,13 @@
 import '../styles/global.css';
 import '../styles/concierge.css';   // chat & drawer styles, loaded on every page
 import '../styles/search.css';      // site-search overlay + /search page styles
+import '../styles/v4.css';          // V4 mega-menu chrome, additive tokens scoped --v4-*
 import { ClientRouter } from 'astro:transitions';
-import Masthead from '../components/Masthead.astro';
-// UtilityBar removed, its content is now integrated into Masthead's
-// utility row. Keeping this comment as a breadcrumb for the migration.
+// V4 menu promotion (2026-05-06): the V2 Masthead is replaced by V4Masthead.
+// V2 Masthead.astro stays in the codebase as reference but is no longer
+// imported here. The V4MobileDrawer replaces V2's #mobileNav overlay.
+import V4Masthead from '../components/v4/V4Masthead.astro';
+import V4MobileDrawer from '../components/v4/V4MobileDrawer.astro';
 import Footer from '../components/Footer.astro';
 import ConciergeDrawer from '../components/ConciergeDrawer.astro';
 import SearchOverlay from '../components/SearchOverlay.astro';
@@ -181,9 +184,9 @@ const isAskPage = rawPathname.startsWith('/ask');
     })();
   </script>
 </head>
-<body data-page={section} data-path={rawPathname}>
+<body data-page={section} data-path={rawPathname} data-v4="true">
 
-  <Masthead section={section} />
+  <V4Masthead section={section} />
 
   {/* data-pagefind-body scopes the index to <main>, so the masthead, footer,
       concierge drawer, and search overlay aren't indexed.
@@ -201,6 +204,10 @@ const isAskPage = rawPathname.startsWith('/ask');
   </main>
 
   <Footer />
+
+  <!-- V4 mobile drawer — replaces the V2 #mobileNav overlay.
+       Bound by the V4 mega+drawer script below. -->
+  <V4MobileDrawer />
 
   <!-- V2 auth phase 1, modal + profile dropdown.
        Modal hidden until any [data-open-auth] element triggers it.
@@ -269,48 +276,159 @@ const isAskPage = rawPathname.startsWith('/ask');
     })();
   </script>
 
+  <!-- V4 mega-menu + mobile drawer behaviour.
+       Replaces V2's #mobileNav burger script. Three responsibilities:
+       1. Hover/focus open + leave/escape/click-outside close on desktop pillars.
+       2. Burger opens the V4 drawer; accordion pillars expand inline.
+       3. data-pi-trigger="true" intercepts clicks and opens the concierge
+          drawer via window.openConcierge() (was previously inside V2 Masthead). -->
   <script is:inline>
-    (function() {
-      function initNav() {
-        var burger = document.querySelector('.masthead__burger');
-        var nav = document.getElementById('mobileNav');
-        if (!burger || !nav) return;
+    (function () {
+      function initV4Mega() {
+        var items = document.querySelectorAll('[data-v4-pillar]');
+        if (!items.length) return;
 
-        // Always reset state cleanly on each page load / transition
-        nav.classList.remove('is-open');
-        burger.classList.remove('is-open');
-        burger.setAttribute('aria-expanded', 'false');
-        document.body.classList.remove('menu-open');
-        document.body.style.overflow = '';
+        function closeAll(except) {
+          items.forEach(function (n) {
+            if (n === except) return;
+            n.classList.remove('is-open');
+            var trig = n.querySelector('[data-v4-pillar-link]');
+            if (trig) trig.setAttribute('aria-expanded', 'false');
+          });
+        }
 
-        // Guard against double-binding on repeated calls
-        if (burger._navBound) return;
-        burger._navBound = true;
+        items.forEach(function (item) {
+          if (item._v4Bound) return;
+          item._v4Bound = true;
+          var link = item.querySelector('[data-v4-pillar-link]');
+          var openTimer = null, closeTimer = null;
 
-        burger.addEventListener('click', function() {
-          var open = nav.classList.toggle('is-open');
-          burger.classList.toggle('is-open', open);
-          burger.setAttribute('aria-expanded', String(open));
-          // body.menu-open lets CSS hide the masthead so its wordmark
-          // doesn't sit on top of the mobile-nav overlay's wordmark.
-          document.body.classList.toggle('menu-open', open);
-          document.body.style.overflow = open ? 'hidden' : '';
+          function open() {
+            clearTimeout(closeTimer);
+            openTimer = setTimeout(function () {
+              closeAll(item);
+              item.classList.add('is-open');
+              if (link) link.setAttribute('aria-expanded', 'true');
+            }, 70);
+          }
+          function close() {
+            clearTimeout(openTimer);
+            closeTimer = setTimeout(function () {
+              item.classList.remove('is-open');
+              if (link) link.setAttribute('aria-expanded', 'false');
+            }, 220);
+          }
+
+          item.addEventListener('mouseenter', open);
+          item.addEventListener('mouseleave', close);
+          if (link) {
+            link.addEventListener('focus', open);
+            link.addEventListener('keydown', function (e) {
+              if (e.key === 'Escape') {
+                item.classList.remove('is-open');
+                link.setAttribute('aria-expanded', 'false');
+                link.focus();
+              }
+            });
+          }
+          var panel = item.querySelector('[data-v4-mega]');
+          if (panel) {
+            panel.addEventListener('keydown', function (e) {
+              if (e.key === 'Escape') {
+                item.classList.remove('is-open');
+                if (link) {
+                  link.setAttribute('aria-expanded', 'false');
+                  link.focus();
+                }
+              }
+            });
+          }
         });
 
-        nav.querySelectorAll('a').forEach(function(link) {
-          link.addEventListener('click', function() {
-            nav.classList.remove('is-open');
-            burger.classList.remove('is-open');
-            burger.setAttribute('aria-expanded', 'false');
-            document.body.classList.remove('menu-open');
-            document.body.style.overflow = '';
+        document.addEventListener('click', function (e) {
+          var target = e.target;
+          var inside = target.closest && target.closest('[data-v4-pillar]');
+          if (!inside) closeAll(null);
+        });
+      }
+
+      function initV4Drawer() {
+        var burger = document.querySelector('.v4-burger');
+        var drawer = document.getElementById('v4Drawer');
+        if (!burger || !drawer) return;
+        if (burger._v4DrawerBound) return;
+        burger._v4DrawerBound = true;
+
+        var closeBtn = drawer.querySelector('[data-v4-drawer-close]');
+        var pillarTriggers = drawer.querySelectorAll('[data-v4-drawer-pillar]');
+
+        function openDrawer() {
+          drawer.classList.add('is-open');
+          burger.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+        }
+        function closeDrawer() {
+          drawer.classList.remove('is-open');
+          burger.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          drawer.querySelectorAll('.v4-drawer__pillar.is-expanded').forEach(function (p) {
+            p.classList.remove('is-expanded');
+            var t = p.querySelector('[data-v4-drawer-pillar]');
+            if (t) t.setAttribute('aria-expanded', 'false');
+          });
+        }
+
+        burger.addEventListener('click', function () {
+          var isOpen = drawer.classList.contains('is-open');
+          if (isOpen) closeDrawer(); else openDrawer();
+        });
+        if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape' && drawer.classList.contains('is-open')) closeDrawer();
+        });
+
+        pillarTriggers.forEach(function (trig) {
+          trig.addEventListener('click', function () {
+            var pillar = trig.closest('.v4-drawer__pillar');
+            if (!pillar) return;
+            var isExpanded = pillar.classList.contains('is-expanded');
+            drawer.querySelectorAll('.v4-drawer__pillar.is-expanded').forEach(function (p) {
+              if (p !== pillar) {
+                p.classList.remove('is-expanded');
+                var t = p.querySelector('[data-v4-drawer-pillar]');
+                if (t) t.setAttribute('aria-expanded', 'false');
+              }
+            });
+            pillar.classList.toggle('is-expanded', !isExpanded);
+            trig.setAttribute('aria-expanded', String(!isExpanded));
+          });
+        });
+
+        drawer.querySelectorAll('a').forEach(function (a) {
+          a.addEventListener('click', closeDrawer);
+        });
+      }
+
+      function initPiTriggers() {
+        document.querySelectorAll('[data-pi-trigger="true"]').forEach(function (el) {
+          if (el._piTrigBound) return;
+          el._piTrigBound = true;
+          el.addEventListener('click', function (e) {
+            if (typeof window.openConcierge !== 'function') return;
+            e.preventDefault();
+            window.openConcierge();
           });
         });
       }
 
-      // Run on first load and after every view-transition swap
-      initNav();
-      document.addEventListener('astro:page-load', initNav);
+      function bootAll() {
+        initV4Mega();
+        initV4Drawer();
+        initPiTriggers();
+      }
+
+      bootAll();
+      document.addEventListener('astro:page-load', bootAll);
     })();
   </script>
 

--- a/next/src/layouts/v3/V3BaseLayout.astro
+++ b/next/src/layouts/v3/V3BaseLayout.astro
@@ -1,0 +1,155 @@
+---
+/**
+ * V3 BaseLayout (staging only).
+ *
+ * Forks production BaseLayout for the V3 staging surface so the live site is
+ * never affected. Loads the V3 stylesheet + tokens, mounts V3 masthead and
+ * footer, keeps the existing concierge drawer + cookie banner (they are
+ * cross-cutting, no point duplicating).
+ *
+ * Mounted at /v3/ pages only. Production /index/, /eat/, etc. continue to
+ * use the unforked BaseLayout.
+ */
+
+import '../../styles/global.css';
+import '../../styles/concierge.css';
+import '../../styles/v3.css';
+import { ClientRouter } from 'astro:transitions';
+import V3Masthead from '../../components/v3/V3Masthead.astro';
+import V3Footer from '../../components/v3/V3Footer.astro';
+import V3ConciergeDock from '../../components/v3/V3ConciergeDock.astro';
+import ConciergeDrawer from '../../components/ConciergeDrawer.astro';
+import CookieBanner from '../../components/CookieBanner.astro';
+
+export interface Props {
+  title: string;
+  description?: string;
+  section?: 'home' | 'eat' | 'stay' | 'explore' | 'plans' | 'journal' | '';
+  canonical?: string;
+  ogImage?: string;
+  noindex?: boolean;
+}
+
+const SITE_URL = 'https://peninsulainsider.com.au';
+
+const {
+  title,
+  description = 'The independent editorial guide to the Mornington Peninsula.',
+  section = 'home',
+  canonical,
+  ogImage = '/images/sourced/home-cover.webp',
+  noindex = true,
+} = Astro.props;
+
+const rawPath = Astro.url.pathname;
+const canonicalUrl = canonical ?? `${SITE_URL}${rawPath}`;
+const ogImageAbs = ogImage.startsWith('http') ? ogImage : `${SITE_URL}${ogImage}`;
+---
+
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="content-language" content="en-AU" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=Outfit:wght@300;400;500;600&display=swap"
+    rel="stylesheet"
+  />
+  <title>{title}</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="description" content={description} />
+  <link rel="canonical" href={canonicalUrl} />
+  <meta name="robots" content={noindex ? 'noindex, nofollow' : 'index, follow'} />
+
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+  <meta property="og:image" content={ogImageAbs} />
+  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Peninsula Insider" />
+
+  <ClientRouter />
+</head>
+<body data-page={section} data-path={rawPath} data-v3="true">
+
+  <V3Masthead section={section} />
+
+  <main>
+    <slot />
+  </main>
+
+  <V3Footer />
+
+  <script is:inline define:vars={{ API_URL: import.meta.env.PUBLIC_CONCIERGE_API_URL || 'http://localhost:8787' }}>
+    window.PI_API_URL = API_URL;
+  </script>
+
+  <ConciergeDrawer />
+  <V3ConciergeDock />
+  <CookieBanner />
+
+  <!-- Sticky-on-scroll masthead, mega-panel reveal, reveal-on-scroll. -->
+  <script is:inline>
+    (function () {
+      function initV3() {
+        var mh = document.querySelector('.v3-masthead');
+        if (mh && !mh._v3StickyBound) {
+          mh._v3StickyBound = true;
+          var onScroll = function () {
+            mh.classList.toggle('is-scrolled', window.scrollY > 80);
+          };
+          window.addEventListener('scroll', onScroll, { passive: true });
+          onScroll();
+        }
+
+        var items = document.querySelectorAll('.v3-nav__item[data-mega]');
+        items.forEach(function (item) {
+          if (item._v3MegaBound) return;
+          item._v3MegaBound = true;
+          var trigger = item.querySelector('.v3-nav__link');
+          var openTimer = null;
+          var closeTimer = null;
+          function open()  { clearTimeout(closeTimer); openTimer  = setTimeout(function () { closeAllExcept(item); item.classList.add('is-open'); }, 70); }
+          function close() { clearTimeout(openTimer);  closeTimer = setTimeout(function () { item.classList.remove('is-open'); }, 220); }
+          item.addEventListener('mouseenter', open);
+          item.addEventListener('mouseleave', close);
+          if (trigger) {
+            trigger.addEventListener('focus', open);
+            trigger.addEventListener('keydown', function (e) {
+              if (e.key === 'Escape') item.classList.remove('is-open');
+            });
+          }
+        });
+        function closeAllExcept(except) {
+          document.querySelectorAll('.v3-nav__item.is-open').forEach(function (n) {
+            if (n !== except) n.classList.remove('is-open');
+          });
+        }
+        document.addEventListener('click', function (e) {
+          var target = e.target;
+          var inside = target.closest && target.closest('.v3-nav__item');
+          if (!inside) closeAllExcept(null);
+        });
+
+        var reveals = document.querySelectorAll('.v3-reveal');
+        if (reveals.length && 'IntersectionObserver' in window) {
+          var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+              if (entry.isIntersecting) {
+                entry.target.classList.add('is-in');
+                io.unobserve(entry.target);
+              }
+            });
+          }, { threshold: 0.12, rootMargin: '0px 0px -10% 0px' });
+          reveals.forEach(function (el) { io.observe(el); });
+        }
+      }
+      initV3();
+      document.addEventListener('astro:page-load', initV3);
+    })();
+  </script>
+</body>
+</html>

--- a/next/src/layouts/v4/V4BaseLayout.astro
+++ b/next/src/layouts/v4/V4BaseLayout.astro
@@ -1,0 +1,262 @@
+---
+/**
+ * V4 BaseLayout (staging only).
+ *
+ * Forks production BaseLayout. Mounts V4 chrome:
+ *   - V4Masthead (V2 utility + brand rows + V4 nav row)
+ *   - V2 Footer (kept — V4 only changes nav, not footer)
+ *   - V4MobileDrawer
+ *   - Existing ConciergeDrawer + SearchOverlay + CookieBanner
+ *
+ * Mounted on /v4/* routes only. V2 production is untouched.
+ */
+
+import '../../styles/global.css';
+import '../../styles/concierge.css';
+import '../../styles/search.css';
+import '../../styles/v4.css';
+import { ClientRouter } from 'astro:transitions';
+import V4Masthead from '../../components/v4/V4Masthead.astro';
+import V4MobileDrawer from '../../components/v4/V4MobileDrawer.astro';
+import Footer from '../../components/Footer.astro';
+import ConciergeDrawer from '../../components/ConciergeDrawer.astro';
+import SearchOverlay from '../../components/SearchOverlay.astro';
+import AuthModal from '../../components/v2/AuthModal.astro';
+import ProfileDropdown from '../../components/v2/ProfileDropdown.astro';
+import CookieBanner from '../../components/CookieBanner.astro';
+
+export interface Props {
+  title: string;
+  description?: string;
+  section?: 'home' | 'eat' | 'wine' | 'stay' | 'explore' | 'escape' | 'whats-on' | 'journal' | 'places' | '';
+  preview?: boolean;
+  canonical?: string;
+  ogImage?: string;
+  ogType?: string;
+  noindex?: boolean;
+  publishedTime?: string;
+  modifiedTime?: string;
+  searchKind?: string;
+  searchExclude?: boolean;
+}
+
+const SITE_URL = 'https://peninsulainsider.com.au';
+const {
+  title,
+  description = 'V4 staging, mega-menu lift on the V2 visual language.',
+  section = 'home',
+  canonical,
+  ogImage = '/images/sourced/home-cover.webp',
+  ogType = 'website',
+  noindex = true,
+  publishedTime,
+  modifiedTime,
+} = Astro.props;
+
+const rawPath = Astro.url.pathname;
+const canonicalUrl = canonical ?? `${SITE_URL}${rawPath}`;
+const ogImageAbs = ogImage.startsWith('http') ? ogImage : `${SITE_URL}${ogImage}`;
+const isAskPage = rawPath.startsWith('/ask');
+---
+
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="content-language" content="en-AU" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Outfit:wght@300;400;500;600&display=swap"
+    rel="stylesheet"
+  />
+  <title>{title}</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="description" content={description} />
+  <link rel="canonical" href={canonicalUrl} />
+  <meta name="robots" content={noindex ? 'noindex, nofollow' : 'index, follow'} />
+
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+  <meta property="og:image" content={ogImageAbs} />
+  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:type" content={ogType} />
+  <meta property="og:site_name" content="Peninsula Insider" />
+  {publishedTime && <meta property="article:published_time" content={publishedTime} />}
+  {modifiedTime && <meta property="article:modified_time" content={modifiedTime} /> }
+
+  <ClientRouter />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <link rel="stylesheet" href="/assets/mobile-fixes.css" />
+  <link rel="stylesheet" href="/assets/scroll-animations.css" />
+</head>
+<body data-page={section} data-path={rawPath} data-v4="true">
+
+  <V4Masthead section={section} />
+
+  <main>
+    <slot />
+  </main>
+
+  <Footer />
+
+  <V4MobileDrawer />
+
+  <ProfileDropdown />
+  <AuthModal />
+
+  <script is:inline define:vars={{ API_URL: import.meta.env.PUBLIC_CONCIERGE_API_URL || 'http://localhost:8787' }}>
+    window.PI_API_URL = API_URL;
+  </script>
+
+  {!isAskPage && <ConciergeDrawer />}
+  <SearchOverlay />
+  <CookieBanner />
+
+  <!-- V4 mega-menu behaviour: hover-open with delay, focus-open, escape-close,
+       click-outside-close. Honours prefers-reduced-motion via CSS. -->
+  <script is:inline>
+    (function () {
+      function initV4Mega() {
+        var items = document.querySelectorAll('[data-v4-pillar]');
+        if (!items.length) return;
+
+        function closeAll(except) {
+          items.forEach(function (n) {
+            if (n === except) return;
+            n.classList.remove('is-open');
+            var trig = n.querySelector('[data-v4-pillar-link]');
+            if (trig) trig.setAttribute('aria-expanded', 'false');
+          });
+        }
+
+        items.forEach(function (item) {
+          if (item._v4Bound) return;
+          item._v4Bound = true;
+          var link = item.querySelector('[data-v4-pillar-link]');
+          var openTimer = null, closeTimer = null;
+
+          function open() {
+            clearTimeout(closeTimer);
+            openTimer = setTimeout(function () {
+              closeAll(item);
+              item.classList.add('is-open');
+              if (link) link.setAttribute('aria-expanded', 'true');
+            }, 70);
+          }
+          function close() {
+            clearTimeout(openTimer);
+            closeTimer = setTimeout(function () {
+              item.classList.remove('is-open');
+              if (link) link.setAttribute('aria-expanded', 'false');
+            }, 220);
+          }
+
+          item.addEventListener('mouseenter', open);
+          item.addEventListener('mouseleave', close);
+          if (link) {
+            link.addEventListener('focus', open);
+            link.addEventListener('keydown', function (e) {
+              if (e.key === 'Escape') {
+                item.classList.remove('is-open');
+                link.setAttribute('aria-expanded', 'false');
+                link.focus();
+              }
+            });
+          }
+          // Inside-panel Esc closes too.
+          var panel = item.querySelector('[data-v4-mega]');
+          if (panel) {
+            panel.addEventListener('keydown', function (e) {
+              if (e.key === 'Escape') {
+                item.classList.remove('is-open');
+                if (link) {
+                  link.setAttribute('aria-expanded', 'false');
+                  link.focus();
+                }
+              }
+            });
+          }
+        });
+
+        // Click outside closes.
+        document.addEventListener('click', function (e) {
+          var target = e.target;
+          var inside = target.closest && target.closest('[data-v4-pillar]');
+          if (!inside) closeAll(null);
+        });
+      }
+
+      function initV4Drawer() {
+        var burger = document.querySelector('.v4-burger');
+        var drawer = document.getElementById('v4Drawer');
+        if (!burger || !drawer) return;
+
+        // Detach the V2 mobile-nav burger handler if any, then bind V4.
+        if (burger._v4DrawerBound) return;
+        burger._v4DrawerBound = true;
+
+        var closeBtn = drawer.querySelector('[data-v4-drawer-close]');
+        var pillarTriggers = drawer.querySelectorAll('[data-v4-drawer-pillar]');
+
+        function openDrawer() {
+          drawer.classList.add('is-open');
+          burger.setAttribute('aria-expanded', 'true');
+          document.body.style.overflow = 'hidden';
+        }
+        function closeDrawer() {
+          drawer.classList.remove('is-open');
+          burger.setAttribute('aria-expanded', 'false');
+          document.body.style.overflow = '';
+          // Collapse all expanded pillars.
+          drawer.querySelectorAll('.v4-drawer__pillar.is-expanded').forEach(function (p) {
+            p.classList.remove('is-expanded');
+            var t = p.querySelector('[data-v4-drawer-pillar]');
+            if (t) t.setAttribute('aria-expanded', 'false');
+          });
+        }
+
+        burger.addEventListener('click', function () {
+          var isOpen = drawer.classList.contains('is-open');
+          if (isOpen) closeDrawer(); else openDrawer();
+        });
+        if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape' && drawer.classList.contains('is-open')) closeDrawer();
+        });
+
+        pillarTriggers.forEach(function (trig) {
+          trig.addEventListener('click', function () {
+            var pillar = trig.closest('.v4-drawer__pillar');
+            if (!pillar) return;
+            var isExpanded = pillar.classList.contains('is-expanded');
+            // Collapse all others.
+            drawer.querySelectorAll('.v4-drawer__pillar.is-expanded').forEach(function (p) {
+              if (p !== pillar) {
+                p.classList.remove('is-expanded');
+                var t = p.querySelector('[data-v4-drawer-pillar]');
+                if (t) t.setAttribute('aria-expanded', 'false');
+              }
+            });
+            pillar.classList.toggle('is-expanded', !isExpanded);
+            trig.setAttribute('aria-expanded', String(!isExpanded));
+          });
+        });
+
+        // Tapping a link closes the drawer.
+        drawer.querySelectorAll('a').forEach(function (a) {
+          a.addEventListener('click', closeDrawer);
+        });
+      }
+
+      initV4Mega();
+      initV4Drawer();
+      document.addEventListener('astro:page-load', function () {
+        initV4Mega();
+        initV4Drawer();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/next/src/lib/nav.ts
+++ b/next/src/lib/nav.ts
@@ -180,13 +180,14 @@ export const footerSectionLinks: NavItem[] = [
  * Footer "About" column.
  */
 export const footerAboutLinks: NavItem[] = [
-  { key: 'about',       label: 'About',           href: '/about/' },
-  { key: 'methodology', label: 'Methodology',     href: '/methodology/' },
-  { key: 'partners',    label: 'Partner with us', href: '/partners/' },
-  { key: 'contact',     label: 'Contact',         href: '/contact/' },
-  { key: 'newsletter',  label: 'Newsletter',      href: '/newsletter/' },
-  { key: 'privacy',     label: 'Privacy',         href: '/privacy/' },
-  { key: 'cookies',     label: 'Cookie settings', href: '#cookie-settings' },
+  { key: 'about',       label: 'About',                href: '/about/' },
+  { key: 'methodology', label: 'Methodology',          href: '/methodology/' },
+  { key: 'map',         label: 'Map of the Peninsula', href: '/explore/map/' },
+  { key: 'partners',    label: 'Partner with us',      href: '/partners/' },
+  { key: 'contact',     label: 'Contact',              href: '/contact/' },
+  { key: 'newsletter',  label: 'Newsletter',           href: '/newsletter/' },
+  { key: 'privacy',     label: 'Privacy',              href: '/privacy/' },
+  { key: 'cookies',     label: 'Cookie settings',      href: '#cookie-settings' },
 ];
 
 /**

--- a/next/src/lib/v3-nav.ts
+++ b/next/src/lib/v3-nav.ts
@@ -1,0 +1,261 @@
+/**
+ * V3 navigation source of truth.
+ *
+ * Five pillars, no overflow menu, three utility surfaces (Ask PI, What's On,
+ * Subscribe). Designed against the V3 strategy doc: refuse the directory
+ * sprawl, lead with reader intent.
+ *
+ * Pillar mega-panels carry three columns each: by intent (mood), by place
+ * (geography), in voice (editorial entry-points). Capped at six items per
+ * column so the panel reads as curation, not sitemap.
+ *
+ * Live URLs are kept where they exist; new sub-routes inside a pillar use
+ * filter querystrings on the existing index pages so nothing 404s.
+ */
+
+export interface V3NavItem {
+  key: string;
+  label: string;
+  href: string;
+  /** Optional one-line dek for mobile + accessibility. */
+  dek?: string;
+}
+
+export interface V3MegaColumn {
+  /** Small caps eyebrow, e.g. "By the meal", "By the place", "In voice". */
+  eyebrow: string;
+  items: V3NavItem[];
+}
+
+export interface V3Pillar extends V3NavItem {
+  /** Mega-panel columns. Three is the rhythm; two is allowed for narrower pillars. */
+  columns: V3MegaColumn[];
+  /** Hero image for the mega-panel left rail. */
+  panelImage?: { src: string; alt: string };
+}
+
+export const v3Pillars: V3Pillar[] = [
+  {
+    key: 'eat',
+    label: 'Eat & Drink',
+    href: '/eat/',
+    dek: 'Restaurants, cellar doors, cafes, bakeries.',
+    panelImage: {
+      src: '/images/sourced/article-long-lunch-01.webp',
+      alt: 'A long lunch table on a Peninsula deck, late afternoon',
+    },
+    columns: [
+      {
+        eyebrow: 'By the meal',
+        items: [
+          { key: 'long-lunch',   label: 'Long lunch',     href: '/journal/the-long-lunch/' },
+          { key: 'hatted',       label: 'Hatted dinner',  href: '/journal/three-italian-dinners/' },
+          { key: 'breakfast',    label: 'Breakfast',      href: '/journal/breakfast-before-the-crowds/' },
+          { key: 'cellar-door',  label: 'Cellar door',    href: '/journal/the-cellar-door-short-list/' },
+          { key: 'cafe',         label: 'Cafe & bakery',  href: '/eat/?type=cafe' },
+          { key: 'pantry',       label: 'Pantry & produce', href: '/journal/the-peninsula-pantry/' },
+        ],
+      },
+      {
+        eyebrow: 'By the place',
+        items: [
+          { key: 'red-hill',   label: 'Red Hill',     href: '/places/red-hill/' },
+          { key: 'sorrento',   label: 'Sorrento',     href: '/places/sorrento/' },
+          { key: 'flinders',   label: 'Flinders',     href: '/places/flinders/' },
+          { key: 'mornington', label: 'Mornington',   href: '/places/mornington/' },
+          { key: 'main-ridge', label: 'Main Ridge',   href: '/places/main-ridge/' },
+          { key: 'merricks',   label: 'Merricks',     href: '/places/merricks/' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'editors-table', label: "Editor's Table",      href: '/journal/?format=editors-table' },
+          { key: 'shortlist',     label: 'The Shortlist',       href: '/journal/?format=shortlist' },
+          { key: 'all-eat',       label: 'Every venue we cover', href: '/eat/' },
+          { key: 'wine-hub',      label: 'Wine country guide',  href: '/wine/' },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'stay',
+    label: 'Stay',
+    href: '/stay/',
+    dek: 'Hotels, villas, cottages, glamping.',
+    panelImage: {
+      src: '/images/sourced/article-vineyard-villa-01.webp',
+      alt: 'A vineyard villa at golden hour, Red Hill',
+    },
+    columns: [
+      {
+        eyebrow: 'By the trip',
+        items: [
+          { key: 'one-night',   label: 'One night',           href: '/journal/the-one-night-escape/' },
+          { key: 'weekend',     label: 'A weekend',           href: '/escape/' },
+          { key: 'family',      label: 'With kids',           href: '/journal/the-peninsula-with-kids/' },
+          { key: 'romantic',    label: 'Two of you',          href: '/journal/the-couples-weekend/' },
+          { key: 'wellness',    label: 'Wellness weekend',    href: '/journal/the-thermal-springs-weekend/' },
+          { key: 'dog',         label: 'Dog friendly',        href: '/dog-friendly/' },
+        ],
+      },
+      {
+        eyebrow: 'By the room',
+        items: [
+          { key: 'hotels',     label: 'Hotels',          href: '/stay/?type=hotel' },
+          { key: 'villas',     label: 'Villas & houses', href: '/stay/?type=villa' },
+          { key: 'bnb',        label: 'B&Bs & cottages', href: '/stay/?type=bnb' },
+          { key: 'glamping',   label: 'Glamping',        href: '/stay/?type=glamping' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'editors-rooms', label: "Editor's stays",       href: '/stay/?featured=true' },
+          { key: 'all-stay',      label: 'Every room we cover',  href: '/stay/' },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'explore',
+    label: 'Explore',
+    href: '/explore/',
+    dek: 'Walks, beaches, towns, the back roads.',
+    panelImage: {
+      src: '/images/sourced/explore-hub-hero-01.webp',
+      alt: 'A coast walk on the Peninsula back beaches',
+    },
+    columns: [
+      {
+        eyebrow: 'By the move',
+        items: [
+          { key: 'walks',     label: 'Walks',          href: '/walks/' },
+          { key: 'beaches',   label: 'Beaches',        href: '/explore/?type=beach' },
+          { key: 'lookouts',  label: 'Lookouts & drives', href: '/explore/?type=lookout' },
+          { key: 'markets',   label: 'Markets',        href: '/explore/?type=market' },
+          { key: 'galleries', label: 'Galleries',      href: '/explore/?type=gallery' },
+          { key: 'on-water',  label: 'On the water',   href: '/boating/' },
+        ],
+      },
+      {
+        eyebrow: 'By the place',
+        items: [
+          { key: 'red-hill',     label: 'Red Hill & ridge',     href: '/places/red-hill/' },
+          { key: 'sorrento',     label: 'Sorrento & cape',      href: '/places/sorrento/' },
+          { key: 'mornington',   label: 'Mornington & bay',     href: '/places/mornington/' },
+          { key: 'point-nepean', label: 'Point Nepean',         href: '/places/point-nepean/' },
+          { key: 'flinders',     label: 'Flinders & coast',     href: '/places/flinders/' },
+          { key: 'all-places',   label: 'Every town we cover',  href: '/places/' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'orientation', label: 'First-visit drive',     href: '/journal/the-peninsula-orientation-drive/' },
+          { key: 'rainy',       label: "Rainy-day plans",       href: '/journal/the-rainy-day-peninsula-without-a-booking/' },
+          { key: 'sunset',      label: 'Sunset moves',          href: '/journal/the-sunset-shortlist/' },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'plans',
+    label: 'Plans',
+    href: '/escape/',
+    dek: 'Pre-shaped weekends, itineraries, and guide-led days.',
+    panelImage: {
+      src: '/images/sourced/article-flinders-weekend-01.webp',
+      alt: 'A shaped Peninsula weekend itinerary in Flinders',
+    },
+    columns: [
+      {
+        eyebrow: 'By the shape',
+        items: [
+          { key: 'one-night', label: 'One night',         href: '/journal/the-one-night-escape/' },
+          { key: 'weekend',   label: 'Two-day weekend',   href: '/escape/?length=weekend' },
+          { key: 'long',      label: 'Long weekend',      href: '/escape/?length=long' },
+          { key: 'kids',      label: 'With kids',         href: '/journal/the-peninsula-with-kids/' },
+          { key: 'wellness',  label: 'Wellness weekend',  href: '/journal/the-thermal-springs-weekend/' },
+        ],
+      },
+      {
+        eyebrow: 'Hand it to a guide',
+        items: [
+          { key: 'tours',     label: 'Operator tours',    href: '/tour/' },
+          { key: 'packages',  label: 'Multi-day packages', href: '/tour-packages/' },
+          { key: 'wine-day',  label: 'Wine-tour day',     href: '/tour/?type=wine' },
+          { key: 'springs',   label: 'Hot-springs day',   href: '/tour/?type=wellness' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'all-plans', label: 'Every plan we publish', href: '/escape/' },
+          { key: 'all-tours', label: 'Every operator we trust', href: '/tour/' },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'journal',
+    label: 'Journal',
+    href: '/journal/',
+    dek: 'Long reads, dispatches, the Shortlist.',
+    panelImage: {
+      src: '/images/sourced/journal-hub-hero-01.webp',
+      alt: 'The Peninsula Insider Journal',
+    },
+    columns: [
+      {
+        eyebrow: 'By the format',
+        items: [
+          { key: 'cover',       label: 'The Cover',          href: '/journal/?format=cover' },
+          { key: 'long-read',   label: 'Long reads',         href: '/journal/?format=long-read' },
+          { key: 'shortlist',   label: 'The Shortlist',      href: '/journal/?format=shortlist' },
+          { key: 'dispatch',    label: 'Weekend dispatch',   href: '/journal/?format=weekend-picker' },
+          { key: 'editors-table', label: "Editor's Table",   href: '/journal/?format=editors-table' },
+        ],
+      },
+      {
+        eyebrow: 'By the read',
+        items: [
+          { key: 'all-journal', label: 'Every issue, every piece', href: '/journal/' },
+          { key: 'methodology', label: 'How we work',              href: '/methodology/' },
+          { key: 'about',       label: 'About PI',                 href: '/about/' },
+        ],
+      },
+    ],
+  },
+];
+
+/** Utility surfaces that live alongside the five pillars but aren't pillars themselves. */
+export const v3Utility = {
+  ask:        { key: 'ask',        label: 'Ask PI',     href: '/ask/' },
+  whatsOn:    { key: 'whats-on',   label: "What's On",  href: '/whats-on/' },
+  subscribe:  { key: 'subscribe',  label: 'Subscribe',  href: '/newsletter/' },
+  account:    { key: 'account',    label: 'Sign in',    href: '/account/' },
+  pass:       { key: 'pass',       label: 'The Pass',   href: '/preview-insider-plans/' },
+  search:     { key: 'search',     label: 'Search',     href: '/search/' },
+};
+
+/** Footer columns for the V3 colophon. Mirrors V2 footer departments but reorganised by V3 pillar. */
+export const v3FooterDepartments: V3NavItem[] = [
+  { key: 'eat',      label: 'Eat & Drink',  href: '/eat/' },
+  { key: 'stay',     label: 'Stay',         href: '/stay/' },
+  { key: 'explore',  label: 'Explore',      href: '/explore/' },
+  { key: 'plans',    label: 'Plans',        href: '/escape/' },
+  { key: 'journal',  label: 'Journal',      href: '/journal/' },
+  { key: 'whats-on', label: "What's On",    href: '/whats-on/' },
+  { key: 'ask',      label: 'Ask PI',       href: '/ask/' },
+];
+
+export const v3FooterAbout: V3NavItem[] = [
+  { key: 'about',       label: 'About',           href: '/about/' },
+  { key: 'methodology', label: 'Methodology',     href: '/methodology/' },
+  { key: 'partners',    label: 'Partner with us', href: '/partners/' },
+  { key: 'pass',        label: 'The Pass',        href: '/preview-insider-plans/' },
+  { key: 'newsletter',  label: 'The Dispatch',    href: '/newsletter/' },
+  { key: 'contact',     label: 'Contact',         href: '/contact/' },
+  { key: 'privacy',     label: 'Privacy',         href: '/privacy/' },
+];

--- a/next/src/lib/v4-nav.ts
+++ b/next/src/lib/v4-nav.ts
@@ -67,11 +67,121 @@ export interface V4Pillar extends V4NavItem {
 
 /** ----------------------------------------------------------------------
  *  PILLARS
+ *
+ *  Order: What's On → Plans → Eat & Drink → Wine → Stay → Explore → Journal.
+ *  What's On leads because the highest-intent question on a Peninsula
+ *  weekend is "what's happening this Saturday?" — the live calendar wins
+ *  the first slot. Plans follows because pre-shaped weekends are the
+ *  next step. Editorial pillars come after intent.
  * ---------------------------------------------------------------------- */
 
 export const v4Pillars: V4Pillar[] = [
 
-  // 1. EAT & DRINK ----------------------------------------------------------
+  // 1. WHAT'S ON ------------------------------------------------------------
+  {
+    key: 'whats-on',
+    label: "What's On",
+    href: '/whats-on/',
+    intro: 'The events calendar with an opinion attached, kids-graded, weather-flagged, worth-the-drive labelled.',
+    topBanner: {
+      text: "This weekend's calendar",
+      ctaLabel: 'Read the dispatch →',
+      ctaHref: '/whats-on/',
+    },
+    rail: {
+      eyebrow: "Editor's pick this weekend",
+      title: "Mt Eliza Farmers' Market",
+      verdict: "Sunday morning, Mt Eliza. Get there before 9 if you want a brunch table. Park at the village.",
+      image: '/images/sourced/article-picnic-01.webp',
+      imageAlt: "Mt Eliza Farmers' Market",
+      href: '/whats-on/mt-eliza-farmers-market/',
+      cta: 'See this week →',
+    },
+    columns: [
+      {
+        eyebrow: 'This weekend',
+        items: [
+          { key: 'all-weekend',     label: 'All this weekend',  href: '/whats-on/' },
+          { key: 'racecourse',      label: 'Racecourse Market', href: '/whats-on/mornington-racecourse-market/' },
+          { key: 'mt-eliza-market', label: "Mt Eliza Farmers'", href: '/whats-on/mt-eliza-farmers-market/' },
+          { key: 'main-street',     label: 'Main Street fest',  href: '/whats-on/main-street-mornington-festival-2026/' },
+        ],
+      },
+      {
+        eyebrow: 'Coming up',
+        items: [
+          { key: 'community',  label: 'Community markets', href: '/whats-on/' },
+          { key: 'festivals',  label: 'Festivals',         href: '/whats-on/' },
+          { key: 'seasonal',   label: 'Seasonal events',   href: '/whats-on/' },
+          { key: 'all-coming', label: 'All upcoming →',    href: '/whats-on/' },
+        ],
+      },
+      {
+        eyebrow: 'By the mood',
+        items: [
+          { key: 'weekend-edit', label: 'Autumn weekend edit', href: '/journal/autumn-weekend-edit/' },
+          { key: 'long-lunch',   label: 'Long-lunch Sunday',   href: '/journal/the-long-lunch/' },
+          { key: 'rainy',        label: 'When it rains',       href: '/journal/the-rainy-day-peninsula-without-a-booking/' },
+          { key: 'kids',         label: 'With kids',           href: '/journal/the-peninsula-with-kids/' },
+          { key: 'all-events',   label: 'Every event →',       href: '/whats-on/' },
+        ],
+      },
+    ],
+    askLine: 'Need a Saturday plan that punishes nobody? Ask PI →',
+  },
+
+  // 2. PLANS ----------------------------------------------------------------
+  {
+    key: 'escape',
+    label: 'Plans',
+    href: '/escape/',
+    intro: 'Pre-shaped Peninsula days, by length, by guide, or by occasion.',
+    rail: {
+      eyebrow: "Editor's pick · Autumn '26",
+      title: 'The Thermal Springs Weekend',
+      verdict: "Hot springs without wasting the rest of the weekend. Two nights at a wine-country room, one long lunch, one steam.",
+      image: '/images/sourced/article-couples-weekend-01.webp',
+      imageAlt: 'A wellness weekend on the Peninsula',
+      href: '/journal/the-thermal-springs-weekend/',
+    },
+    columns: [
+      {
+        eyebrow: 'By the shape',
+        items: [
+          { key: 'one-night', label: 'One night',         href: '/journal/the-one-night-escape/' },
+          { key: 'weekend',   label: 'Two-day weekend',   href: '/escape/' },
+          { key: 'long',      label: 'Long weekend',      href: '/escape/' },
+          { key: 'kids',      label: 'With kids',         href: '/journal/the-peninsula-with-kids/' },
+          { key: 'wellness',  label: 'Wellness weekend',  href: '/journal/the-thermal-springs-weekend/' },
+          { key: 'romantic',  label: 'Romantic two',      href: '/journal/the-couples-weekend/' },
+        ],
+      },
+      {
+        eyebrow: 'Hand it to a guide',
+        items: [
+          { key: 'tours',     label: 'Operator tours',     href: '/tour/' },
+          { key: 'packages',  label: 'Multi-day packages', href: '/tour-packages/' },
+          { key: 'wine-day',  label: 'Wine-tour day',      href: '/tour/' },
+          { key: 'springs',   label: 'Hot-springs day',    href: '/tour/' },
+          { key: 'golf-day',  label: 'Golf day',           href: '/golf/' },
+          { key: 'dolphin',   label: 'Dolphin swim day',   href: '/tour/' },
+        ],
+      },
+      {
+        eyebrow: 'By the occasion',
+        items: [
+          { key: 'weddings',     label: 'Weddings',                  href: '/weddings/' },
+          { key: 'corporate',    label: 'Corporate offsites',        href: '/corporate-events/' },
+          { key: 'corp-guide',   label: 'How to plan a retreat',     href: '/journal/corporate-events-how-to-plan-peninsula-retreat/' },
+          { key: 'group',        label: 'Group of six+',             href: '/escape/' },
+          { key: 'eoy',          label: 'End-of-year offsite',       href: '/corporate-events/' },
+        ],
+      },
+    ],
+    askLine: 'Need the plan shaped around six adults on a Saturday? Ask PI →',
+  },
+
+  // 3. EAT & DRINK ----------------------------------------------------------
   {
     key: 'eat',
     label: 'Eat & Drink',
@@ -83,7 +193,7 @@ export const v4Pillars: V4Pillar[] = [
       verdict: 'Sit at the bar, not the dining room. Better view, faster service. The kingfish is the order.',
       image: '/images/sourced/article-hatted-restaurants-01.webp',
       imageAlt: 'Laura at Pt Leo Estate, the bar with the bay view',
-      href: '/eat/laura/',
+      href: '/eat/laura-pt-leo/',
     },
     columns: [
       {
@@ -93,7 +203,7 @@ export const v4Pillars: V4Pillar[] = [
           { key: 'hatted',       label: 'Hatted dinner',    href: '/journal/three-italian-dinners/' },
           { key: 'breakfast',    label: 'Breakfast',        href: '/journal/breakfast-before-the-crowds/' },
           { key: 'cellar-door',  label: 'Cellar door',      href: '/journal/the-cellar-door-short-list/' },
-          { key: 'cafe',         label: 'Cafe & bakery',    href: '/eat/?type=cafe' },
+          { key: 'cafe',         label: 'Cafes',            href: '/eat/cafes/' },
           { key: 'pantry',       label: 'Pantry & produce', href: '/journal/the-peninsula-pantry/' },
         ],
       },
@@ -111,8 +221,8 @@ export const v4Pillars: V4Pillar[] = [
       {
         eyebrow: 'In voice',
         items: [
-          { key: 'editors-table', label: "Editor's Table",      href: '/journal/?format=editors-table' },
-          { key: 'shortlist',     label: 'The Shortlist',       href: '/journal/?format=shortlist' },
+          { key: 'editors-table', label: "Editor's Table",      href: '/journal/' },
+          { key: 'shortlist',     label: 'The Shortlist',       href: '/journal/the-cellar-door-short-list/' },
           { key: 'pantry-piece',  label: 'Pantry & produce',    href: '/journal/the-peninsula-pantry/' },
           { key: 'all-eat',       label: 'Every venue we cover', href: '/eat/' },
         ],
@@ -121,7 +231,7 @@ export const v4Pillars: V4Pillar[] = [
     askLine: 'Looking for the back-roads version? Ask PI →',
   },
 
-  // 2. WINE -----------------------------------------------------------------
+  // 4. WINE -----------------------------------------------------------------
   {
     key: 'wine',
     label: 'Wine',
@@ -139,32 +249,32 @@ export const v4Pillars: V4Pillar[] = [
       {
         eyebrow: 'By the venue',
         items: [
-          { key: 'cellar-door',     label: 'Cellar door',       href: '/wine/?type=winery' },
-          { key: 'producer',        label: 'Producer (no door)', href: '/wine/?type=producer' },
-          { key: 'brewery',         label: 'Brewery',           href: '/wine/?type=brewery' },
-          { key: 'distillery',      label: 'Distillery',        href: '/wine/?type=distillery' },
-          { key: 'cidery',          label: 'Cidery',            href: '/wine/?type=cidery' },
-          { key: 'pop-up',          label: 'Pop-up tasting',    href: '/wine/?type=pop-up' },
+          { key: 'cellar-door',  label: 'Cellar door',         href: '/wine/cellar-doors/' },
+          { key: 'producer',     label: 'Appointment producers', href: '/wine/appointment-producers/' },
+          { key: 'best-cellar',  label: 'Best cellar doors',   href: '/wine/best-cellar-doors/' },
+          { key: 'brewery',      label: 'Breweries',           href: '/wine/' },
+          { key: 'distillery',   label: 'Distilleries',        href: '/wine/' },
+          { key: 'cider',        label: 'Cider',               href: '/wine/mornington-peninsula-cider/' },
         ],
       },
       {
         eyebrow: 'By the place',
         items: [
           { key: 'red-hill',   label: 'Red Hill',   href: '/wine/red-hill/' },
-          { key: 'main-ridge', label: 'Main Ridge', href: '/places/main-ridge/' },
-          { key: 'merricks',   label: 'Merricks',   href: '/places/merricks/' },
+          { key: 'main-ridge', label: 'Main Ridge', href: '/wine/main-ridge/' },
+          { key: 'merricks',   label: 'Merricks',   href: '/wine/merricks/' },
           { key: 'mornington', label: 'Mornington', href: '/places/mornington/' },
-          { key: 'balnarring', label: 'Balnarring', href: '/places/balnarring/' },
-          { key: 'flinders',   label: 'Flinders',   href: '/places/flinders/' },
+          { key: 'balnarring', label: 'Balnarring', href: '/wine/balnarring/' },
+          { key: 'flinders',   label: 'Flinders',   href: '/wine/flinders/' },
         ],
       },
       {
         eyebrow: 'In voice',
         items: [
           { key: 'cellar-shortlist', label: 'The cellar-door shortlist', href: '/journal/the-cellar-door-short-list/' },
-          { key: 'chardonnay',       label: 'The Chardonnay case',       href: '/journal/the-chardonnay-case/' },
+          { key: 'chardonnay',       label: 'The Chardonnay case',       href: '/wine/chardonnay/' },
           { key: 'pinot-noir',       label: 'The Pinot benchmark',       href: '/wine/pinot-noir/' },
-          { key: 'producer-trail',   label: 'The producer trail',        href: '/journal/?slug=the-producer-trail' },
+          { key: 'producer-trail',   label: 'The producer trail',        href: '/journal/the-producer-trail/' },
           { key: 'all-wine',         label: 'Every winery we cover',     href: '/wine/' },
         ],
       },
@@ -172,7 +282,7 @@ export const v4Pillars: V4Pillar[] = [
     askLine: 'After the ones not on the booking apps? Ask PI →',
   },
 
-  // 3. STAY -----------------------------------------------------------------
+  // 5. STAY -----------------------------------------------------------------
   {
     key: 'stay',
     label: 'Stay',
@@ -201,17 +311,18 @@ export const v4Pillars: V4Pillar[] = [
       {
         eyebrow: 'By the room',
         items: [
-          { key: 'hotels',   label: 'Hotels',          href: '/stay/?type=hotel' },
-          { key: 'villas',   label: 'Villas & houses', href: '/stay/?type=villa' },
-          { key: 'bnb',      label: 'B&Bs & cottages', href: '/stay/?type=bnb' },
-          { key: 'glamping', label: 'Glamping',        href: '/stay/?type=glamping' },
+          { key: 'hotels',   label: 'Hotels',          href: '/stay/' },
+          { key: 'villas',   label: 'Villas & houses', href: '/stay/villas/' },
+          { key: 'bnb',      label: 'B&Bs & cottages', href: '/stay/cottages/' },
+          { key: 'glamping', label: 'Glamping',        href: '/stay/glamping/' },
           { key: 'spa',      label: 'Spa retreats',    href: '/spa/' },
         ],
       },
       {
         eyebrow: 'In voice',
         items: [
-          { key: 'editors-stays', label: "Editor's stays",      href: '/stay/?featured=true' },
+          { key: 'best-spas',     label: 'Best spas',           href: '/journal/best-spas-mornington-peninsula/' },
+          { key: 'dog-stays',     label: 'Dog-friendly stays',  href: '/journal/dog-friendly-accommodation-mornington-peninsula/' },
           { key: 'all-stay',      label: 'Every room we cover', href: '/stay/' },
         ],
       },
@@ -219,12 +330,17 @@ export const v4Pillars: V4Pillar[] = [
     askLine: 'Want the room that opens up on the cancellation list? Ask PI →',
   },
 
-  // 4. EXPLORE --------------------------------------------------------------
+  // 6. EXPLORE --------------------------------------------------------------
   {
     key: 'explore',
     label: 'Explore',
     href: '/explore/',
     intro: "Every move on the Peninsula that isn't a meal or a bed.",
+    topBanner: {
+      text: "How the Peninsula's geography actually works",
+      ctaLabel: 'Open the map →',
+      ctaHref: '/explore/map/',
+    },
     rail: {
       eyebrow: "Editor's pick · Autumn '26",
       title: 'Bushrangers Bay walk',
@@ -237,12 +353,12 @@ export const v4Pillars: V4Pillar[] = [
       {
         eyebrow: 'By the move',
         items: [
-          { key: 'walks',     label: 'Walks',             href: '/walks/' },
-          { key: 'beaches',   label: 'Beaches',           href: '/explore/?type=beach' },
-          { key: 'lookouts',  label: 'Lookouts & drives', href: '/explore/?type=lookout' },
-          { key: 'markets',   label: 'Markets',           href: '/explore/?type=market' },
-          { key: 'galleries', label: 'Galleries',         href: '/explore/?type=gallery' },
-          { key: 'on-water',  label: 'On the water',      href: '/boating/' },
+          { key: 'walks',     label: 'Walks',         href: '/explore/walks/' },
+          { key: 'beaches',   label: 'Beaches',       href: '/explore/beaches/' },
+          { key: 'markets',   label: 'Markets',       href: '/explore/markets/' },
+          { key: 'on-water',  label: 'On the water',  href: '/boating/' },
+          { key: 'fishing',   label: 'Fishing spots', href: '/fishing/' },
+          { key: 'all-moves', label: 'All experiences →', href: '/explore/' },
         ],
       },
       {
@@ -259,122 +375,16 @@ export const v4Pillars: V4Pillar[] = [
       {
         eyebrow: 'In voice',
         items: [
-          { key: 'orientation', label: 'First-visit drive', href: '/journal/the-peninsula-orientation-drive/' },
-          { key: 'rainy',       label: 'Rainy-day plans',   href: '/journal/the-rainy-day-peninsula-without-a-booking/' },
-          { key: 'sunset',      label: 'Sunset moves',      href: '/journal/?slug=sunset-shortlist' },
-          { key: 'water-guide', label: 'On the water guide', href: '/boating/' },
+          { key: 'orientation', label: 'First-visit drive',  href: '/journal/the-peninsula-orientation-drive/' },
+          { key: 'rainy',       label: 'Rainy-day plans',    href: '/journal/the-rainy-day-peninsula-without-a-booking/' },
+          { key: 'sunset',      label: 'Sunset moves',       href: '/journal/the-sunset-drink/' },
+          { key: 'cape-schanck', label: 'Cape Schanck guide', href: '/journal/cape-schanck-guide/' },
         ],
       },
     ],
     askLine: 'Want the walk only locals know? Ask PI →',
   },
 
-  // 5. PLANS ----------------------------------------------------------------
-  {
-    key: 'escape',
-    label: 'Plans',
-    href: '/escape/',
-    intro: 'Pre-shaped Peninsula days, by length, by guide, or by occasion.',
-    rail: {
-      eyebrow: "Editor's pick · Autumn '26",
-      title: 'The Thermal Springs Weekend',
-      verdict: "Hot springs without wasting the rest of the weekend. Two nights at a wine-country room, one long lunch, one steam.",
-      image: '/images/sourced/article-couples-weekend-01.webp',
-      imageAlt: 'A wellness weekend on the Peninsula',
-      href: '/journal/the-thermal-springs-weekend/',
-    },
-    columns: [
-      {
-        eyebrow: 'By the shape',
-        items: [
-          { key: 'one-night', label: 'One night',         href: '/journal/the-one-night-escape/' },
-          { key: 'weekend',   label: 'Two-day weekend',   href: '/escape/?length=weekend' },
-          { key: 'long',      label: 'Long weekend',      href: '/escape/?length=long' },
-          { key: 'kids',      label: 'With kids',         href: '/journal/the-peninsula-with-kids/' },
-          { key: 'wellness',  label: 'Wellness weekend',  href: '/journal/the-thermal-springs-weekend/' },
-          { key: 'romantic',  label: 'Romantic two',      href: '/journal/the-couples-weekend/' },
-        ],
-      },
-      {
-        eyebrow: 'Hand it to a guide',
-        items: [
-          { key: 'tours',     label: 'Operator tours',     href: '/tour/' },
-          { key: 'packages',  label: 'Multi-day packages', href: '/tour-packages/' },
-          { key: 'wine-day',  label: 'Wine-tour day',      href: '/tour/?type=wine' },
-          { key: 'springs',   label: 'Hot-springs day',    href: '/tour/?type=wellness' },
-          { key: 'golf-day',  label: 'Golf day',           href: '/golf/' },
-          { key: 'dolphin',   label: 'Dolphin swim day',   href: '/tour/?type=dolphin' },
-        ],
-      },
-      {
-        eyebrow: 'By the occasion',
-        items: [
-          { key: 'weddings',     label: 'Weddings',                  href: '/weddings/' },
-          { key: 'corporate',    label: 'Corporate offsites',        href: '/corporate-events/' },
-          { key: 'milestones',   label: 'Anniversaries & birthdays', href: '/escape/?occasion=milestone' },
-          { key: 'group',        label: 'Group of six+',             href: '/escape/?group=six-plus' },
-          { key: 'eoy',          label: 'End-of-year offsite',       href: '/corporate-events/?season=summer' },
-        ],
-      },
-    ],
-    askLine: 'Need the plan shaped around six adults on a Saturday? Ask PI →',
-  },
-
-  // 6. WHAT'S ON ------------------------------------------------------------
-  {
-    key: 'whats-on',
-    label: "What's On",
-    href: '/whats-on/',
-    intro: 'The events calendar with an opinion attached, kids-graded, weather-flagged, worth-the-drive labelled.',
-    topBanner: {
-      text: "This weekend's calendar",
-      ctaLabel: 'Read the dispatch →',
-      ctaHref: '/whats-on/',
-    },
-    rail: {
-      eyebrow: "Editor's pick this weekend",
-      title: "Mornington Farmers' Market",
-      verdict: "Saturday morning, Main Street. Get there before 9 or the Pinot vinegar from Quealy is gone. Park at the Pier.",
-      image: '/images/sourced/article-picnic-01.webp',
-      imageAlt: "Mornington Farmers' Market, Main Street",
-      href: '/whats-on/mornington-farmers-market/',
-      cta: 'See this week →',
-    },
-    columns: [
-      {
-        eyebrow: 'This weekend',
-        items: [
-          { key: 'pick-1', label: "Pick 1 (live)", href: '/whats-on/?lens=weekend-pick', live: true },
-          { key: 'pick-2', label: "Pick 2 (live)", href: '/whats-on/?lens=weekend-pick', live: true },
-          { key: 'pick-3', label: "Pick 3 (live)", href: '/whats-on/?lens=weekend-pick', live: true },
-          { key: 'all-weekend', label: 'All this weekend →', href: '/whats-on/?when=this-weekend' },
-        ],
-      },
-      {
-        eyebrow: 'Coming up',
-        items: [
-          { key: 'next-weekend', label: 'Next weekend',  href: '/whats-on/?when=next-weekend' },
-          { key: 'markets',      label: 'Markets',       href: '/whats-on/?category=market' },
-          { key: 'festivals',    label: 'Festivals',     href: '/whats-on/?category=festival' },
-          { key: 'long-weekend', label: 'Long weekends', href: '/whats-on/?when=long-weekend' },
-          { key: 'seasonal',     label: 'Seasonal events', href: '/whats-on/?recurrence=seasonal' },
-          { key: 'all-coming',   label: 'All upcoming →',  href: '/whats-on/' },
-        ],
-      },
-      {
-        eyebrow: 'By the mood',
-        items: [
-          { key: 'worth-drive',  label: 'Worth the drive',  href: '/whats-on/?lens=worth-the-drive' },
-          { key: 'weather',      label: 'Weather-proof',    href: '/whats-on/?weather=proof' },
-          { key: 'kids',         label: 'Kids welcome',     href: '/whats-on/?kids=easy' },
-          { key: 'after-dark',   label: 'After dark',       href: '/whats-on/?lens=after-dark' },
-          { key: 'long-lunch',   label: 'Long-lunch events', href: '/whats-on/?category=long-lunch' },
-          { key: 'all-mood',     label: 'All moods →',      href: '/whats-on/' },
-        ],
-      },
-    ],
-    askLine: 'Need a Saturday plan that punishes nobody? Ask PI →',
-  },
 
   // 7. JOURNAL --------------------------------------------------------------
   {
@@ -393,14 +403,14 @@ export const v4Pillars: V4Pillar[] = [
     },
     columns: [
       {
-        eyebrow: 'By the format',
+        eyebrow: 'Cornerstones',
         items: [
-          { key: 'cover',       label: 'The Cover',           href: '/journal/?format=cover' },
-          { key: 'long-read',   label: 'Long reads',          href: '/journal/?format=long-read' },
-          { key: 'shortlist',   label: 'The Shortlist',       href: '/journal/?format=shortlist' },
-          { key: 'dispatch',    label: 'Weekend dispatch',    href: '/journal/?format=weekend-picker' },
-          { key: 'editors-table', label: "Editor's Table",    href: '/journal/?format=editors-table' },
-          { key: 'cellar-disp', label: 'Cellar-door dispatch', href: '/journal/?format=cellar-door-dispatch' },
+          { key: 'cellar',      label: 'The cellar-door shortlist', href: '/journal/the-cellar-door-short-list/' },
+          { key: 'long-lunch',  label: 'The long lunch',            href: '/journal/the-long-lunch/' },
+          { key: 'one-night',   label: 'The one-night escape',      href: '/journal/the-one-night-escape/' },
+          { key: 'rainy',       label: 'Rainy-day plans',           href: '/journal/the-rainy-day-peninsula-without-a-booking/' },
+          { key: 'orientation', label: 'First-visit drive',         href: '/journal/the-peninsula-orientation-drive/' },
+          { key: 'kids',        label: 'With kids',                 href: '/journal/the-peninsula-with-kids/' },
         ],
       },
       {
@@ -450,11 +460,12 @@ export const v4FooterNiche: V4NavItem[] = [
 ];
 
 export const v4FooterAbout: V4NavItem[] = [
-  { key: 'about',       label: 'About',           href: '/about/' },
-  { key: 'methodology', label: 'Methodology',     href: '/methodology/' },
-  { key: 'partners',    label: 'Partner with us', href: '/partners/' },
-  { key: 'pass',        label: 'The Pass',        href: '/preview-insider-plans/' },
-  { key: 'newsletter',  label: 'The Dispatch',    href: '/newsletter/' },
-  { key: 'contact',     label: 'Contact',         href: '/contact/' },
-  { key: 'privacy',     label: 'Privacy',         href: '/privacy/' },
+  { key: 'about',       label: 'About',                  href: '/about/' },
+  { key: 'methodology', label: 'Methodology',            href: '/methodology/' },
+  { key: 'map',         label: 'Map of the Peninsula',   href: '/explore/map/' },
+  { key: 'partners',    label: 'Partner with us',        href: '/partners/' },
+  { key: 'pass',        label: 'The Pass',               href: '/preview-insider-plans/' },
+  { key: 'newsletter',  label: 'The Dispatch',           href: '/newsletter/' },
+  { key: 'contact',     label: 'Contact',                href: '/contact/' },
+  { key: 'privacy',     label: 'Privacy',                href: '/privacy/' },
 ];

--- a/next/src/lib/v4-nav.ts
+++ b/next/src/lib/v4-nav.ts
@@ -1,0 +1,460 @@
+/**
+ * V4 navigation source of truth.
+ *
+ * Seven pillars (Eat & Drink, Wine, Stay, Explore, Plans, What's On, Journal)
+ * with editorial mega-panel content per pillar. All copy follows BRAND-PI.md
+ * voice rules: no em-dashes, no tourism adjectives, specific over generic,
+ * column items as noun phrases (≤3 words), eyebrows as prepositional phrases.
+ *
+ * Curation discipline: every column capped at 6 items. The mega menu reads
+ * as edited, not exhaustive.
+ *
+ * Image-rail picks: editor's nomination per pillar for the autumn 2026 issue.
+ * Easy to swap on the next issue — change the rail block per pillar.
+ */
+
+export interface V4NavItem {
+  key: string;
+  label: string;
+  href: string;
+  /** For "live" entries on What's On col 1 — render with sage indicator dot. */
+  live?: boolean;
+}
+
+export interface V4MegaColumn {
+  /** Small caps eyebrow, e.g. "By the meal", "By the venue", "In voice". */
+  eyebrow: string;
+  items: V4NavItem[];
+}
+
+export interface V4MegaRail {
+  /** Eyebrow above the title, e.g. "Editor's pick · Autumn '26". */
+  eyebrow: string;
+  /** Pin's name, e.g. "Laura". */
+  title: string;
+  /** Italic verdict line in PI voice. 1–2 sentences. */
+  verdict: string;
+  /** Image src and alt. */
+  image: string;
+  imageAlt: string;
+  /** URL the rail links to. */
+  href: string;
+  /** Optional CTA label override. Defaults to "Open the verdict →". */
+  cta?: string;
+}
+
+export interface V4MegaTopBanner {
+  /** e.g. "This weekend, Sat 10 – Sun 11 May" */
+  text: string;
+  /** Optional CTA label, e.g. "Read the dispatch →" */
+  ctaLabel?: string;
+  /** Optional CTA href. */
+  ctaHref?: string;
+}
+
+export interface V4Pillar extends V4NavItem {
+  /** Sentence-form intro inside the panel. PI voice, no em-dashes. */
+  intro: string;
+  /** Optional banner above the columns (used by What's On). */
+  topBanner?: V4MegaTopBanner;
+  /** Image rail (editor's pin). */
+  rail: V4MegaRail;
+  /** 2 or 3 columns; Journal uses 2. */
+  columns: V4MegaColumn[];
+  /** Sentence-form Ask-PI footer in voice. Always ends "Ask PI →". */
+  askLine: string;
+}
+
+/** ----------------------------------------------------------------------
+ *  PILLARS
+ * ---------------------------------------------------------------------- */
+
+export const v4Pillars: V4Pillar[] = [
+
+  // 1. EAT & DRINK ----------------------------------------------------------
+  {
+    key: 'eat',
+    label: 'Eat & Drink',
+    href: '/eat/',
+    intro: 'Three ways into Eat & Drink, pick the meal, the place, or the editorial route.',
+    rail: {
+      eyebrow: "Editor's pick · Autumn '26",
+      title: 'Laura at Pt Leo Estate',
+      verdict: 'Sit at the bar, not the dining room. Better view, faster service. The kingfish is the order.',
+      image: '/images/sourced/article-hatted-restaurants-01.webp',
+      imageAlt: 'Laura at Pt Leo Estate, the bar with the bay view',
+      href: '/eat/laura/',
+    },
+    columns: [
+      {
+        eyebrow: 'By the meal',
+        items: [
+          { key: 'long-lunch',   label: 'Long lunch',       href: '/journal/the-long-lunch/' },
+          { key: 'hatted',       label: 'Hatted dinner',    href: '/journal/three-italian-dinners/' },
+          { key: 'breakfast',    label: 'Breakfast',        href: '/journal/breakfast-before-the-crowds/' },
+          { key: 'cellar-door',  label: 'Cellar door',      href: '/journal/the-cellar-door-short-list/' },
+          { key: 'cafe',         label: 'Cafe & bakery',    href: '/eat/?type=cafe' },
+          { key: 'pantry',       label: 'Pantry & produce', href: '/journal/the-peninsula-pantry/' },
+        ],
+      },
+      {
+        eyebrow: 'By the place',
+        items: [
+          { key: 'red-hill',   label: 'Red Hill',   href: '/places/red-hill/' },
+          { key: 'sorrento',   label: 'Sorrento',   href: '/places/sorrento/' },
+          { key: 'flinders',   label: 'Flinders',   href: '/places/flinders/' },
+          { key: 'mornington', label: 'Mornington', href: '/places/mornington/' },
+          { key: 'main-ridge', label: 'Main Ridge', href: '/places/main-ridge/' },
+          { key: 'merricks',   label: 'Merricks',   href: '/places/merricks/' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'editors-table', label: "Editor's Table",      href: '/journal/?format=editors-table' },
+          { key: 'shortlist',     label: 'The Shortlist',       href: '/journal/?format=shortlist' },
+          { key: 'pantry-piece',  label: 'Pantry & produce',    href: '/journal/the-peninsula-pantry/' },
+          { key: 'all-eat',       label: 'Every venue we cover', href: '/eat/' },
+        ],
+      },
+    ],
+    askLine: 'Looking for the back-roads version? Ask PI →',
+  },
+
+  // 2. WINE -----------------------------------------------------------------
+  {
+    key: 'wine',
+    label: 'Wine',
+    href: '/wine/',
+    intro: "The Peninsula's strongest editorial authority, by venue type, by place, or by the call.",
+    rail: {
+      eyebrow: "Editor's pick · Autumn '26",
+      title: 'Ten Minutes by Tractor',
+      verdict: 'Three vineyards, one table, and the Wallis Pinot is the pour. The architecture does the rest.',
+      image: '/images/sourced/article-cellar-door-01.webp',
+      imageAlt: 'Ten Minutes by Tractor cellar door, Main Ridge',
+      href: '/wine/ten-minutes-by-tractor/',
+    },
+    columns: [
+      {
+        eyebrow: 'By the venue',
+        items: [
+          { key: 'cellar-door',     label: 'Cellar door',       href: '/wine/?type=winery' },
+          { key: 'producer',        label: 'Producer (no door)', href: '/wine/?type=producer' },
+          { key: 'brewery',         label: 'Brewery',           href: '/wine/?type=brewery' },
+          { key: 'distillery',      label: 'Distillery',        href: '/wine/?type=distillery' },
+          { key: 'cidery',          label: 'Cidery',            href: '/wine/?type=cidery' },
+          { key: 'pop-up',          label: 'Pop-up tasting',    href: '/wine/?type=pop-up' },
+        ],
+      },
+      {
+        eyebrow: 'By the place',
+        items: [
+          { key: 'red-hill',   label: 'Red Hill',   href: '/wine/red-hill/' },
+          { key: 'main-ridge', label: 'Main Ridge', href: '/places/main-ridge/' },
+          { key: 'merricks',   label: 'Merricks',   href: '/places/merricks/' },
+          { key: 'mornington', label: 'Mornington', href: '/places/mornington/' },
+          { key: 'balnarring', label: 'Balnarring', href: '/places/balnarring/' },
+          { key: 'flinders',   label: 'Flinders',   href: '/places/flinders/' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'cellar-shortlist', label: 'The cellar-door shortlist', href: '/journal/the-cellar-door-short-list/' },
+          { key: 'chardonnay',       label: 'The Chardonnay case',       href: '/journal/the-chardonnay-case/' },
+          { key: 'pinot-noir',       label: 'The Pinot benchmark',       href: '/wine/pinot-noir/' },
+          { key: 'producer-trail',   label: 'The producer trail',        href: '/journal/?slug=the-producer-trail' },
+          { key: 'all-wine',         label: 'Every winery we cover',     href: '/wine/' },
+        ],
+      },
+    ],
+    askLine: 'After the ones not on the booking apps? Ask PI →',
+  },
+
+  // 3. STAY -----------------------------------------------------------------
+  {
+    key: 'stay',
+    label: 'Stay',
+    href: '/stay/',
+    intro: 'Rooms by what the trip needs, by what kind of bed, or by editorial pick.',
+    rail: {
+      eyebrow: "Editor's pick · Autumn '26",
+      title: 'Jackalope',
+      verdict: 'The architecture is doing the work. Book Doot Doot Doot for dinner the same night, the room rate justifies the splurge.',
+      image: '/images/sourced/article-vineyard-villa-01.webp',
+      imageAlt: 'Jackalope hotel, Merricks North',
+      href: '/stay/jackalope/',
+    },
+    columns: [
+      {
+        eyebrow: 'By the trip',
+        items: [
+          { key: 'one-night',  label: 'One night',         href: '/journal/the-one-night-escape/' },
+          { key: 'weekend',    label: 'A weekend',         href: '/escape/' },
+          { key: 'kids',       label: 'With kids',         href: '/journal/the-peninsula-with-kids/' },
+          { key: 'romantic',   label: 'Two of you',        href: '/journal/the-couples-weekend/' },
+          { key: 'wellness',   label: 'Wellness weekend',  href: '/spa/' },
+          { key: 'dog',        label: 'Dog friendly',      href: '/dog-friendly/' },
+        ],
+      },
+      {
+        eyebrow: 'By the room',
+        items: [
+          { key: 'hotels',   label: 'Hotels',          href: '/stay/?type=hotel' },
+          { key: 'villas',   label: 'Villas & houses', href: '/stay/?type=villa' },
+          { key: 'bnb',      label: 'B&Bs & cottages', href: '/stay/?type=bnb' },
+          { key: 'glamping', label: 'Glamping',        href: '/stay/?type=glamping' },
+          { key: 'spa',      label: 'Spa retreats',    href: '/spa/' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'editors-stays', label: "Editor's stays",      href: '/stay/?featured=true' },
+          { key: 'all-stay',      label: 'Every room we cover', href: '/stay/' },
+        ],
+      },
+    ],
+    askLine: 'Want the room that opens up on the cancellation list? Ask PI →',
+  },
+
+  // 4. EXPLORE --------------------------------------------------------------
+  {
+    key: 'explore',
+    label: 'Explore',
+    href: '/explore/',
+    intro: "Every move on the Peninsula that isn't a meal or a bed.",
+    rail: {
+      eyebrow: "Editor's pick · Autumn '26",
+      title: 'Bushrangers Bay walk',
+      verdict: 'Two hours, almost nobody on it after lunch, and the wildflowers come out late April. Park at Cape Schanck, not Boneo.',
+      image: '/images/sourced/explore-bushrangers-bay-walk-01.webp',
+      imageAlt: 'Bushrangers Bay walk, late afternoon light',
+      href: '/explore/bushrangers-bay-walk/',
+    },
+    columns: [
+      {
+        eyebrow: 'By the move',
+        items: [
+          { key: 'walks',     label: 'Walks',             href: '/walks/' },
+          { key: 'beaches',   label: 'Beaches',           href: '/explore/?type=beach' },
+          { key: 'lookouts',  label: 'Lookouts & drives', href: '/explore/?type=lookout' },
+          { key: 'markets',   label: 'Markets',           href: '/explore/?type=market' },
+          { key: 'galleries', label: 'Galleries',         href: '/explore/?type=gallery' },
+          { key: 'on-water',  label: 'On the water',      href: '/boating/' },
+        ],
+      },
+      {
+        eyebrow: 'By the place',
+        items: [
+          { key: 'red-hill-ridge', label: 'Red Hill & ridge',     href: '/places/red-hill/' },
+          { key: 'sorrento-cape',  label: 'Sorrento & cape',      href: '/places/sorrento/' },
+          { key: 'mornington-bay', label: 'Mornington & bay',     href: '/places/mornington/' },
+          { key: 'point-nepean',   label: 'Point Nepean',         href: '/places/point-nepean/' },
+          { key: 'flinders-coast', label: 'Flinders & coast',     href: '/places/flinders/' },
+          { key: 'all-places',     label: 'Every town we cover',  href: '/places/' },
+        ],
+      },
+      {
+        eyebrow: 'In voice',
+        items: [
+          { key: 'orientation', label: 'First-visit drive', href: '/journal/the-peninsula-orientation-drive/' },
+          { key: 'rainy',       label: 'Rainy-day plans',   href: '/journal/the-rainy-day-peninsula-without-a-booking/' },
+          { key: 'sunset',      label: 'Sunset moves',      href: '/journal/?slug=sunset-shortlist' },
+          { key: 'water-guide', label: 'On the water guide', href: '/boating/' },
+        ],
+      },
+    ],
+    askLine: 'Want the walk only locals know? Ask PI →',
+  },
+
+  // 5. PLANS ----------------------------------------------------------------
+  {
+    key: 'escape',
+    label: 'Plans',
+    href: '/escape/',
+    intro: 'Pre-shaped Peninsula days, by length, by guide, or by occasion.',
+    rail: {
+      eyebrow: "Editor's pick · Autumn '26",
+      title: 'The Thermal Springs Weekend',
+      verdict: "Hot springs without wasting the rest of the weekend. Two nights at a wine-country room, one long lunch, one steam.",
+      image: '/images/sourced/article-couples-weekend-01.webp',
+      imageAlt: 'A wellness weekend on the Peninsula',
+      href: '/journal/the-thermal-springs-weekend/',
+    },
+    columns: [
+      {
+        eyebrow: 'By the shape',
+        items: [
+          { key: 'one-night', label: 'One night',         href: '/journal/the-one-night-escape/' },
+          { key: 'weekend',   label: 'Two-day weekend',   href: '/escape/?length=weekend' },
+          { key: 'long',      label: 'Long weekend',      href: '/escape/?length=long' },
+          { key: 'kids',      label: 'With kids',         href: '/journal/the-peninsula-with-kids/' },
+          { key: 'wellness',  label: 'Wellness weekend',  href: '/journal/the-thermal-springs-weekend/' },
+          { key: 'romantic',  label: 'Romantic two',      href: '/journal/the-couples-weekend/' },
+        ],
+      },
+      {
+        eyebrow: 'Hand it to a guide',
+        items: [
+          { key: 'tours',     label: 'Operator tours',     href: '/tour/' },
+          { key: 'packages',  label: 'Multi-day packages', href: '/tour-packages/' },
+          { key: 'wine-day',  label: 'Wine-tour day',      href: '/tour/?type=wine' },
+          { key: 'springs',   label: 'Hot-springs day',    href: '/tour/?type=wellness' },
+          { key: 'golf-day',  label: 'Golf day',           href: '/golf/' },
+          { key: 'dolphin',   label: 'Dolphin swim day',   href: '/tour/?type=dolphin' },
+        ],
+      },
+      {
+        eyebrow: 'By the occasion',
+        items: [
+          { key: 'weddings',     label: 'Weddings',                  href: '/weddings/' },
+          { key: 'corporate',    label: 'Corporate offsites',        href: '/corporate-events/' },
+          { key: 'milestones',   label: 'Anniversaries & birthdays', href: '/escape/?occasion=milestone' },
+          { key: 'group',        label: 'Group of six+',             href: '/escape/?group=six-plus' },
+          { key: 'eoy',          label: 'End-of-year offsite',       href: '/corporate-events/?season=summer' },
+        ],
+      },
+    ],
+    askLine: 'Need the plan shaped around six adults on a Saturday? Ask PI →',
+  },
+
+  // 6. WHAT'S ON ------------------------------------------------------------
+  {
+    key: 'whats-on',
+    label: "What's On",
+    href: '/whats-on/',
+    intro: 'The events calendar with an opinion attached, kids-graded, weather-flagged, worth-the-drive labelled.',
+    topBanner: {
+      text: "This weekend's calendar",
+      ctaLabel: 'Read the dispatch →',
+      ctaHref: '/whats-on/',
+    },
+    rail: {
+      eyebrow: "Editor's pick this weekend",
+      title: "Mornington Farmers' Market",
+      verdict: "Saturday morning, Main Street. Get there before 9 or the Pinot vinegar from Quealy is gone. Park at the Pier.",
+      image: '/images/sourced/article-picnic-01.webp',
+      imageAlt: "Mornington Farmers' Market, Main Street",
+      href: '/whats-on/mornington-farmers-market/',
+      cta: 'See this week →',
+    },
+    columns: [
+      {
+        eyebrow: 'This weekend',
+        items: [
+          { key: 'pick-1', label: "Pick 1 (live)", href: '/whats-on/?lens=weekend-pick', live: true },
+          { key: 'pick-2', label: "Pick 2 (live)", href: '/whats-on/?lens=weekend-pick', live: true },
+          { key: 'pick-3', label: "Pick 3 (live)", href: '/whats-on/?lens=weekend-pick', live: true },
+          { key: 'all-weekend', label: 'All this weekend →', href: '/whats-on/?when=this-weekend' },
+        ],
+      },
+      {
+        eyebrow: 'Coming up',
+        items: [
+          { key: 'next-weekend', label: 'Next weekend',  href: '/whats-on/?when=next-weekend' },
+          { key: 'markets',      label: 'Markets',       href: '/whats-on/?category=market' },
+          { key: 'festivals',    label: 'Festivals',     href: '/whats-on/?category=festival' },
+          { key: 'long-weekend', label: 'Long weekends', href: '/whats-on/?when=long-weekend' },
+          { key: 'seasonal',     label: 'Seasonal events', href: '/whats-on/?recurrence=seasonal' },
+          { key: 'all-coming',   label: 'All upcoming →',  href: '/whats-on/' },
+        ],
+      },
+      {
+        eyebrow: 'By the mood',
+        items: [
+          { key: 'worth-drive',  label: 'Worth the drive',  href: '/whats-on/?lens=worth-the-drive' },
+          { key: 'weather',      label: 'Weather-proof',    href: '/whats-on/?weather=proof' },
+          { key: 'kids',         label: 'Kids welcome',     href: '/whats-on/?kids=easy' },
+          { key: 'after-dark',   label: 'After dark',       href: '/whats-on/?lens=after-dark' },
+          { key: 'long-lunch',   label: 'Long-lunch events', href: '/whats-on/?category=long-lunch' },
+          { key: 'all-mood',     label: 'All moods →',      href: '/whats-on/' },
+        ],
+      },
+    ],
+    askLine: 'Need a Saturday plan that punishes nobody? Ask PI →',
+  },
+
+  // 7. JOURNAL --------------------------------------------------------------
+  {
+    key: 'journal',
+    label: 'Journal',
+    href: '/journal/',
+    intro: 'Long reads, dispatches, and the Shortlist, every issue, every piece.',
+    rail: {
+      eyebrow: 'The cover · Vol 04',
+      title: 'On the quiet authority of a good autumn',
+      verdict: "The season the Peninsula stops performing. Vintage trucks finished, weekend crowds thinning, the producers finally with time.",
+      image: '/images/sourced/place-red-hill-01.webp',
+      imageAlt: 'Vine rows in late-season colour, Red Hill',
+      href: '/journal/',
+      cta: 'Read the cover →',
+    },
+    columns: [
+      {
+        eyebrow: 'By the format',
+        items: [
+          { key: 'cover',       label: 'The Cover',           href: '/journal/?format=cover' },
+          { key: 'long-read',   label: 'Long reads',          href: '/journal/?format=long-read' },
+          { key: 'shortlist',   label: 'The Shortlist',       href: '/journal/?format=shortlist' },
+          { key: 'dispatch',    label: 'Weekend dispatch',    href: '/journal/?format=weekend-picker' },
+          { key: 'editors-table', label: "Editor's Table",    href: '/journal/?format=editors-table' },
+          { key: 'cellar-disp', label: 'Cellar-door dispatch', href: '/journal/?format=cellar-door-dispatch' },
+        ],
+      },
+      {
+        eyebrow: 'By the read',
+        items: [
+          { key: 'all-journal', label: 'Every issue, every piece', href: '/journal/' },
+          { key: 'methodology', label: 'How we work',              href: '/methodology/' },
+          { key: 'about',       label: 'About PI',                 href: '/about/' },
+        ],
+      },
+    ],
+    askLine: 'Looking for a piece you read three issues ago? Ask PI →',
+  },
+];
+
+/** Utility surfaces in the masthead row, alongside the pillars. */
+export const v4Utility = {
+  search:    { key: 'search',    label: 'Search',                href: '/search/' },
+  ask:       { key: 'ask',       label: 'Ask PI',                href: '/ask/' },
+  subscribe: { key: 'subscribe', label: 'Get the dispatch',      href: '/newsletter/' },
+  account:   { key: 'account',   label: 'Sign in / Save trip',   href: '/account/' },
+  pass:      { key: 'pass',      label: 'The Pass',              href: '/preview-insider-plans/' },
+};
+
+/** ----------------------------------------------------------------------
+ *  FOOTER (V4 reorganisation, 7 pillars + niche surfaces)
+ * ---------------------------------------------------------------------- */
+
+export const v4FooterDepartments: V4NavItem[] = [
+  { key: 'eat',      label: 'Eat & Drink', href: '/eat/' },
+  { key: 'wine',     label: 'Wine',        href: '/wine/' },
+  { key: 'stay',     label: 'Stay',        href: '/stay/' },
+  { key: 'explore',  label: 'Explore',     href: '/explore/' },
+  { key: 'escape',   label: 'Plans',       href: '/escape/' },
+  { key: 'whats-on', label: "What's On",   href: '/whats-on/' },
+  { key: 'journal',  label: 'Journal',     href: '/journal/' },
+];
+
+export const v4FooterNiche: V4NavItem[] = [
+  { key: 'golf',             label: 'Golf',         href: '/golf/' },
+  { key: 'spa',              label: 'Spa',          href: '/spa/' },
+  { key: 'fishing',          label: 'Fishing',      href: '/fishing/' },
+  { key: 'boating',          label: 'Boating',      href: '/boating/' },
+  { key: 'dog-friendly',     label: 'Dog friendly', href: '/dog-friendly/' },
+  { key: 'weddings',         label: 'Weddings',     href: '/weddings/' },
+  { key: 'corporate-events', label: 'Corporate',    href: '/corporate-events/' },
+];
+
+export const v4FooterAbout: V4NavItem[] = [
+  { key: 'about',       label: 'About',           href: '/about/' },
+  { key: 'methodology', label: 'Methodology',     href: '/methodology/' },
+  { key: 'partners',    label: 'Partner with us', href: '/partners/' },
+  { key: 'pass',        label: 'The Pass',        href: '/preview-insider-plans/' },
+  { key: 'newsletter',  label: 'The Dispatch',    href: '/newsletter/' },
+  { key: 'contact',     label: 'Contact',         href: '/contact/' },
+  { key: 'privacy',     label: 'Privacy',         href: '/privacy/' },
+];

--- a/next/src/pages/v3/index.astro
+++ b/next/src/pages/v3/index.astro
@@ -1,0 +1,266 @@
+---
+/**
+ * V3 Homepage — staging only.
+ *
+ * The full V3 strategy in one route. Production / lives at /index.astro and
+ * is unaffected. This route is noindex (V3BaseLayout default) until you
+ * promote it.
+ *
+ * Block order, top to bottom:
+ *   1. Cinematic Cover (poster + silent loop, dual CTA: read / Ask PI)
+ *   2. Ask PI front-door (input + voice chips)
+ *   3. PillarGrid — shape the weekend (Stay / Explore / Plans / Tours)
+ *   4. WeekendHero — dispatch + 3 events
+ *   5. IntentGrid — 8 voice-led intents
+ *   6. Shortlist — five picks per issue
+ *   7. EditorsLetter — second cinematic moment
+ *   8. InsiderStripe — Pass commercial moment
+ *   9. LateralSurfaces — 3-up: Eat / Stay / Places
+ *  10. Newsletter — compact dispatch sign-up
+ *
+ * Data sources reuse the production content collections (articles, events,
+ * venues, places, experiences, itineraries) via the existing editorial lib.
+ */
+
+import { getCollection } from 'astro:content';
+import V3BaseLayout from '../../layouts/v3/V3BaseLayout.astro';
+import V3HomeCover from '../../components/v3/V3HomeCover.astro';
+import V3AskBlock from '../../components/v3/V3AskBlock.astro';
+import V3PillarGrid from '../../components/v3/V3PillarGrid.astro';
+import V3WeekendHero from '../../components/v3/V3WeekendHero.astro';
+import V3IntentGrid from '../../components/v3/V3IntentGrid.astro';
+import V3Shortlist from '../../components/v3/V3Shortlist.astro';
+import V3EditorsLetter from '../../components/v3/V3EditorsLetter.astro';
+import V3InsiderStripe from '../../components/v3/V3InsiderStripe.astro';
+import V3LateralSurfaces from '../../components/v3/V3LateralSurfaces.astro';
+import V3Newsletter from '../../components/v3/V3Newsletter.astro';
+
+import {
+  routeSlug,
+  isUpcoming,
+  currentSeason,
+  seasonBlurb,
+  dispatchWeekend,
+  formatLabel,
+} from '../../lib/editorial';
+
+// Pull the same collections the V2 home uses, so editorial parity is exact.
+const articles = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+const venues = await getCollection('venues');
+const places = await getCollection('places');
+
+// Weekend dispatch — newest weekend-picker article.
+const weekendDispatch = articles
+  .filter((a) => a.data.format === 'weekend-picker')
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime())[0];
+
+const dispatchWindow = weekendDispatch
+  ? dispatchWeekend(weekendDispatch.data.publishedAt)
+  : { start: new Date(0), end: new Date(0), sat: new Date(), sun: new Date(), label: 'this weekend' };
+
+// Three weekend events.
+const eventsAll = (await getCollection('events'))
+  .filter((e) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(e.data.recurrence)) return true;
+    return isUpcoming(e.data.endDate ?? e.data.startDate);
+  })
+  .sort((a, b) => a.data.startDate.getTime() - b.data.startDate.getTime());
+const weekendEvents = eventsAll
+  .filter((e) => {
+    if (!e.data.lens.includes('weekend-pick' as any)) return false;
+    const start = e.data.startDate;
+    if (start > dispatchWindow.end) return false;
+    const isRecurring = ['weekly', 'monthly', 'ongoing'].includes(e.data.recurrence as string);
+    if (isRecurring) return true;
+    const end = e.data.endDate ?? start;
+    return end >= dispatchWindow.start;
+  })
+  .slice(0, 3);
+
+// Featured cover article.
+const featured = articles.find((a) => a.data.featured && a.data.format !== 'weekend-picker')
+  ?? articles.find((a) => a.data.format !== 'weekend-picker')
+  ?? articles[0];
+
+// The Shortlist — same five picks as V2 home, reused via routeSlug match.
+const editorPicks = articles
+  .filter((a) => routeSlug(a) !== (featured ? routeSlug(featured) : ''))
+  .filter((a) => ['the-chardonnay-case', 'three-italian-dinners', 'the-peninsula-pantry', 'the-long-lunch', 'the-thermal-springs-weekend'].includes(routeSlug(a)))
+  .slice(0, 5);
+
+// Intent grid — 8 voice-led entries, mapped to existing journal slugs.
+const intentSpec: { label: string; slug: string; note: string; image?: string }[] = [
+  { label: 'Long lunch',    slug: 'the-long-lunch',                                note: 'Sunday, slow, one decisive table. The Peninsula’s strongest move.',     image: '/images/sourced/article-long-lunch-01.webp' },
+  { label: 'Rainy day',     slug: 'the-rainy-day-peninsula-without-a-booking',      note: 'Weather-proof and walk-in. No booking, no gamble.',                     image: '/images/sourced/article-rainy-day-01.webp' },
+  { label: 'With kids',     slug: 'the-peninsula-with-kids',                        note: 'A day that punishes no one. Graded, honest, tested.',                   image: '/images/sourced/article-kids-peninsula-01.webp' },
+  { label: 'One night',     slug: 'the-one-night-escape',                           note: '26 hours that feel like a long weekend.',                               image: '/images/sourced/article-couples-weekend-01.webp' },
+  { label: 'Cellar doors',  slug: 'the-cellar-door-short-list',                     note: 'Five producers worth the appointment and the drive.',                  image: '/images/sourced/article-cellar-door-01.webp' },
+  { label: 'Wellness',      slug: 'the-thermal-springs-weekend',                    note: 'Hot springs without wasting the rest of the weekend.',                 image: '/images/sourced/article-vineyard-villa-01.webp' },
+  { label: 'First visit',   slug: 'the-peninsula-orientation-drive',                note: 'Six stops, half a day, zero prior knowledge required.',                image: '/images/sourced/article-orientation-drive-01.webp' },
+  { label: 'Breakfast',     slug: 'breakfast-before-the-crowds',                    note: 'Where locals actually eat at 8 am, not the Instagram queue.',          image: '/images/sourced/article-picnic-01.webp' },
+];
+const intentItems = intentSpec
+  .map((spec) => {
+    const a = articles.find((x) => routeSlug(x) === spec.slug);
+    return a ? { href: `/journal/${spec.slug}/`, label: spec.label, note: spec.note, image: spec.image } : null;
+  })
+  .filter((x): x is NonNullable<typeof x> => x !== null);
+
+// Lateral surfaces — pick one anchor each for Eat / Stay / Places.
+function pickEntity<T extends { data: any }>(coll: T[], slug: string): T | undefined {
+  return coll.find((x: any) => (x.data.slug ?? x.id ?? '').replace(/\.md$/, '') === slug);
+}
+const eatAnchor   = pickEntity(venues as any, 'laura') ?? pickEntity(venues as any, 'ten-minutes-by-tractor') ?? venues.find((v) => ['restaurant'].includes(v.data.type));
+const stayAnchor  = pickEntity(venues as any, 'jackalope') ?? pickEntity(venues as any, 'hotel-sorrento') ?? venues.find((v) => ['hotel','villa','bnb'].includes(v.data.type));
+const placeAnchor = pickEntity(places as any, 'red-hill') ?? places[0];
+
+const lateralColumns = [
+  eatAnchor && {
+    eyebrow: "Editor's Table",
+    title: 'Where to <em>eat</em> right now',
+    href: '/eat/',
+    hrefLabel: 'See every table we cover',
+    card: {
+      href: `/eat/${routeSlug(eatAnchor)}/`,
+      image: (eatAnchor.data as any).image ?? `/images/sourced/category-${(eatAnchor.data as any).type}-01.webp`,
+      imageAlt: eatAnchor.data.name,
+      kind: (eatAnchor.data as any).type ? String((eatAnchor.data as any).type).replace(/^./, (c: string) => c.toUpperCase()) : 'Restaurant',
+      name: eatAnchor.data.name,
+      verdict: (eatAnchor.data as any).signature ?? '',
+      meta: [(eatAnchor.data as any).place ?? 'Peninsula', "Editor's pick"],
+    },
+  },
+  stayAnchor && {
+    eyebrow: 'Sleep here',
+    title: 'Where to <em>stay</em> this issue',
+    href: '/stay/',
+    hrefLabel: 'See every room we cover',
+    card: {
+      href: `/stay/${routeSlug(stayAnchor)}/`,
+      image: (stayAnchor.data as any).image ?? `/images/sourced/category-${(stayAnchor.data as any).type}-01.webp`,
+      imageAlt: stayAnchor.data.name,
+      kind: (stayAnchor.data as any).type ? String((stayAnchor.data as any).type).replace(/^./, (c: string) => c.toUpperCase()) : 'Hotel',
+      name: stayAnchor.data.name,
+      verdict: (stayAnchor.data as any).signature ?? '',
+      meta: [(stayAnchor.data as any).place ?? 'Peninsula', "Editor's pick"],
+    },
+  },
+  placeAnchor && {
+    eyebrow: 'Know the terrain',
+    title: 'Place by <em>place</em>',
+    href: '/places/',
+    hrefLabel: 'See all six towns',
+    card: {
+      href: `/places/${routeSlug(placeAnchor)}/`,
+      image: (placeAnchor.data as any).image ?? '/images/sourced/place-red-hill-01.webp',
+      imageAlt: placeAnchor.data.name,
+      kind: 'Town',
+      name: placeAnchor.data.name,
+      verdict: (placeAnchor.data as any).pitch ?? (placeAnchor.data as any).standfirst ?? '',
+      meta: [(placeAnchor.data as any).zone ?? 'Mornington Peninsula'],
+    },
+  },
+].filter((x): x is NonNullable<typeof x> => Boolean(x));
+
+const season = currentSeason();
+const seasonBlurbData = seasonBlurb[season];
+
+// Cover meta.
+const issueLabel = `Vol 04 · ${new Date().toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}`;
+---
+
+<V3BaseLayout
+  title="Peninsula Insider, V3 Staging Preview"
+  description="V3 homepage staging preview. The new Peninsula Insider experience, in dev."
+  section="home"
+>
+
+  <!-- 1. Cinematic Cover -->
+  {featured && (
+    <V3HomeCover
+      eyebrow={`The Cover Feature · ${issueLabel}`}
+      vineTag="AUTUMN 2026"
+      title={featured.data.title.replace(/\b(quiet|appointment|hidden|long|cellar)\b/i, (m) => `<em>${m}</em>`)}
+      meta={[
+        (formatLabel as any)[featured.data.format] ?? 'The Long Read',
+        featured.data.readingTimeMinutes ? `${featured.data.readingTimeMinutes} min` : null,
+        featured.data.houseByline ? 'The Editors' : (featured.data.author?.id ? String(featured.data.author.id) : 'The Editors'),
+      ].filter(Boolean).join(' · ')}
+      poster="/images/sourced/home-cover-bay-umbrella-01.webp"
+      posterAlt="A red umbrella on a calm Peninsula bay beach"
+      video="/videos/hero.mp4"
+      primaryHref={`/journal/${routeSlug(featured)}/`}
+      primaryLabel="Read the cover"
+      secondaryHref="/ask/"
+      secondaryLabel="Ask PI instead"
+    />
+  )}
+
+  <!-- 2. Ask PI block -->
+  <V3AskBlock />
+
+  <!-- 3. Pillar grid -->
+  <V3PillarGrid />
+
+  <!-- 4. Weekend hero -->
+  <V3WeekendHero
+    dispatch={weekendDispatch ? {
+      href: `/journal/${routeSlug(weekendDispatch)}/`,
+      date: dispatchWindow.label,
+      title: weekendDispatch.data.title.replace(/\b(this|weekend)\b/i, (m) => `<em>${m}</em>`),
+      lede: weekendDispatch.data.dek,
+      ctaLabel: 'Read the dispatch',
+    } : null}
+    events={weekendEvents.map((e) => ({
+      href: `/whats-on/${routeSlug(e)}/`,
+      date: e.data.startDate.toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short' }),
+      title: e.data.title,
+      venue: (e.data as any).venueName ?? (e.data as any).place ?? undefined,
+      flags: [
+        (e.data as any).worthTheDrive ? { label: 'Worth the drive', tone: 'vine' as const } : null,
+        (e.data as any).kidsGrade ? { label: `Kids: ${String((e.data as any).kidsGrade)}`, tone: 'ridge' as const } : null,
+        (e.data as any).weatherProof ? { label: 'Weather-proof', tone: 'default' as const } : null,
+      ].filter((x): x is NonNullable<typeof x> => Boolean(x)),
+    }))}
+  />
+
+  <!-- 5. Intent grid -->
+  {intentItems.length > 0 && <V3IntentGrid items={intentItems} />}
+
+  <!-- 6. Shortlist -->
+  {editorPicks.length > 0 && (
+    <V3Shortlist
+      items={editorPicks.map((a) => ({
+        href: `/journal/${routeSlug(a)}/`,
+        name: a.data.title,
+        meta: [(formatLabel as any)[a.data.format] ?? 'Editorial', a.data.readingTimeMinutes ? `${a.data.readingTimeMinutes} min` : null].filter(Boolean).join(' · '),
+        why: a.data.dek,
+      }))}
+    />
+  )}
+
+  <!-- 7. Editor's Letter -->
+  <V3EditorsLetter
+    title={`On the <em>quiet authority</em> of a good ${seasonBlurbData.label?.toLowerCase() ?? 'autumn'}.`}
+    paragraphs={[
+      `${seasonBlurbData.label ?? 'Autumn'} is the season the Peninsula stops performing. The weekend crowds thin, the vintage trucks finish their last runs, and the ridge takes on the colour it has for about six weeks a year. Most places you want to get into, you can actually get into. The light is good. The rooms are warm. The producers, finally, have time.`,
+      `We've rebuilt the cellar-door shortlist from scratch this season, visited every restaurant on the long-lunch list at least twice, and walked every beach on the ranking. The newsletter, <em>Peninsula This Weekend</em>, lands weekly with the current issue's picks tightened into a single page.`,
+      `If this is your first issue with us, welcome. If you're returning, thanks for the patience through the refit.`,
+    ]}
+    pullQuote="This issue is built for the six weeks where the Peninsula is at its most itself, before winter settles in and the coast goes quiet."
+    image="/images/sourced/place-red-hill-01.webp"
+    imageAlt="Vine rows in late-season colour, Red Hill"
+    imageCaption="The last weekend of vintage, Red Hill, <em>the quietest a working winery ever gets.</em>"
+  />
+
+  <!-- 8. Insider Stripe (Pass) -->
+  <V3InsiderStripe />
+
+  <!-- 9. Lateral surfaces -->
+  {lateralColumns.length > 0 && <V3LateralSurfaces columns={lateralColumns} />}
+
+  <!-- 10. Newsletter -->
+  <V3Newsletter />
+
+</V3BaseLayout>

--- a/next/src/pages/v4/eat/index.astro
+++ b/next/src/pages/v4/eat/index.astro
@@ -1,0 +1,366 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import GuideHero from '../../../components/GuideHero.astro';
+import AudiencePicker from '../../../components/AudiencePicker.astro';
+import CompareBlock from '../../../components/CompareBlock.astro';
+import SectionDivider from '../../../components/SectionDivider.astro';
+import VenueCard from '../../../components/VenueCard.astro';
+import ArticleCard from '../../../components/ArticleCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import EventStrip from '../../../components/EventStrip.astro';
+import { isUpcoming, routeSlug } from '../../../lib/editorial';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+const eatTypes = ['restaurant', 'cafe', 'bakery', 'pub', 'market', 'winery'];
+const venues = (await getCollection('venues'))
+  .filter((venue) => eatTypes.includes(venue.data.type))
+  .sort((a, b) => Number(b.data.authority?.hats ?? 0) - Number(a.data.authority?.hats ?? 0));
+
+const hattedCount = venues.filter((v) => Number(v.data.authority?.hats ?? 0) > 0).length;
+const twoHatCount = venues.filter((v) => Number(v.data.authority?.hats ?? 0) >= 2).length;
+const totalHats = venues.reduce((acc, v) => acc + Number(v.data.authority?.hats ?? 0), 0);
+
+const editorPickSlugs = ['tedesca-osteria', 'barragunda-dining', 'laura-pt-leo'];
+const editorPicks = editorPickSlugs
+  .map((slug) => venues.find((venue) => routeSlug(venue) === slug))
+  .filter((venue): venue is NonNullable<typeof venue> => Boolean(venue));
+
+const longLunchSlugs = ['montalto', 'polperro', 'pt-leo-estate', 'ten-minutes-by-tractor'];
+const longLunches = longLunchSlugs
+  .map((slug) => venues.find((venue) => routeSlug(venue) === slug))
+  .filter((venue): venue is NonNullable<typeof venue> => Boolean(venue));
+
+const casualStops = venues.filter((venue) => ['cafe', 'bakery'].includes(venue.data.type)).slice(0, 6);
+
+// Food + wine events coming up — surfaces from /whats-on/ on the section hub.
+const eatEventCategories = ['food-wine', 'cellar-door', 'market'];
+const eatEvents = (await getCollection('events'))
+  .filter((event) => eatEventCategories.includes(event.data.category))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
+
+const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+const featuredGuideSlugs = [
+  'where-to-eat-mornington-peninsula',
+  'waterfront-restaurants-mornington-peninsula',
+  'hatted-restaurants-mornington-peninsula-2025',
+];
+const featuredGuides = featuredGuideSlugs
+  .map((slug) => articlesAll.find((a) => routeSlug(a) === slug))
+  .filter((a): a is NonNullable<typeof a> => Boolean(a));
+
+const hubs = [
+  { href: '/eat/best-restaurants/',     label: 'Best Restaurants',     sub: 'Ranked by authority' },
+  { href: '/eat/hatted-restaurants/',   label: 'Hatted Restaurants',   sub: '4 two-hat · 7 one-hat' },
+  { href: '/eat/long-lunch/',           label: 'Long Lunch',           sub: 'Two-to-three hour tables' },
+  { href: '/eat/cellar-door-lunch/',    label: 'Cellar Door Lunch',    sub: 'Estate wine, estate produce' },
+  { href: '/eat/fine-dining/',          label: 'Fine Dining',          sub: 'Destination dining rooms' },
+  { href: '/eat/waterfront/',           label: 'Waterfront Dining',    sub: 'Bay-facing positions' },
+  { href: '/eat/seafood/',              label: 'Seafood',              sub: 'Waterfront fish, hatted seafood' },
+  { href: '/eat/brunch/',               label: 'Best Brunch',          sub: 'Coffee rooms worth the drive' },
+  { href: '/eat/cafes/',                label: 'Best Cafes',           sub: 'Village stops · roasters' },
+  { href: '/eat/bakeries/',             label: 'Best Bakeries',        sub: '6 bakeries across the Peninsula' },
+  { href: '/eat/dog-friendly/',         label: 'Dog-Friendly',         sub: 'Confirmed outdoor options' },
+  { href: '/eat/family-friendly/',      label: 'Family-Friendly',      sub: 'Relaxed formats for kids' },
+  { href: '/eat/date-night/',           label: 'Date Night',           sub: 'Intimate rooms worth booking' },
+  { href: '/eat/pubs/',                 label: 'Best Pubs',            sub: 'Bay views and village locals' },
+  { href: '/eat/paddock-to-plate/',     label: 'Paddock to Plate',     sub: 'Farm kitchens, produce trails' },
+  { href: '/eat/markets/',              label: 'Markets',              sub: 'Red Hill · Mornington · Balnarring' },
+];
+
+// ── Schemas ───────────────────────────────────────────────────────────────────
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Eat & Drink' },
+];
+
+const pillarSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Where to Eat on the Mornington Peninsula',
+  description: 'The best restaurants, long lunches, cellar door dining, cafes, bakeries, and waterfront dining on the Mornington Peninsula, an editorial guide, not a directory.',
+  url: 'https://peninsulainsider.com.au/eat/',
+  breadcrumb: {
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://peninsulainsider.com.au/' },
+      { '@type': 'ListItem', position: 2, name: 'Eat & Drink', item: 'https://peninsulainsider.com.au/eat/' },
+    ],
+  },
+};
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: 'What are the best restaurants on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The Good Food Guide awarded 15 hats across 11 Peninsula venues. The four two-hat restaurants, Barragunda Dining, Laura at Pt. Leo Estate, Tedesca Osteria, and Ten Minutes by Tractor, are the clearest destination dining choices.' } },
+    { '@type': 'Question', name: 'Do I need to book restaurants on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Most serious restaurants require bookings, especially on weekends. Hatted venues can book out weeks or months in advance. Walk-in options exist: Montalto Piazza (daily), Foxeys Hangout (no bookings taken), Rare Hare at Willow Creek (walk-in from 2pm weekends), and most cafes and bakeries.' } },
+    { '@type': 'Question', name: 'What is the best area for food on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The Red Hill plateau, including Main Ridge and Red Hill South, has the highest concentration of serious dining. Mornington town has the strongest casual eating scene. Sorrento and Portsea have the best waterfront and atmosphere-first dining. For wine-paired long lunches, stick to the ridge.' } },
+    { '@type': 'Question', name: 'When is the best time to visit the Mornington Peninsula for food?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Autumn (March to May) is the peak dining season, vintage is running on the ridge, fires are lit in cellar door dining rooms, and the summer crowds have thinned enough that the best tables are actually bookable. Spring is a close second.' } },
+    { '@type': 'Question', name: 'Are there dog-friendly restaurants on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yes, outdoor seating options at cafes, village pub beer gardens, and a small number of winery casual dining areas permit dogs. Commonfolk Coffee (back courtyard), The Rocks Mornington (outdoor deck), Portsea Hotel (beer garden), and Green Olive at Red Hill (garden) are confirmed dog-friendly as of April 2026. Verify directly before visiting.' } },
+    { '@type': 'Question', name: 'What is the signature food experience on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The long lunch, a two-to-three-hour table at a vineyard restaurant with estate wine and unhurried service. The Peninsula does this better than almost anywhere else in Victoria. Montalto, Laura, Polperro, and Ten Minutes by Tractor are the definitive versions of the format.' } },
+  ],
+};
+---
+
+<V4BaseLayout
+  title="Where to Eat on the Mornington Peninsula · Peninsula Insider"
+  description="The best restaurants, long lunches, cellar door dining, cafes, and bakeries on the Mornington Peninsula, editorial picks, not a directory. Updated April 2026."
+  section="eat"
+  modifiedTime="2026-04-30"
+  ogImage="/images/sourced/venue-italian-dining-01.webp"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(pillarSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1. CINEMATIC HERO
+       ═══════════════════════════════════════════════════════════════ -->
+  <GuideHero
+    eyebrow={`Eat & Drink · ${venues.length} venues mapped · Last verified 30 Apr 2026`}
+    title="The dining rooms that justify the <em>drive</em>"
+    dek="The Peninsula has more serious cellar door restaurants, more hatted venues, and more long-lunch tables than any region within ninety minutes of Melbourne. This is the editorial guide, not the directory."
+    meta={[
+      { label: `${twoHatCount} two-hat restaurants` },
+      { label: `${totalHats} GFG hats total` },
+      { label: `${hattedCount} hatted venues` },
+      { label: '10 min read' },
+    ]}
+    heroImage="/images/sourced/venue-italian-dining-01.webp"
+    imageAlt="An Italian-leaning Peninsula dining room, table laid, light low"
+    imageCredit="Peninsula Insider"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1.5 AUDIENCE PICKER: persona-led entry to the section
+       ═══════════════════════════════════════════════════════════════ -->
+  <AudiencePicker section="eat" />
+
+  <EventStrip
+    events={eatEvents}
+    eyebrow="Food and wine events coming up"
+    heading="Cellar door weekends and food events worth pencilling in"
+    intro="Pulled from the events registry. Tap an event for editorial notes, or see the full calendar for everything coming up."
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       2. ORIENTATION: Red Hill plateau vs Bay corridor
+       ═══════════════════════════════════════════════════════════════ -->
+  <CompareBlock
+    eyebrow="Two dining cultures, one Peninsula"
+    heading="Red Hill plateau or the Bay corridor"
+    dek="The Peninsula's food scene splits cleanly along geography. Knowing which side you're eating on decides the rest of the day."
+    left={{
+      label: 'Red Hill plateau',
+      title: 'Long lunch country. Estate wine, fires, three-hour tables.',
+      rows: [
+        { label: 'Flagship rooms', value: 'Tedesca Osteria, Laura at Pt. Leo, Ten Minutes by Tractor, Barragunda, Montalto, Polperro, Foxeys Hangout' },
+        { label: 'Format', value: 'Vineyard kitchens with estate wine, kitchen-garden produce, and service built for unhurried multi-hour sittings.' },
+        { label: 'Best for', value: 'Long lunch, special occasions, wine-paired meals, the slow afternoon you came for.' },
+        { label: 'Booking', value: 'Hatted rooms book 4–8 weeks ahead for weekends. Walk-in is rare. Plan first, drive after.' },
+        { label: 'Pair with', value: 'A cellar-door tasting before the table; an Arthurs Seat lookout or Red Hill walk after.' },
+      ],
+    }}
+    right={{
+      label: 'Bay corridor, Mornington to Portsea',
+      title: 'Casual eating, waterfront positions, walk-in possible.',
+      rows: [
+        { label: 'Standout venues', value: 'Commonfolk, The Rocks Mornington, Hotel Sorrento, Portsea Hotel, Mornington and Sorrento bakeries, the village cafes between' },
+        { label: 'Format', value: 'Cafes, bakeries, pubs, waterfront seafood. Day-to-day eating that does not demand a four-hour commitment.' },
+        { label: 'Best for', value: 'Brunch, families, walk-in flexibility, drinks with a view, the meal between activities.' },
+        { label: 'Booking', value: 'Most casual venues take walk-ins. Pub lunches book a day or two ahead. Sorrento Front Beach restaurants book up in summer.' },
+        { label: 'Pair with', value: 'A bay-side beach walk; a Mornington Peninsula winery drive afterwards.' },
+      ],
+    }}
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       3. EDITOR'S PICKS, The hatted tier
+       ═══════════════════════════════════════════════════════════════ -->
+  {editorPicks.length > 0 && (
+    <section class="venues" id="picks">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">The hatted tier</p>
+            <h2 class="venues__title">Three rooms doing the heaviest lifting</h2>
+            <p class="venues__sub venues__sub--standfirst">If lunch is the event and you only have one booking, start with one of these three. Each is a two-hat venue; each is a different argument for what fine dining on the Peninsula should feel like.</p>
+          </div>
+          <a href="/eat/hatted-restaurants/" class="venues__link">All hatted venues →</a>
+        </div>
+        <div class="venues__grid">
+          {editorPicks.map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4. LONG LUNCH SHORTLIST
+       ═══════════════════════════════════════════════════════════════ -->
+  {longLunches.length > 0 && (
+    <section class="venues venues--plain" id="long-lunch">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Long lunch shortlist</p>
+            <h2 class="venues__title">The tables that carry the whole afternoon</h2>
+            <p class="venues__sub venues__sub--standfirst">Below the hatted tier, the rooms that earn three hours without a Good Food Guide rosette. Estate wine, kitchen-garden produce, and service that knows when to leave you alone.</p>
+          </div>
+          <a href="/eat/long-lunch/" class="venues__link">Full long lunch list →</a>
+        </div>
+        <div class="venues__grid">
+          {longLunches.map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       5. HUB NAVIGATION, find what you're looking for
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-formats" aria-label="Eat and drink categories">
+    <div class="container">
+      <div class="hub-formats__intro">
+        <p class="label label--accent">Or jump to a format</p>
+        <h2 class="hub-formats__title">Find the right table for the day</h2>
+        <p class="hub-formats__dek">Sixteen ways to slice the Peninsula's eating. Each lane is a curated list with editorial notes, not a directory dump.</p>
+      </div>
+      <ul class="hub-formats__grid">
+        {hubs.map((hub) => (
+          <li class="hub-formats__cell">
+            <a href={hub.href} class="hub-formats__link">
+              <span class="hub-formats__label">{hub.label}</span>
+              <span class="hub-formats__sub">{hub.sub}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6. CASUAL STOPS, cafes & bakeries
+       ═══════════════════════════════════════════════════════════════ -->
+  {casualStops.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Before and after the booking</p>
+            <h2 class="venues__title">Coffee rooms and bakeries that keep the day inhabited</h2>
+            <p class="venues__sub">Not the destination lunch, the village stops that make a Peninsula day feel local.</p>
+          </div>
+          <a href="/eat/cafes/" class="venues__link">All cafes →</a>
+        </div>
+        <div class="venues__grid">
+          {casualStops.map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       7. EDITORIAL GUIDES
+       ═══════════════════════════════════════════════════════════════ -->
+  {featuredGuides.length > 0 && (
+    <section class="venues" id="guides">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Editorial guides</p>
+            <h2 class="venues__title">Read before you book</h2>
+            <p class="venues__sub">Service pieces that give you the context to make a better dining decision on the Peninsula.</p>
+          </div>
+          <a href="/journal/" class="venues__link">All in the Journal →</a>
+        </div>
+        <div class="venues__grid">
+          {featuredGuides.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       8. FULL DIRECTORY
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="venues" id="all">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Complete dining directory</p>
+          <h2 class="venues__title">All {venues.length} eat-and-drink venues, by authority</h2>
+          <p class="venues__sub">Ordered by editorial weight, hatted rooms first, then the places doing quiet, serious work below them.</p>
+        </div>
+        <a href="/eat/best-restaurants/" class="venues__link">Ranked top 15 →</a>
+      </div>
+      <div class="venues__grid">
+        {venues.slice(0, 24).map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       9. FAQ
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-faq" aria-label="Frequently asked questions">
+    <div class="container">
+      <div class="hub-faq__intro">
+        <p class="label label--accent">Frequently asked</p>
+        <h2 class="hub-faq__title">Six honest answers before you plan the day</h2>
+      </div>
+      <div class="hub-faq__list">
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">What are the best restaurants on the Peninsula?</summary>
+          <div class="hub-faq__a"><p>The Good Food Guide awarded 15 hats across 11 venues. The four two-hat restaurants, Barragunda Dining, Laura at Pt. Leo, Tedesca Osteria, and Ten Minutes by Tractor, are the clearest destination dining choices. For long lunch without the hatted commitment: Montalto, Polperro, and Paringa Estate.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Do I need to book?</summary>
+          <div class="hub-faq__a"><p>Most serious restaurants require bookings, especially on weekends. Hatted venues book weeks or months ahead. Walk-in options: Montalto Piazza (daily), Foxeys Hangout (no bookings taken), Rare Hare at Willow Creek (from 2pm weekends), and most cafes and bakeries.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">What is the best area for food?</summary>
+          <div class="hub-faq__a"><p>The Red Hill plateau has the highest concentration of serious dining. Mornington has the strongest casual eating scene. For wine-paired long lunches, stay on the ridge, Main Ridge and Red Hill South are where the best rooms are.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">When is the best time to visit for food?</summary>
+          <div class="hub-faq__a"><p>Autumn (March–May), vintage running, summer crowds thinned, best tables actually bookable. Spring is a close second. Winter cellar door lunches with fires are underrated.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Are there dog-friendly dining options?</summary>
+          <div class="hub-faq__a"><p>Yes, outdoor seating at cafes, village pub beer gardens, and a small number of winery casual areas. Commonfolk (back courtyard), Portsea Hotel (beer garden), The Rocks Mornington (outdoor deck), and Green Olive at Red Hill (garden) are confirmed as of April 2026. Verify before visiting.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">What is the Peninsula's signature food experience?</summary>
+          <div class="hub-faq__a"><p>The long lunch. A two-to-three-hour table at a vineyard restaurant with estate wine and unhurried service. The Peninsula does this better than almost anywhere else in Victoria. Montalto, Laura, Polperro, and Ten Minutes by Tractor are the definitive versions.</p></div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</V4BaseLayout>
+

--- a/next/src/pages/v4/escape/index.astro
+++ b/next/src/pages/v4/escape/index.astro
@@ -1,0 +1,352 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import GuideHero from '../../../components/GuideHero.astro';
+import CompareBlock from '../../../components/CompareBlock.astro';
+import SectionDivider from '../../../components/SectionDivider.astro';
+import ItineraryCard from '../../../components/ItineraryCard.astro';
+import VenueCard from '../../../components/VenueCard.astro';
+import ArticleCard from '../../../components/ArticleCard.astro';
+import PlaceCard from '../../../components/PlaceCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import { routeSlug, stayTypes } from '../../../lib/editorial';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+const itineraries = (await getCollection('itineraries')).sort(
+  (a, b) => b.data.lengthNights - a.data.lengthNights,
+);
+const allVenues = await getCollection('venues');
+const stays = allVenues.filter((venue) => stayTypes.includes(venue.data.type));
+const places = await getCollection('places');
+const stayHighlights = stays.filter((venue) =>
+  ['jackalope', 'hotel-sorrento', 'flinders-hotel'].includes(routeSlug(venue)),
+);
+const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+const companionSlugs = [
+  'the-sorrento-weekend',
+  'a-winter-peninsula-weekend',
+  'the-birthday-weekend',
+  'where-to-stay-for-a-two-night-escape',
+  'the-vineyard-villa-weekend',
+  'the-thermal-springs-weekend',
+  'a-flinders-weekend',
+];
+const companionReads = companionSlugs
+  .map((slug) => articlesAll.find((a) => routeSlug(a) === slug))
+  .filter((a): a is NonNullable<typeof a> => Boolean(a))
+  .slice(0, 4);
+
+const placeHighlights = places.filter((place) =>
+  ['red-hill', 'cape-schanck', 'sorrento'].includes(routeSlug(place)),
+);
+
+const oneNight = itineraries.filter((it) => it.data.lengthNights <= 1);
+const twoNight = itineraries.filter((it) => it.data.lengthNights === 2);
+const longer = itineraries.filter((it) => it.data.lengthNights >= 3);
+
+const moodGuides = [
+  { label: 'Food & wine',           slug: 'how-to-build-a-red-hill-saturday', sub: 'Lunch, cellar doors, slow drive back' },
+  { label: 'Wellness',              slug: 'the-thermal-springs-weekend',      sub: 'Springs, sauna, one soft dinner' },
+  { label: 'Slow coast',            slug: 'a-flinders-weekend',               sub: 'Flinders, the pier, Bass Strait air' },
+  { label: 'Tip of the peninsula',  slug: 'the-sorrento-weekend',             sub: 'Village base, fort walk, back beach' },
+  { label: 'Celebration',           slug: 'the-birthday-weekend',             sub: 'One anchor dinner, the rest softer' },
+  { label: 'Winter reset',          slug: 'a-winter-peninsula-weekend',       sub: 'Fireplace, hot springs, low-season calm' },
+  { label: 'Quick reset',           slug: 'the-one-night-escape',             sub: '26 hours that feels like three days' },
+  { label: 'With kids',             slug: 'the-peninsula-with-kids',          sub: 'A day that punishes no one' },
+];
+const moodResolved = moodGuides
+  .map((mood) => {
+    const article = articlesAll.find((a) => routeSlug(a) === mood.slug);
+    return article ? { ...mood, article } : null;
+  })
+  .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Plans' },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org', '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: 'How many nights do I need on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Two nights is the Peninsula\'s native rhythm, long enough to slow down, short enough to commit. One night works for a focused escape (Friday evening to Sunday afternoon). Three nights or more turns the trip into something genuinely restorative; the back-beaches and quieter walks reward longer stays.' } },
+    { '@type': 'Question', name: 'Can the Mornington Peninsula be done as a day trip from Melbourne?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yes, but you must choose a single anchor, a long lunch, a hot springs session, or a coastal walk. Trying to fit all three into a day is how good weekends become traffic stories. The drive is 60–90 minutes each way; account for that in your sequence.' } },
+    { '@type': 'Question', name: 'When is the best time to plan a Peninsula escape?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Autumn (March–May) is the strongest season, vintage running on the ridge, summer crowds gone, weekends actually bookable. Spring is a close second. Winter weekends are underrated; cellar doors with fires lit, hot springs steaming, and almost no queue. Summer is the busiest and hardest to book well.' } },
+    { '@type': 'Question', name: 'How much does a Peninsula weekend cost?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A two-night weekend with a mid-range stay, two cellar door visits, and one serious lunch typically runs $800–1,400 per couple including accommodation. Luxury vineyard weekends with a hatted dinner run $1,800+. Budget weekends with self-contained accommodation and walk-in eating start around $500.' } },
+  ],
+};
+---
+
+<V4BaseLayout
+  title="Mornington Peninsula Itineraries · Peninsula Insider"
+  description="Editorial itineraries and weekend plans for doing the Mornington Peninsula slowly and well, one-night quick escapes, two-night sweet-spot weekends, and longer reset trips."
+  section="escape"
+  modifiedTime="2026-04-30"
+  ogImage="/images/sourced/article-sunset-01.webp"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1. CINEMATIC HERO
+       ═══════════════════════════════════════════════════════════════ -->
+  <GuideHero
+    eyebrow={`Plans · ${itineraries.length} weekend itineraries · Last verified 30 Apr 2026`}
+    title="Good Peninsula weekends are built in the <em>sequence</em>"
+    dek="The region is small enough to overdo and varied enough to get wrong. These escape plans are our answer, fewer bookings, better pacing, and just enough structure that the whole thing feels inevitable rather than overplanned."
+    meta={[
+      { label: `${twoNight.length} two-night escapes` },
+      { label: `${oneNight.length} one-night quick resets` },
+      { label: `${longer.length} longer trips` },
+      { label: '7 min read' },
+    ]}
+    heroImage="/images/sourced/article-sunset-01.webp"
+    imageAlt="Golden hour on the Mornington Peninsula, the moment a weekend earns the drive"
+    imageCredit="Peninsula Insider"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       2. ORIENTATION: One night vs Two nights
+       ═══════════════════════════════════════════════════════════════ -->
+  <CompareBlock
+    eyebrow="The decision that shapes everything"
+    heading="One night or two, they are not the same trip"
+    dek="The Peninsula reads completely differently across these two windows. Get the length right and the rest of the planning is easy."
+    left={{
+      label: 'One night · quick reset',
+      title: 'A focused escape. Pick one anchor and let the rest go.',
+      rows: [
+        { label: 'Format', value: 'Drive down Friday evening, one ambitious meal, one walk on Saturday, drive home Sunday afternoon. 26 hours that earns three days of feeling.' },
+        { label: 'Best for', value: 'Couples without long weekends, friends from Melbourne, anyone with limited time who wants the Peninsula to actually land.' },
+        { label: 'Best base', value: 'Mornington or Sorrento, central, walkable, no extra driving once you arrive.' },
+        { label: 'Trade-offs', value: 'No second region. Either you do the ridge or you do the coast, not both. Choose before you book.' },
+        { label: 'Pair with', value: 'A pre-booked hatted dinner Friday night and a Saturday morning walk before brunch.' },
+      ],
+    }}
+    right={{
+      label: 'Two nights · the sweet spot',
+      title: 'The Peninsula\'s native rhythm. Long enough to soften.',
+      rows: [
+        { label: 'Format', value: 'Friday arrival, full Saturday on the ridge, full Sunday on the coast (or vice versa), Monday-morning drive home. The trip stops performing and starts settling.' },
+        { label: 'Best for', value: 'Two-region trips, wine plus walks, ridge plus tip, hot springs plus a beach. Restorative weekends that need a real second day.' },
+        { label: 'Best base', value: 'Red Hill if the food is the centre. Sorrento or Flinders if the coast is the centre. Pick one and commit.' },
+        { label: 'Trade-offs', value: 'More planning, more booking. Hatted rooms and best stays book 4–8 weeks ahead.' },
+        { label: 'Pair with', value: 'A long Saturday lunch on the ridge, hot springs Sunday morning, a coastal walk before the drive home.' },
+      ],
+    }}
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       3. TWO-NIGHT ESCAPES, the sweet spot
+       ═══════════════════════════════════════════════════════════════ -->
+  {twoNight.length > 0 && (
+    <section class="experience-index" aria-label="Two-night escapes">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Two-night escapes</p>
+            <h2 class="venues__title">The sweet spot, long enough to slow down, short enough to commit</h2>
+            <p class="venues__sub venues__sub--standfirst">One lunch that earns the drive, one walk that resets the weekend, one bed that suits the mood. The Peninsula's native shape.</p>
+          </div>
+        </div>
+        <div class="itinerary-grid">
+          {twoNight.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4. ONE-NIGHT QUICK RESETS
+       ═══════════════════════════════════════════════════════════════ -->
+  {oneNight.length > 0 && (
+    <section class="experience-index experience-index--plain" aria-label="One-night escapes">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">One-night quick</p>
+            <h2 class="venues__title">When the weekend is tight but the Peninsula still earns it</h2>
+            <p class="venues__sub venues__sub--standfirst">Designed to feel three times longer than the drive down. Pick one anchor, the meal, the walk, or the soak, and let the rest find its level.</p>
+          </div>
+        </div>
+        <div class="itinerary-grid">
+          {oneNight.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       5. THREE NIGHTS AND BEYOND
+       ═══════════════════════════════════════════════════════════════ -->
+  {longer.length > 0 && (
+    <section class="experience-index" aria-label="Longer escapes">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Three nights and beyond</p>
+            <h2 class="venues__title">For the weekend that refuses to end</h2>
+            <p class="venues__sub">The longer escapes are where the Peninsula stops performing and starts settling into something quieter.</p>
+          </div>
+        </div>
+        <div class="itinerary-grid">
+          {longer.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6. ESCAPE BY MOOD, hub-formats lane
+       ═══════════════════════════════════════════════════════════════ -->
+  {moodResolved.length > 0 && (
+    <section class="hub-formats" aria-label="Plans by mood">
+      <div class="container">
+        <div class="hub-formats__intro">
+          <p class="label label--accent">Or jump in by mood</p>
+          <h2 class="hub-formats__title">Pick the feeling first, let the sequence follow</h2>
+          <p class="hub-formats__dek">Eight ways to enter a Peninsula weekend. Each lane opens a service piece or stay-note that maps the trip the way we'd actually book it.</p>
+        </div>
+        <ul class="hub-formats__grid">
+          {moodResolved.map((mood) => (
+            <li class="hub-formats__cell">
+              <a href={`/journal/${mood.slug}`} class="hub-formats__link">
+                <span class="hub-formats__label">{mood.label}</span>
+                <span class="hub-formats__sub">{mood.sub}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       7. THREE PLANNING RULES, editorial voice moment
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="plan-grid">
+    <div class="container">
+      <div class="plan-grid__inner">
+        <article class="plan-note">
+          <p class="plan-note__label">Rule one</p>
+          <h3>Pick one geography per day</h3>
+          <p>Red Hill, Sorrento, Flinders, and Cape Schanck all ask for different tempos. Stringing them together without thought is how good weekends turn into traffic.</p>
+        </article>
+        <article class="plan-note">
+          <p class="plan-note__label">Rule two</p>
+          <h3>Let lunch or dinner be the event, not both</h3>
+          <p>The Peninsula's strongest move is still daylight dining. If lunch is the headline, keep dinner softer. If dinner matters, keep the afternoon light.</p>
+        </article>
+        <article class="plan-note">
+          <p class="plan-note__label">Rule three</p>
+          <h3>Always leave room for weather</h3>
+          <p>The region gets more interesting when the wind shifts, the sky changes, or dusk suddenly looks too good to waste indoors.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       8. STAY HIGHLIGHTS
+       ═══════════════════════════════════════════════════════════════ -->
+  {stayHighlights.length > 0 && (
+    <section class="venues">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Choose the base first</p>
+            <h2 class="venues__title">Three stays that change the whole plan</h2>
+            <p class="venues__sub">A Peninsula itinerary improves dramatically when the bed matches the landscape you want most.</p>
+          </div>
+          <a href="/stay/" class="venues__link">All stays →</a>
+        </div>
+        <div class="venues__grid">
+          {stayHighlights.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       9. PLACES, sequence by geography
+       ═══════════════════════════════════════════════════════════════ -->
+  {placeHighlights.length > 0 && (
+    <section class="places">
+      <div class="container">
+        <div class="places__header">
+          <p class="label label--accent places__label">Sequence by geography</p>
+          <h2 class="places__title">The best escapes move through the Peninsula in a clean line</h2>
+          <p class="places__sub">Ridge for the lunch, coast for the light, tip for the walk and the bed.</p>
+        </div>
+        <div class="places__grid">
+          {placeHighlights.map((place, index) => (
+            <PlaceCard place={place} variant={index === 1 ? 'sand' : index === 2 ? 'bay' : 'vineyard'} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       10. EDITORIAL GUIDES
+       ═══════════════════════════════════════════════════════════════ -->
+  {companionReads.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Read before you book</p>
+            <h2 class="venues__title">Journal pieces that sharpen the trip</h2>
+            <p class="venues__sub">Service pieces and stay-notes that turn a list of bookings into a proper weekend.</p>
+          </div>
+          <a href="/journal/" class="venues__link">More from the Journal →</a>
+        </div>
+        <div class="venues__grid">
+          {companionReads.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       11. FAQ
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-faq" aria-label="Frequently asked questions">
+    <div class="container">
+      <div class="hub-faq__intro">
+        <p class="label label--accent">Frequently asked</p>
+        <h2 class="hub-faq__title">Four honest answers before you plan the weekend</h2>
+      </div>
+      <div class="hub-faq__list">
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">How many nights do I need on the Peninsula?</summary>
+          <div class="hub-faq__a"><p>Two nights is the Peninsula's native rhythm, long enough to slow down, short enough to commit. One night works for a focused escape (Friday evening to Sunday afternoon). Three nights or more turns the trip into something genuinely restorative; the back-beaches and quieter walks reward longer stays.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Can the Peninsula be done as a day trip from Melbourne?</summary>
+          <div class="hub-faq__a"><p>Yes, but you must choose a single anchor, a long lunch, a hot springs session, or a coastal walk. Trying to fit all three into a day is how good weekends become traffic stories. The drive is 60–90 minutes each way; account for that in your sequence.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">When is the best time to plan an escape?</summary>
+          <div class="hub-faq__a"><p>Autumn (March–May) is the strongest season, vintage running on the ridge, summer crowds gone, weekends actually bookable. Spring is a close second. Winter weekends are underrated; cellar doors with fires lit, hot springs steaming, and almost no queue. Summer is the busiest and hardest to book well.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">How much does a Peninsula weekend cost?</summary>
+          <div class="hub-faq__a"><p>A two-night weekend with a mid-range stay, two cellar door visits, and one serious lunch typically runs $800–1,400 per couple including accommodation. Luxury vineyard weekends with a hatted dinner run $1,800+. Budget weekends with self-contained accommodation and walk-in eating start around $500.</p></div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</V4BaseLayout>

--- a/next/src/pages/v4/explore/index.astro
+++ b/next/src/pages/v4/explore/index.astro
@@ -1,0 +1,483 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import GuideHero from '../../../components/GuideHero.astro';
+import CompareBlock from '../../../components/CompareBlock.astro';
+import SectionDivider from '../../../components/SectionDivider.astro';
+import ExperienceCard from '../../../components/ExperienceCard.astro';
+import PlaceCard from '../../../components/PlaceCard.astro';
+import ItineraryCard from '../../../components/ItineraryCard.astro';
+import ArticleCard from '../../../components/ArticleCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import EventStrip from '../../../components/EventStrip.astro';
+import { routeSlug, currentSeason, seasonBlurb, experienceInSeason, isUpcoming } from '../../../lib/editorial';
+import { buildCollectionPageSchema, buildFaqSchema, buildBreadcrumbSchema } from '../../../lib/schema';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+const experiences = (await getCollection('experiences')).sort((a, b) => a.data.name.localeCompare(b.data.name));
+
+// Family + arts + nature events surfacing from /whats-on/.
+const exploreEventCategories = ['nature', 'family-programs', 'arts', 'exhibition', 'community', 'wellness'];
+const exploreEvents = (await getCollection('events'))
+  .filter((event) => exploreEventCategories.includes(event.data.category))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
+const places = await getCollection('places');
+const itinerariesAll = await getCollection('itineraries');
+const itinerarySlugs = ['flinders-and-cape-reset', 'ridge-to-sea-two-night-escape', 'sorrento-off-season-weekend'];
+const itineraries = itinerarySlugs
+  .map((slug) => itinerariesAll.find((i) => routeSlug(i) === slug))
+  .filter((i): i is NonNullable<typeof i> => Boolean(i));
+const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+const season = currentSeason();
+const blurb = seasonBlurb[season];
+
+const featured = experiences.find((e) => routeSlug(e) === 'bushrangers-bay-walk') ?? experiences[0];
+
+const walks = experiences.filter((e) => e.data.type === 'walk');
+const beaches = experiences.filter((e) => e.data.type === 'beach');
+const lookouts = experiences.filter((e) => e.data.type === 'lookout');
+const markets = experiences.filter((e) => e.data.type === 'market');
+const wellness = experiences.filter((e) => e.data.type === 'wellness');
+const galleriesAttractions = experiences.filter((e) => ['gallery', 'attraction', 'park', 'tour'].includes(e.data.type));
+
+const shortWalks = walks.filter((e) => (e.data.durationMinutes ?? 999) <= 60).slice(0, 4);
+const longWalks = walks.filter((e) => (e.data.durationMinutes ?? 0) > 60).slice(0, 6);
+const seasonal = experiences.filter((e) => experienceInSeason(e, season)).slice(0, 8);
+
+const featuredPlaces = places.filter((p) => ['cape-schanck', 'point-nepean', 'sorrento', 'red-hill'].includes(routeSlug(p)));
+
+const companionSlugs = [
+  'the-point-nepean-half-day',
+  'the-peninsula-beach-swimming-guide',
+  'the-market-saturday',
+  'the-peninsulas-best-late-afternoon-walks',
+  'the-rainy-day-peninsula-without-a-booking',
+  'the-peninsula-with-kids',
+];
+const companionReads = companionSlugs
+  .map((slug) => articlesAll.find((a) => routeSlug(a) === slug))
+  .filter((a): a is NonNullable<typeof a> => Boolean(a));
+
+const exploreHubs = [
+  { href: '/explore/beaches/',          label: "The Peninsula's beaches",   sub: 'Bay vs back-beach, ranked' },
+  { href: '/explore/walks/',            label: 'Coastal walks & tracks',    sub: '11 walks by effort & payoff' },
+  { href: '/explore/hot-springs/',      label: 'Peninsula hot springs',     sub: 'Peninsula Hot Springs vs Alba' },
+  { href: '/explore/golf/',             label: "Peninsula golf",            sub: 'All courses ranked' },
+  { href: '/explore/spas-and-wellness/',label: 'Day spas & wellness',       sub: 'Treatments & retreats' },
+  { href: '/explore/markets/',          label: 'Peninsula markets',         sub: 'Ranked & calendarised' },
+  { href: '/explore/things-to-do/',     label: 'Things to do',              sub: 'Head-term ranked list of 25' },
+  { href: '/explore/day-trips/',        label: 'Day-trip itineraries',      sub: 'Five Melbourne-out routes' },
+  { href: '/explore/weekend-trips/',    label: 'Weekend itineraries',       sub: '2-day, 1-night framings' },
+  { href: '/explore/family-friendly/',  label: 'Family-friendly things',    sub: 'Kid-tested picks by category' },
+  { href: '/explore/dog-friendly/',     label: 'Dog-friendly Peninsula',    sub: 'Beaches, cafés, walks, stays' },
+  { href: '/explore/rainy-day/',        label: 'Rainy-day plans',           sub: 'Springs, galleries, lunches' },
+  { href: '/explore/free/',             label: 'Free things to do',         sub: 'Beaches, walks, lookouts' },
+  { href: '/explore/where-to-base-yourself/', label: 'Where to base yourself', sub: 'Subregion-by-subregion stay logic' },
+  { href: '/explore/getting-here/',     label: 'Getting to the Peninsula',  sub: 'Drive, train+bus, or ferry' },
+  { href: '/explore/getting-around/',   label: 'Getting around',            sub: 'Car-dominant; what works without one' },
+];
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Explore' },
+];
+
+const collectionSchema = buildCollectionPageSchema({
+  name: 'Explore the Mornington Peninsula, Peninsula Insider',
+  description: 'The editorial guide to things to do on the Mornington Peninsula, Victoria. Ranked lists, experience hubs, use-case guides, and itineraries, all fact-verified.',
+  path: '/explore',
+  dateModified: '2026-04-30',
+});
+const faqSchema = buildFaqSchema([
+  { q: 'What is the Mornington Peninsula?',
+    a: 'The Mornington Peninsula is a peninsula and local government area in Victoria, Australia, beginning roughly 40 km south of Melbourne\'s CBD and extending to the tip at Point Nepean. Its bay side (Port Phillip) is calm water; its ocean side (Bass Strait, via the Mornington Peninsula National Park) is surf and cliff. The hinterland, Red Hill, Main Ridge, Merricks, is wine and food country.' },
+  { q: 'How far is the Mornington Peninsula from Melbourne?',
+    a: 'The peninsula begins around 40–50 km from central Melbourne. Mornington town is about 60 km by road (50–60 min). Sorrento is 110 km by road (1 hr 20 min without traffic) or reachable via the Searoad Ferry from Queenscliff.' },
+  { q: 'What is there to do on the Mornington Peninsula?',
+    a: 'Hot springs, beaches (bay and ocean), coastal walks, golf, winery lunches, day spas, surf, markets, lookouts, and whale-watching in season.' },
+  { q: 'When is the best time to visit the Mornington Peninsula?',
+    a: 'Summer (December–February) is peak beach season and most crowded. Autumn (March–May) is the best eating and drinking season and the most comfortable for hinterland visits. Winter is quiet, atmospheric, and ideal for hot springs. Spring is underrated, especially for wildflowers and walking.' },
+  { q: 'Is a car necessary to visit the Mornington Peninsula?',
+    a: 'For most itineraries, yes. Public transport connects Melbourne to Frankston and a limited bus network extends further, but the hinterland, beaches, and most attractions are car-dependent.' },
+]);
+const breadcrumbSchema = buildBreadcrumbSchema([
+  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
+  { name: 'Explore', url: 'https://peninsulainsider.com.au/explore/' },
+]);
+---
+
+<V4BaseLayout
+  title="Things to Do on the Mornington Peninsula · Peninsula Insider"
+  description="The editorial guide to things to do on the Mornington Peninsula, coastal walks, beaches, hot springs, golf, markets, and the experiences worth the drive. Ranked, fact-verified, updated for autumn."
+  section="explore"
+  modifiedTime="2026-04-30"
+  ogImage="/images/sourced/explore-cape-schanck-lighthouse-01.webp"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(collectionSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1. CINEMATIC HERO
+       ═══════════════════════════════════════════════════════════════ -->
+  <GuideHero
+    eyebrow={`Explore · ${experiences.length} Peninsula moves · Last verified 30 Apr 2026`}
+    title="The Peninsula gets better once you leave the <em>table</em>"
+    dek="The strongest weekends here are not built on bookings alone. They need coastline, weather, a market detour, or one good walk between lunch and sunset. This section maps those moves properly."
+    meta={[
+      { label: `${walks.length} walks` },
+      { label: `${beaches.length} beaches` },
+      { label: `${lookouts.length} lookouts` },
+      { label: `${markets.length + wellness.length + galleriesAttractions.length} cultural & wellness` },
+    ]}
+    heroImage="/images/sourced/explore-cape-schanck-lighthouse-01.webp"
+    imageAlt="Cape Schanck Lighthouse and the Bass Strait coast, the Peninsula at its most explorable"
+    imageCredit="Peninsula Insider"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       2. ORIENTATION: Outside layer vs Booked layer
+       ═══════════════════════════════════════════════════════════════ -->
+  <CompareBlock
+    eyebrow="Two layers, one Peninsula"
+    heading="The walk-and-look layer or the booked layer"
+    dek="Every Peninsula day mixes both. Knowing which layer you're leading with, outside and free, or booked and paid, decides the day's tempo."
+    left={{
+      label: 'Outside · walk and look',
+      title: 'Free, weather-led, the spine of any Peninsula weekend.',
+      rows: [
+        { label: 'What it includes', value: 'Coastal and clifftop walks, bay and ocean beaches, lookouts, foreshore tracks, dog-friendly outdoor moves.' },
+        { label: 'Best for', value: 'Mornings, between-meal hours, sunset, and any day when the weather is doing the work for you. The reason most people come back.' },
+        { label: 'Cost', value: 'Free, almost without exception. Parking is the only meaningful expense.' },
+        { label: 'Booking', value: 'None. Walk-up, drive-up. Bring weather-appropriate layers and good shoes.' },
+        { label: 'Strongest moves', value: 'Bushrangers Bay, Cape Schanck boardwalk, Two Bays Trail, Sorrento Back Beach at sunset, Coppins Track, Arthurs Seat lookout.' },
+      ],
+    }}
+    right={{
+      label: 'Booked · paid and indoor-friendly',
+      title: 'Weather-proof anchors. Books out, especially weekends.',
+      rows: [
+        { label: 'What it includes', value: 'Hot springs (Peninsula and Alba), golf courses, day spas, galleries, attractions, market days, food and wine experiences.' },
+        { label: 'Best for', value: 'Anchor sessions on a weekend. Cold weather. Rainy days. Trips where the structure of the day matters more than the weather.' },
+        { label: 'Cost', value: 'From $40 (single market entry) to $400+ (premium spa or thermal experience). Most sessions $80–$180 per person.' },
+        { label: 'Booking', value: 'Required for hot springs, day spas, and golf. Markets and galleries are walk-in. Weekends book 1–4 weeks ahead.' },
+        { label: 'Strongest moves', value: 'Peninsula Hot Springs, Alba Thermal Springs, Spa by Jackalope, Pt Leo Estate sculpture park, Red Hill Market, Mornington Peninsula Regional Gallery.' },
+      ],
+    }}
+  />
+
+  <EventStrip
+    events={exploreEvents}
+    eyebrow="Things on this weekend"
+    heading="Markets, exhibitions, family programs, walks"
+    intro="Pulled from the events registry across nature, family, arts, and community categories."
+    moreHref="/whats-on/"
+    moreLabel="All events"
+    variant="alt"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       3. SEASONAL, what's best right now
+       ═══════════════════════════════════════════════════════════════ -->
+  {seasonal.length > 0 && (
+    <section class="experience-index" aria-label={`What's in season, ${blurb.label}`}>
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">{blurb.label}</p>
+            <h2 class="venues__title">What the Peninsula is best at right now</h2>
+            <p class="venues__sub venues__sub--standfirst">{blurb.line}</p>
+          </div>
+        </div>
+        <div class="experience-grid">
+          {seasonal.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4. COASTAL WALKS, the proper ones
+       ═══════════════════════════════════════════════════════════════ -->
+  {longWalks.length > 0 && (
+    <section class="experience-index experience-index--plain" id="long-walks">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Coastal walks</p>
+            <h2 class="venues__title">The proper walks that reset the weekend</h2>
+            <p class="venues__sub venues__sub--standfirst">Cape Schanck, Bushrangers Bay, the Two Bays. The walks worth clearing an afternoon for.</p>
+          </div>
+          <a href="/explore/walks/" class="venues__link">All {walks.length} walks →</a>
+        </div>
+        <div class="experience-grid">
+          {longWalks.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       5. BETWEEN-MEAL WALKS
+       ═══════════════════════════════════════════════════════════════ -->
+  {shortWalks.length > 0 && (
+    <section class="experience-index" id="short-walks">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Between-meal walks</p>
+            <h2 class="venues__title">Under an hour · good between lunch and dinner</h2>
+            <p class="venues__sub">For the gap in the weekend when a long walk is too much and doing nothing feels wrong.</p>
+          </div>
+        </div>
+        <div class="experience-grid">
+          {shortWalks.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6. BEACHES, LOOKOUTS, MARKETS, WELLNESS, CULTURE
+       ═══════════════════════════════════════════════════════════════ -->
+  {beaches.length > 0 && (
+    <section class="experience-index experience-index--plain" id="beaches">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Beaches</p>
+            <h2 class="venues__title">Which beach, and why</h2>
+            <p class="venues__sub">The bay calm versus the back beaches, pick the one that matches the weather, not the one closest to the car.</p>
+          </div>
+          <a href="/explore/beaches/" class="venues__link">Beach guide →</a>
+        </div>
+        <div class="experience-grid">
+          {beaches.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {lookouts.length > 0 && (
+    <section class="experience-index" id="lookouts">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Lookouts</p>
+            <h2 class="venues__title">Where the Peninsula lays itself out for you</h2>
+            <p class="venues__sub">Short stops, long views, the moments that make the drive home feel considered.</p>
+          </div>
+        </div>
+        <div class="experience-grid">
+          {lookouts.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {markets.length > 0 && (
+    <section class="experience-index experience-index--plain" id="markets">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Markets</p>
+            <h2 class="venues__title">Saturday mornings that shape the rest of the trip</h2>
+            <p class="venues__sub">Farmers' markets, makers' days, and the produce-first way into a Peninsula weekend.</p>
+          </div>
+          <a href="/journal/the-market-saturday/" class="venues__link">Market guide →</a>
+        </div>
+        <div class="experience-grid">
+          {markets.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {wellness.length > 0 && (
+    <section class="experience-index" id="wellness">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Wellness</p>
+            <h2 class="venues__title">Springs, sauna, and the slow layer</h2>
+            <p class="venues__sub">When the weekend needs to reset, not perform.</p>
+          </div>
+        </div>
+        <div class="experience-grid">
+          {wellness.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {galleriesAttractions.length > 0 && (
+    <section class="experience-index experience-index--plain" id="culture">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Galleries & attractions</p>
+            <h2 class="venues__title">Non-beach, non-cellar-door afternoons</h2>
+            <p class="venues__sub">The culture layer, useful when the weather turns or the weekend needs a quieter pace.</p>
+          </div>
+        </div>
+        <div class="experience-grid">
+          {galleriesAttractions.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       7. HUB NAVIGATION, every Explore lane
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-formats" aria-label="Explore categories">
+    <div class="container">
+      <div class="hub-formats__intro">
+        <p class="label label--accent">Or browse by lane</p>
+        <h2 class="hub-formats__title">The Explore section, fully organised</h2>
+        <p class="hub-formats__dek">Sixteen entry points into the Peninsula's outdoor and indoor experiences. Start with the lane that fits the trip you're planning.</p>
+      </div>
+      <ul class="hub-formats__grid">
+        {exploreHubs.map((hub) => (
+          <li class="hub-formats__cell">
+            <a href={hub.href} class="hub-formats__link">
+              <span class="hub-formats__label">{hub.label}</span>
+              <span class="hub-formats__sub">{hub.sub}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       8. ALL EXPERIENCES, alphabetical mosaic
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="experience-index" id="all">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Every explore entry</p>
+          <h2 class="venues__title">All {experiences.length} Peninsula moves, alphabetical</h2>
+          <p class="venues__sub">For when you already know what you're looking for.</p>
+        </div>
+      </div>
+      <div class="experience-grid">
+        {experiences.map((experience) => <ExperienceCard experience={experience} />)}
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       9. PLACES, explore by terrain
+       ═══════════════════════════════════════════════════════════════ -->
+  {featuredPlaces.length > 0 && (
+    <section class="places">
+      <div class="container">
+        <div class="places__header">
+          <p class="label label--accent places__label">By terrain</p>
+          <h2 class="places__title">Explore by pocket of the Peninsula</h2>
+          <p class="places__sub">Each place hub sequences walks, beaches, and lookouts into a real stretch of landscape.</p>
+        </div>
+        <div class="places__grid">
+          {featuredPlaces.map((place, index) => (
+            <PlaceCard place={place} variant={index % 3 === 1 ? 'bay' : index % 3 === 2 ? 'sand' : 'vineyard'} />
+          ))}
+        </div>
+        <p style="margin-top: 1.5rem;"><a href="/places/">Browse all towns →</a></p>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       10. ITINERARIES
+       ═══════════════════════════════════════════════════════════════ -->
+  {itineraries.length > 0 && (
+    <section class="escape-callout">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Turn it into a weekend</p>
+            <h2 class="venues__title">These explore notes feed directly into our escape plans</h2>
+            <p class="venues__sub">Walks and lookouts matter most when they are sequenced with the right lunch and the right bed.</p>
+          </div>
+          <a href="/escape/" class="venues__link">See all escapes →</a>
+        </div>
+        <div class="itinerary-grid">
+          {itineraries.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       11. EDITORIAL GUIDES
+       ═══════════════════════════════════════════════════════════════ -->
+  {companionReads.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">From the Journal</p>
+            <h2 class="venues__title">Further reading for the afternoon half of the trip</h2>
+            <p class="venues__sub">Service pieces that turn a list of activities into an actual day.</p>
+          </div>
+          <a href="/journal/" class="venues__link">All in the Journal →</a>
+        </div>
+        <div class="venues__grid">
+          {companionReads.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       12. FAQ
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-faq" aria-label="Frequently asked questions">
+    <div class="container">
+      <div class="hub-faq__intro">
+        <p class="label label--accent">Frequently asked</p>
+        <h2 class="hub-faq__title">Five honest answers about Peninsula geography and access</h2>
+      </div>
+      <div class="hub-faq__list">
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">What is the Mornington Peninsula?</summary>
+          <div class="hub-faq__a"><p>A peninsula and local government area in Victoria, Australia, beginning roughly 40 km south of Melbourne's CBD and extending to the tip at Point Nepean. Its bay side (Port Phillip) is calm water; its ocean side (Bass Strait, via the Mornington Peninsula National Park) is surf and cliff. The hinterland, Red Hill, Main Ridge, Merricks, is wine and food country.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">How far is the Peninsula from Melbourne?</summary>
+          <div class="hub-faq__a"><p>The peninsula begins around 40–50 km from central Melbourne. Mornington town is about 60 km by road (50–60 min). Sorrento is 110 km by road (1 hr 20 min without traffic) or reachable via the <a href="/explore/getting-here/">Searoad Ferry from Queenscliff</a>.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">What is there to do on the Peninsula?</summary>
+          <div class="hub-faq__a"><p>Hot springs, beaches (bay and ocean), coastal walks, golf, winery lunches, day spas, surf, markets, lookouts, and whale-watching in season. See the full ranked list at <a href="/explore/things-to-do/">things to do on the Mornington Peninsula</a>.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">When is the best time to visit?</summary>
+          <div class="hub-faq__a"><p>Summer (December–February) is peak beach season and most crowded. Autumn (March–May) is the best eating and drinking season and the most comfortable for hinterland visits. Winter is quiet, atmospheric, and ideal for hot springs. Spring is underrated, especially for wildflowers and walking.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Is a car necessary?</summary>
+          <div class="hub-faq__a"><p>For most itineraries, yes. Public transport connects Melbourne to Frankston and a limited bus network extends further, but the hinterland, beaches, and most attractions are car-dependent. See <a href="/explore/getting-around/">getting around</a> for the full picture.</p></div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</V4BaseLayout>

--- a/next/src/pages/v4/index.astro
+++ b/next/src/pages/v4/index.astro
@@ -1,0 +1,509 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../layouts/v4/V4BaseLayout.astro';
+import HomeCover from '../../components/HomeCover.astro';
+import Shortlist from '../../components/Shortlist.astro';
+import EditorsLetter from '../../components/EditorsLetter.astro';
+import InsiderStripe from '../../components/InsiderStripe.astro';
+import PillarNav from '../../components/PillarNav.astro';
+import SectionDivider from '../../components/SectionDivider.astro';
+import { formatLabel } from '../../lib/editorial';
+import VenueCard from '../../components/VenueCard.astro';
+import PlaceCard from '../../components/PlaceCard.astro';
+import ExperienceCard from '../../components/ExperienceCard.astro';
+import ItineraryCard from '../../components/ItineraryCard.astro';
+import ArticleCard from '../../components/ArticleCard.astro';
+import EventCard from '../../components/EventCard.astro';
+import WeekendPickerBlock from '../../components/WeekendPickerBlock.astro';
+import EventStrip from '../../components/EventStrip.astro';
+import { chips, eventsForChip, getChip } from '../../lib/events';
+import InsiderPlans from '../../components/InsiderPlans.astro';
+import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { isUpcoming, routeSlug, stayTypes, currentSeason, seasonBlurb, inSeason, experienceInSeason, dispatchWeekend } from '../../lib/editorial';
+
+const venues = await getCollection('venues');
+const articles = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+const places = await getCollection('places');
+const experiences = await getCollection('experiences');
+const itineraries = await getCollection('itineraries');
+
+// What's On hooks  -  the events differentiator surfaces here so the
+// Weekend Picker / Worth The Drive / Kids Grade language is visible
+// without a click into /whats-on.
+const eventsAll = (await getCollection('events'))
+  .filter((event) => {
+    // 'seasonal' events have explicit end dates, they must not bypass the upcoming check.
+    // Only truly open-ended recurrences (weekly, monthly, ongoing) stay permanently visible.
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    const end = event.data.endDate ?? event.data.startDate;
+    return isUpcoming(end);
+  })
+  .sort((a, b) => a.data.startDate.getTime() - b.data.startDate.getTime());
+const weekendDispatch = articles
+  .filter((article) => article.data.format === 'weekend-picker')
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime())[0];
+// Derive the weekend the dispatch covers from its publishedAt under the
+// Sunday-ahead cadence, so the picker label and events filter stay in sync
+// without per-week edits. Falls back to a static window if no dispatch.
+const dispatchWindow = weekendDispatch
+  ? dispatchWeekend(weekendDispatch.data.publishedAt)
+  : { start: new Date(0), end: new Date(0), sat: new Date(), sun: new Date(), label: 'This weekend' };
+const upcomingWeekendStart = dispatchWindow.start;
+const upcomingWeekendEnd = dispatchWindow.end;
+const weekendPicks = eventsAll
+  .filter((event) => {
+    if (!event.data.lens.includes('weekend-pick' as any)) return false;
+    const start = event.data.startDate;
+    if (start > upcomingWeekendEnd) return false; // starts after this weekend
+    // 'seasonal' events have explicit end dates and must not be treated as always in-window.
+    const isRecurring = ['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence as string);
+    if (isRecurring) return true; // recurring events that have started are always in-window
+    const end = event.data.endDate ?? event.data.startDate;
+    return end >= upcomingWeekendStart;
+  })
+  .slice(0, 3);
+
+const featured = articles.find((a) => a.data.featured && a.data.format !== 'weekend-picker') ?? articles.find((a) => a.data.format !== 'weekend-picker') ?? articles[0];
+const editorPicks = articles
+  .filter((a) => routeSlug(a) !== routeSlug(featured))
+  .filter((a) => ['the-chardonnay-case', 'three-italian-dinners', 'the-peninsula-pantry', 'the-long-lunch', 'the-thermal-springs-weekend'].includes(routeSlug(a)))
+  .slice(0, 5);
+
+const showcase = venues
+  .filter((venue) => ['ten-minutes-by-tractor', 'montalto', 'laura'].includes(routeSlug(venue)));
+const showcaseFallback = venues
+  .filter((venue) => ['restaurant', 'winery'].includes(venue.data.type))
+  .slice(0, 3);
+const diningShowcase = showcase.length >= 3 ? showcase : showcaseFallback;
+
+const experienceHighlights = experiences.filter((entry) =>
+  ['bushrangers-bay-walk', 'arthurs-seat-lookout', 'mornington-peninsula-gallery'].includes(routeSlug(entry))
+);
+const escapePlans = itineraries.slice(0, 3);
+const stayHighlights = venues.filter((venue) =>
+  stayTypes.includes(venue.data.type) && ['jackalope', 'hotel-sorrento', 'port-phillip-estate'].includes(routeSlug(venue))
+);
+const featuredPlaces = places.filter((place) =>
+  ['red-hill', 'sorrento', 'flinders', 'mornington', 'portsea', 'main-ridge'].includes(routeSlug(place))
+);
+const journalHighlights = articles
+  .filter((article) => routeSlug(article) !== routeSlug(featured))
+  .filter((article) => !editorPicks.some((pick) => routeSlug(pick) === routeSlug(article)))
+  .slice(0, 3);
+
+// Intent-driven discovery chips. Each points at an article that answers
+// a real reader intent, so the homepage becomes navigable by need,
+// not just by category.
+const intentRoutes = [
+  { label: 'Long lunch',    slug: 'the-long-lunch',                     note: 'Sunday, slow, one decisive table  -  the Peninsula’s strongest move' },
+  { label: 'Rainy day',     slug: 'the-rainy-day-peninsula-without-a-booking', note: 'Weather-proof and walk-in  -  no booking, no gamble' },
+  { label: 'With kids',     slug: 'the-peninsula-with-kids',            note: 'A day that punishes no one  -  graded, honest, tested' },
+  { label: 'One night',     slug: 'the-one-night-escape',               note: '26 hours that feel like a long weekend' },
+  { label: 'Cellar doors',  slug: 'the-cellar-door-short-list',         note: 'Five producers worth the appointment and the drive' },
+  { label: 'Wellness',      slug: 'the-thermal-springs-weekend',        note: 'Hot springs without wasting the rest of the weekend' },
+  { label: 'First visit',   slug: 'the-peninsula-orientation-drive',    note: 'Six stops, half a day, zero prior knowledge required' },
+  { label: 'Breakfast',     slug: 'breakfast-before-the-crowds',        note: 'Where locals actually eat at 8 am  -  not the Instagram queue' },
+];
+const intentResolved = intentRoutes
+  .map((intent) => {
+    const article = articles.find((a) => routeSlug(a) === intent.slug);
+    return article ? { ...intent, article } : null;
+  })
+  .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+const issueStats = {
+  articles: articles.length,
+  venues: venues.length,
+  places: places.length,
+  experiences: experiences.length,
+  itineraries: itineraries.length,
+};
+
+const now = new Date();
+const issueDate = now.toLocaleDateString('en-AU', { month: 'long', year: 'numeric' });
+
+// Seasonal hook  -  surface venues and experiences whose tags match the
+// current season. Designed to feel like a rotating "what's on right now"
+// rail without needing a manual editorial push each month.
+const season = currentSeason();
+const seasonBlurbData = seasonBlurb[season];
+const seasonalVenues = venues
+  .filter((venue) => inSeason(venue, season))
+  .filter((venue) => ['restaurant', 'winery', 'cafe', 'bakery', 'spa', 'hotel'].includes(venue.data.type))
+  .slice(0, 3);
+const seasonalExperiences = experiences
+  .filter((e) => experienceInSeason(e, season))
+  .slice(0, 3);
+---
+
+<V4BaseLayout
+  title="Peninsula Insider, V4 Staging"
+  description="V4 staging, mega-menu lift on the V2 visual language."
+  section="home"
+>
+  <script type="application/ld+json" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Peninsula Insider',
+    url: 'https://peninsulainsider.com.au',
+    description: 'The independent editorial guide to the Mornington Peninsula, best restaurants, cellar doors, beaches, walks, and places to stay.',
+    inLanguage: 'en-AU',
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: 'https://peninsulainsider.com.au/journal?q={search_term_string}',
+      'query-input': 'required name=search_term_string',
+    },
+  })} />
+  <script type="application/ld+json" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'What is the Mornington Peninsula known for?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'The Mornington Peninsula is known for cool-climate Pinot Noir and Chardonnay, vineyard restaurants, natural hot springs, dramatic ocean coastline, and calm bay beaches, all within 90 minutes of Melbourne. The region has over 50 cellar doors, some of Australia\'s best regional restaurants, and a coastline that runs from sheltered Port Phillip Bay to the wild Southern Ocean.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How far is the Mornington Peninsula from Melbourne?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Mornington town is about 60 km from Melbourne CBD (around 60 minutes via the Mornington Peninsula Freeway). Sorrento and Portsea at the tip of the Peninsula are 95–105 km from the city, roughly 90 minutes in normal traffic. The drive is longer on Friday evenings and Sunday afternoons.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'What is the best time to visit the Mornington Peninsula?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Autumn (March to May) is the best season, vintage is underway on the ridge, the crowds thin after Easter, and the light over the vineyards is at its best. Summer is busiest and most expensive but offers swimming and long evenings. Winter is quiet, with cellar door fires and hot springs at their most appealing. Spring brings wildflowers and uncrowded weekends.',
+        },
+      },
+    ],
+  })} />
+  {featured && (
+    <HomeCover
+      tag="The Cover Feature"
+      issue={`Vol 04 · ${issueDate}`}
+      subLabel="The Long Read"
+      title={featured.data.title}
+      dek={featured.data.dek}
+      byline={featured.data.houseByline ? 'The Peninsula Insider Editors' : (featured.data.author?.id ? String(featured.data.author.id) : 'The Peninsula Insider Editors')}
+      readingTime={featured.data.readingTimeMinutes ? `${featured.data.readingTimeMinutes} min` : undefined}
+      href={`/journal/${routeSlug(featured)}`}
+      images={[
+        /* Three-window daily rotation, picked by visitor's local hour:
+             0:00–07:59  → image 1 (sunset bay, bathing boxes)
+             8:00–15:59  → image 2 (back-beach horse riders)
+            16:00–23:59  → image 3 (bay beach with red umbrella)        */
+        { src: '/images/sourced/home-cover-sunset-bay-01.jpg',          alt: 'Sunset over a Mornington Peninsula bay with bathing boxes in the foreground' },
+        { src: '/images/sourced/home-cover-back-beach-horses-01.jpg',   alt: 'Horse riders on a Peninsula back beach with surf rolling in' },
+        { src: '/images/sourced/home-cover-bay-umbrella-01.webp',       alt: 'A red umbrella on a calm Peninsula bay beach with marram grass' },
+      ]}
+    />
+  )}
+
+  <InsiderPlans />
+
+  <PillarNav />
+
+  {weekendDispatch && <WeekendPickerBlock dispatch={weekendDispatch} weekend={`This weekend · ${dispatchWindow.label}`} />}
+
+  {(() => {
+    const chip = getChip('this-weekend');
+    const weekendEvents = chip ? eventsForChip(chip, eventsAll).slice(0, 3) : [];
+    return weekendEvents.length > 0 && (
+      <EventStrip
+        events={weekendEvents}
+        eyebrow="On the calendar this weekend"
+        heading="Three events worth a Saturday or Sunday"
+        intro="Pulled from the events registry, ranked by what they are actually like to attend. Tap through for the full list, or pick a mood (when it rains, worth the drive, after dark) on the events hub."
+        moreHref="/whats-on/"
+        moreLabel="See the full registry"
+        variant="alt"
+      />
+    );
+  })()}
+
+  {intentResolved.length > 0 && (
+    <section class="intent-strip" aria-label="Start from what you need">
+      <div class="container">
+        <div class="split-intro">
+          <div>
+            <p class="label label--accent">Start from what you need</p>
+            <h2 class="split-intro__title">Start from what you actually want the weekend to do</h2>
+          </div>
+          <p class="split-intro__body">Each one opens a guide built around the question  -  with real names, real opinions, and a plan you can act on this weekend.</p>
+        </div>
+        <div class="intent-chips">
+          {intentResolved.map((intent) => (
+            <a href={`/journal/${intent.slug}`} class="intent-chip">
+              <span class="intent-chip__label">{intent.label}</span>
+              <span class="intent-chip__note">{intent.note}</span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <section class="zone-intro">
+    <div class="container">
+      <div class="split-intro">
+        <div>
+          <p class="label label--accent">Build the weekend</p>
+          <h2 class="split-intro__title">Four ways into the Peninsula, depending on what the trip needs</h2>
+        </div>
+        <p class="split-intro__body">Start with the bed if you want the trip to soften, the walk if you want the afternoon to open up, the itinerary if you want the whole weekend pre-shaped, or hand the wheel to a guide if the day should run itself.</p>
+      </div>
+      <div class="zone-intro__grid zone-intro__grid--four">
+        <a href="/stay/" class="zone-card zone-card--link">
+          <p class="zone-card__label">Stay</p>
+          <h3 class="zone-card__title">Choose the base before the booking list</h3>
+          <p class="zone-card__body">Red Hill stays, Sorrento hotels, and the properties that change the tone of the whole weekend.</p>
+        </a>
+        <a href="/explore/" class="zone-card zone-card--link">
+          <p class="zone-card__label">Explore</p>
+          <h3 class="zone-card__title">Use coastline, weather, and timing properly</h3>
+          <p class="zone-card__body">Late-afternoon walks, market starts, and the non-restaurant moves that make the region feel larger.</p>
+        </a>
+        <a href="/escape/" class="zone-card zone-card--link">
+          <p class="zone-card__label">Plans</p>
+          <h3 class="zone-card__title">Follow a complete weekend, not a loose list</h3>
+          <p class="zone-card__body">Shaped Peninsula escapes that sequence lunch, landscape, and bed in the right order.</p>
+        </a>
+        <a href="/tour/" class="zone-card zone-card--link">
+          <p class="zone-card__label">Tours</p>
+          <h3 class="zone-card__title">Hand the day to a guide who knows the back roads</h3>
+          <p class="zone-card__body">Operator-led wine tours, hot-springs days, and multi-day packages, with editorial notes on who each one actually suits.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <SectionDivider />
+
+  {weekendPicks.length > 0 && (
+    <section class="venues venues--plain" aria-label="Weekend picks">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">This weekend · editor's picks</p>
+            <h2 class="venues__title">{weekendPicks.length === 1 ? 'One event' : weekendPicks.length === 2 ? 'Two events' : 'Three events'} with an opinion attached</h2>
+            <p class="venues__sub">Every entry is kids-graded, weather-flagged, and labelled worth-the-drive or not  -  because nobody else on the Peninsula event web is brave enough to.</p>
+          </div>
+          <a href="/whats-on/" class="venues__link">All What’s On →</a>
+        </div>
+        <div class="event-grid">
+          {weekendPicks.map((event, i) => <EventCard event={event} featured={i === 0} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {/* FeatureArticle removed, the HomeCover at the top is the lead story now. */}
+
+
+  {editorPicks.length > 0 && (
+    <Shortlist
+      eyebrow="The Shortlist"
+      title="Five pieces worth the <em>appointment</em>."
+      dek="The handful we'd send a close friend to this issue, picked for the ratio of payoff to effort, not the view from the tasting room."
+      link={{ label: 'Read all in the Journal', href: '/journal/' }}
+      items={editorPicks.map((article, i) => ({
+        rank: String(i + 1).padStart(2, '0'),
+        meta: [
+          formatLabel[article.data.format] ?? String(article.data.format ?? 'Editorial'),
+          article.data.readingTimeMinutes ? `${article.data.readingTimeMinutes} min read` : 'Editorial',
+          article.data.publishedAt
+            ? new Date(article.data.publishedAt).toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })
+            : '',
+        ].filter(Boolean),
+        name: article.data.title,
+        href: `/journal/${routeSlug(article)}`,
+        why: article.data.dek,
+        tags: (article.data.tags ?? []).slice(0, 2).map((t: string) => ({ label: String(t).replace(/-/g, ' ') })),
+      }))}
+    />
+  )}
+
+  <EditorsLetter
+    eyebrow="Editor's Letter"
+    title={`On the <em>quiet authority</em> of a good ${seasonBlurbData.label?.toLowerCase() ?? 'autumn'}.`}
+    paragraphs={[
+      `${seasonBlurbData.label ?? 'Autumn'} is the season the Peninsula stops performing. The weekend crowds thin, the vintage trucks finish their last runs, and the ridge takes on the colour it has for about six weeks a year. Most places you want to get into, you can actually get into. The light is good. The rooms are warm. The producers, finally, have time.`,
+      `We've rebuilt the cellar-door shortlist from scratch this season, visited every restaurant on the long-lunch list at least twice, and walked every beach on the ranking. The newsletter, <em>Peninsula This Weekend</em>, lands weekly with the current issue's picks tightened into a single page.`,
+      `If this is your first issue with us, welcome. If you're returning, thanks for the patience through the refit.`,
+    ]}
+    pullQuote={`This issue is built for the six weeks where the Peninsula is at its most itself, before winter settles in and the coast goes quiet.`}
+    signatureName="The Editors"
+    signatureRole="Peninsula Insider"
+    image="/images/sourced/place-red-hill-01.webp"
+    imageAlt="Vine rows in late-season colour, Red Hill"
+    imageCaption="The last weekend of vintage, Red Hill, <em>the quietest a working winery ever gets.</em>"
+  />
+
+  <InsiderStripe />
+
+  {diningShowcase.length > 0 && (
+    <section class="venues venues--scroll-mobile">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Editor's Table</p>
+            <h2 class="venues__title">The dining rooms still doing the strongest work</h2>
+            <p class="venues__sub venues__sub--standfirst">Begin with the meal if lunch is the point of the trip.</p>
+          </div>
+          <a href="/eat/" class="venues__link">All venues →</a>
+        </div>
+        <div class="venues__grid">
+          {diningShowcase.map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {(seasonalVenues.length > 0 || seasonalExperiences.length > 0) && (
+    <section class="seasonal-shelf">
+      <div class="container">
+        <div class="split-intro">
+          <div>
+            <p class="label label--accent">{seasonBlurbData.label}</p>
+            <h2 class="split-intro__title">Right now, the Peninsula is best at this</h2>
+          </div>
+          <p class="split-intro__body">{seasonBlurbData.line}</p>
+        </div>
+        <div class="seasonal-shelf__grid">
+          {seasonalVenues.length > 0 && (
+            <div class="seasonal-shelf__col">
+              <p class="label label--accent">Tables & rooms in season</p>
+              <ul class="seasonal-shelf__list">
+                {seasonalVenues.map((venue) => (
+                  <li>
+                    <a href={`/${stayTypes.includes(venue.data.type) ? 'stay' : ['winery', 'producer', 'brewery', 'distillery'].includes(venue.data.type) ? 'wine' : 'eat'}/${routeSlug(venue)}`}>
+                      <span class="seasonal-shelf__name">{venue.data.name}</span>
+                      <span class="seasonal-shelf__note">{venue.data.signature}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {seasonalExperiences.length > 0 && (
+            <div class="seasonal-shelf__col">
+              <p class="label label--accent">Walks & moves in season</p>
+              <ul class="seasonal-shelf__list">
+                {seasonalExperiences.map((experience) => (
+                  <li>
+                    <a href={`/explore/${routeSlug(experience)}`}>
+                      <span class="seasonal-shelf__name">{experience.data.name}</span>
+                      <span class="seasonal-shelf__note">{experience.data.editorNote.split('.').slice(0, 1).join('.')}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {experienceHighlights.length > 0 && (
+    <section class="experience-index">
+      <div class="container">
+        <div class="split-intro">
+          <div>
+            <p class="label label--accent">After lunch</p>
+            <h2 class="split-intro__title">The moves that stop the Peninsula feeling like one long reservation</h2>
+          </div>
+          <p class="split-intro__body">These are the useful second acts, not filler. A real walk, a market start, or a beach at the right hour changes what kind of place the Peninsula becomes.</p>
+        </div>
+        <div class="experience-grid">
+          {experienceHighlights.map((experience) => <ExperienceCard experience={experience} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {escapePlans.length > 0 && (
+    <section class="escape-callout">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Plans</p>
+            <h2 class="venues__title">When the Peninsula deserves more than a day trip</h2>
+            <p class="venues__sub venues__sub--standfirst">A shaped weekend that puts lunch, walk, and bed in the right order  -  so you stop planning and start going.</p>
+          </div>
+          <a href="/escape/" class="venues__link">All escapes →</a>
+        </div>
+        <div class="itinerary-grid">
+          {escapePlans.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {places.length > 0 && (
+    <section class="places">
+      <div class="container">
+        <div class="places__header">
+          <p class="label label--accent places__label">Know the terrain</p>
+          <h2 class="places__title">The Peninsula, place by place</h2>
+          <p class="places__sub">Six towns that organise the region around them  -  ridge, coast, and bay.</p>
+        </div>
+        <div class="places__grid">
+          {featuredPlaces.map((place, index) => (
+            <PlaceCard
+              place={place}
+              variant={index % 3 === 1 ? 'bay' : index % 3 === 2 ? 'sand' : 'vineyard'}
+            />
+          ))}
+        </div>
+        <div class="places__footer">
+          <a href="/places/" class="venues__link">All {issueStats.places} places →</a>
+        </div>
+      </div>
+    </section>
+  )}
+
+  {stayHighlights.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Sleep here</p>
+            <h2 class="venues__title">Three stays that immediately change the plan</h2>
+          </div>
+          <a href="/stay/" class="venues__link">All stays →</a>
+        </div>
+        <div class="venues__grid">
+          {stayHighlights.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {journalHighlights.length > 0 && (
+    <section class="venues venues--hide-mobile">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Fresh from the Journal</p>
+            <h2 class="venues__title">The most recent service pieces and dispatches</h2>
+          </div>
+          <a href="/journal/" class="venues__link">Journal →</a>
+        </div>
+        <div class="venues__grid">
+          {journalHighlights.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <NewsletterBlock />
+</V4BaseLayout>

--- a/next/src/pages/v4/journal/index.astro
+++ b/next/src/pages/v4/journal/index.astro
@@ -1,0 +1,250 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import SectionHero from '../../../components/SectionHero.astro';
+import ArticleCard from '../../../components/ArticleCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import { formatLabel, routeSlug, heroBackgroundStyle } from '../../../lib/editorial';
+
+const articles = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+const featured = articles.find((article) => article.data.featured) ?? articles[0];
+const featuredSlug = featured ? routeSlug(featured) : null;
+const latest = articles.filter((article) => routeSlug(article) !== featuredSlug);
+
+// Everything except the lead is available for grouping.
+const rest = latest;
+
+// Three "editor's picks"  -  the stories that are doing the most work this week.
+const pickSlugs = [
+  'the-sorrento-weekend',
+  'the-market-saturday',
+  'the-peninsula-beach-swimming-guide',
+];
+const picks = pickSlugs
+  .map((slug) => rest.find((article) => routeSlug(article) === slug))
+  .filter((article): article is NonNullable<typeof article> => Boolean(article));
+
+// Group the rest by format for navigation by mood.
+const formatOrder: Array<{ key: string; title: string; intro: string }> = [
+  {
+    key: 'weekend-picker',
+    title: 'Weekend Picker',
+    intro: 'Our weekly Peninsula This Weekend dispatches, built for the weekend ahead: one pick, one weather-proof backup, and one useful planning note.',
+  },
+  {
+    key: 'service',
+    title: 'Service pieces',
+    intro: 'Useful before you book. Weekend shapes, rainy-day plans, family trips, and the questions readers actually ask.',
+  },
+  {
+    key: 'long-lunch-list',
+    title: 'Long lunch lists',
+    intro: 'The daylight-dining playbook. Which tables earn the drive, and how to pick the right one for your day.',
+  },
+  {
+    key: 'cellar-door-dispatch',
+    title: 'Cellar door dispatches',
+    intro: 'The producers worth the appointment, the wines worth the cellar, and the arguments happening in the vines.',
+  },
+  {
+    key: 'stay-notes',
+    title: 'Stay notes',
+    intro: 'The rooms, cottages, and villas that change the shape of a weekend.',
+  },
+  {
+    key: 'insider-edit',
+    title: 'Insider edits',
+    intro: 'Shortlists with a point of view  -  the places locals rotate through, not the ones brochures push.',
+  },
+  {
+    key: 'slow-peninsula',
+    title: 'Slow Peninsula',
+    intro: 'Field notes from the quieter end of the region. Weather, light, time, and the pieces no one is rushing.',
+  },
+  {
+    key: 'editors-letter',
+    title: "Editor's letters",
+    intro: 'Where the issue is framed  -  what changed, what matters, what to read first.',
+  },
+  {
+    key: 'interview',
+    title: 'Interviews',
+    intro: 'Long-form conversations with the people building the Peninsula worth writing about.',
+  },
+  {
+    key: 'investigation',
+    title: 'Investigations',
+    intro: 'Reporting with edges. Where we spend the extra weeks.',
+  },
+];
+
+const groups = formatOrder
+  .map((group) => ({
+    ...group,
+    articles: rest.filter((article) => article.data.format === group.key),
+  }))
+  .filter((group) => group.articles.length > 0);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Journal' },
+];
+---
+
+<V4BaseLayout
+  title="Mornington Peninsula Journal · Peninsula Insider"
+  description="Long-form Peninsula journalism, service pieces, and editorial dispatches, written by editors who live on the Peninsula."
+  section="journal"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+  <SectionHero
+    eyebrow="Journal"
+    subEyebrow="Dispatches · lists · essays · stay notes"
+    title="Long-form notes from a region best read <em>slowly.</em>"
+    dek="The Journal is where Peninsula Insider moves past directories and into voice. Browse by format below, or jump straight to the three pieces doing the most work right now."
+    gradient="journal"
+    visualLabel="Long lunch notebook · cellar door dispatches"
+    heroImage="/images/sourced/journal-hub-hero-01.webp"
+  />
+
+  <!-- Editor’s desk note  -  a short seasonal framing block that tells
+       the reader what the Journal is focused on right now. Creates the
+       sense of a living editorial desk rather than a static archive. -->
+  <section class="editors-desk" aria-label="Editor’s note">
+    <div class="container">
+      <div class="editors-desk__inner">
+        <div class="editors-desk__col">
+          <p class="label label--accent">From the editor’s desk</p>
+          <h2 class="editors-desk__title">What we’re writing about this season</h2>
+          <p class="editors-desk__body">Autumn on the Peninsula is vintage season on the ridge and fireplace-lunch season everywhere else. The Journal is leaning into the service pieces that help you build a weekend around those two moods  -  plus a cellar-door dispatch series, honest stay notes, and the rolling <em>Peninsula This Weekend</em> brief refreshed each week.</p>
+          <p class="editors-desk__body">Every piece below answers a real question a weekend visitor actually asks. If we can’t finish the sentence <em>“Read this before you…”</em> then we don’t publish it.</p>
+        </div>
+        <div class="editors-desk__col editors-desk__formats">
+          <p class="label">Formats in this issue</p>
+          <ul class="editors-desk__format-list">
+            <li><strong>Service pieces</strong>  -  the practical guides: weekend shapes, rainy-day plans, family trips</li>
+            <li><strong>Long lunch lists</strong>  -  the daylight-dining playbook</li>
+            <li><strong>Cellar door dispatches</strong>  -  the wines, the producers, the arguments in the vines</li>
+            <li><strong>Weekend Picker</strong>  -  one pick, one backup, one skip  -  published weekly for the weekend ahead</li>
+            <li><strong>Stay notes</strong>  -  the rooms that change the shape of a weekend</li>
+            <li><strong>Insider edits</strong>  -  shortlists with a point of view</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Planning guides, curated index of service-journal landing pages.
+       These are standalone Astro routes (not content-collection entries), so
+       they don't appear in the dynamic format-grouped lists below. This section
+       is the authoritative hub → service-page link so nothing gets orphaned. -->
+  <section class="planning-guides" aria-label="Planning guides">
+    <div class="container">
+      <div class="planning-guides__header">
+        <p class="label label--accent">Planning guides</p>
+        <h2 class="planning-guides__title">Read this before you book.</h2>
+        <p class="planning-guides__dek">Service pieces and seasonal guides for the specific weekend you're trying to build. Each one answers a real question a weekend visitor actually asks.</p>
+      </div>
+      <ul class="planning-guides__grid">
+        <li><a href="/journal/mornington-peninsula-itinerary/"><span class="planning-guides__eyebrow">Itinerary</span><span class="planning-guides__name">The best 3-day Mornington Peninsula plan</span></a></li>
+        <li><a href="/journal/mornington-peninsula-day-trip/"><span class="planning-guides__eyebrow">Day trip</span><span class="planning-guides__name">Mornington Peninsula day trip from Melbourne</span></a></li>
+        <li><a href="/journal/mornington-peninsula-hot-springs-guide/"><span class="planning-guides__eyebrow">Hot springs</span><span class="planning-guides__name">The Peninsula hot springs guide</span></a></li>
+        <li><a href="/journal/mornington-peninsula-winery-tour/"><span class="planning-guides__eyebrow">Cellar doors</span><span class="planning-guides__name">Self-drive winery tour, the route that works</span></a></li>
+        <li><a href="/journal/mornington-peninsula-with-kids/"><span class="planning-guides__eyebrow">Family</span><span class="planning-guides__name">Mornington Peninsula with kids, the honest guide</span></a></li>
+        <li><a href="/journal/dog-friendly-mornington-peninsula/"><span class="planning-guides__eyebrow">Dogs</span><span class="planning-guides__name">Dog-friendly Peninsula, beaches, cafés, stays</span></a></li>
+        <li><a href="/journal/mornington-peninsula-in-autumn/"><span class="planning-guides__eyebrow">Season</span><span class="planning-guides__name">The Peninsula in autumn, vintage and fires</span></a></li>
+        <li><a href="/journal/mornington-peninsula-in-winter/"><span class="planning-guides__eyebrow">Season</span><span class="planning-guides__name">The Peninsula in winter, what still runs</span></a></li>
+        <li><a href="/journal/free-things-to-do-mornington-peninsula/"><span class="planning-guides__eyebrow">Budget</span><span class="planning-guides__name">Free things to do on the Peninsula</span></a></li>
+        <li><a href="/journal/best-brunch-mornington-peninsula/"><span class="planning-guides__eyebrow">Eat</span><span class="planning-guides__name">Best brunch on the Mornington Peninsula</span></a></li>
+        <li><a href="/journal/mornington-peninsula-wedding-venues/"><span class="planning-guides__eyebrow">Wedding</span><span class="planning-guides__name">Peninsula wedding venues worth the weekend</span></a></li>
+        <li><a href="/explore/best-walks/"><span class="planning-guides__eyebrow">Walks</span><span class="planning-guides__name">Best walks on the Mornington Peninsula</span></a></li>
+      </ul>
+    </div>
+  </section>
+
+  {featured && (
+    <section class="feature feature--compact">
+      <div class="container">
+        <div class="feature__inner">
+          <div class="feature__image-block feature__image-block--bay" aria-hidden="true" style={heroBackgroundStyle(featured.data)}>
+            <div class="feature__image-overlay"></div>
+            <span class="feature__image-tag">Lead story</span>
+          </div>
+          <div class="feature__content">
+            <div class="feature__label">
+              <span class="label label--accent">{formatLabel[featured.data.format] ?? featured.data.format}</span>
+            </div>
+            <h2 class="feature__title">
+              <a href={`/journal/${featuredSlug}`}>{featured.data.title}</a>
+            </h2>
+            <p class="feature__dek">{featured.data.dek}</p>
+            <div class="feature__byline">
+              {featured.data.readingTimeMinutes && (
+                <>
+                  <span class="feature__byline-name">{featured.data.readingTimeMinutes} min read</span>
+                  <span class="feature__byline-dot" aria-hidden="true"></span>
+                </>
+              )}
+              <span class="feature__byline-meta">{featured.data.publishedAt.toLocaleDateString('en-AU', { month: 'long', day: 'numeric', year: 'numeric' })}</span>
+            </div>
+            <a href={`/journal/${featuredSlug}`} class="feature__cta">Read the piece →</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )}
+
+  {picks.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Editor's picks</p>
+            <h2 class="venues__title">Three pieces to read first</h2>
+            <p class="venues__sub">If you only have 20 minutes with the Journal, start here.</p>
+          </div>
+        </div>
+        <div class="venues__grid">
+          {picks.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <section class="format-nav">
+    <div class="container">
+      <p class="label label--accent format-nav__label">Navigate by format</p>
+      <p class="format-nav__sub">Every piece in the Journal carries a format tag. Pick the kind of reading you want  -  or keep scrolling and let the page sort itself.</p>
+      <div class="format-nav__chips">
+        {groups.map((group) => (
+          <a href={`#${group.key}`} class="format-chip">
+            <span class="format-chip__name">{group.title}</span>
+            <span class="format-chip__count">{group.articles.length}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  {groups.map((group) => (
+    <section class="venues venues--alt" id={group.key}>
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">{formatLabel[group.key] ?? group.title}</p>
+            <h2 class="venues__title">{group.title}</h2>
+            <p class="venues__sub">{group.intro}</p>
+          </div>
+          <span class="venues__count">{group.articles.length} pieces</span>
+        </div>
+        <div class="venues__grid">
+          {group.articles.map((article) => <ArticleCard article={article} hideType />)}
+        </div>
+      </div>
+    </section>
+  ))}
+
+  <NewsletterBlock />
+</V4BaseLayout>

--- a/next/src/pages/v4/stay/index.astro
+++ b/next/src/pages/v4/stay/index.astro
@@ -1,0 +1,379 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import GuideHero from '../../../components/GuideHero.astro';
+import CompareBlock from '../../../components/CompareBlock.astro';
+import SectionDivider from '../../../components/SectionDivider.astro';
+import VenueCard from '../../../components/VenueCard.astro';
+import ItineraryCard from '../../../components/ItineraryCard.astro';
+import ArticleCard from '../../../components/ArticleCard.astro';
+import PlaceCard from '../../../components/PlaceCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import { routeSlug, stayTypes, currentSeason, seasonBlurb } from '../../../lib/editorial';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+const venues = (await getCollection('venues')).filter((v) => stayTypes.includes(v.data.type));
+const itineraries = await getCollection('itineraries');
+const places = await getCollection('places');
+const season = currentSeason();
+const blurb = seasonBlurb[season];
+
+const featuredStaySlugs = ['jackalope', 'hotel-sorrento', 'flinders-hotel'];
+const featuredStays = featuredStaySlugs
+  .map((slug) => venues.find((v) => routeSlug(v) === slug))
+  .filter((v): v is NonNullable<typeof v> => Boolean(v));
+
+const ridgeZones = ['red-hill-plateau', 'hinterland'];
+const coastZones = ['ocean-coast', 'back-beaches', 'tip'];
+const bayZones = ['bayside'];
+const ridgeStays = venues.filter((v) => ridgeZones.includes(v.data.zone));
+const coastStays = venues.filter((v) => coastZones.includes(v.data.zone));
+const bayStays = venues.filter((v) => bayZones.includes(v.data.zone));
+
+const vineyardStays = venues.filter((v) => {
+  const moods: string[] = v.data.tags?.mood ?? [];
+  return moods.includes('cellar-door') || moods.includes('long-lunch') || ridgeZones.includes(v.data.zone);
+}).slice(0, 6);
+const coastalStays = venues.filter((v) => {
+  const moods: string[] = v.data.tags?.mood ?? [];
+  return moods.includes('beach') || moods.includes('waterfront') || coastZones.includes(v.data.zone);
+}).slice(0, 6);
+const wellnessStays = venues.filter((v) => {
+  const moods: string[] = v.data.tags?.mood ?? [];
+  return moods.includes('wellness') || v.data.type === 'spa';
+}).slice(0, 4);
+
+const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+const companionSlugs = [
+  'where-to-stay-for-a-two-night-escape',
+  'the-one-night-escape',
+  'the-vineyard-villa-weekend',
+  'the-thermal-springs-weekend',
+];
+const companionReads = companionSlugs
+  .map((slug) => articlesAll.find((a) => routeSlug(a) === slug))
+  .filter((a): a is NonNullable<typeof a> => Boolean(a));
+
+const placeHighlights = places.filter((p) => ['red-hill', 'sorrento', 'flinders'].includes(routeSlug(p)));
+
+const stayHubs = [
+  { href: '/stay/luxury/',                          label: 'Luxury',                  sub: 'Design hotels, vineyard villas' },
+  { href: '/stay/boutique-hotels/',                 label: 'Boutique Hotels',         sub: 'Character stays in Flinders, Sorrento' },
+  { href: '/stay/winery-accommodation/',            label: 'Winery Accommodation',    sub: 'Stay where the long lunch happens' },
+  { href: '/stay/couples/',                         label: 'Couples',                 sub: 'Stays that shape a weekend for two' },
+  { href: '/stay/dog-friendly/',                    label: 'Dog-Friendly',            sub: 'Useful when the dog is coming' },
+  { href: '/stay/glamping/',                        label: 'Glamping',                sub: 'Thermal and experience-led stays' },
+  { href: '/stay/villas/',                          label: 'Villas',                  sub: 'Private bases with room to breathe' },
+  { href: '/stay/cottages/',                        label: 'Cottages',                sub: 'Slow rural weekends, fireplace logic' },
+  { href: '/stay/resorts/',                         label: 'Resorts & Retreats',      sub: 'Wellness and thermal stays' },
+  { href: '/stay/where-to-stay-mornington-peninsula/', label: 'Where to Base Yourself', sub: 'Choose the right Peninsula zone' },
+  { href: '/stay/sorrento/',                        label: 'Stay in Sorrento',        sub: 'Village atmosphere, beach access' },
+  { href: '/stay/red-hill/',                        label: 'Stay in Red Hill',        sub: 'Food, wine, fireplaces, hinterland' },
+  { href: '/stay/flinders/',                        label: 'Stay in Flinders',        sub: 'Quiet ocean-side village weekends' },
+  { href: '/stay/mornington/',                      label: 'Stay in Mornington',      sub: 'Practical northern Peninsula base' },
+  { href: '/stay/cape-schanck/',                    label: 'Stay in Cape Schanck',    sub: 'Retreat-led southern reset' },
+];
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Stay' },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org', '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: 'Where is the best area to stay on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Red Hill and Main Ridge for cellar door weekends, vineyard restaurants are walkable from many stays. Sorrento for coastal village atmosphere and ocean beach access. Mornington town for the most accessible base from Melbourne (60 minutes). The right answer depends on the weekend you want, wine country, beach village, or practical proximity.' } },
+    { '@type': 'Question', name: 'How much does accommodation cost on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Budget $250–400/night for a good mid-range self-contained villa or cottage. Luxury vineyard stays (Jackalope, Lindenderry) run $450–800/night. Budget options in Rosebud, Dromana, and Rye start from $150/night. Prices peak in summer and over long weekends, autumn midweek offers the best value.' } },
+    { '@type': 'Question', name: 'Is one night enough on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'One night works for a focused escape, arrive Friday evening, spend Saturday on the ridge (cellar doors + lunch), and drive home Sunday after a morning walk. Two nights is better: it allows a beach day, a second area to explore, and the slower pace the Peninsula rewards. Base in Mornington or Sorrento for single-night trips.' } },
+  ],
+};
+---
+
+<V4BaseLayout
+  title="Where to Stay on the Mornington Peninsula · Peninsula Insider"
+  description="Where to stay on the Mornington Peninsula, hotels, vineyard villas, coastal cottages, and farm stays. Every property visited and reviewed. Updated for autumn."
+  section="stay"
+  modifiedTime="2026-04-30"
+  ogImage="/images/sourced/venue-jackalope-hotel-01.webp"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1. CINEMATIC HERO
+       ═══════════════════════════════════════════════════════════════ -->
+  <GuideHero
+    eyebrow={`Stay · ${venues.length} properties · Last verified 30 Apr 2026`}
+    title="Choose the base, and the whole <em>weekend</em> changes"
+    dek="The Peninsula is a region of distinct moods packed close together. A Red Hill country-house weekend produces a different trip from a Sorrento main-street hotel. This hub sorts the beds by the kind of weekend you actually want."
+    meta={[
+      { label: `${venues.length} stays mapped` },
+      { label: `${ridgeStays.length} ridge & hinterland` },
+      { label: `${coastStays.length} coastal village` },
+      { label: '9 min read' },
+    ]}
+    heroImage="/images/sourced/venue-jackalope-hotel-01.webp"
+    imageAlt="Jackalope Hotel, Merricks North vineyard at dusk"
+    imageCredit="Peninsula Insider"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       2. ORIENTATION: Ridge & hinterland vs Coastal village
+       ═══════════════════════════════════════════════════════════════ -->
+  <CompareBlock
+    eyebrow="Two distinct stay corridors"
+    heading="Ridge & hinterland or Coastal village"
+    dek="The biggest decision in a Peninsula trip is not which property, it is which side of the region you wake up on. Each anchors a different weekend."
+    left={{
+      label: 'Ridge & hinterland',
+      title: 'Vineyard country. Fireplaces. Lunch within walking distance.',
+      rows: [
+        { label: 'Flagship stays', value: 'Jackalope (Merricks North), Lindenderry (Red Hill), Polperro Villas, Tucks Ridge, Montalto cottages, vineyard villa rentals' },
+        { label: 'What you get', value: 'Country-house pace, low light, eucalypts and fences, a cellar door dining room within ten minutes of the bed.' },
+        { label: 'Best for', value: 'Two-night food-and-wine weekends. Couples. Slow restorative trips. Winter visits with fires lit.' },
+        { label: 'Trade-offs', value: 'No swimming distance. Limited walk-out infrastructure. You drive to everything but the lunch.' },
+        { label: 'Pair with', value: 'A long lunch on Saturday, a cellar-door tasting on Sunday morning, and a hot-springs visit before the drive home.' },
+      ],
+    }}
+    right={{
+      label: 'Coastal village, Sorrento, Portsea, Flinders, Mornington',
+      title: 'Bay light, ferry edge, walk-out beaches, social theatre.',
+      rows: [
+        { label: 'Flagship stays', value: 'Hotel Sorrento, The Continental Sorrento, Portsea Hotel, Flinders Hotel, Mornington foreshore cottages, Mount Martha bay houses' },
+        { label: 'What you get', value: 'Walking distance to a beach and a meal. Late dusk light over the bay. The Peninsula at its most social.' },
+        { label: 'Best for', value: 'Single-night escapes. Family trips. Visitors who want to leave the car parked. Summer weekends with friends.' },
+        { label: 'Trade-offs', value: 'Busy in peak season. The cellar-door day requires a drive. Less of the inland country-house feel.' },
+        { label: 'Pair with', value: 'A Sorrento Back Beach sunset, a Hotel Sorrento dinner, the morning ferry to Queenscliff, or a Mornington cliff walk.' },
+      ],
+    }}
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       3. EDITOR'S PICKS
+       ═══════════════════════════════════════════════════════════════ -->
+  {featuredStays.length > 0 && (
+    <section class="venues" id="editors">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Editor's picks</p>
+            <h2 class="venues__title">Three stays worth planning the trip around</h2>
+            <p class="venues__sub venues__sub--standfirst">From design-hotel spectacle to quieter village-hotel weekends, three rooms that change what the trip feels like, each anchoring a different version of the Peninsula.</p>
+          </div>
+          <a href="/journal/where-to-stay-for-a-two-night-escape/" class="venues__link">Editor's stay guide →</a>
+        </div>
+        <div class="venues__grid">
+          {featuredStays.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4. VINEYARD WEEKENDS, ridge & hinterland
+       ═══════════════════════════════════════════════════════════════ -->
+  {vineyardStays.length > 0 && (
+    <section class="venues venues--plain" id="vineyard">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Vineyard weekends</p>
+            <h2 class="venues__title">Beds with a long lunch already attached</h2>
+            <p class="venues__sub venues__sub--standfirst">The stays that make the Red Hill version of the Peninsula hold together, close to cellar doors, built for pinot pacing.</p>
+          </div>
+          <a href="/wine/" class="venues__link">Wine country →</a>
+        </div>
+        <div class="venues__grid">
+          {vineyardStays.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       5. COASTAL WEEKENDS
+       ═══════════════════════════════════════════════════════════════ -->
+  {coastalStays.length > 0 && (
+    <section class="venues" id="coastal">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Coastal weekends</p>
+            <h2 class="venues__title">For salt air, dusk walks, and back-beach weather</h2>
+            <p class="venues__sub venues__sub--standfirst">Rooms that put you near limestone, open water, and the quieter southern end of the region.</p>
+          </div>
+          <a href="/places/sorrento/" class="venues__link">Sorrento hub →</a>
+        </div>
+        <div class="venues__grid">
+          {coastalStays.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6. WELLNESS & RETREATS
+       ═══════════════════════════════════════════════════════════════ -->
+  {wellnessStays.length > 0 && (
+    <section class="venues venues--plain" id="wellness">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Wellness & retreats</p>
+            <h2 class="venues__title">The Peninsula's slow-down layer</h2>
+            <p class="venues__sub">Springs, spa cabins, and farm-stay beds for the weekend that has to do more with less.</p>
+          </div>
+          <a href="/journal/the-thermal-springs-weekend/" class="venues__link">Thermal springs guide →</a>
+        </div>
+        <div class="venues__grid">
+          {wellnessStays.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       7. HUB NAVIGATION
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-formats" aria-label="Stay categories" id="browse-stay-hubs">
+    <div class="container">
+      <div class="hub-formats__intro">
+        <p class="label label--accent">Or browse by stay type</p>
+        <h2 class="hub-formats__title">The stay section, fully organised</h2>
+        <p class="hub-formats__dek">Fifteen lanes into the Peninsula's beds. Start with the kind of weekend you want, then move into the right zones and properties.</p>
+      </div>
+      <ul class="hub-formats__grid">
+        {stayHubs.map((hub) => (
+          <li class="hub-formats__cell">
+            <a href={hub.href} class="hub-formats__link">
+              <span class="hub-formats__label">{hub.label}</span>
+              <span class="hub-formats__sub">{hub.sub}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       8. ALL STAYS, full directory
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="venues" id="all">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">All stays</p>
+          <h2 class="venues__title">Every bed currently mapped, hotel to cottage</h2>
+          <p class="venues__sub">{blurb.line}</p>
+        </div>
+      </div>
+      <div class="venues__grid">
+        {venues.slice(0, 24).map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+      </div>
+    </div>
+  </section>
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       9. ITINERARIES
+       ═══════════════════════════════════════════════════════════════ -->
+  {itineraries.length > 0 && (
+    <section class="escape-callout" id="itineraries">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Turn the bed into a plan</p>
+            <h2 class="venues__title">The best stays make the itinerary easier</h2>
+            <p class="venues__sub">If the room is right, the rest of the weekend starts arranging itself.</p>
+          </div>
+          <a href="/escape/" class="venues__link">See escape plans →</a>
+        </div>
+        <div class="itinerary-grid">
+          {itineraries.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       10. PLACES
+       ═══════════════════════════════════════════════════════════════ -->
+  {placeHighlights.length > 0 && (
+    <section class="places">
+      <div class="container">
+        <div class="places__header">
+          <p class="label label--accent places__label">Choose the district</p>
+          <h2 class="places__title">Browse stays through the places they belong to</h2>
+          <p class="places__sub">Each hub pulls together the beds, tables, and walks that belong to that stretch of the Peninsula.</p>
+        </div>
+        <div class="places__grid">
+          {placeHighlights.map((place, index) => (
+            <PlaceCard
+              place={place}
+              variant={index === 1 ? 'bay' : index === 2 ? 'sand' : 'vineyard'}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       11. EDITORIAL GUIDES
+       ═══════════════════════════════════════════════════════════════ -->
+  {companionReads.length > 0 && (
+    <section class="venues venues--plain">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">From the Journal</p>
+            <h2 class="venues__title">Read the stay logic before you book</h2>
+            <p class="venues__sub">Service pieces that make the difference between a good weekend and one that runs itself.</p>
+          </div>
+          <a href="/journal/" class="venues__link">All in the Journal →</a>
+        </div>
+        <div class="venues__grid">
+          {companionReads.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       12. FAQ
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-faq" aria-label="Frequently asked questions">
+    <div class="container">
+      <div class="hub-faq__intro">
+        <p class="label label--accent">Frequently asked</p>
+        <h2 class="hub-faq__title">Three honest answers before you book the bed</h2>
+      </div>
+      <div class="hub-faq__list">
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Where is the best area to stay on the Peninsula?</summary>
+          <div class="hub-faq__a"><p>Red Hill and Main Ridge for cellar-door weekends, vineyard restaurants are walkable from many stays. Sorrento for coastal village atmosphere and ocean beach access. Mornington town for the most accessible base from Melbourne (60 minutes). The right answer depends on the weekend you want, wine country, beach village, or practical proximity.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">How much does accommodation cost?</summary>
+          <div class="hub-faq__a"><p>Budget $250–400/night for a good mid-range self-contained villa or cottage. Luxury vineyard stays (Jackalope, Lindenderry) run $450–800/night. Budget options in Rosebud, Dromana, and Rye start from $150/night. Prices peak in summer and over long weekends, autumn midweek offers the best value.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Is one night enough on the Peninsula?</summary>
+          <div class="hub-faq__a"><p>One night works for a focused escape, arrive Friday evening, spend Saturday on the ridge (cellar doors + lunch), and drive home Sunday after a morning walk. Two nights is better: it allows a beach day, a second area to explore, and the slower pace the Peninsula rewards. Base in Mornington or Sorrento for single-night trips.</p></div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</V4BaseLayout>

--- a/next/src/pages/v4/whats-on/index.astro
+++ b/next/src/pages/v4/whats-on/index.astro
@@ -1,0 +1,476 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import GuideHero from '../../../components/GuideHero.astro';
+import EventChipBar from '../../../components/EventChipBar.astro';
+import CompareBlock from '../../../components/CompareBlock.astro';
+import SectionDivider from '../../../components/SectionDivider.astro';
+import EventCard from '../../../components/EventCard.astro';
+import WeekendPickerBlock from '../../../components/WeekendPickerBlock.astro';
+import EventStrip from '../../../components/EventStrip.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import {
+  dispatchWeekend,
+  eventCategoryLabel,
+  isUpcoming,
+  routeSlug,
+} from '../../../lib/editorial';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+const now = new Date();
+const events = (await getCollection('events'))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    const end = event.data.endDate ?? event.data.startDate;
+    return isUpcoming(end, now);
+  })
+  .sort((a, b) => a.data.startDate.getTime() - b.data.startDate.getTime());
+
+const dispatches = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .filter((a) => a.data.format === 'weekend-picker')
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+const currentDispatch = dispatches[0];
+
+const dispatchWindow = currentDispatch
+  ? dispatchWeekend(currentDispatch.data.publishedAt)
+  : { start: new Date(0), end: new Date(0), sat: new Date(), sun: new Date(), label: 'This weekend' };
+const upcomingWeekendStart = dispatchWindow.start;
+const upcomingWeekendEnd = dispatchWindow.end;
+
+const nextWeekendEvents = events.filter((event) => {
+  const start = event.data.startDate;
+  if (start > upcomingWeekendEnd) return false;
+  const isRecurring = ['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence as string);
+  if (isRecurring) return true;
+  const end = event.data.endDate ?? event.data.startDate;
+  return end >= upcomingWeekendStart;
+});
+
+const editorsPicks = nextWeekendEvents.filter((event) => event.data.lens.includes('weekend-pick')).slice(0, 3);
+const skipEvents = events.filter((event) => event.data.skipThis);
+
+const categoryOrder: Array<{ key: string; title: string; blurb: string }> = [
+  { key: 'racing-sport',     title: 'Racing & Sport',           blurb: "The Peninsula's racing days and endurance weekends, the single category Melbourne visitors under-plan." },
+  { key: 'writers-ideas',    title: 'Writers & Ideas',          blurb: 'Festivals, panels and literary weekends with a programme worth planning a stay around.' },
+  { key: 'market',           title: 'Markets, Ranked',          blurb: "The Peninsula runs eight recurring markets. Here they are in the order we'd actually attend them." },
+  { key: 'cellar-door',      title: 'Cellar Door Events',       blurb: "Release weekends, winemaker dinners and tastings, the region's strongest category, rarely treated as events." },
+  { key: 'live-music',       title: 'Live Music',               blurb: 'Sunday sessions, ridge vineyard sets, and the recurring gigs no other Peninsula site tracks.' },
+  { key: 'wellness',         title: 'Wellness & Retreats',      blurb: 'Thermal circuits, sound baths, and the ongoing programming at Alba and the Hot Springs.' },
+  { key: 'family-programs',  title: 'Kids & Family',            blurb: "School-holiday programmes graded A/B/C. We've been to most of them. We'll tell you which ones." },
+  { key: 'nature',           title: 'Nature & Council Gems',    blurb: 'Free council-run walks, ranger programmes, and the best-hidden family assets on the Peninsula.' },
+  { key: 'exhibition',       title: 'Exhibitions & Galleries',  blurb: "The region's serious public art, a strong rainy-day category nobody leans into." },
+  { key: 'civic',            title: 'Civic & Annual',           blurb: 'ANZAC dawn services, council events, and the moments the Peninsula steps out of its tourist costume.' },
+  { key: 'festival',         title: 'Festivals',                blurb: 'Multi-day programming that defines the Peninsula calendar.' },
+];
+
+const groups = categoryOrder
+  .map((group) => ({ ...group, items: events.filter((e) => e.data.category === group.key) }))
+  .filter((group) => group.items.length > 0);
+
+const lensOrder: Array<{ key: string; label: string; note: string }> = [
+  { key: 'weekend-pick',    label: 'Weekend Pick',     note: "What we'd actually book" },
+  { key: 'family-saturday', label: 'Family Saturday',  note: 'A-grade kids days' },
+  { key: 'rainy-day',       label: 'Rainy Day',        note: 'Weather-proof options' },
+  { key: 'worth-the-drive', label: 'Worth The Drive',  note: 'From Melbourne, unprompted' },
+  { key: 'date-idea',       label: 'Date Idea',        note: 'Adult-first weekends' },
+  { key: 'school-holidays', label: 'School Holidays',  note: 'Kid-graded, A/B/C' },
+  { key: 'free',            label: 'Free',             note: 'No ticket required' },
+  { key: 'locals-know',     label: 'Locals Know',      note: 'Under-published picks' },
+];
+
+const lensCounts = Object.fromEntries(
+  lensOrder.map((lens) => [lens.key, nextWeekendEvents.filter((e) => e.data.lens.includes(lens.key as any)).length])
+) as Record<string, number>;
+
+const totalEvents = events.length;
+const totalGroups = groups.length;
+const recurringCount = events.filter((e) => ['weekly', 'monthly', 'ongoing'].includes(e.data.recurrence)).length;
+const oneOffCount = totalEvents - recurringCount;
+
+// ── Standouts of the season ──────────────────────────────────────────────
+// Top events ranked purely by visitor appeal score, irrespective of when
+// they happen. Doesn't depend on lens tags, so always populated.
+const standouts = [...events]
+  .filter((e) => (e.data.visitorAppealScore ?? 0) >= 4)
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 6);
+
+// ── On this week (Mon-Fri before the weekend) ───────────────────────────
+// Events that fall in the weekday window leading up to the upcoming
+// weekend. Recurring (weekly, monthly, ongoing) events count if they
+// have a startDate weekday between Monday and Friday.
+const day = 24 * 60 * 60 * 1000;
+const weekdayWindowStart = new Date(upcomingWeekendStart.getTime() - 5 * day);
+const weekdayWindowEnd = new Date(upcomingWeekendStart.getTime() - 1);
+const thisWeekEvents = events.filter((event) => {
+  const isRecurring = ['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence as string);
+  const start = event.data.startDate;
+  const end = event.data.endDate ?? start;
+  if (isRecurring) {
+    const wd = start.getDay();
+    return wd >= 1 && wd <= 5;
+  }
+  return end >= weekdayWindowStart && start <= weekdayWindowEnd;
+})
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 6);
+
+// ── Recurring on the calendar ─────────────────────────────────────────────
+// Weekly + monthly events with their cadence shown explicitly. These are
+// the predictable Peninsula institutions: Red Hill Market, Mornington
+// Farmers Market, Sunday Sessions at the Hot Springs, etc.
+const recurringEvents = events
+  .filter((e) => ['weekly', 'monthly'].includes(e.data.recurrence))
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 9);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: "What's On" },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org', '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: 'When does the Peninsula This Weekend dispatch publish?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Weekly, for the upcoming weekend (Saturday and Sunday). One pick, one weather-proof backup, and one useful planning note. Subscribers receive it by email; the latest is always pinned at the top of this page.' } },
+    { '@type': 'Question', name: 'Are the kids-grade A/B/C ratings genuine?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yes. We attend or have attended every family programme we grade. A means we\'d return without hesitation. B means it works but has a flaw. C means we wouldn\'t go back. Grades are visible on every event with the family-saturday or school-holidays lens.' } },
+    { '@type': 'Question', name: 'Why do some events carry a planning note?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Because the rest of the Peninsula press won\'t name them. We pick one or two events a month that are over-marketed, badly run, or not what their copy claims. One short paragraph explaining why. The word "Insider" doing actual work.' } },
+    { '@type': 'Question', name: 'Do you cover events outside the Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'No. Mornington Peninsula only, defined as Mount Martha down to Portsea, plus Hastings and the Western Port fringe. We don\'t cover Phillip Island, the Bellarine, or Frankston. The constraint is what makes the recommendations sharp.' } },
+  ],
+};
+---
+
+<V4BaseLayout
+  title="What's On Mornington Peninsula · Peninsula Insider"
+  description="The Peninsula's events page with an editorial point of view. Weekend picks, kids-graded school holidays, worth-the-drive badges, and useful planning notes."
+  section="whats-on"
+  modifiedTime="2026-04-30"
+  ogImage="/images/sourced/category-market-02.webp"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1. CINEMATIC HERO
+       ═══════════════════════════════════════════════════════════════ -->
+  <GuideHero
+    eyebrow={`What's On · ${totalEvents} curated events · Reviewed weekly`}
+    title="Peninsula events, with an <em>opinion</em> for a change"
+    dek="The Peninsula event web is a list-and-walk-away zone. Every other site publishes the calendar; nobody adds much context. This page does: weekend picks, kids-grade A/B/C on every family event, and useful planning notes when the logistics matter."
+    meta={[
+      { label: `${totalEvents} curated events` },
+      { label: `${totalGroups} categories` },
+      { label: `${recurringCount} recurring programmes` },
+      { label: 'Reviewed weekly' },
+    ]}
+    heroImage="/images/sourced/category-market-02.webp"
+    imageAlt="Saturday morning at a Peninsula farmers market, the recurring event spine of the calendar"
+    imageCredit="Peninsula Insider"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1.5 CHIP BAR  -  editorial entry points to mood collections
+       ═══════════════════════════════════════════════════════════════ -->
+  <section style="padding: clamp(1.5rem, 3vw, 2.5rem) 0 0;">
+    <div class="container">
+      <p class="label label--accent" style="margin-bottom: 0.6rem;">Find your weekend shape</p>
+      <EventChipBar active="hub" />
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       2. THE EDITORIAL FRAME, what we'd actually book and what to know
+       ═══════════════════════════════════════════════════════════════ -->
+  <CompareBlock
+    eyebrow="The editorial promise"
+    heading="What we'd actually book, and what we'd flag early"
+    dek="Every other Peninsula calendar lists everything. Ours adds a point of view and practical context. Two lanes below shape every recommendation on this page."
+    left={{
+      label: "Worth booking",
+      title: "Three lenses, one editorial standard.",
+      rows: [
+        { label: 'Weekend Pick',     value: "What the editor would book this weekend if she could only book one. Under three picks per week, usually one." },
+        { label: 'Worth The Drive',  value: 'The events worth the 90-minute return from Melbourne without any other reason. Genuine destination programming.' },
+        { label: 'Family Saturday',  value: 'A-graded kids days, no pre-show queues, no parking gymnastics, no padded lunch break. We\'ve been to all of them.' },
+        { label: 'Locals Know',      value: 'Under-published picks. The recurring sessions, market stalls, and producer days the visitor feeds miss every time.' },
+        { label: 'Free',             value: 'Council-run walks, ranger programmes, and free public events that are genuinely worth the time, not filler.' },
+      ],
+    }}
+    right={{
+      label: "Worth knowing",
+      title: "Short planning notes for the events that need context.",
+      rows: [
+        { label: 'What we flag',     value: 'Events that suit a narrow audience, get crowded quickly, or work best when you know the trade-offs before booking.' },
+        { label: 'How we decide',    value: 'A named editor attends or attended in person, or has direct reporting from a trusted Peninsula source. We do not add planning notes on hearsay.' },
+        { label: 'Why we publish',   value: 'Because readers need context, not just listings. Timing, access, and fit are often the difference between a good Peninsula day and a messy one.' },
+        { label: 'Frequency',        value: 'Only when the context materially changes how we would plan the day.' },
+        { label: 'Recourse',         value: 'If you run an event and think the context has changed, the contact form is open. We revise when the facts move.' },
+      ],
+    }}
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       3. WEEKEND PICKER DISPATCH
+       ═══════════════════════════════════════════════════════════════ -->
+  {currentDispatch && (
+    <>
+      <WeekendPickerBlock dispatch={currentDispatch} weekend={`This weekend · ${dispatchWindow.label}`} />
+      {/* Dispatch surface always carries event richness, even when the editor
+          hasn't curated specific picks into the article yet. Top 3 by visitor
+          appeal score, filtered to events in the upcoming weekend window. */}
+      {nextWeekendEvents.length > 0 && (
+        <EventStrip
+          events={[...nextWeekendEvents].sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0)).slice(0, 3)}
+          eyebrow="Also worth knowing"
+          heading={`Three events on the ground this weekend, ${dispatchWindow.label}`}
+          intro="Pulled live from the events registry. Editor's anchor picks below; these are the data-ranked supporting cast."
+          moreHref="/whats-on/by-mood/this-weekend/"
+          moreLabel="See the full weekend"
+          variant="alt"
+        />
+      )}
+    </>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4. THIS WEEKEND'S ANCHORS
+       ═══════════════════════════════════════════════════════════════ -->
+  {editorsPicks.length > 0 && (
+    <section class="venues venues--plain" id="lens-weekend-pick">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">This weekend's anchors</p>
+            <h2 class="venues__title">If you only do two things this weekend</h2>
+            <p class="venues__sub venues__sub--standfirst">The clearest event anchors shaping the Peninsula from {dispatchWindow.label}, the picks the editor would put her own weekend around.</p>
+          </div>
+          <span class="venues__count">{editorsPicks.length} picks</span>
+        </div>
+        <div class="event-grid">
+          {editorsPicks.map((event, i) => <EventCard event={event} featured={i === 0} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4.5 STANDOUTS OF THE SEASON, top by visitor appeal
+       Ranked purely by visitor appeal score, doesn't depend on lens
+       tags so always populated. The "best things on right now" view.
+       ═══════════════════════════════════════════════════════════════ -->
+  {standouts.length > 0 && (
+    <section class="venues" id="standouts">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Standouts on the calendar</p>
+            <h2 class="venues__title">The six events worth shaping a weekend around</h2>
+            <p class="venues__sub venues__sub--standfirst">Ranked by what they are actually like to attend. Coastrek, the Sorrento Writers Festival, the Red Hill Show. Across the season, not just this weekend.</p>
+          </div>
+          <span class="venues__count">{standouts.length} standouts</span>
+        </div>
+        <div class="event-grid">
+          {standouts.map((event, i) => <EventCard event={event} featured={i === 0} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4.6 ON THIS WEEK, midweek events
+       For the Wednesday traveller booking Friday, or the local
+       wondering what's happening before the weekend hits.
+       ═══════════════════════════════════════════════════════════════ -->
+  {thisWeekEvents.length > 0 && (
+    <section class="venues venues--plain" id="this-week">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">On this week</p>
+            <h2 class="venues__title">Mid-week events worth a Tuesday or a Wednesday</h2>
+            <p class="venues__sub venues__sub--standfirst">The Peninsula doesn't shut down between weekends. Markets, exhibitions, weekday programmes, and the recurring sessions that anchor the locals' calendar.</p>
+          </div>
+          <span class="venues__count">{thisWeekEvents.length} this week</span>
+        </div>
+        <div class="event-grid">
+          {thisWeekEvents.map((event) => <EventCard event={event} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4.7 RECURRING ON THE CALENDAR, the predictable spine
+       Weekly and monthly events with their cadence shown. These are
+       the Peninsula institutions, predictable and always available.
+       ═══════════════════════════════════════════════════════════════ -->
+  {recurringEvents.length > 0 && (
+    <section class="venues venues--alt" id="recurring">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Recurring on the calendar</p>
+            <h2 class="venues__title">The Peninsula's predictable spine</h2>
+            <p class="venues__sub venues__sub--standfirst">Markets, sessions, and programmes that run on a known cadence. Plan ahead, no surprises, the regional rhythm a local takes for granted.</p>
+          </div>
+          <span class="venues__count">{recurringEvents.length} recurring</span>
+        </div>
+        <div class="event-grid">
+          {recurringEvents.map((event) => <EventCard event={event} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       5. BROWSE BY MOOD, hub-formats lane
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-formats" aria-label="Browse events by mood">
+    <div class="container">
+      <div class="hub-formats__intro">
+        <p class="label label--accent">Or browse by mood</p>
+        <h2 class="hub-formats__title">Pick the feeling first, let the events follow</h2>
+        <p class="hub-formats__dek">Eight reader-intent lenses cut across the calendar. Each opens the events on this weekend that match the mood.</p>
+      </div>
+      <ul class="hub-formats__grid">
+        {lensOrder.map((lens) => (
+          <li class={`hub-formats__cell${lensCounts[lens.key] === 0 ? ' is-empty' : ''}`}>
+            <a href={`#lens-${lens.key}`} class="hub-formats__link">
+              <span class="hub-formats__label">{lens.label} · {lensCounts[lens.key]}</span>
+              <span class="hub-formats__sub">{lens.note}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6. PER-LENS GRIDS
+       ═══════════════════════════════════════════════════════════════ -->
+  {lensOrder.filter((lens) => lens.key !== 'weekend-pick' && lensCounts[lens.key] > 0).map((lens) => {
+    const lensEvents = nextWeekendEvents.filter((event) => event.data.lens.includes(lens.key as any));
+    return (
+      <section class="venues venues--plain" id={`lens-${lens.key}`}>
+        <div class="container">
+          <div class="venues__header">
+            <div>
+              <p class="label label--accent">{lens.label}</p>
+              <h2 class="venues__title">{lens.note}</h2>
+              <p class="venues__sub">{lensEvents.length} event{lensEvents.length === 1 ? '' : 's'} matching this mood for {dispatchWindow.label}.</p>
+            </div>
+            <span class="venues__count">{lensEvents.length}</span>
+          </div>
+          <div class="event-grid">
+            {lensEvents.map((event, i) => <EventCard event={event} featured={i === 0} />)}
+          </div>
+        </div>
+      </section>
+    );
+  })}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       7. WORTH KNOWING
+       ═══════════════════════════════════════════════════════════════ -->
+  {skipEvents.length > 0 && (
+    <section class="skip-block" id="lens-skip">
+      <div class="container">
+        <div class="skip-block__inner">
+          <div>
+            <p class="label label--accent">Worth knowing</p>
+            <h2 class="skip-block__title">Extra context for events that need it</h2>
+            <p class="skip-block__body">Short notes on fit, timing, and trade-offs so readers can plan with their eyes open.</p>
+          </div>
+          <div class="skip-block__list">
+            {skipEvents.map((event) => (
+              <article class="skip-entry">
+                <h3 class="skip-entry__title">
+                  <a href={`/whats-on/${routeSlug(event)}`}>{event.data.title}</a>
+                </h3>
+                <p class="skip-entry__reason">{event.data.skipReason ?? event.data.editorVerdict ?? event.data.summary}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       8. CATEGORY GROUPS
+       ═══════════════════════════════════════════════════════════════ -->
+  {groups.map((group) => (
+    <section class="venues venues--alt" id={`cat-${group.key}`}>
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">{eventCategoryLabel[group.key] ?? group.title}</p>
+            <h2 class="venues__title">{group.title}</h2>
+            <p class="venues__sub">{group.blurb}</p>
+          </div>
+          <span class="venues__count">{group.items.length} events</span>
+        </div>
+        <div class="event-grid">
+          {group.items.map((event) => <EventCard event={event} />)}
+        </div>
+      </div>
+    </section>
+  ))}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       9. EDITORIAL STATS
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="events-stats">
+    <div class="container">
+      <dl class="events-stats__list">
+        <div><dt>Curated events</dt><dd>{totalEvents}</dd></div>
+        <div><dt>Categories</dt><dd>{totalGroups}</dd></div>
+        <div><dt>Recurring programmes</dt><dd>{recurringCount}</dd></div>
+        <div><dt>One-off events</dt><dd>{oneOffCount}</dd></div>
+      </dl>
+      <p class="events-stats__note">
+        Reviewed weekly by a named editor. We publish what we'd actually attend, with context where the timing, fit, or logistics matter. If you think we've missed something, <a href="/contact/">tell us</a>.
+      </p>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       10. FAQ
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-faq" aria-label="Frequently asked questions">
+    <div class="container">
+      <div class="hub-faq__intro">
+        <p class="label label--accent">Frequently asked</p>
+        <h2 class="hub-faq__title">Four answers about how this calendar works</h2>
+      </div>
+      <div class="hub-faq__list">
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">When does the Peninsula This Weekend dispatch publish?</summary>
+          <div class="hub-faq__a"><p>Weekly, for the upcoming weekend (Saturday and Sunday). One pick, one weather-proof backup, and one useful planning note. Subscribers receive it by email; the latest is always pinned at the top of this page.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Are the kids-grade A/B/C ratings genuine?</summary>
+          <div class="hub-faq__a"><p>Yes. We attend or have attended every family programme we grade. A means we'd return without hesitation. B means it works but has a flaw. C means we wouldn't go back. Grades are visible on every event with the family-saturday or school-holidays lens.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Why do some events carry a planning note?</summary>
+          <div class="hub-faq__a"><p>Because the useful part of an events guide is context. When an event is likely to be crowded, logistically awkward, or a better fit for a different kind of visitor, we say so briefly and plainly so readers can plan around it.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Do you cover events outside the Peninsula?</summary>
+          <div class="hub-faq__a"><p>No. Mornington Peninsula only, defined as Mount Martha down to Portsea, plus Hastings and the Western Port fringe. We don't cover Phillip Island, the Bellarine, or Frankston. The constraint is what makes the recommendations sharp.</p></div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</V4BaseLayout>

--- a/next/src/pages/v4/wine/index.astro
+++ b/next/src/pages/v4/wine/index.astro
@@ -1,0 +1,337 @@
+---
+import { getCollection } from 'astro:content';
+import V4BaseLayout from '../../../layouts/v4/V4BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import GuideHero from '../../../components/GuideHero.astro';
+import CompareBlock from '../../../components/CompareBlock.astro';
+import SectionDivider from '../../../components/SectionDivider.astro';
+import VenueCard from '../../../components/VenueCard.astro';
+import ArticleCard from '../../../components/ArticleCard.astro';
+import PlaceCard from '../../../components/PlaceCard.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import EventStrip from '../../../components/EventStrip.astro';
+import { routeSlug, currentSeason, seasonBlurb, isUpcoming } from '../../../lib/editorial';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+const wineTypes = ['winery', 'producer', 'brewery', 'distillery'];
+
+// Cellar door + wine events surfacing from /whats-on/ on the wine hub.
+const wineEventCategories = ['cellar-door', 'food-wine'];
+const wineEvents = (await getCollection('events'))
+  .filter((event) => wineEventCategories.includes(event.data.category))
+  .filter((event) => {
+    if (['weekly', 'monthly', 'ongoing'].includes(event.data.recurrence)) return true;
+    return isUpcoming(event.data.endDate ?? event.data.startDate);
+  })
+  .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
+  .slice(0, 3);
+const venues = (await getCollection('venues'))
+  .filter((venue) => wineTypes.includes(venue.data.type))
+  .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
+
+const wineries = venues.filter((v) => v.data.type === 'winery');
+const producers = venues.filter((v) => v.data.type === 'producer');
+const breweries = venues.filter((v) => v.data.type === 'brewery');
+const distilleries = venues.filter((v) => v.data.type === 'distillery');
+
+const benchmarkSlugs = [
+  'pt-leo-estate', 'montalto', 'paringa-estate', 'polperro', 'dexter-wines', 'ocean-eight',
+];
+const benchmarks = benchmarkSlugs
+  .map((slug) => venues.find((venue) => routeSlug(venue) === slug))
+  .filter((venue): venue is NonNullable<typeof venue> => Boolean(venue));
+
+const appointmentOnly = venues
+  .filter((venue) => venue.data.bookingProvider === 'direct' || Number(venue.data.authority?.hallidayScore ?? 0) >= 95)
+  .filter((venue) => !benchmarks.some((b) => routeSlug(b) === routeSlug(venue)))
+  .slice(0, 6);
+
+const places = await getCollection('places');
+const wineHubs = places.filter((place) =>
+  ['red-hill', 'main-ridge', 'merricks', 'balnarring', 'moorooduc', 'tuerong'].includes(routeSlug(place)),
+);
+
+const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+const companionSlugs = [
+  'the-chardonnay-case', 'the-cellar-door-short-list', 'how-to-build-a-red-hill-saturday', 'the-peninsula-pantry',
+];
+const companionReads = companionSlugs
+  .map((slug) => articlesAll.find((a) => routeSlug(a) === slug))
+  .filter((a): a is NonNullable<typeof a> => Boolean(a));
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Wine Country' },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org', '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: 'What wine is the Mornington Peninsula known for?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Pinot Noir and Chardonnay are the benchmark varieties, the cool maritime climate and basalt soils of the Red Hill plateau produce some of Australia\'s most consistent cool-climate examples. The region also has a growing reputation for Pinot Gris and Shiraz. Over 50 cellar doors are open to visitors, concentrated on the ridge between Red Hill and Main Ridge.' } },
+    { '@type': 'Question', name: 'Do I need to book cellar door visits on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Some cellar doors operate by appointment only (Ten Minutes by Tractor, Main Ridge Estate, Paringa Estate). Others welcome walk-ins (Montalto, Polperro, Red Hill Estate). Check before you drive, appointment-only cellar doors are common on the plateau and the experience is better when expected. Weekend afternoons are busiest.' } },
+    { '@type': 'Question', name: 'How many wineries are on the Mornington Peninsula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The Mornington Peninsula has over 200 vineyards and approximately 50–60 cellar doors open to visitors. Most are concentrated on the Red Hill plateau between Dromana, Red Hill, and Main Ridge. The region is compact, you can visit three cellar doors in an afternoon without rushing if you stay on the ridge.' } },
+  ],
+};
+---
+
+<V4BaseLayout
+  title="Best Wineries Mornington Peninsula · Peninsula Insider"
+  description="The best cellar doors on the Mornington Peninsula, Pinot Noir, Chardonnay, cool-climate producers, breweries, and distilleries. Appointment tastings and walk-in cellar doors. Updated for autumn."
+  section="wine"
+  modifiedTime="2026-04-30"
+  ogImage="/images/sourced/article-cellar-door-01.webp"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       1. CINEMATIC HERO
+       ═══════════════════════════════════════════════════════════════ -->
+  <GuideHero
+    eyebrow={`Wine Country · ${wineries.length} wineries · ${producers.length + breweries.length + distilleries.length} other producers · Last verified 30 Apr 2026`}
+    title="The Peninsula's best bottles start on the <em>ridge</em>"
+    dek="Pinot noir and chardonnay built on basalt, plus the breweries, distilleries, and producers rounding out the region. Sorted by what they're actually for, long lunches, appointment tastings, and afternoons that earn the drive."
+    meta={[
+      { label: `${wineries.length} wineries` },
+      { label: `${breweries.length} breweries` },
+      { label: `${distilleries.length} distilleries` },
+      { label: `${producers.length} producers` },
+    ]}
+    heroImage="/images/sourced/article-cellar-door-01.webp"
+    imageAlt="A Peninsula cellar door, bottles open, glasses poured, the moment before the tasting"
+    imageCredit="Peninsula Insider"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       2. ORIENTATION: Walk-in vs Appointment
+       ═══════════════════════════════════════════════════════════════ -->
+  <CompareBlock
+    eyebrow="Two ways into a Peninsula wine afternoon"
+    heading="Walk-in cellar doors or appointment producers"
+    dek="Knowing which kind of tasting you're booking decides the whole shape of the day. Both have their place. They are not interchangeable."
+    left={{
+      label: 'Walk-in · long lunch',
+      title: 'Anchor the day on one cellar door. Stay three hours.',
+      rows: [
+        { label: 'Flagship rooms', value: 'Montalto, Polperro, Pt. Leo Estate, Red Hill Estate, Foxeys Hangout, Paringa Estate' },
+        { label: 'Format', value: 'Walk-in tasting at the bar, optional purchase, then a long lunch in the on-site dining room. The afternoon shapes itself around the table.' },
+        { label: 'Best for', value: 'First-time visitors, mixed-interest groups, groups where one person wants the wine and the rest want the lunch.' },
+        { label: 'Booking', value: 'Cellar doors take walk-ins; the dining rooms book 2–6 weeks ahead for weekends. Hatted rooms (Laura, Tedesca) book further out.' },
+        { label: 'Vibe', value: 'Considered, social, fire-lit in winter. The Peninsula at its most generous.' },
+      ],
+    }}
+    right={{
+      label: 'Appointment · the obsessive afternoon',
+      title: 'Two small tastings, one village meal in between.',
+      rows: [
+        { label: 'Flagship rooms', value: 'Ten Minutes by Tractor, Main Ridge Estate, Dexter Wines, Quealy Winemakers, Eldridge Estate, Garagiste' },
+        { label: 'Format', value: 'Booked tasting with the winemaker or cellar-door manager. Smaller pours, more conversation, often the back-vintages and trial blocks.' },
+        { label: 'Best for', value: 'Wine-literate visitors, second-time-on-the-ridge weekends, the trip where the wine is genuinely the point.' },
+        { label: 'Booking', value: 'Always required. 1–3 weeks ahead is comfortable. Some producers run by-the-bottle pre-paid tastings; others charge per head, redeemable.' },
+        { label: 'Vibe', value: 'Quiet, focused, slightly more like work. Reward exceeds the effort.' },
+      ],
+    }}
+  />
+
+  <EventStrip
+    events={wineEvents}
+    eyebrow="Cellar door events"
+    heading="Release weekends and winemaker dinners worth a booking"
+    intro="The Peninsula's strongest event category, rarely treated as events. Tap an event for editorial notes."
+    moreHref="/whats-on/"
+    moreLabel="All events"
+  />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       3. BENCHMARK CELLAR DOORS
+       ═══════════════════════════════════════════════════════════════ -->
+  {benchmarks.length > 0 && (
+    <section class="venues" id="benchmarks">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Benchmark cellar doors</p>
+            <h2 class="venues__title">The producers anchoring the region right now</h2>
+            <p class="venues__sub venues__sub--standfirst">Halliday scores matter less than editorial weight. This is the shortlist we'd put in front of a first-time visitor and a returning obsessive both, the rooms that consistently justify the drive.</p>
+          </div>
+          <a href="/journal/the-cellar-door-short-list/" class="venues__link">Read the shortlist →</a>
+        </div>
+        <div class="venues__grid">
+          {benchmarks.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       4. APPOINTMENT PRODUCERS
+       ═══════════════════════════════════════════════════════════════ -->
+  {appointmentOnly.length > 0 && (
+    <section class="venues venues--plain" id="appointment">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Appointment producers</p>
+            <h2 class="venues__title">Worth planning the drive around</h2>
+            <p class="venues__sub venues__sub--standfirst">The producers that reward a booking, smaller tastings, closer to the winemaking, often the most interesting conversations of the weekend.</p>
+          </div>
+        </div>
+        <div class="venues__grid">
+          {appointmentOnly.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       5. THE WIDER PRODUCER NETWORK, breweries, distilleries, producers
+       ═══════════════════════════════════════════════════════════════ -->
+  {breweries.length > 0 && (
+    <section class="venues" id="breweries">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Breweries</p>
+            <h2 class="venues__title">The Peninsula's beer shortlist</h2>
+            <p class="venues__sub">Where the weekend wants a slightly less serious spine. The breweries doing real work outside the wine story.</p>
+          </div>
+        </div>
+        <div class="venues__grid">
+          {breweries.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {distilleries.length > 0 && (
+    <section class="venues venues--plain" id="distilleries">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Distilleries</p>
+            <h2 class="venues__title">Gin, whisky, and the slow craft layer</h2>
+            <p class="venues__sub">Small-batch producers working quietly behind the wine story.</p>
+          </div>
+        </div>
+        <div class="venues__grid">
+          {distilleries.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  {producers.length > 0 && (
+    <section class="venues" id="producers">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">Producers & makers</p>
+            <h2 class="venues__title">Cheese, truffles, olive oil, chocolate, the wider Peninsula pantry</h2>
+            <p class="venues__sub">The producers that round out a long lunch with everything the cellar door forgot.</p>
+          </div>
+          <a href="/journal/the-peninsula-pantry/" class="venues__link">Read the pantry piece →</a>
+        </div>
+        <div class="venues__grid">
+          {producers.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <SectionDivider />
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6. ALL WINERIES, full directory
+       ═══════════════════════════════════════════════════════════════ -->
+  {wineries.length > 0 && (
+    <section class="venues venues--plain" id="wineries">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">All wineries</p>
+            <h2 class="venues__title">{wineries.length} cellar doors across the region</h2>
+            <p class="venues__sub">Sorted by authority. Expect a spread from three-hat destinations to back-road pinot rooms.</p>
+          </div>
+        </div>
+        <div class="venues__grid">
+          {wineries.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       7. WINE COUNTRY, BY PLACE
+       ═══════════════════════════════════════════════════════════════ -->
+  {wineHubs.length > 0 && (
+    <section class="places" id="hubs">
+      <div class="container">
+        <div class="places__header">
+          <p class="label label--accent places__label">Wine country, by place</p>
+          <h2 class="places__title">The hubs that organise the region</h2>
+          <p class="places__sub">Each hub pulls the cellar doors, producers, and long lunches into one stretch of landscape.</p>
+        </div>
+        <div class="places__grid">
+          {wineHubs.map((place) => <PlaceCard place={place} variant="vineyard" />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       8. EDITORIAL GUIDES
+       ═══════════════════════════════════════════════════════════════ -->
+  {companionReads.length > 0 && (
+    <section class="venues" id="reads">
+      <div class="container">
+        <div class="venues__header">
+          <div>
+            <p class="label label--accent">From the Journal</p>
+            <h2 class="venues__title">The wine arguments worth reading before you buy</h2>
+            <p class="venues__sub">Service pieces and dispatches that shape the cellar-door day better than any tasting note.</p>
+          </div>
+          <a href="/journal/" class="venues__link">All in the Journal →</a>
+        </div>
+        <div class="venues__grid">
+          {companionReads.map((article) => <ArticleCard article={article} />)}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       9. FAQ
+       ═══════════════════════════════════════════════════════════════ -->
+  <section class="hub-faq" aria-label="Frequently asked questions">
+    <div class="container">
+      <div class="hub-faq__intro">
+        <p class="label label--accent">Frequently asked</p>
+        <h2 class="hub-faq__title">Three honest answers before you book</h2>
+      </div>
+      <div class="hub-faq__list">
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">What wine is the Peninsula known for?</summary>
+          <div class="hub-faq__a"><p>Pinot Noir and Chardonnay are the benchmark varieties, the cool maritime climate and basalt soils of the Red Hill plateau produce some of Australia's most consistent cool-climate examples. The region also has a growing reputation for Pinot Gris and Shiraz. Over 50 cellar doors are open to visitors, concentrated on the ridge between Red Hill and Main Ridge.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">Do I need to book cellar door visits?</summary>
+          <div class="hub-faq__a"><p>Some cellar doors operate by appointment only (Ten Minutes by Tractor, Main Ridge Estate, Paringa Estate). Others welcome walk-ins (Montalto, Polperro, Red Hill Estate). Check before you drive, appointment-only cellar doors are common on the plateau and the experience is better when expected. Weekend afternoons are busiest.</p></div>
+        </details>
+        <details class="hub-faq__item">
+          <summary class="hub-faq__q">How many wineries are on the Peninsula?</summary>
+          <div class="hub-faq__a"><p>Over 200 vineyards and approximately 50–60 cellar doors open to visitors. Most are concentrated on the Red Hill plateau between Dromana, Red Hill, and Main Ridge. The region is compact, you can visit three cellar doors in an afternoon without rushing if you stay on the ridge.</p></div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock />
+</V4BaseLayout>
+

--- a/next/src/styles/v3.css
+++ b/next/src/styles/v3.css
@@ -205,9 +205,11 @@ body[data-v3="true"] {
   padding: 0;
   gap: clamp(18px, 3vw, 36px);
 }
-.v3-nav__item {
-  position: relative;
-}
+/* Intentionally NOT position:relative — the mega panel anchors to
+   .v3-masthead__nav-row (full width) instead of the tiny nav item.
+   Keeping items in static flow so .v3-mega { left:0; right:0; } spans
+   the whole nav row. */
+.v3-nav__item { position: static; }
 .v3-nav__link {
   font-family: var(--v3-sans);
   font-size: 14px;
@@ -431,19 +433,26 @@ body[data-v3="true"] {
 }
 .v3-cover__media img,
 .v3-cover__media video {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center;
 }
+.v3-cover__media img { z-index: 1; }    /* poster underneath */
+.v3-cover__media video { z-index: 2; background: #000; }  /* video on top once it loads */
 .v3-cover__media::after {
   content: "";
   position: absolute;
   inset: 0;
+  z-index: 3;
+  pointer-events: none;
   background: linear-gradient(180deg,
-    rgba(0,0,0,0.15) 0%,
+    rgba(0,0,0,0.30) 0%,
     rgba(0,0,0,0.05) 30%,
-    rgba(0,0,0,0.25) 65%,
-    rgba(0,0,0,0.7) 100%);
+    rgba(0,0,0,0.20) 60%,
+    rgba(0,0,0,0.78) 100%);
 }
 .v3-cover__inner {
   position: relative;
@@ -456,8 +465,9 @@ body[data-v3="true"] {
   font-size: 11px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.85);
+  color: rgba(255,255,255,0.92) !important;
   margin-bottom: 18px;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.5);
 }
 .v3-cover__eyebrow strong {
   font-weight: 500;
@@ -475,15 +485,19 @@ body[data-v3="true"] {
   letter-spacing: -0.01em;
   max-width: 18ch;
   margin: 0 0 18px 0;
-  text-shadow: 0 2px 18px rgba(0,0,0,0.35);
+  /* Force white over the image — global.css sets h1 { color: var(--text) }
+     which is dark and would otherwise win over inherited color. */
+  color: #fff !important;
+  text-shadow: 0 2px 18px rgba(0,0,0,0.45);
 }
-.v3-cover__title em { font-style: italic; color: #fff; }
+.v3-cover__title em { font-style: italic; color: #fff !important; }
 .v3-cover__meta {
   font-family: var(--v3-sans);
   font-size: 13px;
   letter-spacing: 0.06em;
-  color: rgba(255,255,255,0.85);
+  color: rgba(255,255,255,0.92) !important;
   margin-bottom: 28px;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.4);
 }
 .v3-cover__cta-row {
   display: inline-flex;
@@ -1143,8 +1157,9 @@ body[data-v3="true"] {
   line-height: 1.1;
   margin: 0 auto 14px;
   max-width: 22ch;
+  color: #fff !important;  /* override global h2 { color: var(--dark) } */
 }
-.v3-stripe__title em { font-style: italic; }
+.v3-stripe__title em { font-style: italic; color: #fff !important; }
 .v3-stripe__body {
   font-family: var(--v3-serif);
   font-size: 18px;

--- a/next/src/styles/v3.css
+++ b/next/src/styles/v3.css
@@ -1,0 +1,1517 @@
+/* =========================================================
+   Peninsula Insider — V3 design tokens & components
+   ---------------------------------------------------------
+   Loaded ONLY by V3BaseLayout. Production V2 styles continue
+   to live in global.css and are unaffected.
+
+   Philosophy: editorial chrome stays restrained, imagery and
+   motion do the heavy lifting. Colour palette = palette of
+   conditions (paper, ink, bay, vine, ridge, hairline).
+   ========================================================= */
+
+:root {
+  /* V3 palette of conditions. Coexists with V2 tokens; named
+     under --v3- to keep the live site untouched. */
+  --v3-paper:        #F6F1E8;
+  --v3-paper-warm:   #FAF6EE;
+  --v3-ink:          #1A1A1A;
+  --v3-ink-soft:     #4A4541;
+  --v3-bay:          #1E5C7A;
+  --v3-bay-deep:     #134357;
+  --v3-vine:         #A8362B;
+  --v3-vine-deep:    #842419;
+  --v3-ridge:        #7A8A6A;
+  --v3-hairline:     #D9D2C2;
+  --v3-hairline-soft:#E8E2D3;
+  --v3-shadow:       0 12px 32px -16px rgba(26, 26, 26, 0.18);
+  --v3-shadow-deep:  0 24px 60px -24px rgba(26, 26, 26, 0.32);
+
+  /* Motion tokens. */
+  --v3-ease:         cubic-bezier(0.2, 0.8, 0.2, 1);
+  --v3-d-fast:       180ms;
+  --v3-d-base:       280ms;
+  --v3-d-slow:       480ms;
+
+  /* Type. */
+  --v3-serif:  'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+  --v3-sans:   'Outfit', system-ui, -apple-system, sans-serif;
+
+  /* Layout. */
+  --v3-max-w:   1200px;
+  --v3-gutter:  clamp(20px, 4vw, 56px);
+}
+
+/* =========================================================
+   V3 LAYOUT WRAPPER
+   ========================================================= */
+body[data-v3="true"] {
+  background: var(--v3-paper);
+  color: var(--v3-ink);
+  font-family: var(--v3-sans);
+  font-weight: 300;
+  line-height: 1.65;
+  font-size: 17px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.v3-container {
+  width: 100%;
+  max-width: var(--v3-max-w);
+  margin: 0 auto;
+  padding-left: var(--v3-gutter);
+  padding-right: var(--v3-gutter);
+}
+
+.v3-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  font-family: var(--v3-sans);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--v3-bay);
+  margin: 0 0 14px 0;
+}
+.v3-eyebrow--vine  { color: var(--v3-vine); }
+.v3-eyebrow--ridge { color: var(--v3-ridge); }
+.v3-eyebrow::before {
+  content: "";
+  display: block;
+  width: 28px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.45;
+}
+
+.v3-rule {
+  border: 0;
+  border-top: 1px solid var(--v3-hairline);
+  margin: 0;
+}
+
+.v3-display {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  color: var(--v3-ink);
+  margin: 0;
+}
+.v3-display em { font-style: italic; font-weight: 500; color: var(--v3-bay-deep); }
+
+/* =========================================================
+   V3 UTILITY BAR
+   ========================================================= */
+.v3-utility {
+  background: var(--v3-ink);
+  color: var(--v3-paper);
+  font-family: var(--v3-sans);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.v3-utility__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 32px;
+  gap: 16px;
+}
+.v3-utility__edition { opacity: 0.85; }
+.v3-utility__edition strong {
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fff;
+  margin-right: 8px;
+}
+.v3-utility__links { display: inline-flex; gap: 18px; }
+.v3-utility__links a {
+  color: var(--v3-paper);
+  text-decoration: none;
+  opacity: 0.85;
+  transition: opacity var(--v3-d-fast) var(--v3-ease);
+}
+.v3-utility__links a:hover { opacity: 1; }
+@media (max-width: 640px) {
+  .v3-utility__edition span:first-child { display: none; }
+  .v3-utility__inner { height: 30px; }
+  .v3-utility__links { gap: 14px; }
+}
+
+/* =========================================================
+   V3 MASTHEAD
+   ========================================================= */
+.v3-masthead {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: var(--v3-paper);
+  border-bottom: 1px solid var(--v3-hairline);
+  transition: box-shadow var(--v3-d-base) var(--v3-ease);
+}
+.v3-masthead.is-scrolled {
+  box-shadow: var(--v3-shadow);
+}
+
+.v3-masthead__brand {
+  padding: 22px 0 10px;
+  text-align: center;
+  border-bottom: 1px solid var(--v3-hairline-soft);
+}
+.v3-masthead.is-scrolled .v3-masthead__brand { padding: 12px 0 6px; }
+
+.v3-masthead__logo {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(22px, 3.2vw, 30px);
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  color: var(--v3-ink);
+  display: inline-block;
+}
+.v3-masthead__logo span {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--v3-bay-deep);
+}
+.v3-masthead__tagline {
+  display: block;
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--v3-ink-soft);
+  margin-top: 4px;
+}
+.v3-masthead.is-scrolled .v3-masthead__tagline { display: none; }
+
+.v3-masthead__nav-row {
+  position: relative;
+}
+.v3-masthead__nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  height: 56px;
+}
+
+.v3-nav {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: clamp(18px, 3vw, 36px);
+}
+.v3-nav__item {
+  position: relative;
+}
+.v3-nav__link {
+  font-family: var(--v3-sans);
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  color: var(--v3-ink);
+  text-decoration: none;
+  padding: 18px 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-bottom: 2px solid transparent;
+  transition: color var(--v3-d-fast) var(--v3-ease), border-color var(--v3-d-fast) var(--v3-ease);
+}
+.v3-nav__link:hover,
+.v3-nav__item.is-open > .v3-nav__link,
+.v3-nav__item[aria-current="true"] > .v3-nav__link {
+  color: var(--v3-bay-deep);
+  border-bottom-color: var(--v3-bay);
+}
+.v3-nav__link--journal { font-style: italic; font-family: var(--v3-serif); font-size: 18px; letter-spacing: 0; }
+
+.v3-nav__chev {
+  width: 8px;
+  height: 8px;
+  margin-top: 2px;
+  transition: transform var(--v3-d-fast) var(--v3-ease);
+}
+.v3-nav__item.is-open .v3-nav__chev { transform: rotate(180deg); }
+
+.v3-masthead__utility-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.v3-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--v3-hairline);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--v3-ink);
+  cursor: pointer;
+  transition: background var(--v3-d-fast) var(--v3-ease), border-color var(--v3-d-fast) var(--v3-ease);
+}
+.v3-iconbtn:hover { background: var(--v3-paper-warm); border-color: var(--v3-bay); color: var(--v3-bay-deep); }
+
+.v3-ask-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px 8px 10px;
+  border-radius: 999px;
+  background: var(--v3-ink);
+  color: var(--v3-paper);
+  text-decoration: none;
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--v3-ink);
+  transition: background var(--v3-d-fast) var(--v3-ease), transform var(--v3-d-fast) var(--v3-ease);
+}
+.v3-ask-pill:hover { background: var(--v3-bay-deep); border-color: var(--v3-bay-deep); transform: translateY(-1px); }
+.v3-ask-pill__dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--v3-vine);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--v3-serif);
+  font-size: 12px;
+  font-style: italic;
+  color: #fff;
+  line-height: 1;
+}
+
+.v3-subscribe-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--v3-vine);
+  color: #fff;
+  text-decoration: none;
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  transition: background var(--v3-d-fast) var(--v3-ease), transform var(--v3-d-fast) var(--v3-ease);
+}
+.v3-subscribe-cta:hover { background: var(--v3-vine-deep); transform: translateY(-1px); }
+
+/* =========================================================
+   V3 MEGA PANEL
+   ========================================================= */
+.v3-mega {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  background: var(--v3-paper);
+  border-top: 1px solid var(--v3-hairline);
+  border-bottom: 1px solid var(--v3-hairline);
+  box-shadow: var(--v3-shadow);
+  padding: 36px 0 40px;
+  display: none;
+  z-index: 70;
+}
+.v3-nav__item.is-open .v3-mega { display: block; }
+
+.v3-mega__grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr 1fr 1fr;
+  gap: 36px;
+  align-items: start;
+}
+.v3-mega__rail {
+  position: relative;
+  border-radius: 4px;
+  overflow: hidden;
+  aspect-ratio: 4 / 5;
+  background: var(--v3-ink);
+}
+.v3-mega__rail img { width: 100%; height: 100%; object-fit: cover; opacity: 0.95; }
+.v3-mega__rail-caption {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  right: 16px;
+  color: #fff;
+  font-family: var(--v3-serif);
+  font-size: 22px;
+  line-height: 1.15;
+  font-style: italic;
+  text-shadow: 0 2px 12px rgba(0,0,0,0.5);
+}
+.v3-mega__col h3 {
+  font-family: var(--v3-sans);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--v3-bay);
+  margin: 0 0 14px 0;
+}
+.v3-mega__col ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 10px; }
+.v3-mega__col a {
+  font-family: var(--v3-serif);
+  font-size: 19px;
+  color: var(--v3-ink);
+  text-decoration: none;
+  letter-spacing: 0.005em;
+  transition: color var(--v3-d-fast) var(--v3-ease);
+  display: inline-block;
+  padding-bottom: 1px;
+  border-bottom: 1px solid transparent;
+}
+.v3-mega__col a:hover {
+  color: var(--v3-bay-deep);
+  border-bottom-color: var(--v3-bay);
+}
+
+@media (max-width: 980px) {
+  .v3-mega__grid { grid-template-columns: 1fr 1fr; gap: 28px; }
+  .v3-mega__rail { display: none; }
+}
+@media (max-width: 640px) {
+  .v3-masthead__nav-row { display: none; }
+  .v3-mega { display: none; }
+}
+
+/* =========================================================
+   V3 MOBILE MASTHEAD
+   ========================================================= */
+.v3-masthead__mobile {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+  border-top: 1px solid var(--v3-hairline-soft);
+}
+@media (max-width: 640px) {
+  .v3-masthead__mobile { display: flex; }
+  .v3-masthead__brand { padding: 14px 0 6px; }
+}
+.v3-burger {
+  width: 40px; height: 40px;
+  display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 4px;
+  border: 1px solid var(--v3-hairline);
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+}
+.v3-burger span { display: block; width: 16px; height: 1.5px; background: var(--v3-ink); }
+
+/* =========================================================
+   V3 HOME COVER (cinematic)
+   ========================================================= */
+.v3-cover {
+  position: relative;
+  min-height: 84vh;
+  display: flex;
+  align-items: flex-end;
+  background: var(--v3-ink);
+  color: #fff;
+  overflow: hidden;
+  isolation: isolate;
+}
+.v3-cover__media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+.v3-cover__media img,
+.v3-cover__media video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.v3-cover__media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg,
+    rgba(0,0,0,0.15) 0%,
+    rgba(0,0,0,0.05) 30%,
+    rgba(0,0,0,0.25) 65%,
+    rgba(0,0,0,0.7) 100%);
+}
+.v3-cover__inner {
+  position: relative;
+  z-index: 1;
+  padding: 120px 0 64px;
+  width: 100%;
+}
+.v3-cover__eyebrow {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.85);
+  margin-bottom: 18px;
+}
+.v3-cover__eyebrow strong {
+  font-weight: 500;
+  margin-right: 10px;
+  padding: 3px 10px;
+  background: var(--v3-vine);
+  border-radius: 2px;
+  color: #fff;
+}
+.v3-cover__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(40px, 7vw, 88px);
+  line-height: 1.04;
+  letter-spacing: -0.01em;
+  max-width: 18ch;
+  margin: 0 0 18px 0;
+  text-shadow: 0 2px 18px rgba(0,0,0,0.35);
+}
+.v3-cover__title em { font-style: italic; color: #fff; }
+.v3-cover__meta {
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: rgba(255,255,255,0.85);
+  margin-bottom: 28px;
+}
+.v3-cover__cta-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.v3-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 22px;
+  border-radius: 999px;
+  font-family: var(--v3-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  border: 1px solid currentColor;
+  transition: background var(--v3-d-base) var(--v3-ease),
+              color      var(--v3-d-base) var(--v3-ease),
+              transform  var(--v3-d-base) var(--v3-ease);
+}
+.v3-btn--solid {
+  background: var(--v3-paper);
+  color: var(--v3-ink);
+  border-color: var(--v3-paper);
+}
+.v3-btn--solid:hover { transform: translateY(-2px); background: #fff; color: var(--v3-bay-deep); }
+.v3-btn--ghost {
+  background: transparent;
+  color: #fff;
+  border-color: rgba(255,255,255,0.6);
+}
+.v3-btn--ghost:hover { transform: translateY(-2px); border-color: #fff; background: rgba(255,255,255,0.08); }
+.v3-btn--vine {
+  background: var(--v3-vine);
+  color: #fff;
+  border-color: var(--v3-vine);
+}
+.v3-btn--vine:hover { background: var(--v3-vine-deep); border-color: var(--v3-vine-deep); }
+
+@media (max-width: 640px) {
+  .v3-cover { min-height: 78vh; }
+  .v3-cover__inner { padding: 96px 0 40px; }
+}
+
+/* =========================================================
+   V3 ASK PI BLOCK (homepage front-door)
+   ========================================================= */
+.v3-ask {
+  background: var(--v3-paper-warm);
+  padding: 88px 0;
+  border-bottom: 1px solid var(--v3-hairline-soft);
+}
+.v3-ask__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.8fr);
+  gap: 56px;
+  align-items: center;
+}
+.v3-ask__intro h2 {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(34px, 4.4vw, 56px);
+  line-height: 1.05;
+  margin: 0 0 18px 0;
+  color: var(--v3-ink);
+}
+.v3-ask__intro h2 em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-ask__intro p {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 19px;
+  line-height: 1.45;
+  color: var(--v3-ink-soft);
+  margin: 0;
+  max-width: 36ch;
+}
+.v3-ask__form {
+  display: grid;
+  gap: 20px;
+}
+.v3-ask__field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: #fff;
+  border: 1px solid var(--v3-hairline);
+  border-radius: 4px;
+  transition: border-color var(--v3-d-fast) var(--v3-ease), box-shadow var(--v3-d-fast) var(--v3-ease);
+}
+.v3-ask__field:focus-within {
+  border-color: var(--v3-bay);
+  box-shadow: 0 0 0 4px rgba(30, 92, 122, 0.08);
+}
+.v3-ask__avatar {
+  width: 44px;
+  height: 44px;
+  margin: 8px 0 8px 14px;
+  border-radius: 50%;
+  background: var(--v3-ink) url('/images/pi-mark.svg') center/65% no-repeat;
+  flex-shrink: 0;
+  position: relative;
+}
+.v3-ask__avatar::after {
+  content: "";
+  position: absolute;
+  bottom: 2px; right: 2px;
+  width: 9px; height: 9px;
+  background: var(--v3-ridge);
+  border-radius: 50%;
+  border: 2px solid #fff;
+}
+.v3-ask__input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  padding: 18px 16px;
+  font-family: var(--v3-serif);
+  font-size: 19px;
+  color: var(--v3-ink);
+  outline: none;
+}
+.v3-ask__input::placeholder { color: var(--v3-ink-soft); font-style: italic; opacity: 0.75; }
+.v3-ask__submit {
+  border: 0;
+  background: var(--v3-ink);
+  color: var(--v3-paper);
+  padding: 14px 22px;
+  margin-right: 8px;
+  border-radius: 4px;
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--v3-d-fast) var(--v3-ease);
+}
+.v3-ask__submit:hover { background: var(--v3-bay-deep); }
+.v3-ask__chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.v3-ask__chip {
+  display: inline-flex;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--v3-hairline);
+  background: transparent;
+  color: var(--v3-ink-soft);
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 15px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color var(--v3-d-fast) var(--v3-ease), color var(--v3-d-fast) var(--v3-ease), background var(--v3-d-fast) var(--v3-ease);
+}
+.v3-ask__chip:hover {
+  border-color: var(--v3-bay);
+  color: var(--v3-bay-deep);
+  background: #fff;
+}
+.v3-ask__hint {
+  font-family: var(--v3-sans);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--v3-ink-soft);
+  margin-top: -6px;
+}
+
+@media (max-width: 880px) {
+  .v3-ask__inner { grid-template-columns: 1fr; gap: 32px; }
+  .v3-ask { padding: 64px 0; }
+}
+
+/* =========================================================
+   V3 PILLAR GRID (Stay / Explore / Plans / Tours)
+   ========================================================= */
+.v3-pillargrid { padding: 96px 0; }
+.v3-pillargrid__intro {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 40px;
+  align-items: end;
+  margin-bottom: 48px;
+}
+.v3-pillargrid__intro h2 {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(30px, 3.8vw, 48px);
+  line-height: 1.05;
+  margin: 0;
+}
+.v3-pillargrid__intro h2 em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-pillargrid__intro p {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 19px;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+.v3-pillargrid__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.v3-pillarcard {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 28px 24px 32px;
+  background: #fff;
+  border: 1px solid var(--v3-hairline);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--v3-ink);
+  position: relative;
+  transition: transform var(--v3-d-base) var(--v3-ease),
+              box-shadow var(--v3-d-base) var(--v3-ease),
+              border-color var(--v3-d-base) var(--v3-ease);
+}
+.v3-pillarcard:hover {
+  transform: translateY(-4px);
+  border-color: var(--v3-bay);
+  box-shadow: var(--v3-shadow);
+}
+.v3-pillarcard__icon {
+  width: 32px; height: 32px;
+  color: var(--v3-bay);
+}
+.v3-pillarcard__label {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--v3-bay);
+}
+.v3-pillarcard__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.2;
+  margin: 0;
+}
+.v3-pillarcard__body {
+  font-family: var(--v3-sans);
+  font-size: 14px;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+.v3-pillarcard__cta {
+  margin-top: auto;
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--v3-bay-deep);
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 980px) {
+  .v3-pillargrid__intro { grid-template-columns: 1fr; gap: 16px; }
+  .v3-pillargrid__grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 560px) {
+  .v3-pillargrid { padding: 64px 0; }
+  .v3-pillargrid__grid {
+    grid-template-columns: 80% 80%;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding-bottom: 8px;
+  }
+  .v3-pillarcard { scroll-snap-align: start; }
+}
+
+/* =========================================================
+   V3 WEEKEND HERO
+   ========================================================= */
+.v3-weekend {
+  background: var(--v3-paper-warm);
+  padding: 96px 0;
+  border-top: 1px solid var(--v3-hairline-soft);
+  border-bottom: 1px solid var(--v3-hairline-soft);
+}
+.v3-weekend__grid {
+  display: grid;
+  grid-template-columns: 0.85fr 1.5fr;
+  gap: 56px;
+  align-items: start;
+}
+.v3-weekend__date {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 21px;
+  color: var(--v3-bay-deep);
+  margin: 0 0 8px 0;
+}
+.v3-weekend__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(30px, 3.6vw, 44px);
+  line-height: 1.05;
+  margin: 0 0 18px 0;
+}
+.v3-weekend__title em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-weekend__lede {
+  font-family: var(--v3-serif);
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--v3-ink-soft);
+  max-width: 38ch;
+  margin: 0 0 24px 0;
+}
+.v3-weekend__cta { margin-top: 8px; }
+.v3-weekend__events {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 980px) {
+  .v3-weekend__grid { grid-template-columns: 1fr; gap: 32px; }
+  .v3-weekend__events { grid-template-columns: 1fr; }
+}
+
+/* =========================================================
+   V3 INTENT GRID
+   ========================================================= */
+.v3-intent { padding: 96px 0; }
+.v3-intent__intro {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 40px;
+  align-items: end;
+  margin-bottom: 48px;
+}
+.v3-intent__intro h2 {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(30px, 3.8vw, 48px);
+  line-height: 1.05;
+  margin: 0;
+}
+.v3-intent__intro h2 em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-intent__intro p {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 19px;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+.v3-intent__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.v3-intentcard {
+  display: grid;
+  grid-template-columns: 1fr 78px;
+  gap: 14px;
+  padding: 22px;
+  border: 1px solid var(--v3-hairline);
+  background: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--v3-ink);
+  align-items: start;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--v3-d-base) var(--v3-ease),
+              box-shadow var(--v3-d-base) var(--v3-ease),
+              border-color var(--v3-d-base) var(--v3-ease);
+}
+.v3-intentcard:hover {
+  transform: translateY(-3px);
+  border-color: var(--v3-bay);
+  box-shadow: var(--v3-shadow);
+}
+.v3-intentcard__label {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.1;
+  color: var(--v3-ink);
+}
+.v3-intentcard__note {
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--v3-ink-soft);
+  display: block;
+  margin-top: 6px;
+}
+.v3-intentcard__img {
+  width: 78px; height: 78px;
+  border-radius: 4px;
+  background: var(--v3-paper-warm) center/cover no-repeat;
+}
+.v3-intentcard__arrow {
+  position: absolute;
+  bottom: 14px; right: 18px;
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  color: var(--v3-bay-deep);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity var(--v3-d-base) var(--v3-ease), transform var(--v3-d-base) var(--v3-ease);
+}
+.v3-intentcard:hover .v3-intentcard__arrow { opacity: 1; transform: translateX(0); }
+
+@media (max-width: 980px) {
+  .v3-intent__intro { grid-template-columns: 1fr; gap: 16px; }
+  .v3-intent__grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 560px) {
+  .v3-intent { padding: 64px 0; }
+  .v3-intent__grid { grid-template-columns: 1fr; }
+}
+
+/* =========================================================
+   V3 EVENT CARD (compact, weekend strip)
+   ========================================================= */
+.v3-eventcard {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  background: #fff;
+  border: 1px solid var(--v3-hairline);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--v3-ink);
+  transition: transform var(--v3-d-base) var(--v3-ease), border-color var(--v3-d-base) var(--v3-ease);
+}
+.v3-eventcard:hover { transform: translateY(-3px); border-color: var(--v3-bay); }
+.v3-eventcard__date {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--v3-bay);
+}
+.v3-eventcard__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.15;
+  margin: 0;
+}
+.v3-eventcard__venue {
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  color: var(--v3-ink-soft);
+}
+.v3-eventcard__flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+.v3-flag {
+  display: inline-flex;
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--v3-paper-warm);
+  color: var(--v3-ink-soft);
+  border: 1px solid var(--v3-hairline);
+}
+.v3-flag--ridge { background: rgba(122, 138, 106, 0.14); color: var(--v3-ridge); border-color: rgba(122, 138, 106, 0.4); }
+.v3-flag--vine  { background: rgba(168, 54, 43, 0.10); color: var(--v3-vine); border-color: rgba(168, 54, 43, 0.4); }
+
+/* =========================================================
+   V3 EDITORIAL CARD (article / shortlist / dispatch)
+   ========================================================= */
+.v3-editorial-card {
+  display: grid;
+  gap: 12px;
+  text-decoration: none;
+  color: var(--v3-ink);
+}
+.v3-editorial-card__media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  background: var(--v3-paper-warm);
+  overflow: hidden;
+  border-radius: 4px;
+}
+.v3-editorial-card__media img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transition: transform var(--v3-d-slow) var(--v3-ease);
+}
+.v3-editorial-card:hover .v3-editorial-card__media img { transform: scale(1.04); }
+.v3-editorial-card__meta {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--v3-bay);
+}
+.v3-editorial-card__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(22px, 2.4vw, 28px);
+  line-height: 1.15;
+  margin: 0;
+}
+.v3-editorial-card__title em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-editorial-card__dek {
+  font-family: var(--v3-sans);
+  font-size: 14px;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+
+/* =========================================================
+   V3 ENTITY CARD (venue / place / itinerary / experience)
+   ========================================================= */
+.v3-entity-card {
+  display: grid;
+  gap: 12px;
+  text-decoration: none;
+  color: var(--v3-ink);
+  position: relative;
+}
+.v3-entity-card__media {
+  position: relative;
+  aspect-ratio: 5 / 4;
+  background: var(--v3-paper-warm);
+  overflow: hidden;
+  border-radius: 4px;
+}
+.v3-entity-card__media img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transition: transform var(--v3-d-slow) var(--v3-ease);
+}
+.v3-entity-card:hover .v3-entity-card__media img { transform: scale(1.04); }
+.v3-entity-card__overlay {
+  position: absolute;
+  top: 12px; left: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.92);
+  color: var(--v3-bay-deep);
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.v3-entity-card__name {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.15;
+  margin: 0;
+}
+.v3-entity-card__verdict {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 16px;
+  line-height: 1.4;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+.v3-entity-card__meta {
+  display: flex;
+  gap: 12px;
+  font-family: var(--v3-sans);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--v3-ink-soft);
+}
+.v3-entity-card__meta span + span::before { content: "·"; margin-right: 12px; opacity: 0.4; }
+
+/* =========================================================
+   V3 LATERAL SURFACES (3-up: eat / stay / places)
+   ========================================================= */
+.v3-lateral { padding: 96px 0; background: var(--v3-paper); }
+.v3-lateral__intro {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 40px;
+  align-items: end;
+  margin-bottom: 48px;
+}
+.v3-lateral__intro h2 {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(30px, 3.8vw, 48px);
+  line-height: 1.05;
+  margin: 0;
+}
+.v3-lateral__intro h2 em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-lateral__intro p {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 19px;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+.v3-lateral__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+}
+.v3-lateral__col {
+  display: grid;
+  gap: 16px;
+}
+.v3-lateral__col-head a {
+  display: block;
+  text-decoration: none;
+  color: var(--v3-ink);
+}
+.v3-lateral__col-eyebrow {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--v3-bay);
+  margin-bottom: 8px;
+}
+.v3-lateral__col-title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(24px, 2.6vw, 30px);
+  line-height: 1.1;
+  margin: 0 0 12px 0;
+}
+.v3-lateral__col-title em { font-style: italic; color: var(--v3-bay-deep); }
+
+@media (max-width: 980px) {
+  .v3-lateral__intro { grid-template-columns: 1fr; gap: 16px; }
+  .v3-lateral__grid { grid-template-columns: 1fr; gap: 48px; }
+}
+
+/* =========================================================
+   V3 INSIDER STRIPE (Pass)
+   ========================================================= */
+.v3-stripe {
+  background: linear-gradient(180deg, var(--v3-vine-deep) 0%, var(--v3-vine) 100%);
+  color: #fff;
+  padding: 80px 0;
+  text-align: center;
+}
+.v3-stripe__eyebrow {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.85);
+  margin-bottom: 14px;
+}
+.v3-stripe__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.1;
+  margin: 0 auto 14px;
+  max-width: 22ch;
+}
+.v3-stripe__title em { font-style: italic; }
+.v3-stripe__body {
+  font-family: var(--v3-serif);
+  font-size: 18px;
+  line-height: 1.5;
+  color: rgba(255,255,255,0.92);
+  margin: 0 auto 24px;
+  max-width: 50ch;
+}
+.v3-stripe .v3-btn--solid {
+  background: #fff;
+  color: var(--v3-vine-deep);
+  border-color: #fff;
+}
+.v3-stripe .v3-btn--solid:hover { color: var(--v3-vine); background: var(--v3-paper); }
+
+/* =========================================================
+   V3 NEWSLETTER (compact)
+   ========================================================= */
+.v3-newsletter {
+  background: var(--v3-paper-warm);
+  border-top: 1px solid var(--v3-hairline-soft);
+  padding: 80px 0;
+}
+.v3-newsletter__inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  align-items: center;
+}
+.v3-newsletter h3 {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(28px, 3.2vw, 40px);
+  line-height: 1.1;
+  margin: 0 0 14px 0;
+}
+.v3-newsletter h3 em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-newsletter p {
+  font-family: var(--v3-serif);
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--v3-ink-soft);
+  margin: 0;
+}
+.v3-newsletter__form {
+  display: flex;
+  gap: 8px;
+}
+.v3-newsletter__input {
+  flex: 1;
+  padding: 16px;
+  border: 1px solid var(--v3-hairline);
+  background: #fff;
+  border-radius: 4px;
+  font-family: var(--v3-sans);
+  font-size: 15px;
+  color: var(--v3-ink);
+}
+.v3-newsletter__input:focus { outline: none; border-color: var(--v3-bay); }
+
+@media (max-width: 880px) {
+  .v3-newsletter__inner { grid-template-columns: 1fr; gap: 20px; }
+  .v3-newsletter__form { flex-direction: column; }
+}
+
+/* =========================================================
+   V3 EDITOR'S LETTER
+   ========================================================= */
+.v3-letter { padding: 96px 0; background: var(--v3-paper); }
+.v3-letter__inner {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 56px;
+  align-items: center;
+}
+.v3-letter__media {
+  aspect-ratio: 4 / 5;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+  background: var(--v3-paper-warm);
+}
+.v3-letter__media img { width: 100%; height: 100%; object-fit: cover; }
+.v3-letter__caption {
+  position: absolute;
+  bottom: 14px;
+  left: 16px;
+  right: 16px;
+  font-family: var(--v3-serif);
+  font-style: italic;
+  color: #fff;
+  font-size: 14px;
+  text-shadow: 0 2px 12px rgba(0,0,0,0.6);
+}
+.v3-letter h2 {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(34px, 4.4vw, 56px);
+  line-height: 1.05;
+  margin: 0 0 24px 0;
+}
+.v3-letter h2 em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-letter__body p {
+  font-family: var(--v3-serif);
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--v3-ink);
+  margin: 0 0 18px 0;
+}
+.v3-letter__body p:first-of-type::first-letter {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: 4.5em;
+  line-height: 0.8;
+  float: left;
+  margin: 0.08em 0.12em 0 0;
+  color: var(--v3-bay-deep);
+}
+.v3-letter__pullquote {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.4;
+  color: var(--v3-bay-deep);
+  border-left: 3px solid var(--v3-bay);
+  padding-left: 18px;
+  margin: 24px 0 0 0;
+}
+.v3-letter__signoff {
+  margin-top: 26px;
+  font-family: var(--v3-sans);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--v3-ink-soft);
+}
+
+@media (max-width: 980px) {
+  .v3-letter__inner { grid-template-columns: 1fr; gap: 28px; }
+}
+
+/* =========================================================
+   V3 SHORTLIST
+   ========================================================= */
+.v3-shortlist { padding: 96px 0; background: var(--v3-paper-warm); border-top: 1px solid var(--v3-hairline-soft); border-bottom: 1px solid var(--v3-hairline-soft); }
+.v3-shortlist__intro {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  align-items: end;
+  margin-bottom: 40px;
+}
+.v3-shortlist__badge {
+  display: inline-flex;
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--v3-vine);
+  border: 1px solid var(--v3-vine);
+  padding: 4px 12px;
+  border-radius: 999px;
+  margin-bottom: 14px;
+}
+.v3-shortlist__title {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(34px, 4.4vw, 52px);
+  line-height: 1.05;
+  margin: 0;
+}
+.v3-shortlist__title em { font-style: italic; color: var(--v3-bay-deep); }
+.v3-shortlist__intro p {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 18px;
+  color: var(--v3-ink-soft);
+  margin: 0;
+  max-width: 38ch;
+}
+.v3-shortlist__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--v3-hairline);
+}
+.v3-shortlist__item {
+  border-bottom: 1px solid var(--v3-hairline);
+}
+.v3-shortlist__item a {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 28px;
+  align-items: center;
+  padding: 22px 0;
+  text-decoration: none;
+  color: var(--v3-ink);
+  transition: padding-left var(--v3-d-base) var(--v3-ease);
+}
+.v3-shortlist__item a:hover { padding-left: 12px; }
+.v3-shortlist__num {
+  font-family: var(--v3-serif);
+  font-weight: 400;
+  font-style: italic;
+  font-size: 36px;
+  color: var(--v3-bay-deep);
+  font-feature-settings: "onum";
+}
+.v3-shortlist__name {
+  font-family: var(--v3-serif);
+  font-weight: 500;
+  font-size: clamp(22px, 2.4vw, 28px);
+  line-height: 1.2;
+}
+.v3-shortlist__why {
+  font-family: var(--v3-sans);
+  font-size: 13px;
+  color: var(--v3-ink-soft);
+  margin-top: 4px;
+}
+.v3-shortlist__arrow {
+  font-family: var(--v3-sans);
+  color: var(--v3-bay-deep);
+  font-size: 16px;
+}
+
+@media (max-width: 760px) {
+  .v3-shortlist__intro { grid-template-columns: 1fr; gap: 16px; }
+  .v3-shortlist__item a { grid-template-columns: 50px 1fr; gap: 16px; }
+  .v3-shortlist__arrow { display: none; }
+}
+
+/* =========================================================
+   V3 CONCIERGE DOCK (bottom-right floating avatar)
+   ========================================================= */
+.v3-dock {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 80;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px 8px 8px;
+  background: var(--v3-ink);
+  color: var(--v3-paper);
+  border-radius: 999px;
+  text-decoration: none;
+  font-family: var(--v3-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  box-shadow: var(--v3-shadow-deep);
+  cursor: pointer;
+  border: 0;
+  transition: transform var(--v3-d-base) var(--v3-ease), background var(--v3-d-base) var(--v3-ease);
+}
+.v3-dock:hover { transform: translateY(-2px); background: var(--v3-bay-deep); }
+.v3-dock__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--v3-paper) url('/images/pi-mark.svg') center/65% no-repeat;
+  position: relative;
+  flex-shrink: 0;
+}
+.v3-dock__avatar::after {
+  content: "";
+  position: absolute;
+  bottom: 1px; right: 1px;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--v3-ridge);
+  border: 2px solid var(--v3-ink);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .v3-dock__avatar { animation: v3-breathe 4s ease-in-out infinite; }
+  @keyframes v3-breathe {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(122, 138, 106, 0.55); }
+    50%      { box-shadow: 0 0 0 8px rgba(122, 138, 106, 0); }
+  }
+}
+@media (max-width: 640px) {
+  .v3-dock { bottom: 16px; right: 16px; padding: 6px 14px 6px 6px; font-size: 13px; }
+  .v3-dock__avatar { width: 30px; height: 30px; }
+  .v3-dock__label { display: none; }
+}
+
+/* =========================================================
+   V3 FOOTER
+   ========================================================= */
+.v3-footer {
+  background: var(--v3-ink);
+  color: var(--v3-paper);
+  padding: 64px 0 32px;
+}
+.v3-footer__grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 32px;
+  margin-bottom: 32px;
+}
+.v3-footer__brand .v3-masthead__logo {
+  color: var(--v3-paper);
+  font-size: 28px;
+}
+.v3-footer__brand .v3-masthead__logo span { color: var(--v3-paper-warm); }
+.v3-footer__brand p {
+  font-family: var(--v3-serif);
+  font-style: italic;
+  font-size: 15px;
+  color: rgba(246, 241, 232, 0.8);
+  margin: 8px 0 0;
+  max-width: 32ch;
+}
+.v3-footer__col h4 {
+  font-family: var(--v3-sans);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--v3-paper-warm);
+  margin: 0 0 14px 0;
+  font-weight: 500;
+}
+.v3-footer__col ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.v3-footer__col a {
+  font-family: var(--v3-serif);
+  font-size: 16px;
+  color: rgba(246, 241, 232, 0.85);
+  text-decoration: none;
+  transition: color var(--v3-d-fast) var(--v3-ease);
+}
+.v3-footer__col a:hover { color: #fff; }
+
+.v3-footer__base {
+  border-top: 1px solid rgba(246, 241, 232, 0.18);
+  padding-top: 24px;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--v3-sans);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: rgba(246, 241, 232, 0.7);
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+@media (max-width: 880px) {
+  .v3-footer__grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 560px) {
+  .v3-footer__grid { grid-template-columns: 1fr; gap: 24px; }
+}
+
+/* =========================================================
+   V3 REVEAL ON SCROLL (editorial blocks only)
+   ========================================================= */
+@media (prefers-reduced-motion: no-preference) {
+  .v3-reveal {
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 600ms var(--v3-ease), transform 600ms var(--v3-ease);
+  }
+  .v3-reveal.is-in {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -47,7 +47,7 @@ body[data-v4="true"] .masthead {
 }
 .v4-masthead-nav__inner {
   display: flex;
-  align-items: stretch;
+  align-items: center;          /* Vertical centerline shared by pillars and actions */
   justify-content: space-between;
   gap: 24px;
   height: var(--v4-mega-row-h);
@@ -55,13 +55,15 @@ body[data-v4="true"] .masthead {
 
 .v4-pillars {
   display: flex;
+  align-items: stretch;
   list-style: none;
   margin: 0;
   padding: 0;
   gap: clamp(14px, 2.4vw, 30px);
+  height: 100%;                 /* fill the nav row so the underline sits at the bottom */
 }
 .v4-pillars__item {
-  position: static;        /* mega panel anchors to .v4-masthead-nav */
+  position: static;             /* mega panel anchors to .v4-masthead-nav */
   display: flex;
   align-items: stretch;
 }
@@ -73,9 +75,10 @@ body[data-v4="true"] .masthead {
   color: var(--text);
   text-decoration: none;
   display: inline-flex;
-  align-items: center;
+  align-items: center;          /* text centered vertically inside the full-height link */
   gap: 4px;
   padding: 0 2px;
+  height: 100%;
   border-bottom: 2px solid transparent;
   transition: color var(--v4-mega-open-delay) var(--v4-ease),
               border-color var(--v4-mega-open-delay) var(--v4-ease);
@@ -134,7 +137,8 @@ body[data-v4="true"] .masthead {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 14px 7px 8px;
+  padding: 0 14px 0 8px;
+  height: 36px;                /* match v4-iconbtn for shared centerline */
   border-radius: 999px;
   background: var(--dark);
   color: var(--white);
@@ -171,7 +175,8 @@ body[data-v4="true"] .masthead {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
+  padding: 0 16px;
+  height: 36px;                /* match v4-iconbtn + v4-ask-pill */
   border-radius: 999px;
   background: var(--accent);
   color: var(--white);

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -1,0 +1,598 @@
+/* =========================================================
+   Peninsula Insider — V4 mega-menu chrome
+   ---------------------------------------------------------
+   Loaded ONLY by V4BaseLayout. V2 production styles in
+   global.css are unaffected; V4 inherits V2's colour and
+   type tokens unchanged. New tokens are scoped under --v4-.
+
+   The lift: editorial mega-menu IA on V2's existing visual
+   language. Cream paper, ochre, gold, sage, Cormorant +
+   Outfit — all kept. Only chrome and behaviour change.
+   ========================================================= */
+
+:root {
+  --v4-mega-w:           1240px;
+  --v4-mega-rail-w:      280px;
+  --v4-mega-col-gap:     40px;
+  --v4-mega-row-h:       56px;
+  --v4-mega-pad-y:       40px;
+  --v4-mega-open-delay:  70ms;
+  --v4-mega-close-delay: 220ms;
+
+  --v4-shadow-mega:      0 16px 40px -16px rgba(30, 27, 24, 0.18);
+  --v4-shadow-mega-soft: 0 8px 24px -12px rgba(30, 27, 24, 0.12);
+
+  --v4-focus-ring:       0 0 0 3px rgba(139, 78, 59, 0.22);
+  --v4-hairline-mega:    rgba(30, 27, 24, 0.10);
+
+  --v4-ease:             cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* =========================================================
+   MASTHEAD
+   ========================================================= */
+body[data-v4="true"] .masthead {
+  /* V2 masthead first two rows reused as-is. We just override
+     the third (nav) row beneath. */
+  position: sticky;
+  top: 0;
+  z-index: 60;
+}
+
+.v4-masthead-nav {
+  position: relative;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.v4-masthead-nav__inner {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 24px;
+  height: var(--v4-mega-row-h);
+}
+
+.v4-pillars {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: clamp(14px, 2.4vw, 30px);
+}
+.v4-pillars__item {
+  position: static;        /* mega panel anchors to .v4-masthead-nav */
+  display: flex;
+  align-items: stretch;
+}
+.v4-pillars__link {
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 2px;
+  border-bottom: 2px solid transparent;
+  transition: color var(--v4-mega-open-delay) var(--v4-ease),
+              border-color var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-pillars__item:hover .v4-pillars__link,
+.v4-pillars__item.is-open .v4-pillars__link,
+.v4-pillars__item[aria-current="page"] .v4-pillars__link {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.v4-pillars__link--journal {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 18px;
+  letter-spacing: 0;
+}
+.v4-pillars__chev {
+  width: 8px; height: 8px;
+  margin-top: 1px;
+  transition: transform var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-pillars__item.is-open .v4-pillars__chev { transform: rotate(180deg); }
+.v4-pillars__link:focus-visible {
+  outline: none;
+  box-shadow: var(--v4-focus-ring);
+  border-radius: 2px;
+}
+
+.v4-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.v4-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px; height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  text-decoration: none;
+  transition: background var(--v4-mega-open-delay) var(--v4-ease),
+              border-color var(--v4-mega-open-delay) var(--v4-ease),
+              color var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-iconbtn:hover {
+  background: var(--bg-alt);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.v4-iconbtn:focus-visible { outline: none; box-shadow: var(--v4-focus-ring); }
+
+.v4-ask-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px 7px 8px;
+  border-radius: 999px;
+  background: var(--dark);
+  color: var(--white);
+  text-decoration: none;
+  font-family: 'Outfit', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--dark);
+  transition: background var(--v4-mega-open-delay) var(--v4-ease),
+              transform   var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-ask-pill:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+.v4-ask-pill:focus-visible { outline: none; box-shadow: var(--v4-focus-ring); }
+.v4-ask-pill__dot {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--white);
+  line-height: 1;
+}
+
+.v4-subscribe-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--white);
+  text-decoration: none;
+  font-family: 'Outfit', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  transition: background var(--v4-mega-open-delay) var(--v4-ease),
+              transform   var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-subscribe-cta:hover {
+  background: var(--acc-h);
+  transform: translateY(-1px);
+}
+.v4-subscribe-cta:focus-visible { outline: none; box-shadow: var(--v4-focus-ring); }
+
+/* Hide V4 nav on mobile — mobile drawer handles it. */
+@media (max-width: 760px) {
+  .v4-masthead-nav { display: none; }
+}
+
+/* =========================================================
+   MEGA PANEL
+   ========================================================= */
+.v4-mega {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--v4-shadow-mega);
+  padding: var(--v4-mega-pad-y) 0;
+  display: none;
+  z-index: 70;
+  /* When opening, animate in from above. */
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity var(--v4-mega-close-delay) var(--v4-ease),
+              transform var(--v4-mega-close-delay) var(--v4-ease);
+}
+.v4-pillars__item.is-open .v4-mega {
+  display: block;
+  opacity: 1;
+  transform: translateY(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .v4-mega { transition: none; transform: none; }
+}
+
+.v4-mega__container {
+  width: 100%;
+  max-width: var(--v4-mega-w);
+  margin: 0 auto;
+  padding-left: clamp(20px, 4vw, 56px);
+  padding-right: clamp(20px, 4vw, 56px);
+}
+
+.v4-mega__intro {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 16px;
+  line-height: 1.45;
+  color: var(--soft);
+  margin: 0 0 24px 0;
+  max-width: 80ch;
+}
+
+.v4-mega__grid {
+  display: grid;
+  grid-template-columns: var(--v4-mega-rail-w) repeat(var(--v4-cols, 3), 1fr);
+  gap: var(--v4-mega-col-gap);
+  align-items: start;
+}
+.v4-mega--cols-2 { --v4-cols: 2; }
+.v4-mega--cols-3 { --v4-cols: 3; }
+.v4-mega--rail-wide { --v4-mega-rail-w-effective: 360px; }
+.v4-mega--rail-wide .v4-mega__grid { grid-template-columns: 360px repeat(var(--v4-cols, 2), 1fr); }
+
+@media (max-width: 1080px) {
+  .v4-mega__grid { grid-template-columns: 220px repeat(var(--v4-cols, 3), 1fr); gap: 28px; }
+}
+@media (max-width: 920px) {
+  .v4-mega__grid { grid-template-columns: 1fr 1fr; }
+  .v4-mega__rail { display: none; }
+}
+
+/* =========================================================
+   MEGA RAIL (image + verdict)
+   ========================================================= */
+.v4-mega__rail {
+  display: block;
+  text-decoration: none;
+  color: var(--text);
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  transition: transform var(--v4-mega-close-delay) var(--v4-ease),
+              border-color var(--v4-mega-close-delay) var(--v4-ease),
+              box-shadow var(--v4-mega-close-delay) var(--v4-ease);
+}
+.v4-mega__rail:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: var(--v4-shadow-mega-soft);
+}
+.v4-mega__rail-image {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  background: var(--bg-alt);
+  overflow: hidden;
+}
+.v4-mega__rail-image img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transition: transform 600ms var(--v4-ease);
+}
+.v4-mega__rail:hover .v4-mega__rail-image img { transform: scale(1.04); }
+.v4-mega__rail-body { padding: 16px 18px 18px; }
+.v4-mega__rail-eyebrow {
+  font-family: 'Outfit', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 6px 0;
+}
+.v4-mega__rail-title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.15;
+  margin: 0 0 6px 0;
+  color: var(--text);
+}
+.v4-mega__rail-verdict {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--soft);
+  margin: 0 0 12px 0;
+}
+.v4-mega__rail-cta {
+  font-family: 'Outfit', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+/* =========================================================
+   MEGA COLUMN
+   ========================================================= */
+.v4-mega__col {}
+.v4-mega__col-eyebrow {
+  font-family: 'Outfit', sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 14px 0;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--v4-hairline-mega);
+}
+.v4-mega__col-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 9px;
+}
+.v4-mega__col-list a {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.25;
+  color: var(--text);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 1px 0;
+  border-bottom: 1px solid transparent;
+  transition: color var(--v4-mega-open-delay) var(--v4-ease),
+              border-color var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-mega__col-list a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.v4-mega__col-list a:focus-visible {
+  outline: none;
+  box-shadow: var(--v4-focus-ring);
+  border-radius: 2px;
+}
+.v4-mega__col-list a[data-live]::before {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--sage);
+  flex-shrink: 0;
+  animation: v4-pulse 2.4s ease-in-out infinite;
+}
+@keyframes v4-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.55; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .v4-mega__col-list a[data-live]::before { animation: none; }
+}
+
+/* =========================================================
+   TOP BANNER (used in What's On)
+   ========================================================= */
+.v4-mega__top-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  margin: 0 0 24px 0;
+  border-radius: 4px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.v4-mega__top-banner-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 18px;
+  color: var(--text);
+}
+.v4-mega__top-banner-text::before {
+  content: "";
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--sage);
+}
+.v4-mega__top-banner-cta {
+  font-family: 'Outfit', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+}
+.v4-mega__top-banner-cta:hover { text-decoration: underline; }
+
+/* =========================================================
+   ASK-PI FOOTER LINE (bottom of every panel)
+   ========================================================= */
+.v4-mega__ask {
+  margin: 28px 0 0 0;
+  padding-top: 20px;
+  border-top: 1px solid var(--v4-hairline-mega);
+  text-align: center;
+}
+.v4-mega__ask a {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 18px;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--v4-hairline-mega);
+  padding-bottom: 1px;
+  transition: color var(--v4-mega-open-delay) var(--v4-ease),
+              border-color var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-mega__ask a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.v4-mega__ask a:focus-visible { outline: none; box-shadow: var(--v4-focus-ring); border-radius: 2px; }
+
+/* =========================================================
+   MOBILE DRAWER
+   ========================================================= */
+.v4-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: var(--bg);
+  display: none;
+  overflow-y: auto;
+}
+.v4-drawer.is-open { display: block; }
+.v4-drawer__head {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 1;
+}
+.v4-drawer__close {
+  width: 40px; height: 40px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.v4-drawer__brand {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 20px;
+  text-decoration: none;
+  color: var(--text);
+}
+.v4-drawer__brand span { font-style: italic; color: var(--accent); }
+
+.v4-drawer__pillars { list-style: none; margin: 0; padding: 0; }
+.v4-drawer__pillar { border-bottom: 1px solid var(--border); }
+.v4-drawer__pillar-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: transparent;
+  border: 0;
+  padding: 18px 20px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 22px;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+.v4-drawer__pillar-trigger[aria-expanded="true"] { color: var(--accent); }
+.v4-drawer__pillar-trigger-arrow {
+  width: 12px; height: 12px;
+  transition: transform 200ms var(--v4-ease);
+}
+.v4-drawer__pillar-trigger[aria-expanded="true"] .v4-drawer__pillar-trigger-arrow {
+  transform: rotate(90deg);
+}
+.v4-drawer__pillar-body {
+  display: none;
+  padding: 0 20px 24px;
+  background: var(--bg-alt);
+}
+.v4-drawer__pillar.is-expanded .v4-drawer__pillar-body { display: block; }
+.v4-drawer__pillar-rail {
+  display: block;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--v4-hairline-mega);
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--accent);
+  text-decoration: none;
+}
+.v4-drawer__pillar-col { padding: 18px 0; border-bottom: 1px solid var(--v4-hairline-mega); }
+.v4-drawer__pillar-col:last-of-type { border-bottom: 0; }
+.v4-drawer__pillar-col-eyebrow {
+  font-family: 'Outfit', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 10px 0;
+}
+.v4-drawer__pillar-col-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.v4-drawer__pillar-col-list a {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 18px;
+  color: var(--text);
+  text-decoration: none;
+  display: block;
+  padding: 4px 0;
+}
+.v4-drawer__pillar-ask {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--v4-hairline-mega);
+  text-align: center;
+}
+.v4-drawer__pillar-ask a {
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--accent);
+  text-decoration: none;
+}
+.v4-drawer__foot {
+  padding: 24px 20px 32px;
+  display: grid;
+  gap: 12px;
+}
+.v4-drawer__foot a {
+  font-family: 'Outfit', sans-serif;
+  font-size: 14px;
+  color: var(--text);
+  text-decoration: none;
+}
+
+/* The mobile burger button — show only when V4 chrome is mounted on mobile.
+   We rely on the existing burger element in the V2 Masthead (.masthead__burger),
+   the V4 layout binds it to open V4 drawer instead of V2 mobile-nav. */
+@media (min-width: 761px) {
+  .v4-drawer { display: none !important; }
+}
+
+/* =========================================================
+   ACCESSIBILITY
+   ========================================================= */
+.v4-sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -200,6 +200,67 @@ body[data-v4="true"] .masthead {
 }
 
 /* =========================================================
+   V4 MOBILE MASTHEAD
+   ---------------------------------------------------------
+   V2's global.css hides .masthead__utility AND .masthead__brand
+   on mobile to make room for V2's third nav row. V4 doesn't use
+   that nav row, so we re-show the brand row in a compacted form
+   (logo left, burger right) and keep utility hidden.
+
+   Scoped to body[data-v4="true"] so V2 staging pages or the
+   /v3/ surface aren't affected.
+   ========================================================= */
+@media (max-width: 760px) {
+  body[data-v4="true"] .masthead__utility { display: none; }
+
+  /* Re-show the brand row (V2 hides it on mobile to make room for V2's nav row,
+     which V4 doesn't use). Make it a flex bar with the container as the flex
+     wrapper. */
+  body[data-v4="true"] .masthead__brand {
+    display: block !important;
+    padding: 0;
+  }
+  body[data-v4="true"] .masthead__brand .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    min-height: 56px;
+  }
+  body[data-v4="true"] .masthead__brand-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    min-width: 0;
+  }
+  body[data-v4="true"] .masthead__brand .masthead__logo {
+    font-size: 22px;
+    line-height: 1.1;
+    text-decoration: none;
+  }
+  /* Hide the desktop tagline on mobile — too long for the bar. */
+  body[data-v4="true"] .masthead__brand .masthead__tagline { display: none; }
+
+  /* Burger sits at the right of the container. Visibility is already
+     handled by V2 global.css `.masthead__burger { display: flex !important }`
+     at this breakpoint — we only need it not to shrink. */
+  body[data-v4="true"] .v4-burger { flex-shrink: 0; }
+}
+
+/* Extra-small screens: tighten the bar height. */
+@media (max-width: 380px) {
+  body[data-v4="true"] .masthead__brand .container {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    min-height: 52px;
+  }
+  body[data-v4="true"] .masthead__brand .masthead__logo { font-size: 20px; }
+}
+
+/* =========================================================
    MEGA PANEL
    ========================================================= */
 .v4-mega {


### PR DESCRIPTION
Rolls out the V4 7-pillar editorial mega-menu to peninsulainsider.com.au. Menu chrome only, no other V4 changes are user-facing.

## What's user-facing in this PR

- The masthead nav row is replaced. Old: 8 pillars + chevron-More menu. New: 7 pillars (What's On, Plans, Eat & Drink, Wine, Stay, Explore, *Journal*) each opening to a three-column editorial mega-panel with image rail, intro line, and Ask-PI footer.
- Mobile burger now opens a full-screen accordion drawer (one pillar expanded at a time).
- Footer gains one new link: "Map of the Peninsula" → `/explore/map/`.
- Explore mega-panel has a sage-dotted top banner surfacing the same map: *"How the Peninsula's geography actually works → Open the map"*.
- Concierge wiring preserved: every `Ask PI →` line in mega panels and in the drawer opens the concierge in-place via `window.openConcierge()`.

That's it for production behavior change.

## What's in the branch but staging-only (noindex, no SEO impact)

- `/v3/` — V3 strategy preview (cinematic cover, etc.). Routes are `noindex` and visible only to people with the URL.
- `/v4/` and `/v4/{eat,wine,stay,explore,escape,whats-on,journal}/` — V4 staging copies for hover-testing the menu. All `noindex`.

These exist for ongoing review and don't affect the live experience.

## Rollback runbook

A rollback tag was created **before this branch landed**: [`pre-v4-menu-2026-05-06`](https://github.com/richmondjw/peninsula-insider/releases/tag/pre-v4-menu-2026-05-06) → points at `f33b5ea70` (state of main as of 2026-05-06 after the Cape Schanck link-audit fix).

### If anything breaks after merge

**Option A — revert the merge commit (recommended, safer):**
```bash
git checkout main
git pull origin main
git revert -m 1 <merge-commit-sha>      # creates a clean revert commit
git push origin main
```
Auto-deploy ships the revert in ~3 minutes.

**Option B — hard reset (use only if revert is messy):**
```bash
git checkout main
git reset --hard pre-v4-menu-2026-05-06
git push origin main --force-with-lease
```
This rewrites main history. Approve before doing this.

In either case, V2 `Masthead.astro` is untouched in the codebase and one import-line swap away in `BaseLayout.astro` if a partial rollback is preferred.

## Files changed (production-affecting)

| File | Change |
|---|---|
| `next/src/layouts/BaseLayout.astro` | Swapped `Masthead` → `V4Masthead`, mounted `V4MobileDrawer`, loaded `v4.css`, replaced V2 burger script with V4 mega+drawer behavior, set `body[data-v4="true"]` |
| `next/src/lib/nav.ts` | Added `Map of the Peninsula` to `footerAboutLinks` |
| `next/src/components/v4/*` (7 files) | New components: V4Masthead, V4MegaPanel, V4MegaColumn, V4MegaRail, V4PillarLink, V4PillarTopBanner, V4MobileDrawer |
| `next/src/lib/v4-nav.ts` | New: 7-pillar data, mega-panel content, image rails, footer cols |
| `next/src/styles/v4.css` | New: V4 design tokens (additive) + component styles + mobile responsive rules |

V2 production files preserved unchanged: `Masthead.astro`, `Footer.astro`, `ConciergeDrawer.astro`, `SearchOverlay.astro`, `CookieBanner.astro`, all card components, all page templates.

## Pre-merge readiness verification

- ✅ Every nav href resolves to a live V2 route (78 unique URLs audited, 0 404s).
- ✅ Two hard-fail rail URLs fixed: `/eat/laura/` → `/eat/laura-pt-leo/`, `/whats-on/mornington-farmers-market/` → `/whats-on/mt-eliza-farmers-market/`.
- ✅ ~33 querystring filter links rewritten to real V2 category pages (cafes, beaches, walks, markets, villas, glamping, cellar-doors, appointment-producers, chardonnay, etc.).
- ✅ All 7 image rail assets exist on disk.
- ✅ V2 integrations preserved: concierge drawer, search overlay, cookie banner, gtag analytics, view transitions, auth modal, profile dropdown.
- ✅ ARIA: `aria-haspopup`, `aria-expanded`, `aria-current="page"`, `role="menu"/"menuitem"`, `role="dialog"`, focus contract honored.
- ✅ `prefers-reduced-motion` honored (no transitions when reduced).
- ✅ Mobile: burger button visible on phones (V2 hides `.masthead__brand` on mobile, fixed via scoped `body[data-v4="true"]` override). Drawer accordion works.
- ✅ Voice/copy: zero em-dashes in user-facing menu copy, zero tourism-board adjectives.
- ✅ Build: 1209 pages, 0 errors, ~25s build time.

## Smoke tests recommended on Vercel preview before merge

1. Land on `/` → hover each of 7 pillars → mega panels open with rail + columns + Ask-PI line.
2. Hover **Explore** → top banner reads *"How the Peninsula's geography actually works → Open the map"*.
3. Click any **Ask PI** footer line → concierge drawer opens in-place (does NOT navigate to `/ask/`).
4. Click search icon → search overlay opens.
5. Visit `/eat/`, `/wine/`, `/stay/`, etc. → matching pillar gets ochre underline (`aria-current`).
6. Resize to ≤760px → burger appears in brand row (logo left, burger right).
7. Tap burger → drawer opens; tap pillar → accordion expands; tap link → drawer closes and navigates.
8. Footer → "Map of the Peninsula" present in About column → lands on `/explore/map/`.
9. Tab through masthead → focus advances; Escape returns focus to trigger.
10. Production URLs sanity: try a venue page (`/eat/laura-pt-leo/`), a journal piece (`/journal/the-cellar-door-short-list/`), a wine venue page (`/wine/ten-minutes-by-tractor/`) → all carry V4 chrome.

## Test plan

- [ ] Vercel/preview build green
- [ ] Hover-test each of 7 pillars on home + on each pillar sub-page
- [ ] Mobile burger → drawer accordion works on real phone
- [ ] Concierge drawer fires from Ask-PI lines
- [ ] Search overlay opens from icon
- [ ] Footer Map link visible and lands
- [ ] No console errors in dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)