### PR TITLE
fix(menu): Ask PI pill opens concierge drawer instead of navigating

### DIFF
--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -102,7 +102,7 @@ const {
               <line x1="21" y1="21" x2="16.5" y2="16.5" />
             </svg>
           </a>
-          <a href={v4Utility.ask.href} class="v4-ask-pill" aria-label="Ask PI">
+          <a href={v4Utility.ask.href} class="v4-ask-pill" aria-label="Ask PI" data-pi-trigger="true">
             <span class="v4-ask-pill__dot">PI</span>
             Ask PI
           </a>

--- a/next/src/components/v4/V4MobileDrawer.astro
+++ b/next/src/components/v4/V4MobileDrawer.astro
@@ -67,7 +67,7 @@ import { v4Pillars, v4Utility } from '../../lib/v4-nav';
   <div class="v4-drawer__foot">
     <a href={v4Utility.search.href}>Search Peninsula Insider</a>
     <a href={v4Utility.account.href}>{v4Utility.account.label}</a>
-    <a href={v4Utility.ask.href}>Ask PI</a>
+    <a href={v4Utility.ask.href} data-pi-trigger="true">Ask PI</a>
     <a href={v4Utility.subscribe.href}>{v4Utility.subscribe.label}</a>
   </div>
 </div>


### PR DESCRIPTION
The masthead **Ask PI** pill currently navigates to `/ask/` (full-page concierge). This PR makes it open the floating concierge drawer in the bottom-right corner instead, matching the behavior of every "Ask PI →" footer line inside the mega panels.

## Diff

Two-line change adding `data-pi-trigger="true"` to:
1. `V4Masthead.astro` — the Ask PI pill in the masthead utility actions row
2. `V4MobileDrawer.astro` — the Ask PI link in the mobile drawer footer

The global handler in `BaseLayout.astro` that intercepts `[data-pi-trigger="true"]` clicks and calls `window.openConcierge()` already exists from the V4 menu promotion. This change just opts these two anchors into that behavior.

## Behavior after merge

- **Click Ask PI in masthead** → concierge drawer slides in from bottom-right, current page stays put. ✓
- **Click Ask PI in mobile drawer footer** → drawer auto-closes, then concierge opens. ✓
- **Right-click / Cmd-click / middle-click / no-JS** → still navigates to `/ask/` (href preserved as fallback for keyboard accessibility and progressive enhancement). ✓

## Risk

Trivial. Same `data-pi-trigger="true"` pattern is already live and verified on:
- All 7 mega-panel "Ask PI →" footer lines
- All 7 mobile-drawer pillar-accordion "Ask PI →" footer lines

No new JS, no new CSS, no new handler. Just two attribute additions.

## Rollback

Single revert. Branch state preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)