### PR TITLE
ops(seo): May 2026 monthly audit + methodology + GA4 scaffold

### DIFF
--- a/ops/reports/seo/audit-2026-05/00-executive-summary.md
+++ b/ops/reports/seo/audit-2026-05/00-executive-summary.md
@@ -1,0 +1,128 @@
+# 00, Executive summary, May 2026 monthly SEO audit
+
+Date: 2026-05-08
+Author: Claude (PI SEO desk)
+For: James (and Emma, if it ever matters)
+Read time: 5 minutes
+Read the rest only if a section's claim seems wrong or you want the receipts.
+
+## In one paragraph
+
+Indexation is largely solved. The site went from 39 indexed URLs (May 1) to 233 (May 5) and 14 of 14 priority URLs are PASS. The technical chassis is materially better than the click numbers suggest. **The two structural problems left are: hero images are CSS backgrounds (invisible to Google Images), and seven of nine commercial conversion surfaces have zero contextual links from the editorial layer.** Fix those two things and a third (snippet rewrites on the chardonnay-case and pub-guide pages) and the next monthly audit should show clicks materially up. The longer plan layers on a content cadence aimed at three winnable SERPs (dog-friendly, day-trip, cellar-doors), a graded-walks rebuild, and the start of a sustainable inbound-link layer via a Featured-by-PI badge program.
+
+## Where we stand (data, not opinion)
+
+Last 28 days, ending 2026-05-02 (per `daily-log.md` 2026-05-04 entry):
+
+| Metric | Value | vs Day-1 baseline (2026-05-01) |
+|---|---:|---:|
+| Clicks | 29 | +6 (+26%) |
+| Impressions | 2,873 | +1,093 (+61%) |
+| CTR | 1.01% | down from 1.29% (more impressions on long-tail at lower position) |
+| Avg position | 16.8 | barely moved |
+| Indexed URLs (full inventory) | 233 / 418 (56%) | from 39 / 349 (11%) |
+| Indexed PRIORITY URLs | 14 / 14 (100%) | from 2 / 14 (14%) |
+
+The 233-from-39 indexation jump came largely from one experiment (2026-05-01-01, the duplicate-canonical fix on place pages). That single template fix unblocked the entire spine.
+
+## The five things that matter most this month
+
+These are the top items from `06-opportunity-matrix.md`. Each has a measurable outcome and a small effort estimate. Composite scores in brackets.
+
+1. **Fix the orphaned conversion-surface links** (composite 30, score-leader). The Pass page is linked from a footer label that points to `/preview-insider-plans/` instead of `/pass/` (`next/src/lib/v4-nav.ts:470`). Awards is missing from masthead, More menu, and footer entirely. Two trivial edits in two files; structural orphans become reachable.
+
+2. **Add Awards to masthead More menu and footer About column** (composite 28). Same theme as #1. The Awards cluster has zero internal links from any indexable surface.
+
+3. **Render `pressMentions` and won-awards on `VenueDetailTemplate`** (composite 26). The data is already structured in venue files (`data.authority.pressMentions`, `data.authority.awards`); the visual block is missing. One PR lifts trust signals across 134 venue pages and creates dozens of new internal links into the Awards cluster.
+
+4. **Add a "Is this your venue? Claim it." link to `VenueDetailTemplate`** (composite 26). First venue-page → operator-claim path. Polite text link near the editor note, not a banner. Operator-claim is the priority-2 commercial surface and currently has no discovery path.
+
+5. **Convert journal/place/venue heroes from CSS `background-image` to `<img>`** (composite 23). The single highest-leverage technical fix. Right now every editorial hero image is invisible to Google Images, has no alt text for image-search, can't use `loading="lazy"`, and is unlikely to be Discover-eligible. Affects 200+ pages. Half-day to ship; weeks to compound.
+
+## The biggest risks
+
+1. **PageSpeed Insights / Core Web Vitals data is missing.** PSI v5 quota was exhausted before this audit ran. Field data is also assumed unavailable (site is below CrUX threshold at 23 clicks/28d). We are flying blind on real-user performance until `psi-pull.mjs` (matrix #11) and the `web-vitals` RUM reporter (matrix #32) are wired up. Both are scheduled for the 60-day window.
+
+2. **Bio depth and reviews/testimonials score 0.1 and 0.0 respectively on the E-E-A-T scale.** Site mean is 0.8 / 3.0. The single `editorial.json` author with no named individuals is the structural cap. Google rewards named expertise, and right now PI has structured-content advantages but human-authority disadvantages. Section 05 lays out a path that respects the editorial-collective voice while still adding signal.
+
+3. **`/whats-on/` HTML payload is 460KB**, three times the homepage. Renders 90+ event cards inline. Likely a TBT/LCP risk on mobile. PROXY-flagged; PSI confirmation pending.
+
+4. **The `dog-friendly-mornington-peninsula.astro` page is the site's #1 query magnet** (5 of top 10 queries by impressions are dog-friendly variants) and it is the most structurally weak journal page on the site: hand-coded outside the article collection, hardcoded no-trailing-slash canonical and `mainEntityOfPage`, falls back to generic `og:image`, contains 17 em-dashes (project rule violation). Migration to the article collection is matrix #9, scheduled for the 60-day window.
+
+## Where PI can realistically win in the next 90 days
+
+From the competitive analysis (`03-competitive-gap.md §5`), three SERPs are winnable in the next 90 days:
+
+- **"best cellar doors mornington peninsula"**, already at position 4. Push to 1-2 with refresh frequency (already verified Apr 2026), comparison table, and structured FAQ.
+- **"dog friendly mornington peninsula"**, PI has the right product and voice. Build out hub sub-pages (daycare, vets, weather contingencies) and link from the hub.
+- **"mornington peninsula day trip"**, most contestable SERP. Top 5 is independent travel blogs of varying quality, none of which are MP specialists. A single 2,500-word editorial day plan is the play.
+
+Three SERPs are deliberately deprioritised:
+
+- "things to do mornington peninsula", five tourism / government domains in top 5.
+- "where to stay mornington peninsula", booking-intent SERP owned by OTAs.
+- "mornington peninsula weekend", head-term event-intent; rebuild as `/whats-on/this-weekend/` instead of chasing.
+
+## What I need from you
+
+**This week (manual, blocking)**:
+- Submit `sitemap.xml` to GSC → Sitemaps (already in backlog).
+- Submit reindex requests for the 5 niche-hub URLs from experiment 2026-05-05-01 (`/dog-friendly/`, `/whats-on/`, `/corporate-events/`, `/ask/`, `/explore/golf/`).
+- After dog-friendly snippet rewrite deploys: submit reindex for `/journal/dog-friendly-mornington-peninsula/`.
+- Approve the daily-log "tomorrow's queue" plan that emerged from this audit (next experiment is the chardonnay-case snippet rewrite, then the orphan conversion-link fixes from item #1 above).
+
+**This month (decision)**:
+- Editorial decision: is the house byline ("The Peninsula Insider") indefinite? If yes, document it on `/about/` and `/methodology/` so it's deliberate. If no, name at least one editor and add a `Person` JSON-LD entity. Either way, the bio-depth axis lifts.
+- Confirm the four winnable / contestable / difficult query verdicts above match commercial intent. If "where to stay" is too important to deprioritise, the plan changes.
+- Approve the consolidate list (3 clusters of competing URLs, see `08-content-roadmap.md`). Consolidations are 301s, James approves before merge.
+
+**This quarter (decision)**:
+- Whether to keep house byline or name editors.
+- Whether the 90-day plan's targeted clicks (≥ 200 by 2026-08-06) is the right ambition or if you want to push harder.
+- Whether to commission an editorial slate for the 6 new content pieces in the build list.
+
+## How this audit was made
+
+- Two parallel research agents (technical health, competitive benchmark) and one combined agent (content / conversion / E-E-A-T).
+- Real GSC data from `daily-log.md` and `baseline.md`.
+- Live HTML pulls of 15 representative URLs.
+- Source-code review of the Astro templates.
+- Live SERP comparison via WebSearch + WebFetch on 8 priority queries.
+- Competitive page-level comparison against 8 sites (Visit MP, Broadsheet, Time Out, Concrete Playground, Australian Traveller, Halliday, The Urban List, The Ninch).
+- GA4 is not authed for this audit. 7 conversion-funnel questions are explicitly marked QUANTIFY ON GA4 AUTH; the next monthly audit will fill them in.
+
+## What's in the rest of this audit folder
+
+| File | What it is |
+|---|---|
+| `00-executive-summary.md` | this file |
+| `01-technical-health.md` | 24 prioritised technical fixes, file:line, effort, severity |
+| `02-content-clusters.md` | 14-cluster map, intent alignment, 20 content gaps, 20 internal-link pairs |
+| `03-competitive-gap.md` | 8-competitor profiles, head-to-head SERP comparison, 15 backlink targets |
+| `04-conversion-paths.md` | 9-surface inventory, funnel traces, 19 file-level fixes |
+| `05-authority-trust.md` | E-E-A-T scoring across 11 templates, About/Contact/Methodology audit, 15 backlink opportunities |
+| `06-opportunity-matrix.md` | 45 ranked opportunities scored on impact/effort/speed/commercial/confidence |
+| `07-30-60-90.md` | 17 named experiments mapped to 30, 60, 90-day windows with measurement dates |
+| `08-content-roadmap.md` | 6 builds, 9 refreshes, 3 consolidations, 20 internal-link pairs, editorial-pipeline brief |
+| `methodology.md` (parent dir) | The operating rhythm. Daily, weekly, monthly, quarterly. Decision rules for fix / refresh / consolidate / delete / expand |
+
+## Diff vs prior audit
+
+This is the first monthly audit. There is no prior audit to diff against. Future audits open with a "What changed since last audit" block in this file.
+
+## Confidence and caveats
+
+- The matrix scores are evidence-based but not infallible. Item ranks may shift as experiments confirm or refute hypotheses; the 30/60/90 plan has explicit dependency notes for what to reconsider on REFUTED outcomes.
+- The "three winnable SERPs" claim assumes Google's ranking signals stay stable across the next 90 days. SERP volatility is a real risk; the daily loop catches sudden shifts.
+- The 90-day click target of ≥ 200 (vs 29 today) is ambitious but grounded: it requires only that the structural unblocks (item 1 above) and the snippet rewrites compound at the rate they did in May (clicks went 23 → 29 in 4 days from the canonical fix alone).
+- GA4 is the missing piece. Once authed (deferred from this audit), the conversion-path numbers fill in and the priority order may shift.
+
+---
+
+End of executive summary. The full audit folder is dense; no need to read it cold. Pick a section based on the question you have, e.g.:
+
+- "what's the biggest technical fix?" → `01-technical-health.md §0` (TL;DR)
+- "what should we ship next week?" → `06-opportunity-matrix.md` top 5 + `07-30-60-90.md` 30-day window
+- "what content do I need to commission?" → `08-content-roadmap.md` build list
+- "who are we actually competing with?" → `03-competitive-gap.md §2`
+- "how does this work as an ongoing operation?" → `methodology.md` (parent dir)

--- a/ops/reports/seo/audit-2026-05/01-technical-health.md
+++ b/ops/reports/seo/audit-2026-05/01-technical-health.md
@@ -1,0 +1,816 @@
+# Peninsula Insider, Monthly SEO audit · Technical health
+
+**Date:** 2026-05-08
+**Scope:** Technical-SEO portion of the May 2026 monthly audit. Indexation, canonicals, HTTPS, and the known sitemap duplicate are covered by the daily SEO operation in `ops/reports/seo/` and are NOT re-audited here. This file covers the gaps the daily loop does not hit.
+**Reviewer:** Claude (PI SEO desk)
+**Inputs:** Live HTML pulls of 15 representative URLs, source code review of the Astro templates, the `ops/reports/seo/url-inventory.md` file (418 URLs · 233 indexed · 140 Discovered-not-indexed), and the `baseline.md` snapshot from 2026-05-01.
+
+---
+
+## 0. TL;DR, what's actually broken
+
+The site's technical baseline is materially better than the indexation numbers suggest. The structural problems are smaller and more fixable than they look:
+
+1. **PSI v5 API quota was exhausted before this audit ran.** Real Core Web Vitals lab + field data is unavailable in this report and labelled as `MISSING` in §1. The workaround used (curl-based byte/timing measurement) is a PROXY, not a substitute. P0 follow-up: enable the Chrome UX Report API key and rerun PSI for the 7 representative URLs out of band.
+2. **Article and place page hero images render as CSS `background-image`, not `<img>`.** This is the single highest-impact technical-SEO gap: the editorial hero is invisible to Google Images, has no `alt` for image-search ranking signals, cannot use `loading="lazy"`, and is unlikely to be recognised by Google Discover. See §5.
+3. **`/journal/dog-friendly-mornington-peninsula/` is hand-coded as a `.astro` page (not from the content collection), passes a no-trailing-slash canonical to BaseLayout, hardcodes `mainEntityOfPage` to the no-slash form in JSON-LD, contains 17 em-dashes (project rule violation), and falls back to the generic site `og:image`.** This is the dominant query magnet on the site (5 of 10 top queries by impressions are dog-friendly variants) and it is materially under-built.
+4. **Schema gap on the Pass commercial page:** `/pass/` ships only Organization + BreadcrumbList. No `Product` / `Offer` / `Service` schema for the membership tiers, so the page cannot earn rich result eligibility for "Mornington Peninsula membership" queries.
+5. **Schema gap on the Wine and Journal hubs:** `/wine/` and `/journal/` ship FAQ + Breadcrumb only. No `CollectionPage`, no `ItemList`. The Eat and Places hubs already have these, the inconsistency is a direct, low-effort fix.
+6. **Sitemap quality is honest but mid-tier.** 390 entries, 1 known duplicate (the orchestrator already flagged this), and `lastmod` is set to `TODAY` for the homepage and most hubs because `lastmod = TODAY` is the default in `sitemap.xml.ts:6` for any URL without an explicit override. This signals "everything changes every day" to crawlers. Real lastmods are emitted only for collection-driven entries (venues, journal articles, etc).
+7. **`/whats-on/` HTML payload is 460KB, 3× the homepage and 2.5× a place page.** That hub renders 90+ event cards inline. Likely a TBT/LCP risk on mobile.
+
+A prioritised, severity-tagged fix list is in §8.
+
+---
+
+## 1. Core Web Vitals & PageSpeed
+
+### Status: PSI v5 API quota exceeded before lab data could be collected
+
+A multi-URL parallel fetch against the public PSI v5 endpoint at the start of this audit run returned `429 Too Many Requests`, then resolved to:
+
+```
+"code": 429,
+"message": "Quota exceeded for quota metric 'Queries' and limit 'Queries per day'
+  of service 'pagespeedonline.googleapis.com'
+  for consumer 'project_number:583797351490'."
+```
+
+The PSI web UI (`https://pagespeed.web.dev/analysis?url=...`) was also fetched but it is a JavaScript-rendered SPA, the markdown-converted DOM only contains the loading interface. CrUX direct API requires an enabled API key (the project I have access to has `chromeuxreport.googleapis.com` disabled, surfaced as a 403 SERVICE_DISABLED).
+
+**This is itself the first finding.** The daily SEO loop in `ops/scripts/seo/` does not currently capture PSI lab data on a rolling cadence, there is no `psi-pull.mjs` equivalent for `gsc-pull.mjs`. The May audit therefore inherits zero historical lab/field data, and the PSI quota cap on the ad-hoc workflow makes it brittle.
+
+**Recommended P0:** Add `ops/scripts/seo/psi-pull.mjs` running once weekly against the 7 representative URLs below, with a Google Cloud API key + CrUX project enabled, writing to `ops/reports/seo/cwv-history.jsonl`. Without this, every monthly audit hits the same 429 wall.
+
+### Lab-data table (PSI MISSING, proxy values from curl)
+
+The closest signal we can get without PSI is the raw HTTP transfer:
+
+| URL | HTML bytes | Server time-to-first-byte (curl, AU) | `<img>` count | `<script>` count | CSS sheets |
+|---|---:|---:|---:|---:|---:|
+| `/` | 150,273 | 73ms | 17 | 23 | 7 |
+| `/journal/dog-friendly-mornington-peninsula/` | 139,397 | 55ms | 11 | 23 | 7 |
+| `/eat/best-restaurants/` | 168,389 | 64ms | 12 | 23 | 7 |
+| `/places/sorrento/` | 195,769 | 53ms | 11 | 24 | 7 |
+| `/wine/best-cellar-doors/` | 156,064 | 63ms | 11 | 22 | 7 |
+| `/whats-on/` | **460,362** | 52ms | 11 | 23 | 7 |
+| `/pass/` | 137,140 | **283ms** | 11 | 23 | 8 |
+
+Source: `curl -sL -o /dev/null -w "%{size_download}|%{time_starttransfer}"` from the audit machine to the GitHub Pages edge.
+
+**What this is, and what it is not.**
+This is *not* Core Web Vitals. It is a transfer-weight and edge-latency check. LCP on mobile would be dominated by the hero image (which is a CSS `background-image` for journal/place templates and ranges 168KB to 491KB, see §5), not the HTML. INP is dominated by the V4 mega menu hover handlers and the Lenis smooth-scroll RAF loop (`BaseLayout.astro:506-540`), neither of which is observable from server-side bytes. CLS is dominated by the hero rotator on the homepage (`HomeCover.astro:84-100`) and by the chip-bar mount on `/whats-on/`, also not observable from server-side bytes.
+
+**Two findings the proxy data can support:**
+
+1. **`/whats-on/` HTML is 3× the homepage and 2.6× the average page.** The page renders all 90+ events as `<EventCard>` instances inline (`whats-on/index.astro:279, 405, 428, 451, 474, 520, 571`). Each EventCard contributes both DOM and a save-button handler. Mobile LCP risk is real even though we can't measure it. Fixes: (a) lazy-mount the lower category sections via IntersectionObserver, (b) move the temporal-tabs panels to `<details>` until-clicked, (c) cap the recurring-events panel at the next 9 instances rather than rendering every recurrence.
+2. **`/pass/` time-to-first-byte was 283ms vs ~60ms for every other page.** The first byte from GitHub Pages should be cache-warmed and identical across pages; 5× the latency on a single page suggests cache miss timing (this URL is rarely visited) rather than a server problem. **PROXY only, not a real perf finding.** Re-test cold and warm to confirm.
+
+### Field-data row (PSI MISSING)
+
+| URL | LCP | INP | CLS | FCP | TTFB | Field data available? |
+|---|---|---|---|---|---|---|
+| `/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+| `/journal/dog-friendly-mornington-peninsula/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+| `/eat/best-restaurants/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+| `/places/sorrento/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+| `/wine/best-cellar-doors/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+| `/whats-on/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+| `/pass/` | MISSING | MISSING | MISSING | MISSING | MISSING | Pending PSI re-run |
+
+ASSUMPTION (not verified for this audit, based on the 23-clicks-in-28-days traffic level reported in `baseline.md`): every URL on Peninsula Insider will return "not enough real-world data" from PSI's CrUX field data. The site does not yet have the traffic threshold (the CrUX origin record needs ~100 sessions/28d minimum, per-URL records need much more). **This itself is a finding**, until traffic crosses the threshold, we can only act on lab data, not real-user data, and we cannot triangulate "what real visitors experience" against ranking outcomes. A useful intermediate is enabling Real User Monitoring via the `web-vitals` JS library (75 lines of code), reporting to Supabase. That would give us per-URL CWV before CrUX does.
+
+### Where the lab-data risks actually sit (code-level evidence)
+
+Without PSI we can still call out the code paths that are most likely to lose points:
+
+| Risk | Code evidence | Likely metric impact |
+|---|---|---|
+| Unoptimised hero images on journal/place pages (range 168KB–491KB) | `editorial.ts:360-365` (`heroBackgroundStyle`) emits `background-image: url(...)` with no responsive `image-set()`, no width/height, no `<picture>` source set | LCP +0.5s to +1.5s on slow mobile |
+| Lenis smooth-scroll RAF loop runs on every page, no idle abort | `BaseLayout.astro:506-540` | INP +50–100ms, TBT +20–50ms |
+| Two render-blocking external font requests | `BaseLayout.astro:104-107` (`Cormorant Garamond` + `Outfit` from Google Fonts, no `font-display` override) | FCP +200ms cold |
+| 7 stylesheets imported, 5 of them inline in BaseLayout (`global.css`, `concierge.css`, `search.css`, `v4.css`, plus 2 enhancement CSS sheets) | `BaseLayout.astro:11-13, 142-146` | CSS render-block budget; FCP +100–300ms |
+| Hero image rotator on home preloads + cycles 5 images (one is `loading="eager" fetchpriority="high"`, the rest are eager) | `HomeCover.astro:86-95` | First image is fine, but the other 4 contribute to network waterfall and total transfer |
+| Cookie banner script registers a consent listener that gates gtag.js, gtag eventually loads, blocking nothing but adding to total weight | `BaseLayout.astro:153-187` | Marginal but real on /pass/ where every ms of TBT matters |
+
+These are P1 lab-only suspicions. They become P0 only once PSI confirms (or refutes) them.
+
+---
+
+## 2. Schema audit
+
+### Live verification (live HTML, 2026-05-08)
+
+The numbers in this section are from `curl https://peninsulainsider.com.au/<url> | grep '<script type="application/ld+json"'` counts, with the `@type` values extracted and de-duplicated.
+
+| URL | LD-JSON blocks | `@type` values present | Notable absences |
+|---|---:|---|---|
+| `/` | 3 | Organization, WebSite (+SearchAction), FAQPage | No BreadcrumbList (homepage doesn't need one in strict spec, but Google sometimes infers; not a real gap) |
+| `/journal/dog-friendly-mornington-peninsula/` | 4 | Organization, Article, FAQPage, BreadcrumbList | Hand-coded page, schema is fine |
+| `/journal/` (hub) | 2 | Organization, BreadcrumbList | **No CollectionPage, no ItemList** |
+| `/eat/best-restaurants/` | 4 | Organization, ItemList (+ListItem), FAQPage, BreadcrumbList | Solid |
+| `/eat/` (hub) | 4 | Organization, FAQPage, BreadcrumbList, CollectionPage | Solid |
+| `/eat/polperro/` (winery filed under /eat/) | 3 | Organization, Winery (LocalBusiness), BreadcrumbList | Canonical points at `/wine/polperro/` correctly |
+| `/wine/` (hub) | 3 | Organization, FAQPage, BreadcrumbList | **No CollectionPage, no ItemList** |
+| `/wine/best-cellar-doors/` | 3 | Organization, FAQPage, BreadcrumbList | **No ItemList** (Eat best-restaurants has it; this hub does not) |
+| `/wine/polperro/` (winery canonical home) | 4 | Organization, Winery (LocalBusiness), BreadcrumbList, GeoCoordinates/PostalAddress | Solid |
+| `/places/` (hub) | 5 | Organization, CollectionPage, FAQPage, BreadcrumbList, WebSite | Solid |
+| `/places/sorrento/` | 4 | Organization, TouristDestination, FAQPage, BreadcrumbList | Solid |
+| `/whats-on/` (hub) | 3 | Organization, FAQPage, BreadcrumbList | **No CollectionPage, no ItemList of upcoming events** |
+| `/whats-on/mornington-cup-2026/` | 3 | Organization, Event (+Offer +Place), BreadcrumbList | Solid |
+| `/fishing/locations/rye-pier/` | 3 | Organization, Place, Article, BreadcrumbList, FAQPage | Solid (best-instrumented vertical on the site) |
+| `/pass/` | 2 | Organization, BreadcrumbList | **No Product, no Offer, no Service** |
+
+### Per-template code review
+
+| Template | File | Schema emission |
+|---|---|---|
+| Global head (Organization) | `next/src/layouts/BaseLayout.astro:131-137` | Always emits Organization. Logo points to `/images/sourced/home-cover.webp`, a hero photograph, not a logo. Schema.org does not strictly require square / minimum dimensions for `Organization.logo` but `NewsArticle` rich results (when we ever earn them) have a 112×112px minimum logo requirement that this asset meets only because it's much larger; a real square logo would also enable `imageObject.width`/`height` validation in Search Console. |
+| Homepage | `next/src/pages/index.astro:70-112` | WebSite (with SearchAction sitelinks) + FAQPage. `searchAction.target` is `/journal?q={search_term_string}`, note this points at `/journal/` with a query param that the journal index page doesn't currently consume; the actual search overlay binds to `/search/`. Either fix the SearchAction target or add `?q=` parsing to journal index. |
+| Journal article (collection) | `next/src/pages/journal/[slug].astro:75-109` | Article + (optional) FAQPage. Breadcrumbs component adds BreadcrumbList. `image` is suppressed when the hero is the placeholder fallback. `mainEntityOfPage` is `https://peninsulainsider.com.au/journal/{slug}/` (with trailing slash), correct. |
+| Journal article (hand-coded) | `next/src/pages/journal/dog-friendly-mornington-peninsula.astro:9-19` | Article + FAQPage. **`mainEntityOfPage` and `url` are hardcoded to the NO-trailing-slash form** (`/journal/dog-friendly-mornington-peninsula`). `<link rel="canonical">` ends up with the trailing slash because BaseLayout normalises (`BaseLayout.astro:84`), so Google sees a mismatch between canonical (with `/`) and schema URL (without `/`). Likely benign but worth fixing. |
+| Eat venue | `next/src/pages/eat/[slug].astro:78-107` | Restaurant / Cafe / Bakery / BarOrPub / LocalBusiness / Winery (mapped from `venue.data.type`). `address` and `geo` always emitted. No `aggregateRating` or `priceRange` issues. Wineries served on `/eat/{slug}/` correctly canonical to `/wine/{slug}/` per `[slug].astro:70-72`. VenueDetailTemplate adds Breadcrumbs. **Missing:** no `image` field on the schema (the hero is a CSS background, see §5). |
+| Wine venue | `next/src/pages/wine/[slug].astro:72-84` | `buildWinerySchema` (Winery + LocalBusiness multi-type) + optional Restaurant / LodgingBusiness for venues with associated restaurant or accommodation + optional FAQPage + BreadcrumbList. The multi-type Winery+LocalBusiness pattern is a deliberate choice (`schema.ts:36`) and is well-formed. `image` *is* emitted when a real hero exists (`schema.ts:43-45`). |
+| Place page | `next/src/pages/places/[slug].astro:297-308` | TouristDestination (+ optional FAQPage from `townFaqs`) + BreadcrumbList. `geo` always emitted from `place.data.coordinates`. **Missing:** no `image` on TouristDestination, no `containsPlace` linking to the venues filed under each town. The town FAQs are well-edited and substantial (12 towns have hand-written FAQs). |
+| Whats-on event detail | `next/src/pages/whats-on/[slug].astro:70` (delegates to `events.ts:eventJsonLd`) | Event with full Offer + Place + GeoCoordinates + organiser. Best-instrumented event schema in the codebase. |
+| Whats-on hub | `next/src/pages/whats-on/index.astro` | FAQPage + (Breadcrumbs adds BreadcrumbList). **Missing:** no `ItemList` of upcoming events, no `CollectionPage`. The hub renders 90+ events but advertises none of them in structured data, a clear miss for a primary editorial differentiator. |
+| Fishing location | `next/src/pages/fishing/locations/[slug].astro:21` (delegates to `schema.ts:buildFishingLocationSchema`) | `@graph` of Place + Article + (optional) FAQPage + BreadcrumbList. Best-instrumented vertical template on the site. The boating/fishing block is a mature schema implementation that the older sections should be harmonised to. |
+
+### Schema-level gaps and what I'd change
+
+| Gap | Files affected | Effort | Severity |
+|---|---|---|---|
+| No `Product` / `Offer` schema on `/pass/` for the three membership tiers | `next/src/pages/pass.astro` | 30 min | P1, commercial conversion surface |
+| No `ItemList` on `/wine/best-cellar-doors/` (peer page `/eat/best-restaurants/` has it) | `next/src/pages/wine/best-cellar-doors.astro` | 30 min | P1, primary commercial keyword surface |
+| No `CollectionPage` + `ItemList` on `/wine/`, `/journal/`, `/whats-on/` (Eat and Places already have it) | three index files | 1h total | P1, hub eligibility for sitelinks |
+| `Organization.logo` is a hero photo, not a square logo | `BaseLayout.astro:136`, `schema.ts:5` | half-day (asset creation + replace) | P2, required for News rich result eligibility eventually |
+| WebSite SearchAction `target` points at `/journal?q=` which doesn't render results | `index.astro:79-80` | 15 min, point at `/search/?q={search_term_string}` instead | P1, sitelinks search box behaviour |
+| `image` not emitted on TouristDestination / TouristAttraction schemas | `places/[slug].astro:297-308`, `lib/schema.ts:252-287` | 1h | P2 |
+| `mainEntityOfPage` / `url` mismatch in hand-coded journal Article schema (no trailing slash) | `journal/dog-friendly-mornington-peninsula.astro:17-18` | 5 min | P2 |
+| No `BreadcrumbList` on the homepage | `index.astro` | optional, Google infers; spec doesn't require | P3 |
+| No `Article.image` on `/eat/[slug]`, hero is rendered as CSS background, schema has no image at all | `pages/eat/[slug].astro:88-107` | 30 min, pull from `data.heroImage.src` | P1, Discover, Search image carousel eligibility |
+
+---
+
+## 3. Mobile usability
+
+| Check | Status | Evidence |
+|---|---|---|
+| Viewport meta present | PASS | `BaseLayout.astro:100`, `<meta name="viewport" content="width=device-width, initial-scale=1">` |
+| HTML lang attribute | PASS | `BaseLayout.astro:97`, `lang="en-AU"`; `content-language` http-equiv on line 101 |
+| V4 mega-menu collapses to drawer on mobile | PASS | V4MobileDrawer is mounted globally (`BaseLayout.astro:212`); the mega panels switch to accordion behaviour at `≤1024px` (`BaseLayout.astro:255` matchMedia gate on the ask-pill kill) |
+| Tap-target spacing on the V4 drawer | PARTIAL, needs visual QA | Drawer pillar links emit at `<a href={item.href}>{item.label}</a>` with no minimum-height padding declared in the inline CSS for V4MobileDrawer. The PI default font is `Outfit 14px` per the global stylesheet. Tap targets need 44×44px minimum per WCAG; can't verify without a real device. ASSUMPTION: probably fine because nav items are list-rows with line-height, but worth a manual QA run. |
+| Sticky subscribe pill on mobile | PASS | Bottom-left, fades in at 50% scroll, hidden on `/newsletter`, `/ask`, `/account` (`BaseLayout.astro:269-310`) |
+| Forms have correct input types and autocomplete | PASS, newsletter form uses `type="email"` and `autocomplete="email"`. Did not verify other forms in this pass. | Sample: Polperro page newsletter form |
+| Horizontal scroll on mobile | UNKNOWN, not verified | Cannot test without a viewport simulator in this audit. Project rule says BRAND-PI.md voice must avoid em-dashes, not that the layouts must avoid horizontal overflow; flagging for visual QA. |
+| Mobile-only pill CSS exists | PASS | `BaseLayout.astro:269-310` shows `subscribe-pill` and `data-path` body attribute used to hide it on specific routes |
+
+**Findings:**
+
+1. There is no programmatic mobile-usability check in the daily SEO loop. A 2-line addition to `pull.mjs` could call PSI's `lighthouseResult.audits['viewport']` and `tap-targets` audits on each priority URL and write to a daily file.
+2. `V4Masthead.astro` mobile breakpoint logic is responsive-CSS only, not JS-detected. That's good for performance, the masthead works without JS. Minus 1 risk because it means the menu chrome is server-rendered, plus 1 maintenance overhead because every CSS breakpoint change is a potential regression.
+
+---
+
+## 4. Internal linking depth
+
+### Hub → child page link counts (live HTML, 2026-05-08)
+
+| Hub | Live internal links to direct children | Children in collection / sitemap | Coverage |
+|---|---:|---:|---:|
+| `/journal/` | 99 unique `/journal/*` links | 134 journal entries in sitemap | 73% |
+| `/whats-on/` | 78 unique `/whats-on/*` links | 90 events in sitemap | 86% |
+| `/eat/` | 117 unique `/eat/*` links | 27 eat venues in sitemap | 433% (links cover sub-hubs and tag pages too) |
+| `/wine/` | 70 unique `/wine/*` links | 25 wine venues in sitemap | 280% (sub-hubs included) |
+| `/places/` | 40 unique `/places/*` links | 20 place pages | 200% |
+| `/explore/` | 58 unique `/explore/*` links | 44 explore entries in sitemap | 132% |
+
+**Reading:** every hub links well above the count of its leaf children. The high `/eat/` and `/wine/` percentages are because each hub also exposes sub-category pages (`/eat/cafes/`, `/wine/red-hill/` etc.) that are not in the leaf-venues count.
+
+### Specific Discovered-not-indexed URL audit
+
+For each unindexed URL I checked whether it has at least one inbound internal link from its parent hub. **All 25 URLs sampled had at least one link**:
+
+#### Sample: 9 of the 76 unindexed journal URLs
+| Slug | Inbound links from `/journal/` |
+|---|---:|
+| `the-birthday-weekend` | 1 |
+| `the-peninsula-orientation-drive` | 4 |
+| `the-producer-trail` | 3 |
+| `rainy-day-peninsula` | 1 |
+| `the-spring-peninsula` | 1 |
+| `the-sunset-drink` | 3 |
+| `the-sunset-hour` | 1 |
+| `best-spas-mornington-peninsula` | 3 |
+| `mornington-peninsula-itinerary` | 1 |
+
+#### Sample: 10 of the 11 unindexed places
+| Slug | Inbound links from `/places/` |
+|---|---:|
+| `balnarring` | 2 |
+| `cape-schanck` | 1 |
+| `dromana` | 2 |
+| `merricks` | 4 |
+| `moorooduc` | 1 |
+| `mount-martha` | 2 |
+| `point-nepean` | 4 |
+| `rosebud` | 1 |
+| `shoreham` | 1 |
+| `tuerong` | 1 |
+
+#### Sample: 5 of the 13 unindexed wineries
+| Slug | Inbound from `/eat/` | Inbound from `/wine/` |
+|---:|---:|---:|
+| `kooyong` | 1 | 1 |
+| `montalto` | 1 | 1 |
+| `ten-minutes-by-tractor` | 1 | 3 |
+| `willow-creek-vineyard` | 1 | 1 |
+| `yabby-lake` | 1 | 1 |
+
+**Reading:**
+
+- "Discovered – not indexed" is **not** primarily a missing-internal-link problem on this site. The links exist, just thinly. Most discovered-not-indexed URLs have 1–4 inbound links from the parent hub.
+- The **link density** (1 link is typical, 4 is uncommon) is the more likely signal. Compare to `dog-friendly-mornington-peninsula` (the indexed one) which is linked from the explore mega menu, the dog-friendly hub, the footer, plus contextual journal pieces, the 5+ link threshold seems to correlate with indexation here.
+- **The thinnest cases are the ones to fix:** `the-birthday-weekend`, `rainy-day-peninsula`, `the-spring-peninsula`, `the-sunset-hour`, `mornington-peninsula-itinerary` each have only 1 link from `/journal/`. Adding contextual cross-links from related-content rails would push them over the threshold.
+
+### Footer / global nav link check
+
+The footer (`next/src/components/Footer.astro:34-65`) exposes:
+- 7 Departments via `v4FooterDepartments` (all 7 pillars: Eat, Wine, Stay, Explore, Plans, What's On, Journal) ✓
+- All 21 places via `buildFooterPlaceLinks(places)` ✓ (so every `/places/{slug}/` has an always-on footer link from every page on the site, strong canonical-anchor signal)
+- 7 Colophon links (about, methodology, map, partners, pass, newsletter, contact, privacy)
+
+The V4 mega-menu (`next/src/lib/v4-nav.ts`) exposes hand-curated 6-items-per-column featured links, this is the curated, editorial version. It does NOT expose every leaf URL (intentional, BRAND-PI voice rule).
+
+The `v4FooterNiche` array (`v4-nav.ts:455-463`) defines `golf, spa, fishing, boating, dog-friendly, weddings, corporate-events` but **the Footer.astro component does NOT render them.** Footer renders `v4FooterDepartments` and `aboutLinks` (a synonym for the colophon list), but `v4FooterNiche` is unused. This is a 5-minute fix: add a "Special interests" column in the footer and render `v4FooterNiche`. That puts every niche hub on every page on the site.
+
+### Orphan check
+
+Cannot complete a true orphan check without crawling. **PROXY:** the 16 "URL is unknown to Google" entries in `url-inventory.md` are the closest proxy for orphans. Review:
+
+```
+/eat/main-ridge-estate/        , no main-ridge-estate venue file in /content/venues/
+/eat/ocean-eight/               , present in eat sitemap (`ocean-eight` is a wine venue, slug variant)
+/eat/stonier-wines/             , present in eat sitemap (slug variant)
+/explore/rye-ocean-beach/       , appears in /explore/ hub link list, so not orphaned
+/journal/how-to-plan-a-peninsula-weekend/ , slug variant; canonical is probably `/journal/the-one-night-escape/`
+/stay/hotel-sorrento(/)         , duplicate slug (with and without slash); needs canonicalisation
+/stay/port-phillip-estate(/)    , same
+/wine/advance-mussel-supply(/)  , same
+/wine/crittenden-estate/        , present in /wine/ hub, just unindexed
+/wine/hurley-vineyard/          , same
+/wine/main-ridge-dairy/         , same
+/wine/main-ridge-estate/        , same
+```
+
+**Action:** verify in `next/src/content/venues/` whether each "unknown to Google" URL still corresponds to an existing source file. If it does, request indexing. If it doesn't, add a 301 to the canonical destination.
+
+---
+
+## 5. Image SEO
+
+### The headline finding: hero images are CSS background-images
+
+`next/src/lib/editorial.ts:360-365` defines:
+
+```
+export function heroBackgroundStyle(data: any): string {
+  return `background-image: url(${resolveHeroSrc(data)}); background-size: cover; background-position: center;`;
+}
+```
+
+This helper is used on:
+
+- `next/src/pages/journal/[slug].astro:165`, every journal article hero
+- `next/src/components/VenueDetailTemplate.astro`, every eat / stay / wine venue hero
+- `next/src/components/PlaceDetailTemplate.astro`, every place page hero (also via cards)
+
+**Implications:**
+
+1. The hero image has **no `alt` attribute** in the rendered HTML. There is `aria-label` on the role="img" wrapper (`pages/journal/[slug].astro:165`), but Google Image search does not consume `aria-label` the way it consumes `<img alt>`. So the editorial hero is essentially invisible to image search.
+2. **No `loading="lazy"`** is possible, CSS images load whenever the matching CSS rule parses. For the article and place hero, that's eager regardless. Fine for LCP (the hero is the LCP candidate so eager is desirable), but wasteful for any below-the-fold image rendered as background, which is also the pattern for venue cards (`venue-card__hero`).
+3. **No responsive `image-set()`**, the hero is a single `.webp` URL at full resolution served to mobile and desktop alike. A 470KB hero on a 360px-wide phone is literal bandwidth waste.
+4. **No `width`/`height`** layout hint, increases CLS risk. (Mitigated for journal/place because the hero block is a fixed-aspect div, but still suboptimal.)
+5. **Discover eligibility is questionable.** Google Discover prefers stories with `<img>` heroes ≥1200px wide. CSS background-images are crawlable but don't reliably feed Discover's image-richness signals. The site's editorial format (long, opinionated, photo-driven) is a textbook Discover candidate, but the pattern of hiding hero photos as CSS doesn't help.
+
+### Hero image weights (live HEAD requests)
+
+| Image | Bytes | Used as hero on |
+|---|---:|---|
+| `/images/sourced/home-cover.webp` | 490,600 | Homepage cover, `Organization.logo`, default OG fallback |
+| `/images/sourced/place-sorrento-01.webp` | 351,724 | `/places/sorrento/` |
+| `/images/sourced/spa-alba-thermal-springs-01.webp` | 242,438 | Plans pillar mega-menu rail |
+| `/images/sourced/place-rye-01.webp` | 168,960 | `/places/rye/`, `/journal/dog-friendly-mornington-peninsula/` |
+| `/images/sourced/explore-bushrangers-bay-walk-01.webp` | 85,032 | Explore pillar mega-menu rail |
+| `/images/sourced/article-picnic-01.webp` | 470,156 | What's On mega-menu rail |
+| `/images/sourced/article-cellar-door-01.webp` | (not measured) | Wine pillar mega-menu rail |
+
+**Mean hero weight:** ~280KB. **Worst case:** 491KB. For a mobile hero served eagerly to a 360px-wide screen, that's 4–6× the bandwidth budget. The images are already `.webp` (better than JPEG by ~25%), but they are not served with `srcset`/`sizes` or `<picture>` source sets. Even a single `image-set()` on the CSS background, `image-set(url(...) 1x, url(...-2x) 2x)`, would chop mobile hero weight by 50% to 70%.
+
+### Spot-check: are hero images keyed by URL on Google's image index?
+
+Cannot verify without a Google Search Console API call against the image-search property. PROXY: the `Organization.logo` URL `/images/sourced/home-cover.webp` is the OG image fallback for any article with no explicit hero, including the dog-friendly page that is the site's #1 query magnet (38 + 20 + 11 + 8 = 77 impressions across 4 dog-related queries in the last 28d per `baseline.md`). That fallback dilutes the per-article OG image signal, every fallback article shares the same OG image, which Google Discover de-prioritises.
+
+### Image alt-text spot check
+
+Sample of `<img>` tags from the live homepage HTML:
+
+```
+<img src="/images/sourced/article-picnic-01.webp" alt="Mt Eliza Farmers' Market" loading="lazy">
+<img src="/images/sourced/spa-alba-thermal-springs-01.webp" alt="Thermal springs pools on the Mornington Peninsula" loading="lazy">
+<img src="/images/sourced/article-hatted-restaurants-01.webp" alt="Laura at Pt Leo Estate, the bar with the bay view" loading="lazy">
+<img src="/images/sourced/article-cellar-door-01.webp" alt="Ten Minutes by Tractor cellar door, Main Ridge" loading="lazy">
+<img src="/images/sourced/article-vineyard-villa-01.webp" alt="Jackalope hotel, Merricks North" loading="lazy">
+<img src="/images/sourced/explore-bushrangers-bay-walk-01.webp" alt="Bushrangers Bay walk, late afternoon light" loading="lazy">
+<img src="/images/sourced/place-red-hill-01.webp" alt="Vine rows in late-season colour, Red Hill" loading="lazy">
+<img class="home-cover__slide is-active" src="/images/sourced/explore-bushrangers-bay-walk-01.webp" alt="Bushrangers Bay on the Mornington Peninsula" loading="eager" fetchpriority="high">
+```
+
+**Reading:** alt text is good, descriptive, place-named, written in editorial voice. `loading="lazy"` is consistently applied. `fetchpriority="high"` is applied to the first cover-rotator slide. This is solid. The problem is **only** the CSS-background hero pattern, `<img>` tags inside the V4 mega menu rails and venue cards (where they're emitted as `<img>`) are well-marked.
+
+**On `/places/sorrento/`** (195KB HTML), 7 of 11 `<img>` tags use `loading="lazy"`. The four that don't are mega-menu rails inside the (preloaded) drawer markup, server-rendered but display:none until opened. Acceptable.
+
+### Quick wins on image SEO
+
+| Fix | File | Effort | Impact |
+|---|---|---|---|
+| Add `<img>` element alongside the CSS background hero on journal/place pages, with `loading="eager"`, `fetchpriority="high"`, `width`/`height`, and the same `alt` from `data.heroImage.alt` | `editorial.ts:360-365` and templates | half-day | Discover eligibility, image-search ranking, LCP layout-shift fix |
+| Generate 800w + 1600w renditions of every hero image and serve via `<img srcset>` or CSS `image-set()` | new build step | 1 day | Mobile transfer reduction 40-70% |
+| Replace `Organization.logo` with a real square logo asset (≥112×112px) | new asset + `BaseLayout.astro:136`, `schema.ts:5` | half-day | News rich result eligibility, better OG fallback |
+| Verify every article in the content collection has an explicit `heroImage.src` and `.alt`. The dog-friendly journal page falls back to `home-cover.webp` because it's hand-coded; the collection-driven pages should not. | content audit (separate task) | day+ | Per-article OG image diversity, Discover signals |
+
+---
+
+## 6. Sitemap quality
+
+### Live sitemap stats (curl https://peninsulainsider.com.au/sitemap.xml, 2026-05-08)
+
+| Metric | Value |
+|---|---:|
+| Total `<url>` entries | 390 |
+| Distinct lastmod dates | 28 |
+| Earliest lastmod | 2026-03-15 |
+| URL count by section (top 10) | journal 100, whats-on 90, explore 44, fishing 34, eat 27, stay 26, wine 25, places 20, boating 11, escape 6 |
+| Duplicate `<loc>` entries | 1 (`/journal/free-things-to-do-mornington-peninsula/`), already known |
+
+### Source
+
+`next/src/pages/sitemap.xml.ts` is a route handler. Key behaviours:
+
+- **lastmod default = TODAY** when the underlying entry has no `publishedAt` date (line 6, 12). This means most hub pages (homepage, /eat/, /wine/, /journal/, /places/, /whats-on/, etc.) emit `<lastmod>2026-05-08</lastmod>` on every build. That signals "everything changed today" and is mildly noisy for crawlers.
+- **All paths force a trailing slash** (line 9), `loc` ends in `/`. Consistent with BaseLayout canonicalisation, no slash-variant URLs in the sitemap.
+- **Section priority assignment** (lines 83-99): top hubs (`dog-friendly`, `whats-on`, `corporate-events`, `fishing`, `ask`) get priority 1.0; remaining lanes (`eat`, `stay`, `wine`, `explore`, `escape`, `journal`, `places`, `weddings`) get 0.9; sub-hubs (`fishing/species`, `boating/ramps` etc.) get 0.8; pillar Articles get 0.7.
+- **Past one-off events are excluded** (line 196), only events with a future end date or a recurrence flag are sitemap-listed. Good hygiene.
+- **The /spa/ and /walks/ redirect stubs are excluded** (line 67-71). Good.
+- **The /golf/ redirect stub is excluded** (line 72-76, comment 76). Good. /explore/golf/ is sitemap-listed instead.
+
+### Gap vs GSC's 418 known URLs (per baseline)
+
+`baseline.md` reports 418 URLs known to GSC. The current sitemap emits 390. The 28-URL gap is plausibly:
+- 8 redirect URLs (per `url-inventory.md` "Page with redirect")
+- 4 noindex URLs (per inventory)
+- 16 "URL is unknown to Google", these may be in our sitemap but GSC just hasn't crawled them yet
+- The remaining gap (~28-(8+4)=16 URLs) is consistent with no-slash variants Google has historically indexed and which we no longer emit
+
+**This is the right behaviour.** A clean trailing-slash-only sitemap is what we want.
+
+### Sitemap-quality findings
+
+| Finding | Severity | Fix |
+|---|---|---|
+| `<lastmod>` defaults to TODAY for all hub-page entries | P2 | In `sitemap.xml.ts:8`, accept an optional `lastmod` per `entries.push(...)` and pass real publish dates from collection metadata. Use `new Date('2026-04-30')` from CHANGELOG for hub pages until per-hub frontmatter exists. |
+| Single duplicate entry (`free-things-to-do-mornington-peninsula`) | P1 | Already on the daily SEO backlog; tracked. Looks like the slug is emitted both from the SEO journal landing pages list (line 121) and from the articles loop (line 156). De-dupe with a Set in the URL helper or use a check before push. |
+| One-off events expire from the sitemap once endDate passes, but the static `[slug]` route is generated at build, so the URL still 200s and may be index-eligible | P2 | Either add `noindex` on past one-off event detail pages, or (cheaper) accept it because Google will just demote them naturally |
+| Sitemap is monolithic (390 entries in one file), fine for now, but at the projected 1000+ entries it should split into per-section sitemaps with a sitemap index | P3 | Plan when sitemap > 1000 |
+| No image sitemap | P2 | Generate `/sitemap-images.xml` listing every editorial hero image with caption + title + license URL. Important once we move heroes from CSS-background to `<img>` (see §5) |
+| No news sitemap | P3 | Optional. Worth adding once dispatch frequency is verified > 1/week |
+
+### Robots.txt cross-check
+
+```
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /_astro/
+
+# Block AI training crawlers (GPTBot, CCBot, ClaudeBot, anthropic-ai, Google-Extended,
+# Bytespider, Amazonbot)
+# Allow citation bots (Googlebot, Bingbot, DuckDuckBot, PerplexityBot, OAI-SearchBot)
+
+Sitemap: https://peninsulainsider.com.au/sitemap.xml
+```
+
+**PASS**, sitemap is referenced. Disallows are minimal and correct (`/_astro/` is the build-output directory, properly hidden). The AI-bot disallows are intentional per the project's editorial position.
+
+---
+
+## 7. URL hygiene
+
+### Trailing-slash consistency
+`BaseLayout.astro:81-84` normalises every canonical URL to include a trailing slash:
+
+```
+const rawPathname = Astro.url.pathname.replace(/^\/V2/, '') || '/';
+const normalizedPath = rawPathname === '/' ? '/' : rawPathname.replace(/\/?$/, '/');
+const rawCanonical = canonical ?? `${SITE_URL}${normalizedPath}`;
+const canonicalUrl = rawCanonical.endsWith('/') ? rawCanonical : rawCanonical + '/';
+```
+
+Live verification (curl, 2026-05-08):
+- `https://peninsulainsider.com.au/journal/the-birthday-weekend` → `301` → `https://peninsulainsider.com.au/journal/the-birthday-weekend/` ✓
+- `https://peninsulainsider.com.au/journal/the-birthday-weekend/` → `200` ✓
+
+GitHub Pages enforces the redirect at the edge, confirmed 301. **Trailing-slash consistency: PASS.**
+
+### HTTP → HTTPS redirect
+Live verification: `http://peninsulainsider.com.au/` → `301` → `https://peninsulainsider.com.au/`. **HTTPS enforcement: PASS** (already verified by orchestrator on 2026-05-01).
+
+### WWW vs non-WWW
+Live verification: `https://www.peninsulainsider.com.au/` → `301` → `https://peninsulainsider.com.au/`. **www→non-www enforcement: PASS.** Canonical apex is non-WWW, consistent with the `SITE_URL` constant in `BaseLayout.astro:46` and `schema.ts:1`.
+
+### Query-parameter URLs
+Spot search of the codebase shows utm parameters are appended to outbound links (escape pages, tour pages, BF analytics) but never to internal canonicals. The site has no on-site filter or pagination URL pattern that uses query strings, filters are client-side JS-only, and pagination doesn't exist (the journal hub renders all stories inline). No internal `?` URL canonical issues.
+
+**One concern:** the WebSite SearchAction `target` (`index.astro:79`) is `https://peninsulainsider.com.au/journal?q={search_term_string}`. The `/journal/` index does not currently parse `?q=`. Either the search overlay URL `/search/?q=` should be used, or `/journal?q=` should respond by populating a search filter. Without this, sitelinks search box if Google ever earns the site one will silently 404-into-no-results.
+
+### Mixed-content / external-script audit
+- Two Google Fonts external requests (preconnect + stylesheet), HTTPS, fine
+- Google Tag Manager loaded conditionally on consent, HTTPS, fine
+- Supabase API URL conditional on signed-in users, HTTPS, fine
+- Lenis from `node_modules`, bundled, no external request
+
+No mixed-content risk identified.
+
+### Encoding / language
+- `<html lang="en-AU">` ✓
+- `<meta http-equiv="content-language" content="en-AU">` ✓
+- `<meta property="og:locale" content="en_AU">` ✓
+- Charset UTF-8 ✓ (BaseLayout:99)
+
+PASS.
+
+---
+
+## 8. Concrete fix list (prioritised)
+
+### P0, fix this week
+
+1. **Enable PSI v5 monitoring.** Add `ops/scripts/seo/psi-pull.mjs` running weekly via cron, against the 7 representative URLs from §1, with a Cloud-project API key (CrUX project must be enabled). Append rows to `ops/reports/seo/cwv-history.jsonl`. Without this, every monthly audit hits the 429 quota wall. **File:** new `ops/scripts/seo/psi-pull.mjs`. **Effort:** half-day. **Impact:** unlocks the entire technical-SEO performance loop.
+
+2. **Convert journal article and place hero from CSS `background-image` to `<img>` element.** The single biggest discoverable-on-Google upgrade available. Add `<img loading="eager" fetchpriority="high" width=... height=... alt={article.data.heroImage.alt} src={article.data.heroImage.src}>` adjacent to or replacing the current background-image div. Keep the CSS `cover/center` framing via `object-fit: cover`. **Files:** `next/src/pages/journal/[slug].astro:165`, `next/src/components/VenueDetailTemplate.astro` (around the hero block), `next/src/components/PlaceDetailTemplate.astro`. **Effort:** half-day. **Impact:** Discover eligibility, image-search ranking, layout-shift fix on hero.
+
+3. **Add `Product` / `Offer` schema to `/pass/`.** The page is the site's commercial conversion surface and currently has zero rich-result eligibility. Three `Offer` entries (Reader free, Insider paid TBD, Founders limited) plus a parent `Product` (Peninsula Insider Pass). **File:** `next/src/pages/pass.astro` (add a `<script type="application/ld+json">` block). **Effort:** 30 min. **Impact:** rich results for "Mornington Peninsula membership" queries.
+
+4. **Fix the WebSite SearchAction target.** `index.astro:79-80` points at `/journal?q={search_term_string}` which the journal hub does not consume. Change to `https://peninsulainsider.com.au/search/?q={search_term_string}` (the SearchOverlay URL). **File:** `next/src/pages/index.astro:79-80`. **Effort:** 5 min. **Impact:** sitelinks search box behaviour when Google awards one.
+
+### P1, fix this month
+
+5. **Add `ItemList` schema to `/wine/best-cellar-doors/`** to match the pattern at `/eat/best-restaurants/`. **File:** `next/src/pages/wine/best-cellar-doors.astro` (use `buildItemListSchema` from `lib/schema.ts:173`). **Effort:** 30 min. **Impact:** wine commercial-keyword rich-result eligibility.
+
+6. **Add `CollectionPage` + `ItemList` schema to `/wine/`, `/journal/`, `/whats-on/` hubs.** The Eat and Places hubs already do this. **Files:** `next/src/pages/wine/index.astro:90`, `next/src/pages/journal/index.astro` (currently emits no JSON-LD beyond Org+Breadcrumbs), `next/src/pages/whats-on/index.astro`. **Effort:** 1h total. **Impact:** hub-page sitelinks eligibility.
+
+7. **Add a "Special interests" column in the footer rendering `v4FooterNiche`.** The array is already defined (`v4-nav.ts:455-463`) listing golf, spa, fishing, boating, dog-friendly, weddings, corporate-events. The footer currently doesn't render it. Adding it gives every niche hub a global, every-page footer link, direct crawl-priority signal for the lanes Google currently under-indexes. **File:** `next/src/components/Footer.astro:34-65`. **Effort:** 15 min. **Impact:** crawl signal to the niche lanes (mirrors the experiment that bumped sitemap priority for these hubs on 2026-05-05).
+
+8. **Re-write the `dog-friendly-mornington-peninsula.astro` hand-coded page to use the article collection.** Currently the page hardcodes the Article + FAQ schema, hardcodes a no-trailing-slash canonical, falls back to `home-cover.webp` for OG image, and contains 17 em-dashes (project rule violation). Migrating it into `next/src/content/articles/dog-friendly-mornington-peninsula.md` lets it use the collection template and inherit hero, OG image, and freshness signals. **Files:** delete `pages/journal/dog-friendly-mornington-peninsula.astro`; create `content/articles/dog-friendly-mornington-peninsula.md` with proper frontmatter (`heroImage`, `publishedAt`, `updatedAt`, `dek`, `faq`). **Effort:** 1h. **Impact:** the site's #1 query magnet stops drifting from the rest of the editorial chassis.
+
+9. **Lazy-mount lower sections of `/whats-on/`.** The hub renders 90+ EventCard components inline (460KB HTML). Wrap the category-section blocks in a small IntersectionObserver-driven hydration shell so the initial DOM is cut by ~70%. **File:** `next/src/pages/whats-on/index.astro:560-600` (the category sections). **Effort:** half-day. **Impact:** mobile LCP/TBT improvement (PROXY estimate, awaiting PSI confirmation).
+
+10. **Fix the journal article schema-canonical mismatch.** `journal/dog-friendly-mornington-peninsula.astro:17-18` hardcodes `mainEntityOfPage` and `url` in JSON-LD without the trailing slash, while BaseLayout normalises the `<link rel=canonical>` to have one. **File:** `next/src/pages/journal/dog-friendly-mornington-peninsula.astro:17-18`. **Effort:** 5 min. **Impact:** schema/canonical consistency. Resolved automatically once #8 is done.
+
+11. **Add `image` field to TouristDestination schema on `/places/[slug]/`.** **File:** `next/src/pages/places/[slug].astro:297-308`. **Effort:** 5 min. **Impact:** image carousel eligibility for place-page rich results.
+
+12. **Add `image` field to Restaurant/Cafe/Winery schema on `/eat/[slug]/`.** Currently the venue schema has no image at all (`pages/eat/[slug].astro:88-107` builds the schema without `image`). Pull from `venue.data.heroImage.src`. **File:** `next/src/pages/eat/[slug].astro:88-107`. **Effort:** 15 min. **Impact:** Discover eligibility, image-rich-result eligibility on every venue page.
+
+13. **De-duplicate the journal sitemap entry for `free-things-to-do-mornington-peninsula`.** The slug is emitted from both the explicit SEO list (`sitemap.xml.ts:121`) and the journal articles loop (`sitemap.xml.ts:156`). Either skip the SEO list entry when an article exists with the same slug, or use a `Set<string>` of `loc` values before push. **File:** `next/src/pages/sitemap.xml.ts`. **Effort:** 15 min.
+
+14. **Generate 800w + 1600w renditions of editorial hero images.** The mean hero is ~280KB. A two-rendition `<picture>` source set or CSS `image-set()` halves mobile transfer. Astro can do this via the `<Image>` component, or a build script can generate offline. **Files:** new `scripts/build-hero-renditions.mjs`, plus update the templates that consume hero src. **Effort:** 1 day. **Impact:** mobile LCP improvement (PROXY-estimated 40–70% transfer reduction on hero).
+
+### P2, backlog
+
+15. **Replace `Organization.logo` asset with a real square logo (≥112×112px).** Currently uses `home-cover.webp` (a hero photograph). Required for News rich results when the site eventually qualifies. **Files:** new `/public/images/logo.png`, then `BaseLayout.astro:136` and `schema.ts:5`. **Effort:** half-day (asset creation + replace).
+
+16. **Add `noindex` to past one-off event detail pages.** The static `[slug]` route generates pages for every event but the sitemap excludes past events. Add a build-time check in `whats-on/[slug].astro` that emits `noindex={pastDateAndOneOff}`. **File:** `next/src/pages/whats-on/[slug].astro`. **Effort:** 30 min.
+
+17. **Audit content collection hero images.** Verify every article, venue, place has `heroImage.src` and `heroImage.alt` populated and not pointing at a placeholder. Currently `eat/[slug].astro:73-75` and others have a `placeholder` check that falls back to `home-cover.webp`, track which entries fall back. **Effort:** 1 day (data-quality audit).
+
+18. **Add image sitemap.** Once heroes are converted to `<img>`, generate `/sitemap-images.xml` listing every editorial hero with caption + license. **File:** new `pages/sitemap-images.xml.ts`. **Effort:** half-day.
+
+19. **Configure RUM via `web-vitals` JS library.** Site traffic is below the CrUX threshold so PSI field data is unavailable. Adding 75 lines of `web-vitals` JS that posts LCP/INP/CLS to a Supabase RPC gives per-URL RUM 6 months earlier than CrUX would. **File:** new `next/src/components/WebVitalsReporter.astro`, mount in `BaseLayout.astro` after the body tag. **Effort:** half-day. **Impact:** real per-URL CWV data starting next deploy.
+
+20. **Compute lastmod from real publish/update dates for hub pages.** Currently `sitemap.xml.ts:6` uses `TODAY` as the default. Hubs aren't actually changing daily; signalling otherwise is mildly noisy. **File:** `next/src/pages/sitemap.xml.ts`. **Effort:** 30 min.
+
+### P3, nice-to-have
+
+21. Add `BreadcrumbList` to homepage (Google infers; spec-strict only). **Effort:** 15 min.
+
+22. Plan sitemap-index split when entry count crosses 1000. **Effort:** half-day when triggered.
+
+23. Track tap-target spacing on the V4 mobile drawer with a one-off real-device QA. **Effort:** 1h.
+
+24. Add a `font-display: swap` override on the Google Fonts request to remove the FCP block. The `display=swap` parameter is already in the URL (`BaseLayout.astro:105`). PROXY-verified. **No fix needed**, was a false suspect; documenting that we checked.
+
+---
+
+## Appendix A, Files referenced (clickable from IDE)
+
+- `next/src/layouts/BaseLayout.astro:46`, SITE_URL constant
+- `next/src/layouts/BaseLayout.astro:81-84`, canonical normalisation (trailing-slash enforce)
+- `next/src/layouts/BaseLayout.astro:100`, viewport meta
+- `next/src/layouts/BaseLayout.astro:131-137`, Organization JSON-LD (global)
+- `next/src/layouts/BaseLayout.astro:153-187`, gtag consent gate
+- `next/src/layouts/BaseLayout.astro:506-540`, Lenis smooth-scroll RAF loop
+- `next/src/components/Breadcrumbs.astro:45-57`, BreadcrumbList JSON-LD emitter
+- `next/src/components/Footer.astro:34-65`, footer department + place link rendering
+- `next/src/components/HomeCover.astro:84-100`, homepage hero rotator (5 images, eager-loaded)
+- `next/src/lib/editorial.ts:360-365`, `heroBackgroundStyle` (CSS background-image helper, the §5 root-cause)
+- `next/src/lib/schema.ts:25-93`, `buildWinerySchema`
+- `next/src/lib/schema.ts:140-151`, `buildBreadcrumbSchema`
+- `next/src/lib/schema.ts:173-207`, `buildItemListSchema`
+- `next/src/lib/schema.ts:218-237`, `buildCollectionPageSchema`
+- `next/src/lib/schema.ts:252-287`, `buildTouristDestinationSchema` (no image field)
+- `next/src/lib/schema.ts:600-631`, `buildArticleSchema`
+- `next/src/lib/schema.ts:700-765`, `buildFishingLocationSchema` (best-instrumented vertical)
+- `next/src/lib/v4-nav.ts:445-453`, `v4FooterDepartments`
+- `next/src/lib/v4-nav.ts:455-463`, `v4FooterNiche` (currently unused by Footer.astro)
+- `next/src/pages/index.astro:70-112`, homepage WebSite + SearchAction + FAQPage schemas
+- `next/src/pages/index.astro:79-80`, SearchAction target (the `/journal?q=` mismatch)
+- `next/src/pages/sitemap.xml.ts:6`, TODAY lastmod default
+- `next/src/pages/sitemap.xml.ts:9`, trailing-slash enforce
+- `next/src/pages/sitemap.xml.ts:67-99`, section priority assignment
+- `next/src/pages/sitemap.xml.ts:121-127`, SEO journal pages list
+- `next/src/pages/sitemap.xml.ts:155-157`, articles loop (duplicate-emission source)
+- `next/src/pages/sitemap.xml.ts:191-198`, past-event sitemap exclusion
+- `next/src/pages/journal/[slug].astro:75-109`, Article + FAQ schema (collection-driven)
+- `next/src/pages/journal/[slug].astro:165`, hero rendered as background-image
+- `next/src/pages/journal/dog-friendly-mornington-peninsula.astro:17-18`, hardcoded no-slash mainEntityOfPage
+- `next/src/pages/journal/dog-friendly-mornington-peninsula.astro:68`, hardcoded no-slash canonical
+- `next/src/pages/eat/[slug].astro:78-107`, venue schema build (no `image`)
+- `next/src/pages/eat/[slug].astro:70-72`, winery-on-eat-URL canonical to /wine/
+- `next/src/pages/wine/[slug].astro:72-84`, wine venue schema build (full graph)
+- `next/src/pages/places/[slug].astro:297-308`, TouristDestination schema (no `image`)
+- `next/src/pages/whats-on/[slug].astro:70`, Event schema (delegates to events.ts)
+- `next/src/pages/whats-on/index.astro:279-571`, 90+ EventCard inline renders
+- `next/src/pages/fishing/locations/[slug].astro:21`, buildFishingLocationSchema
+- `next/src/pages/pass.astro`, only Organization + BreadcrumbList; missing Product/Offer
+- `ops/reports/seo/baseline.md`, May 1 frozen baseline
+- `ops/reports/seo/url-inventory.md`, 418-URL inventory
+- `ops/reports/seo/daily-log.md`, daily SEO operation
+- `ops/reports/seo/experiments.md`, experiment ledger
+
+---
+
+## Appendix B, What this audit did NOT cover
+
+These are deliberately scoped out, either because the daily SEO loop already covers them or because they belong in other audits (content quality, ad firewall, accessibility) running this month:
+
+- Indexation deltas vs prior month
+- Canonical correctness on each priority URL (the daily loop confirms 14/14 PASS)
+- HTTPS enforcement (already verified 2026-05-01)
+- The known sitemap duplicate (already on the daily backlog)
+- Content quality, voice, brand-rule adherence (a separate audit)
+- Backlink profile / referring domains (not a technical-SEO concern; covered by SEO ops separately)
+- Accessibility (WCAG) audit (out of scope for this file; tap-target spacing flagged as a single line for visual QA)
+- Editorial cadence and dispatch quality
+- Concierge / Ask PI availability
+- Ad firewall / commercial labelling
+
+The boundaries here are intentional. This audit's job is the technical chassis. The chassis is in better shape than the headline indexation numbers imply, but the §5 finding (CSS-background hero) is the single highest-leverage technical-SEO upgrade still available.
+
+---
+
+## Appendix C, Verification commands (replay this audit)
+
+Every finding in §1 to §7 is replayable. The orchestrator can re-run any block individually. All commands assume the audit machine has `curl` and a network path to peninsulainsider.com.au.
+
+### Schema audit (replay §2)
+
+Count and list the JSON-LD `@type` values on a single URL:
+
+```
+curl -sL https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/ \
+  | grep -oE '"@type":"[^"]+"' | sort -u
+```
+
+Count JSON-LD blocks on the 15 representative URLs:
+
+```
+for url in \
+  "https://peninsulainsider.com.au/" \
+  "https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/" \
+  "https://peninsulainsider.com.au/eat/best-restaurants/" \
+  "https://peninsulainsider.com.au/places/sorrento/" \
+  "https://peninsulainsider.com.au/wine/best-cellar-doors/" \
+  "https://peninsulainsider.com.au/whats-on/" \
+  "https://peninsulainsider.com.au/whats-on/mornington-cup-2026/" \
+  "https://peninsulainsider.com.au/eat/polperro/" \
+  "https://peninsulainsider.com.au/wine/polperro/" \
+  "https://peninsulainsider.com.au/fishing/locations/rye-pier/" \
+  "https://peninsulainsider.com.au/pass/" \
+  "https://peninsulainsider.com.au/places/" \
+  "https://peninsulainsider.com.au/journal/" \
+  "https://peninsulainsider.com.au/eat/" \
+  "https://peninsulainsider.com.au/wine/" ; do
+  count=$(curl -sL "$url" | grep -oE '<script type="application/ld\+json"' | wc -l)
+  printf "%-3d %s\n" "$count" "$url"
+done
+```
+
+### Page weight + resource count (replay §1 proxy)
+
+```
+for url in \
+  "https://peninsulainsider.com.au/" \
+  "https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula/" \
+  "https://peninsulainsider.com.au/eat/best-restaurants/" \
+  "https://peninsulainsider.com.au/places/sorrento/" \
+  "https://peninsulainsider.com.au/wine/best-cellar-doors/" \
+  "https://peninsulainsider.com.au/whats-on/" \
+  "https://peninsulainsider.com.au/pass/"; do
+  result=$(curl -sL -o /tmp/page-test.html \
+    -w "%{size_download}|%{time_starttransfer}|%{http_code}" "$url")
+  imgs=$(grep -oE '<img[^>]*>' /tmp/page-test.html | wc -l)
+  scripts=$(grep -oE '<script' /tmp/page-test.html | wc -l)
+  echo "${url}|${result}|imgs=${imgs}|scripts=${scripts}"
+done
+```
+
+### Hero-image weight check (replay §5 weight table)
+
+```
+for img in \
+  /images/sourced/home-cover.webp \
+  /images/sourced/place-sorrento-01.webp \
+  /images/sourced/spa-alba-thermal-springs-01.webp \
+  /images/sourced/place-rye-01.webp \
+  /images/sourced/explore-bushrangers-bay-walk-01.webp \
+  /images/sourced/article-picnic-01.webp ; do
+  bytes=$(curl -sIL https://peninsulainsider.com.au${img} \
+    | grep -i '^content-length:' | head -1 | tr -d '\r' | awk '{print $2}')
+  echo "${bytes} bytes  ${img}"
+done
+```
+
+### Internal link density (replay §4 hub link counts)
+
+```
+for hub in journal whats-on eat wine places explore ; do
+  count=$(curl -sL https://peninsulainsider.com.au/${hub}/ \
+    | grep -oE "<a href=\"/${hub}/[^\"]+\"" | sort -u | wc -l)
+  echo "/${hub}/ → ${count} unique internal links"
+done
+```
+
+### Sitemap stats (replay §6 totals)
+
+```
+curl -sL https://peninsulainsider.com.au/sitemap.xml | grep -c '<url>'
+curl -sL https://peninsulainsider.com.au/sitemap.xml | grep -oE '<loc>[^<]+</loc>' | sort | uniq -d
+curl -sL https://peninsulainsider.com.au/sitemap.xml \
+  | grep -oE '<loc>[^<]+' | sed 's|<loc>||' \
+  | grep -E '^https://peninsulainsider.com.au/(eat|wine|journal|places|whats-on|explore|escape|stay|fishing|boating)/' \
+  | awk -F'/' '{print $4}' | sort | uniq -c | sort -rn
+```
+
+### Trailing-slash, HTTPS, WWW redirects (replay §7)
+
+```
+curl -sIL https://peninsulainsider.com.au/journal/the-birthday-weekend | head -3
+curl -sIL http://peninsulainsider.com.au/ | head -3
+curl -sIL https://www.peninsulainsider.com.au/ | head -3
+```
+
+### PSI v5 lab + field data (when quota allows)
+
+```
+curl -sL "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://peninsulainsider.com.au/&strategy=mobile&category=performance&key=$PSI_KEY" \
+  | jq '{
+      score: .lighthouseResult.categories.performance.score,
+      lcp: .lighthouseResult.audits["largest-contentful-paint"].displayValue,
+      tbt: .lighthouseResult.audits["total-blocking-time"].displayValue,
+      cls: .lighthouseResult.audits["cumulative-layout-shift"].displayValue,
+      field: .loadingExperience.metrics
+    }'
+```
+
+This audit hit the daily quota; document and deferred. The orchestrator should set `PSI_KEY` and add the call to `psi-pull.mjs`.
+
+---
+
+## Appendix D, Schema-vs-spec gap matrix (full)
+
+This matrix shows every recommended schema field per template, and which are present. P1/P2 fixes from §8 reference these gaps.
+
+### `Article` (used on `/journal/[slug]/`, `/journal/dog-friendly-mornington-peninsula/`, fishing-vertical articles)
+
+| Recommended field | Present (collection-driven journal) | Present (hand-coded dog-friendly) | Notes |
+|---|---|---|---|
+| `headline` | ✓ | ✓ | |
+| `description` | ✓ | ✓ | |
+| `datePublished` | ✓ | ✓ | |
+| `dateModified` | ✓ (when `updatedAt` set) | ✗ | Hand-coded page misses it |
+| `author` | ✓ Organization | ✓ Organization | Could promote to Person where author is named |
+| `publisher` | ✓ | ✓ | Logo points at hero (see §2 P2 #15) |
+| `image` | ✓ when not placeholder | ✗ | Hand-coded misses it |
+| `mainEntityOfPage` | ✓ trailing-slash | ✗ no-slash | Mismatch with canonical (P1 fix #10) |
+| `url` | ✓ trailing-slash | ✗ no-slash | Same |
+| `articleSection` | ✗ | ✗ | Could populate from `format` field |
+| `keywords` | ✗ | ✗ | Could populate from `tags` array |
+
+### `Restaurant` / `Cafe` / `Bakery` / `BarOrPub` / `Winery` (`/eat/[slug]/`)
+
+| Recommended | Present | Notes |
+|---|---|---|
+| `name` | ✓ | |
+| `description` | ✓ | |
+| `address` (PostalAddress) | ✓ | streetAddress, addressRegion, addressCountry |
+| `geo` (GeoCoordinates) | ✓ | |
+| `url` (external website) | ✓ when set | |
+| `telephone` | ✓ when set | |
+| `priceRange` | ✓ when set | |
+| `image` | **✗** | P1 fix #12 |
+| `servesCuisine` (Restaurant) | ✗ | Could populate |
+| `acceptsReservations` | ✗ on `/eat/` (✓ on `/wine/[slug]` Restaurant inner schema) | |
+| `openingHoursSpecification` | ✗ on `/eat/` (✓ on `/wine/[slug]` Winery schema when `data.visiting.openingHours` set) | |
+| `aggregateRating` | ✗ (intentional, no AggregateRating per ACCC editorial integrity) | |
+| `review` | ✗ (could surface editorVerdict, `/wine/[slug]` does this) | |
+
+### `Winery` / `LocalBusiness` (`/wine/[slug]/`)
+
+`buildWinerySchema` in `lib/schema.ts:25-93` is the most complete venue schema in the codebase. Includes multi-type `['Winery', 'LocalBusiness']`, `sameAs` (MPVA + Halliday URLs), `image`, full `address`, `geo`, `areaServed`, `telephone`, `priceRange`, `knowsAbout`, optional `openingHoursSpecification`, optional `review`. **No gaps to flag for the wine vertical.**
+
+### `Event` (`/whats-on/[slug]/`)
+
+`eventJsonLd` in `lib/events.ts` produces a complete graph: Event + Offer + Place + GeoCoordinates + organizer + image when present. **No gaps.**
+
+### `TouristDestination` (`/places/[slug]/`)
+
+| Recommended | Present | Notes |
+|---|---|---|
+| `name` | ✓ | |
+| `description` | ✓ | from `place.data.intro` |
+| `geo` | ✓ when set | |
+| `url` | ✓ | |
+| `address` | **✗** | could add addressLocality, addressRegion |
+| `image` | **✗** | P1 fix #11 |
+| `containsPlace` | **✗** | could link the venues filed under this town |
+| `touristType` | ✗ | optional |
+
+### `CollectionPage` + `ItemList` (hub pages)
+
+| Hub | CollectionPage | ItemList | Status |
+|---|---|---|---|
+| `/eat/` | ✓ | ✓ | Solid |
+| `/wine/` | ✗ | ✗ | P1 fix #6 |
+| `/places/` | ✓ | ✗ (could add) | Acceptable |
+| `/journal/` | ✗ | ✗ | P1 fix #6 |
+| `/whats-on/` | ✗ | ✗ | P1 fix #6 |
+| `/explore/` | not audited live | | |
+| `/escape/` | not audited live | | |
+| `/stay/` | not audited live | | |
+
+### `Product` / `Offer` / `Service` (commercial pages)
+
+| Page | Schema | Status |
+|---|---|---|
+| `/pass/` | None (only Organization + Breadcrumbs) | P0 fix #3 |
+| `/tour/[slug]/` | TouristTrip + Service + Offer | Solid (per `lib/schema.ts:425-484`) |
+| `/tour-packages/[slug]/` | TouristTrip + AggregateOffer | Solid |
+| `/partners/apply/` | not audited | likely fine, not commercial-conversion |
+
+---
+
+## Appendix E, Linking-density follow-ups
+
+### Discovered-not-indexed URLs sorted by inbound link count
+
+For the next monthly SEO loop. The 9 journal slugs in §4 with only 1 inbound link from `/journal/` are the highest-priority cross-link targets:
+
+```
+the-birthday-weekend                     1 inbound
+rainy-day-peninsula                       1 inbound
+the-spring-peninsula                      1 inbound
+the-sunset-hour                           1 inbound
+mornington-peninsula-itinerary            1 inbound
+the-peninsula-orientation-drive           4 inbound  (less urgent)
+the-producer-trail                        3 inbound  (less urgent)
+the-sunset-drink                          3 inbound  (less urgent)
+best-spas-mornington-peninsula            3 inbound  (less urgent)
+```
+
+### Suggested cross-link mappings (P2 backlog, half-day to ship)
+
+| From article (high-traffic / indexed) | To unindexed article | Rationale |
+|---|---|---|
+| `/journal/dog-friendly-mornington-peninsula/` | `/journal/rainy-day-peninsula/` | Same audience, weather-flexible plan |
+| `/journal/the-thermal-springs-weekend/` | `/journal/the-spring-peninsula/`, `/journal/best-spas-mornington-peninsula/` | Adjacent topic clusters |
+| `/journal/the-cellar-door-short-list/` | `/journal/mornington-peninsula-winery-tour/`, `/journal/the-producer-trail/` | Cross-link inside the wine cluster |
+| `/journal/three-italian-dinners/` | `/journal/breakfast-before-the-crowds/`, `/journal/where-to-eat-without-a-booking/` | Eat-cluster horizontal linking |
+| `/journal/the-pub-guide/` | `/journal/the-pub-crawl/`, `/journal/the-friday-night-arrival/` | Pub cluster |
+| `/journal/mornington-peninsula-day-trip/` | `/journal/mornington-peninsula-itinerary/`, `/journal/the-four-hour-peninsula/` | Itinerary cluster |
+| `/journal/the-couples-weekend/` | `/journal/the-birthday-weekend/`, `/journal/the-vineyard-villa-weekend/` | Romantic-weekend cluster |
+
+Where a "from" article has a `relatedArticles` frontmatter list (`pickRelatedArticles` pattern in `journal/[slug].astro:41`), the suggestion is to add the unindexed slug to that list. The 6-slot related-rail bump that landed 2026-05-05 (per the comment at `journal/[slug].astro:41-45`) makes room for these.
+
+### A "linking depth" metric for the daily SEO loop
+
+The daily loop could compute, for each Discovered-not-indexed URL, the count of unique inbound internal links from indexed pages. Track the metric over time. URLs whose inbound count rises but indexation status doesn't change after a month are candidates for content quality intervention rather than crawl-signal fixes.

--- a/ops/reports/seo/audit-2026-05/02-content-clusters.md
+++ b/ops/reports/seo/audit-2026-05/02-content-clusters.md
@@ -1,0 +1,455 @@
+# 02, Content clusters & search-intent alignment
+
+Date: 2026-05-08
+Author: Claude (audit-2026-05)
+Inputs: `ops/reports/seo/baseline.md`, `url-inventory.md`, `daily-log.md` (May 1 to May 4 entries), `experiments.md`, full `next/src/pages/*` and `next/src/content/*` tree.
+
+The site is 1052 built pages. GSC sees 418 known URLs; of those, 233 (56%) are PASS, 140 (33%) are Discovered-not-indexed, 17 are alternate-canonical, 16 are unknown, 8 are redirects, 4 are noindex (`url-inventory.md:6-15`). Last 28 days: 29 clicks, 2,873 impressions, 1.01% CTR, position 16.8 (`daily-log.md:521-527`).
+
+The dataset shows a site that has solved indexation for its priority spine (14/14 priority URLs PASS by 2026-05-04, `daily-log.md:529-547`) but still has long-tail clusters that are flat (no hub spokes), thin on internal links, or stranded behind broken navigation. This document maps every cluster, scores intent alignment for the queries that actually drive impressions, and prescribes specific links and new pages to write.
+
+---
+
+## 1. Cluster map (overview table)
+
+| # | Cluster | Built URLs (est.) | Indexed (PASS) | Discovered | Spine | Spine indexed? | Top performer (clicks/impr last 28d) |
+|---|---|---:|---:|---:|---|---|---|
+| 1 | Town hubs (`/places/`) | 21 | 10 | 11 | `/places/` listing | Discovered | `/places/flinders/` (0 / minor) |
+| 2 | Eat (`/eat/`) | ~35 | 18 | 14 | `/eat/best-restaurants/` | PASS | `/eat/` (2 / 183) |
+| 3 | Wine (`/wine/`) | ~30 | 13 | 13 | `/wine/best-cellar-doors/` | PASS | `/wine/` (1 / 289) |
+| 4 | Stay (`/stay/`) | ~10 | 6 | 0 | `/stay/best-accommodation/` | PASS | `/stay/` (0 / 95) |
+| 5 | Explore (`/explore/`) | ~52 | 9 | 32 | `/explore/best-walks/` | PASS | `/explore/` (0 / 0 reported) |
+| 6 | Escape (`/escape/`) | 6 | 1 | 5 | `/escape/` listing | Discovered | `/escape/the-peninsula-golf-weekend/` |
+| 7 | Journal (`/journal/`) | ~110 | 38 | 58 | `/journal/` archive | (PASS) | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` (3 / 47) |
+| 8 | Fishing (`/fishing/`) | ~30 | 28 | 1 | `/fishing/` hub | PASS | `/fishing/locations/point-leo-beach/` (2 / 8) |
+| 9 | Boating (`/boating/`) | 8 | 8 | 0 | `/boating/` hub | PASS | (no clicks yet) |
+| 10 | Dog-friendly | ~7 articles + hub | 4 articles | 1 hub + 3 sibling articles | `/dog-friendly/` | Discovered | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` (3 / 47) |
+| 11 | What's On (`/whats-on/`) | ~85 | 84 | 1 (the hub) | `/whats-on/` listing | Discovered | `/whats-on/mornington-cup-2026` (1 / 230) |
+| 12 | Awards (`/awards/`) | 11 (1 + 9 cats + nominate) | 0 directly observed | 0 directly observed (likely unknown) | `/awards/` | Unknown | (no impressions reported) |
+| 13 | Commercial spine (Pass / Submit / Newsletter / Ask / Itinerary / Partners) | ~10 | ~3 | 4 | none coherent | mixed | (none ranking) |
+| 14 | Niche (Golf / Spa / Tour / Weddings / Corporate / Insiders 30 / Alerts) | ~15 | 1 (`/weddings/`) | 4-5 | each uses its own index | mostly Discovered | (no clicks yet) |
+
+Counts are derived from `url-inventory.md` (GSC-known set of 418), then cross-referenced with the built-page tree under `next/src/pages/*`. Cluster totals exceed indexed+discovered counts where pages exist but were not surfaced to GSC at the inspection time on 2026-05-05.
+
+---
+
+## 2. Cluster-by-cluster detail
+
+### 2.1 Town hubs (`/places/`), flagship cluster, indexation just stabilised
+
+**Built URLs**: 21 (`/places/` index + 20 town slugs from `next/src/content/places/*.json`).
+
+**Indexed (10)**: `/`, `/places/flinders/`, `/places/hastings/`, `/places/main-ridge/`, `/places/mornington/`, `/places/portsea/`, `/places/red-hill/`, `/places/rye/`, `/places/safety-beach/`, `/places/sorrento/` (`url-inventory.md:133-142`). The `/places/red-hill` no-slash variant is also indexed; this is a known http/slash duplicate the site is consolidating via the May 1 HTTPS-enforce change.
+
+**Discovered, not indexed (11)**: `/places/`, `/places/balnarring/`, `/places/cape-schanck/`, `/places/dromana/`, `/places/merricks/`, `/places/moorooduc/`, `/places/mount-martha/`, `/places/point-nepean/`, `/places/rosebud/`, `/places/shoreham/`, `/places/tuerong/` (`url-inventory.md:372-382`).
+
+**Spine**: `/places/` is the listing hub. It is itself **Discovered, not indexed** despite linking to all 20 children. This blocks crawl flow into the half of the cluster Google has not yet indexed.
+
+**Top performer last 28d**: `/places/flinders/` is the only place hub generating notable impressions; the `/places/` hub has been earning impressions since May 1 (the experiment 2026-05-01-01 fix unblocked the cluster).
+
+**Coverage gaps**:
+- 9 town hubs are built but not yet indexed; pattern matches Phase 1 of indexation, where hubs that are linked only from `/places/` index don't get crawl signal because the index is itself unindexed.
+- `/places/blairgowrie/` JSON exists in `next/src/content/places/blairgowrie.json` but no page is reaching GSC; check it's emitting from `[slug].astro`.
+
+**Internal-linking pattern**: hub-and-spoke. `[slug].astro:80-89` cross-links 4 related articles per place via tag/title match. Articles do NOT consistently link back to the place hub. This is the missing return-link.
+
+**Action**: lift `/places/` index to indexed (sitemap priority + a contextual link from `/journal/dog-friendly-mornington-peninsula/` in the body and from `index.astro:51-54` (places rail). Add a one-line "More on Sorrento → /places/sorrento/" link to every journal article whose tag list includes a town slug.
+
+### 2.2 Eat (`/eat/`), high-impression listing pages, weak venue conversion
+
+**Built URLs**: ~35 (1 hub + 18 venue pages indexed + 14 unindexed wineries/specialty + 14 thematic listicles like `/eat/cellar-door-lunch.astro`, `/eat/hatted-restaurants.astro`, etc).
+
+**Indexed venues (per `url-inventory.md:31-49`)**: bistro-elba, elan-vineyard, flinders-general-store, flinders-pier-takeaway, kerri-greens, la-baracca-tgallant, merricks-general-wine-store, ouest-france-bistro, pho-rosebud, point-leo-wine-terrace, polperro, port-phillip-estate, sorrento-gelato, sorrento-hotel, sourdough-kitchen, the-rocks-mornington, yabby-lake. **Plus** the `/eat/` hub and `/eat/best-restaurants/` (the canonical spine).
+
+**Discovered, not indexed (14)**: every "winery-as-restaurant" page (crittenden-estate, eldridge-estate, foxeys-hangout, hurley-vineyard, kooyong, montalto, moorooduc-estate, paradigm-hill, paringa-estate, pt-leo-estate, quealy-winemakers, red-hill-estate, t-gallant, ten-minutes-by-tractor, willow-creek-vineyard) (`url-inventory.md:260-274`).
+
+**Spine**: `/eat/best-restaurants/` is correctly canonical and PASS. `/eat/` itself has 183 impressions over last 28d at position 36.3 with 2 clicks, 1.09% CTR (`daily-log.md:594`) - high-volume low-rank, classic page-2 tail.
+
+**Top performer**: `/eat/` listing (183 impr / 2 clicks). `/eat/pho-rosebud/` ranks position 7.6 with 57 impressions and 0% CTR (`daily-log.md:613`) - snippet failure on a top-of-page-1 page.
+
+**Coverage gaps**:
+- The 14 unindexed winery pages are now resolved by experiment 2026-05-05-03 (the canonical now points to `/wine/{winery}/`). They will deindex from `/eat/` over coming weeks; this is the desired state, not a gap.
+- Thematic listicles `/eat/cellar-door-lunch.astro`, `/eat/hatted-restaurants.astro`, `/eat/long-lunch.astro`, etc are indexable but absent from `url-inventory.md` - they may not be in sitemap, or they're not reaching GSC. Verify in `sitemap.xml.ts`.
+- Query "best restaurants in mornington peninsula" gets 14 impressions at position 46.4 (`daily-log.md:572`). The page exists at `/eat/best-restaurants/` but is at page 4-5, not page 1.
+
+**Internal-linking pattern**: hub-and-spoke. `eat/[slug].astro:24-28` shows up to 3 related venues filtered by place. Articles cross-link to venues via `relatedVenues` ref arrays. The hub is indexed but isn't getting click-through, suggesting snippet failure plus weak SERP rank.
+
+**Action**: rewrite `/eat/best-restaurants/` title/meta to compete against Broadsheet/Visit Mornington Peninsula for "best restaurants mornington peninsula" (currently at page 5). Add an FAQ block to `/eat/` (already in homepage; not yet on `/eat/` hub).
+
+### 2.3 Wine (`/wine/`), biggest impression-volume cluster, lowest CTR
+
+**Built URLs**: ~30 (`/wine/` hub + `/wine/best-cellar-doors/` + 13 indexed venues + 13 unindexed venues + 6 sub-region/varietal pages).
+
+**Indexed (13 venues + 2 hubs)**: avani-wines, circe-wines, dexter-wines, eldridge-estate, mornington-peninsula-cider, ocean-eight, onannon, paradigm-hill, polperro, red-hill-cheese, stonier-wines (`url-inventory.md:240-251`), plus `/wine/`, `/wine/best-cellar-doors/`.
+
+**Discovered, not indexed (13)**: foxeys-hangout, kooyong, montalto, moorooduc-estate, paringa-estate, port-phillip-estate, pt-leo-estate, quealy-winemakers, red-hill-estate, t-gallant, ten-minutes-by-tractor, willow-creek-vineyard, yabby-lake (`url-inventory.md:384-396`).
+
+**Spine**: `/wine/best-cellar-doors/` PASS. `/wine/` hub is the highest-impression cluster on the entire site at 289 impressions, 0.35% CTR, position 21.3 over last 28d (`daily-log.md:607`).
+
+**Coverage gaps**:
+- 13 of the 26 cellar-door venue pages are stuck "Discovered". This is the same 14 winery pattern from /eat/. Now that experiment 2026-05-05-03 routes /eat/winery → canonical /wine/winery, the /wine/ versions should pick up signal that was previously split.
+- Sub-region pages (`/wine/red-hill.astro`, `/wine/balnarring.astro`, `/wine/main-ridge.astro`, `/wine/merricks.astro`, `/wine/flinders.astro`, `/wine/moorooduc-tuerong.astro`) and varietal pages (`/wine/chardonnay.astro`, `/wine/pinot-noir.astro`) are not in the GSC inventory, verify they are in `sitemap.xml.ts`.
+- `/wine/best-wineries-mornington-peninsula.astro` looks like a duplicate of `/wine/best-cellar-doors/`; if so, consolidate to one canonical.
+
+**Internal-linking pattern**: spine to spokes via `/wine/best-cellar-doors/`. Spokes do not return-link strongly.
+
+**Action**: add `/wine/best-cellar-doors/` and the four sub-region hubs (red-hill, balnarring, main-ridge, merricks) as cluster links from every `/wine/{venue}/` page. The `/journal/the-chardonnay-case/` article is a top of page 1 ranker (position 5.6, 71+55 impressions, 0% CTR) and links nowhere structural; add a return-link block from it to the wine hub spine.
+
+### 2.4 Stay (`/stay/`), high impressions, weak indexation depth
+
+**Built URLs**: ~10 (1 hub + 1 spine + 6 venue pages + 1 dog-friendly subhub).
+
+**Indexed (6 venues + 2 hubs)**: `/stay/`, `/stay/best-accommodation/`, `/stay/crittenden-villas`, `/stay/dog-friendly/`, `/stay/endota-spa-sorrento`, `/stay/peninsula-hot-springs-glamping/`, `/stay/sorrento-coastal-retreat/` (`url-inventory.md:143-149`).
+
+**Unknown to Google (4)**: `/stay/hotel-sorrento`, `/stay/port-phillip-estate` and slash variants (`url-inventory.md:430-433`). The `http://peninsulainsider.com.au/stay/hotel-sorrento` zombie URL has been collecting 109 impressions at 0% CTR / position 53.7 (`daily-log.md:611`). It should consolidate to https with the May 1 enforcement, but Google's not picked up the new state for these URLs yet.
+
+**Spine**: `/stay/best-accommodation/` (indexed, 65-68 impr at 0% CTR).
+
+**Top performer**: `/stay/` (95-106 impressions, 0% CTR, position 27-29; `daily-log.md:603`).
+
+**Coverage gaps**:
+- Only 6 venue pages exist for an entire accommodation cluster. The Peninsula has 50+ stay-worthy venues; this cluster is materially under-built.
+- High-impression but unranked queries: "accommodation near peninsula hot springs" (16-19 impressions at position 67.8), "hotel near sorrento pier booking" (15 impr, position 65.9), "5 star accommodation/hotel mornington peninsula", "best places to stay mornington peninsula" (8-9 impr at position 49). Each represents transactional intent the site can serve but isn't ranking for.
+
+**Internal-linking pattern**: hub plus dog-friendly sub-hub. Few articles link directly to stay venues.
+
+**Action**: most expensive cluster gap. See "Content gaps" section below for specific articles.
+
+### 2.5 Explore (`/explore/`), 32 unindexed pages, the largest single deficit
+
+**Built URLs**: ~52 (1 hub + 1 spine + ~50 walks/beaches/golf/galleries).
+
+**Indexed (9)**: `/explore/`, `/explore/balnarring-beach/`, `/explore/beaches/`, `/explore/best-walks/`, `/explore/bushrangers-bay-walk/`, `/explore/montalto-sculpture-trail/`, `/explore/safety-beach-foreshore/`, `/explore/sea-search-encounters`, `/explore/st-andrews-beach-golf-course`, `/explore/walks/` (`url-inventory.md:51-60`).
+
+**Discovered, not indexed (32)**: arthurs-seat-lookout, cape-schanck-boardwalk, cape-schanck-lighthouse-walk, coastal-walk-cape-schanck, coppins-track, dromana-beach, eagle-ridge-golf-course, farnsworth-track, flinders-golf-club, greens-bush-two-bays-section, gunnamatta-ocean-beach, moonah-links, mornington-foreshore-walk, mornington-golf-club, mornington-peninsula-gallery, mount-martha-beach, point-nepean-fort-walk, point-nepean-national-park, portsea-front-beach, portsea-golf-club, pt-leo-sculpture-park, racv-cape-schanck-golf-course, red-hill-hinterland-cycling, red-hill-market, sorrento-back-beach, sorrento-ferry, sorrento-golf-club, sorrento-ocean-baths, summit-circuit-arthurs-seat, the-dunes-golf-links, the-national-golf-club, two-bays-walking-track (`url-inventory.md:280-311`).
+
+**Spine**: `/explore/best-walks/` PASS.
+
+**Top performer**: query "free things to do in mornington peninsula" hits the `/journal/free-things-to-do-mornington-peninsula/` page at 16 impr/position 20.3 (`daily-log.md:564`). The `/explore/` hub gets minimal traffic.
+
+**Coverage gaps**:
+- Same Phase-1 indexation pattern as /places/ pre-fix: spokes are linked from a hub but the hub itself doesn't carry the contextual body-link signal Google needs.
+- Golf cluster (10 courses) is sub-merged inside `/explore/`. Should it be its own `/golf/` cluster? `/golf/` is currently a noindex redirect-stub (per `daily-log.md:669`); the canonical golf hub is `/explore/golf/`. This is messy. Pick one path.
+- Sub-region page `/explore/walks/` is indexed; the per-walk pages mostly aren't. Apply the related-articles experiment pattern to walks: bump the related-articles limit on `/journal/walks-bushrangers-bay-walk-guide/` and other indexed walk articles to surface the 32 unindexed siblings.
+
+**Internal-linking pattern**: hub-and-spoke nominal, but the spokes are isolated. Add walk pages as related links from the indexed walk-articles.
+
+**Action**: replicate experiment 2026-05-05-02 (journal internal linking) for walks. Pick 4 indexed source articles (`/journal/walks-bushrangers-bay-walk-guide/`, `/journal/cape-schanck-guide/`, `/journal/point-nepean-national-park-guide/`, `/journal/the-peninsulas-best-late-afternoon-walks/`) and seed their related-experiences arrays with the 32 unindexed walk pages.
+
+### 2.6 Escape (`/escape/`), 1 indexed of 6
+
+**Built URLs**: 6 (`/escape/` hub + 5 plans).
+
+**Indexed (1)**: `/escape/the-peninsula-golf-weekend/` (`url-inventory.md:50`).
+
+**Discovered, not indexed (5)**: `/escape/`, `/escape/ridge-to-sea-two-night-escape/`, `/escape/sorrento-off-season-weekend/`, `/escape/the-family-day-out/`, `/escape/wellness-weekend/` (`url-inventory.md:275-279`).
+
+**Spine**: `/escape/` hub - itself unindexed. Same pathology as `/dog-friendly/` and `/places/` index.
+
+**Action**: bump sitemap priority + add contextual body-link from `/journal/the-couples-weekend/`, `/journal/the-thermal-springs-weekend/`, and `/journal/the-easter-peninsula/` (all indexed). Manual reindex submission for the hub.
+
+### 2.7 Editorial / Journal (`/journal/`), the demand engine, 58 articles unindexed
+
+**Built URLs**: 110 articles (172 markdown files in `next/src/content/articles/` minus drafts, plus an index page and the format taxonomy structure).
+
+**Indexed (38)**: see `url-inventory.md:94-131` for the full list. Highlights: dog-friendly-cafes-pubs-wineries-mornington-peninsula (clicks earner), the-pub-guide, the-chardonnay-case, three-italian-dinners, the-cellar-door-short-list, area-guide-{flinders, dromana, mornington, sorrento, red-hill, portsea, main-ridge, merricks}, mornington-peninsula-day-trip, mornington-peninsula-with-kids, mornington-peninsula-in-autumn, the-couples-weekend, the-easter-peninsula, the-long-lunch, the-thermal-springs-weekend.
+
+**Discovered, not indexed (58)**: see `url-inventory.md:314-371`. Highlights: best-brunch, best-golf-courses, best-spas, mornington-peninsula-itinerary, mornington-peninsula-winery-guide, mornington-peninsula-winery-tour, the-birthday-weekend, the-dog-friendly-peninsula, the-four-hour-peninsula, the-market-saturday, the-one-night-escape, the-peninsula-orientation-drive, the-peninsula-pantry, the-peninsula-picnic, the-peninsula-with-kids, the-producer-trail, the-pub-crawl, the-rainy-day-peninsula-without-a-booking, the-school-holidays-survival-guide, the-seafood-list, the-sorrento-weekend, the-spring-peninsula, the-vineyard-villa-weekend, things-to-do-mornington-peninsula, waterfront-restaurants-mornington-peninsula, weddings-where-guests-stay-mornington-peninsula, where-to-eat-without-a-booking, where-to-stay-mornington-peninsula, where-to-walk-the-dog-mornington-peninsula.
+
+**Spine**: `/journal/` archive. The journal has no thematic spine pages; readers navigate by /journal/[slug] only. This means crawl signal is dispersed evenly across 110 articles.
+
+**Top performer**: `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` (3 clicks / 47 impressions / position 5.9; `daily-log.md:593`).
+
+**Coverage gaps**:
+- 58 articles unindexed. Experiment 2026-05-05-02 has shipped to address ~15 of these via related-articles seeding. The other 43 still need treatment.
+- Many of these are "service" pieces with strong commercial intent: `where-to-stay-mornington-peninsula`, `where-to-eat-without-a-booking`, `things-to-do-mornington-peninsula`, `mornington-peninsula-itinerary`, `mornington-peninsula-winery-guide`, `best-brunch`, `best-spas`, `best-golf-courses`. These should be the highest-priority indexation targets.
+
+**Internal-linking pattern**: rich. `[slug].astro:41-44` auto-picks 6 related articles by format/tag, plus explicit `relatedArticles` refs. Cross-links to venues, experiences, places, and itineraries also rich. The cluster is well-connected internally; the bottleneck is outside referrers and depth.
+
+**Action**: identify the 5 highest-traffic indexed articles, treat each as a "spoke source" and seed 6 explicit `relatedArticles` refs to unindexed siblings. Targets per source:
+
+| Source (indexed) | Seed unindexed targets |
+|---|---|
+| `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` (already done) | dog-daycare, emergency-vet, dog-friendly-accommodation, dog-friendly-wineries, where-to-walk-the-dog, the-dog-friendly-peninsula |
+| `/journal/three-italian-dinners/` | the-seafood-list, where-to-eat-without-a-booking, breakfast-before-the-crowds, hatted-restaurants-mornington-peninsula-2025, waterfront-restaurants-mornington-peninsula |
+| `/journal/the-cellar-door-short-list/` (already done) | mornington-peninsula-winery-guide, mornington-peninsula-winery-tour, dog-friendly-wineries, peninsula-hot-springs-vs-alba, weddings-where-guests-stay |
+| `/journal/the-couples-weekend/` | the-birthday-weekend, the-one-night-escape, the-vineyard-villa-weekend, the-sorrento-weekend, where-to-stay-for-a-two-night-escape |
+| `/journal/the-thermal-springs-weekend/` | mornington-peninsula-hot-springs-guide, peninsula-hot-springs-vs-alba, mornington-peninsula-stay-and-soak, best-spas-mornington-peninsula, a-winter-peninsula-weekend |
+| `/journal/mornington-peninsula-day-trip/` | mornington-peninsula-itinerary, the-four-hour-peninsula, the-peninsula-orientation-drive, the-point-nepean-half-day, things-to-do-mornington-peninsula |
+
+### 2.8 Fishing (`/fishing/`), strongest cluster, fully indexed
+
+**Built URLs**: ~30 (1 hub + locations index + 14 location pages + species index + 12 species pages + charters index + 4 charter pages + seasons sub-page).
+
+**Indexed (28)**: see `url-inventory.md:61-93`. Notably the entire cluster is indexed; the only non-indexed page is `/fishing/species/flathead/` (`url-inventory.md:312`).
+
+**Spine**: `/fishing/` hub PASS. Three sub-spines: locations, charters, species, all PASS.
+
+**Top performer**: `/fishing/locations/point-leo-beach/` (2 clicks / 8 impr / position 6.6), `/fishing/locations/gunnamatta-beach/` (1 click / 14 impr), `/fishing/species/gummy-shark/` (1 click / 26 impr / position 8.5) (`daily-log.md:594-597`). Per `daily-log.md:464`, the fishing cluster lit up at the May 3-4 indexation jump and is now the second demand cluster after dog-friendly.
+
+**Coverage gaps**: minimal. Add flathead. Consider seasonal pages: `/fishing/seasons/whiting-spring`, `/fishing/seasons/squid-summer-autumn` to mirror `/fishing/seasons/snapper-run-oct-dec/` (the existing seasonal page).
+
+**Internal-linking pattern**: deep cross-link between locations, charters, species. Best-structured cluster on the site. Use this as the architectural model for the others.
+
+### 2.9 Boating (`/boating/`), small cluster, fully indexed, no demand yet
+
+**Built URLs**: 8. All indexed (`url-inventory.md:20-30`).
+
+**Action**: leave alone. Demand will follow if it follows.
+
+### 2.10 Dog-friendly, the highest-leverage demand cluster
+
+**Built URLs**: 1 hub (`/dog-friendly/`) + 7 articles + sub-cluster pages.
+
+**Indexed**: 4 articles (dog-friendly-cafes-pubs-wineries, dog-friendly-beaches, dog-friendly-mornington-peninsula, plus the `/eat/dog-friendly.astro`, `/wine/dog-friendly.astro`, `/stay/dog-friendly.astro` thematic pages).
+
+**Discovered, not indexed (4)**: `/dog-friendly/` hub, `/journal/dog-daycare-boarding-groomers-pet-shops-mornington-peninsula/`, `/journal/dog-friendly-accommodation-mornington-peninsula/`, `/journal/dog-friendly-wineries-mornington-peninsula/`, `/journal/emergency-vet-pet-help-mornington-peninsula/`, `/journal/where-to-walk-the-dog-mornington-peninsula/`, `/journal/the-dog-friendly-peninsula/` (`url-inventory.md:259, 323-325, 343, 354, 371`).
+
+**Top performer**: `/journal/dog-friendly-mornington-peninsula/` ranks at position 8.3 with 49 impressions and 0% CTR for "dog friendly guide mornington peninsula" alone (`daily-log.md:567`); 5 of the top-10 impression queries on the entire site are dog-related (`baseline.md:46-55`).
+
+**Demand context**: per `baseline.md:98`, dog-friendly is the single biggest content cluster opportunity at this stage. Experiment 2026-05-04-01 ships a CTR-focused snippet rewrite on the main hub article; experiment 2026-05-05-01 lifts the `/dog-friendly/` hub.
+
+**Spine**: `/dog-friendly/` should be the spine. It is currently Discovered. The 6 thematic/practical articles below it are the spokes. Once both shipped experiments deploy, this cluster should consolidate into a tight hub-and-spoke.
+
+**Action**: after experiments 2026-05-04-01 and 2026-05-05-01 land in GSC (target 2026-05-12 measurement), pick the next two unindexed dog-friendly articles for explicit promotion: `dog-friendly-accommodation-mornington-peninsula` and `dog-friendly-wineries-mornington-peninsula`. Add internal links from any `/wine/{venue}/` page where the venue's `dogPolicy` is friendly.
+
+### 2.11 What's On (`/whats-on/`), fully indexed events, hub is unindexed
+
+**Built URLs**: ~85. Per `url-inventory.md:152-237` 84 event pages indexed. Only the `/whats-on/` hub itself is Discovered (`url-inventory.md:383`).
+
+**Spine**: `/whats-on/` hub.
+
+**Top performer**: `/whats-on/mornington-cup-2026` (228 impr at position 7.6, 0.44% CTR; `baseline.md:67`). The Mornington Cup race itself was 17 days ago, demand has died but the historical impressions remain; per `daily-log.md:471` the page now has zero recent impressions.
+
+**Coverage gaps**: events are well covered. The hub indexation will be picked up by experiment 2026-05-05-01 (sitemap priority bump).
+
+**Action**: snippet rewrite the seasonal events that have approaching dates. Currently in season: autumn-winery-walk-2026, michael-vale-exhibition-at-mprg, foxeys-hangout-vegetable-feast, sorrento-writers-festival-2026 (June), winter-wine-weekend (June). Each needs a title that includes the year and a meta that opens with the date and venue.
+
+### 2.12 Awards (`/awards/`), built but invisible to Google and the rest of the site
+
+**Built URLs**: 11 (`/awards/` index, `/awards/nominate/`, plus 9 category pages from `[slug].astro`).
+
+**Indexed**: zero pages observed in `url-inventory.md`. Awards is not in the GSC-known set, which means **Google has not crawled `/awards/` at all** as of 2026-05-05.
+
+**Why**: zero internal links from anywhere in the editorial layer. `/awards/` is not in the masthead nav (`next/src/lib/nav.ts:34-43`), not in the More menu (`nav.ts:55-66`), not in the footer About column (`v4-nav.ts:465-474`), and grep returns no `/awards/` link anywhere outside the awards directory itself.
+
+**Action (P0)**: this is a "dark page" structurally. Either lift it into nav and link from at least 5 articles, or accept that it won't earn organic.
+
+### 2.13 Commercial spine (Pass / Submit / Newsletter / Ask / Itinerary / Partners)
+
+| URL | Indexable | GSC status | Internal link count |
+|---|---|---|---:|
+| `/pass/` | yes (canonical set) | not in inventory | 0 in editorial layer (footer entry points to a `/preview-insider-plans/` preview page, see `v4-nav.ts:470`) |
+| `/newsletter/` | yes | not in inventory | 1 (`Footer.astro` via `v4FooterAbout`) |
+| `/submit/` | yes | not in inventory | 0 in editorial layer |
+| `/ask/` | yes | Discovered (`url-inventory.md:257`) | drawer-trigger, plus 0 hyperlinks |
+| `/itinerary/` | yes | not in inventory | 1 (`Masthead.astro:56`, hidden until saved items exist) |
+| `/partners/` | yes | not in inventory | 1 (`Footer.astro` via `v4FooterAbout`), plus 1 from `/about/` |
+
+The commercial spine is structurally orphaned. Each surface is indexable but Google barely sees it because it's barely linked. See `04-conversion-paths.md` for the funnel impact.
+
+### 2.14 Niche (Golf / Spa / Tour / Weddings / Corporate / Insiders 30 / Alerts)
+
+| URL | Indexable | Status |
+|---|---|---|
+| `/weddings/` | yes | PASS (`url-inventory.md:151`) |
+| `/corporate-events/` | yes | Discovered (`url-inventory.md:258`) |
+| `/golf/` | noindex per `daily-log.md:669` | not indexable |
+| `/explore/golf/` | yes | not in inventory (verify) |
+| `/spa/` | yes | not in inventory |
+| `/tour/` | yes | only `/tour/fishing-tours/` indexed (`url-inventory.md:150`) |
+| `/insiders-30/` | yes | not in inventory |
+| `/alerts/` | yes | not in inventory |
+
+**Action**: each is a hub built ahead of demand. Treat as long-term ambition, not P0. The exception is `/insiders-30/` (the annual ranked list), this is a citation-bait surface and needs to earn its first set of crawls; promote from index.astro.
+
+---
+
+## 3. Search-intent alignment
+
+The 18 queries with ≥10 impressions across the May 1-4 daily logs, classified by intent and matched to the page that ranks for them.
+
+| # | Query | Impr 28d | Pos | Intent | PI page that ranks | Page intent fit |
+|---|---|---:|---:|---|---|---|
+| 1 | dog friendly guide mornington peninsula | 49 | 8.3 | Informational | `/journal/dog-friendly-mornington-peninsula/` | Excellent match (long-form guide) |
+| 2 | 34 western parade point leo vic 3916 | 46 | 27.8 | Navigational (address) | legacy directory page | Wrong intent, user wants a map, we show a listing |
+| 3 | a dog-friendly guide mornington peninsula | 30 | 7.1 | Informational | `/journal/dog-friendly-mornington-peninsula/` | Excellent match |
+| 4 | 20 junction road merricks north vic 3926 | 21 | 33.8 | Navigational (address) | legacy directory page | Wrong intent |
+| 5 | accommodation near peninsula hot springs | 19 | 67.8 | Commercial-investigative | none ranking | No PI page targets this; need one |
+| 6 | free things to do in mornington peninsula | 16 | 20.3 | Informational/local | `/journal/free-things-to-do-mornington-peninsula/` | Good match, ranking weak |
+| 7 | best restaurants in mornington peninsula | 14 | 46.4 | Commercial-investigative | `/eat/best-restaurants/` | Excellent intent fit, weak rank |
+| 8 | dog friendly beaches mornington peninsula | 11 | 17.6 | Informational/local | `/journal/dog-friendly-beaches-mornington-peninsula/` | Excellent match |
+| 9 | hotel near sorrento pier booking | 11-15 | 65.9 | Transactional | `http://...stay/hotel-sorrento` zombie | Right venue, wrong URL state |
+| 10 | endota sorrento | 12 | 5.7 | Navigational (brand) | `/stay/endota-spa-sorrento` | Excellent match, ranking on page 1 |
+| 11 | best places to stay mornington peninsula | 9 | 49.2 | Commercial-investigative | `/stay/best-accommodation/` | Excellent intent fit, weak rank |
+| 12 | dog beaches mornington peninsula | 8 | 21.4 | Informational/local | `/journal/dog-friendly-beaches-mornington-peninsula/` | Excellent match |
+| 13 | best restaurants mornington peninsula | 7 | 47.7 | Commercial-investigative | `/eat/best-restaurants/` | Excellent intent fit, weak rank |
+| 14 | gummy shark size limit | 2 | 8.5 | Informational | `/fishing/species/gummy-shark/` | Excellent match (1 click) |
+| 15 | laura at pt leo estate | 1 | 1.0 | Navigational (chef brand) | unknown | Top spot, 1 click |
+| 16 | pt leo estate | 1 | 6.0 | Navigational | `/wine/pt-leo-estate/` (Discovered) or `/eat/pt-leo-estate/` (Discovered) | Both targets unindexed; the click on this query is from the May 3 dog-friendly snippet seeing |
+| 17 | "endota" | 2 | 44.5 | Navigational (brand) | unknown | Wrong page or bad SERP placement |
+| 18 | 5 star hotel mornington peninsula | 2 | 25.0 | Commercial-investigative | none specific | No 5-star focused stay page |
+
+**Key intent mismatches**:
+
+1. **Address queries** (queries 2, 4): the page that ranks is a legacy directory listing showing the address. The user wants a map or a venue page; we serve a listing. Either noindex these legacy pages (per `backlog.md:21`) or redirect them to the venue page on the address.
+
+2. **Hotel near Sorrento pier booking** (query 9): user has transactional intent ("booking" in query) but lands on the http:// zombie of `/stay/hotel-sorrento` at position 65.9. Once HTTPS-enforce propagates, the canonical https URL should pick up. Add a "Book direct" CTA.
+
+3. **Best-restaurants** queries (7, 13): the right page (`/eat/best-restaurants/`) ranks at page 5 despite being a strong fit. This is a content-depth and link-equity gap, not an intent gap. Action: see Content gaps below.
+
+4. **Accommodation near Peninsula Hot Springs** (query 5): the user wants a specific stay-near-attraction shape. We don't have an article for this; the closest is `/journal/mornington-peninsula-stay-and-soak/` (Discovered, not indexed) (`url-inventory.md:334`). Build/promote that.
+
+---
+
+## 4. Content gaps, articles to build
+
+Twenty new pages or substantial rewrites, ordered by leverage. Each maps to a query cluster, a known PI gap, and an existing PI surface that supports the pitch.
+
+| # | Title | Target query | Cluster | Why | Effort | Link from |
+|---|---|---|---|---|---|---|
+| 1 | Stays Near Peninsula Hot Springs | "accommodation near peninsula hot springs" (19 impr/wk, pos 67.8) | Stay | High-impression query with no targeted page; the closest is unindexed | Medium | `/journal/the-thermal-springs-weekend/`, `/stay/peninsula-hot-springs-glamping/`, `/journal/peninsula-hot-springs-vs-alba/` |
+| 2 | Hotels Near Sorrento Pier (with editorial booking notes) | "hotel near sorrento pier booking" (15 impr/wk, pos 65.9) | Stay | Transactional intent, page exists at zombie URL only | Small (rebuild on https) | `/places/sorrento/`, `/journal/the-sorrento-weekend/` |
+| 3 | The 5-Star Stay List | "5 star accommodation mornington peninsula" / "5 star hotel" | Stay | Whole tier under-served | Medium | `/stay/best-accommodation/`, all luxury stays |
+| 4 | Where to Stay on the Mornington Peninsula (definitive) | "where to stay mornington peninsula", "best places to stay" (8-9 impr/wk, pos 49.2) | Stay | Article exists (`where-to-stay-mornington-peninsula.mdx`) but Discovered; needs depth + internal-link push | Small (refresh + link) | All `/places/{town}/` hubs, the journal hub |
+| 5 | Best Restaurants on the Mornington Peninsula (rebuild for 2026) | "best restaurants in mornington peninsula" (14 impr/wk, pos 46.4) | Eat | `/eat/best-restaurants/` exists but pages 4-5; needs 2026 freshness, more depth, FAQ schema | Medium (rebuild) | `/eat/`, `/places/red-hill/`, `/journal/where-to-eat-mornington-peninsula/` |
+| 6 | Hatted Restaurants on the Mornington Peninsula (2025-26 GFG) | "hatted restaurants mornington peninsula" | Eat | Article exists (Discovered, not indexed), refresh + link push | Small | `/eat/best-restaurants/`, `/journal/three-italian-dinners/` |
+| 7 | Mornington Peninsula Winery Guide (rebuild) | "mornington peninsula winery", "wineries mornington peninsula" | Wine | Article exists (Discovered), refresh, link from chardonnay-case | Medium | `/wine/best-cellar-doors/`, `/journal/the-chardonnay-case/`, `/journal/the-cellar-door-short-list/` |
+| 8 | The 2026 Mornington Cup Day Guide (next-year evergreen) | "mornington cup", "mornington races" | Whats-on | Old MC2026 page is dead; this should be a multi-year evergreen with annual update | Small (rewrite) | `/whats-on/`, `/places/mornington/`, `/journal/the-easter-peninsula/` |
+| 9 | Sorrento Writers Festival 2026: Tickets, Schedule, Where to Stay | "sorrento writers festival" | Whats-on | Page exists (`/whats-on/sorrento-writers-festival-2026/`); add event schema + pre/post coverage articles | Small | `/places/sorrento/`, `/journal/the-sorrento-weekend/` |
+| 10 | Free Things to Do on the Mornington Peninsula (rebuild) | "free things to do in mornington peninsula" (16 impr/wk, pos 20.3) | Explore | Page exists, ranking page 2; needs depth + on-page UX rebuild + FAQ schema | Medium | `/places/*/` hubs, `/explore/`, `/journal/things-to-do-mornington-peninsula/` |
+| 11 | Best Walks on the Mornington Peninsula (build out from 9 indexed) | "best walks mornington peninsula" | Explore | Spine `/explore/best-walks/` exists; expand with 32 unindexed walk pages as the cited destinations | Medium | `/explore/`, `/journal/walks-bushrangers-bay-walk-guide/` |
+| 12 | Mornington Peninsula in Winter: A Cold-Weather Guide | "mornington peninsula winter", "winter weekend mornington peninsula" | Journal | Article exists (Discovered: `mornington-peninsula-in-winter`, `a-winter-peninsula-weekend`); refresh + push | Small | seasonal homepage rotation, `/journal/the-thermal-springs-weekend/` |
+| 13 | Mornington Peninsula in Spring: The Vintage-Approach Calendar | "mornington peninsula spring", "spring weekend mornington peninsula" | Journal | Article exists (Discovered: `the-spring-peninsula`); refresh for spring season | Small | `/wine/`, `/journal/the-chardonnay-case/` |
+| 14 | A Wet-Weather Mornington Peninsula Plan | "rainy day mornington peninsula", "what to do mornington peninsula raining" | Journal | Article exists (Discovered: `the-rainy-day-peninsula-without-a-booking`, `rainy-day-peninsula`); consolidate into one canonical and push | Small (consolidate) | All season hubs, `/explore/` |
+| 15 | The Best Beaches on the Mornington Peninsula | "best beaches mornington peninsula", "mornington peninsula beaches" | Explore | Spine page `/explore/beaches/` indexed; needs more depth + per-beach FAQ + dog-rules table | Medium | `/places/{coastal towns}/`, `/journal/dog-friendly-beaches-mornington-peninsula/` |
+| 16 | The Long Lunch: Mornington Peninsula Cellar-Door Restaurants Worth a Saturday | "long lunch mornington peninsula", "vineyard restaurants mornington peninsula" | Eat | Article exists (Discovered? `the-long-lunch` is Discovered per `url-inventory.md:125`) | Small (link push) | `/wine/best-cellar-doors/`, `/eat/cellar-door-lunch.astro` |
+| 17 | Best Brunch on the Mornington Peninsula | "best brunch mornington peninsula" | Eat | Article exists (Discovered: `best-brunch-mornington-peninsula`); refresh + push | Small | `/places/sorrento/`, `/journal/three-italian-dinners/` |
+| 18 | Best Spas on the Mornington Peninsula | "best spas mornington peninsula", "mornington peninsula spa" | Spa | Article exists (Discovered: `best-spas-mornington-peninsula`); refresh + push | Small | `/spa/`, `/journal/peninsula-hot-springs-vs-alba/` |
+| 19 | The Mornington Peninsula Itinerary (canonical 2-3 day plan) | "mornington peninsula itinerary", "things to do mornington peninsula 2 days" | Escape/Journal | Article exists (Discovered); should be the indexable "spine" of the entire journal cluster | Medium (rebuild) | `/escape/`, `/itinerary/`, `/places/{all towns}/` |
+| 20 | The Insider's 30: 2026 Edition (annual ranked list) | "best mornington peninsula", "top mornington peninsula" | Insiders 30 | Cluster `/insiders-30/` is built but invisible; the annual list is the citation-bait surface | Large (annual editorial) | All venue pages, all journal articles |
+
+---
+
+## 5. Existing-content actions for the 140 unindexed URLs
+
+Pattern-grouped recommendations rather than 140 individual lines. Each group references the URLs in `url-inventory.md`.
+
+### Keep, unindexed but legitimate; push internal links
+
+**Group A: 11 unindexed wine/cellar-door venues** (`url-inventory.md:384-396`).
+**Action**: link each from `/wine/best-cellar-doors/` (the spine), from `/journal/the-chardonnay-case/`, and from each town hub `/places/{town}/` where the venue lives. Add the venue to the relevant article `relatedVenues` arrays.
+
+**Group B: 14 unindexed wine-as-restaurant pages under `/eat/`** (`url-inventory.md:260-274`).
+**Action**: experiment 2026-05-05-03 already canonicalises these to `/wine/{slug}/`. Verify on next discovery run that the alternate-canonical count drops. No further work; the /wine/{venue} canonical is the home.
+
+**Group C: 32 unindexed walks/golf/galleries** (`url-inventory.md:280-311`).
+**Action**: replicate experiment 2026-05-05-02 (related-articles seeding) for the explore cluster. Source articles: `/journal/walks-bushrangers-bay-walk-guide/`, `/journal/cape-schanck-guide/`, `/journal/point-nepean-national-park-guide/`. Each gets a `relatedExperiences` array of 6 unindexed walk slugs.
+
+**Group D: 9 unindexed town hubs** (`url-inventory.md:372-382`).
+**Action**: contextual body link from each tagged journal article. e.g. `/journal/the-easter-peninsula/` mentions Sorrento and Portsea, confirm the body has one link to `/places/sorrento/` and one to `/places/portsea/`.
+
+**Group E: 11 unindexed dog-friendly + accommodation + winery + season articles in journal** (subset of `url-inventory.md:314-371`).
+**Action**: experiment 2026-05-05-02 covered 15 of these; the remaining 43 need the same treatment. See Section 7 (internal-linking) below.
+
+**Group F: 5 unindexed escape plans** (`url-inventory.md:275-279`).
+**Action**: contextual body link from each season article (`the-easter-peninsula`, `the-thermal-springs-weekend`, `the-couples-weekend`).
+
+**Group G: 5 commercial spine pages** (Discovered: `/ask/`, `/dog-friendly/`, `/escape/`, `/places/`, `/whats-on/`).
+**Action**: experiment 2026-05-05-01 ships sitemap priority bumps for these. Manual reindex submission pending James action.
+
+### Refresh, content exists but is thin or stale
+
+- `the-birthday-weekend` (Discovered, also has http variants): consolidate to single canonical, refresh for autumn 2026 freshness.
+- `the-peninsula-orientation-drive`: this is the Phase-2 driving-loop article; refresh with 2026 stops.
+- `the-school-holidays-survival-guide`: needs a 2026-school-term refresh.
+- `peninsula-this-weekend-april-24`, `peninsula-this-weekend-april-26`: these were one-off weekend dispatches that have now aged out. Either consolidate into a "weekly archive" hub or 410 if they're not generating any traffic.
+
+### Consolidate, multiple URLs serving the same query intent
+
+- `the-rainy-day-peninsula-without-a-booking` + `rainy-day-peninsula` + `the-peninsula-with-kids` (rainy-day overlap). Merge into one canonical "Rainy Day Mornington Peninsula" article; 301 redirect the others.
+- `mornington-peninsula-itinerary` + `mornington-peninsula-day-trip` + `the-four-hour-peninsula`: three articles competing for "mornington peninsula itinerary"-shape queries. Make `mornington-peninsula-itinerary` the canonical spine; the other two link to it.
+- `where-to-eat-without-a-booking` + `breakfast-before-the-crowds` + `where-to-eat-mornington-peninsula`: three separate "where to eat" articles. Cluster them; each should clearly target a different shape ("no booking", "early/breakfast", "definitive list").
+
+### Delete (or 410), programmatic / low-quality / off-brand
+
+Only the 4 noindex pages (`url-inventory.md:457-461`): `/explore/bushrangers-bay/`, `/explore/mornington-peninsula-walk/`, `/journal/mornington-peninsula-beach-guide/`, `/journal/the-peninsula-beach-swimming-guide/`. Verify these are intentional; if not, lift the noindex.
+
+The address-string queries (`baseline.md:46-55`) suggest legacy directory pages still exist and serve listings to address-search users. Per `backlog.md:21`, this is a known investigation, find these pages and either noindex or 410 them.
+
+---
+
+## 6. Internal-linking opportunities (specific source → target pairs)
+
+Twenty pairs. Each pair adds one or two contextual body links to push equity into specific unindexed pages. Implementation: edit the source article markdown to insert a one-sentence body paragraph linking to the target.
+
+| # | Source page (indexed, has impressions) | Target page (Discovered, needs lift) | Rationale |
+|---|---|---|---|
+| 1 | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` (3 clicks) | `/journal/dog-friendly-accommodation-mornington-peninsula/` | Same cluster; the cafés piece naturally cross-references where to stay |
+| 2 | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` | `/journal/dog-friendly-wineries-mornington-peninsula/` | The cafés piece talks about Foxeys and other wineries; link the dedicated guide |
+| 3 | `/journal/the-pub-guide/` (1 click, 65 impr) | `/journal/the-pub-crawl/` | Pub guide → pub crawl, natural body-link |
+| 4 | `/journal/the-pub-guide/` | `/journal/where-to-eat-without-a-booking/` | Pubs are the canonical no-booking option |
+| 5 | `/journal/the-chardonnay-case/` (71 impr at pos 5.6) | `/journal/mornington-peninsula-winery-guide/` | The case piece argues a thesis; the guide is the systematic complement |
+| 6 | `/journal/the-chardonnay-case/` | `/journal/mornington-peninsula-winery-tour/` | The case piece, then the tour piece |
+| 7 | `/journal/the-cellar-door-short-list/` | `/journal/dog-friendly-wineries-mornington-peninsula/` | The short-list piece names wineries; some are dog-friendly |
+| 8 | `/journal/the-couples-weekend/` | `/journal/the-birthday-weekend/` | Same audience |
+| 9 | `/journal/the-couples-weekend/` | `/journal/the-vineyard-villa-weekend/` | Same shape |
+| 10 | `/journal/the-thermal-springs-weekend/` | `/journal/peninsula-hot-springs-vs-alba/` | The thermal-springs weekend piece names hot springs; the comparison piece is the natural follow-on |
+| 11 | `/journal/the-thermal-springs-weekend/` | `/journal/mornington-peninsula-stay-and-soak/` | Same cluster, different shape |
+| 12 | `/journal/three-italian-dinners/` | `/journal/the-seafood-list/` | The Italian piece is dinner-shape; the seafood piece is its sibling |
+| 13 | `/journal/three-italian-dinners/` | `/journal/where-to-eat-without-a-booking/` | Italian piece talks about booking pressure; link the no-booking piece |
+| 14 | `/journal/where-to-eat-mornington-peninsula/` | `/journal/best-brunch-mornington-peninsula/` | Where-to-eat is the canonical entry; brunch is a sibling shape |
+| 15 | `/journal/where-to-eat-mornington-peninsula/` | `/journal/hatted-restaurants-mornington-peninsula-2025/` | Same cluster |
+| 16 | `/journal/the-easter-peninsula/` | `/places/sorrento/` (already indexed) and `/places/portsea/` (already indexed), these are confirmation pairs | Body-link verification only |
+| 17 | `/places/sorrento/` | `/journal/the-sorrento-weekend/` (Discovered) | Place hub to the article specifically about that place |
+| 18 | `/places/red-hill/` | `/journal/how-to-build-a-red-hill-saturday/` (Discovered) | Same pattern |
+| 19 | `/wine/best-cellar-doors/` | `/journal/dog-friendly-wineries-mornington-peninsula/` | Subset of the cellar-door audience |
+| 20 | `/eat/best-restaurants/` | `/journal/waterfront-restaurants-mornington-peninsula/` (Discovered) | Subset of best-restaurants |
+
+The pattern: each source article gets a one-sentence editorial body paragraph (not a footer rail) linking to the target. This replicates the mechanism that worked in experiment 2026-05-05-01, contextual body links carry crawl weight that nav links do not.
+
+---
+
+## 7. Cluster-spine readiness summary
+
+| Cluster | Spine | Spine indexed? | Spine has FAQ schema? | Spine has clear CTAs? | Cluster ready for next-stage growth? |
+|---|---|---|---|---|---|
+| Town hubs | `/places/` | No | Unknown | Yes (place cards) | No - lift index page first |
+| Eat | `/eat/best-restaurants/` | Yes | No | Partial | Almost - add schema |
+| Wine | `/wine/best-cellar-doors/` | Yes | No | Partial | Almost - add schema |
+| Stay | `/stay/best-accommodation/` | Yes | No | Weak | No - cluster is too thin (6 venues) |
+| Explore | `/explore/best-walks/` | Yes | No | Yes | Almost - need spokes lifted |
+| Escape | `/escape/` | No | No | Yes | No - lift index, then push spokes |
+| Journal | `/journal/` archive | Likely yes | No | Weak | No - 58 unindexed spokes |
+| Fishing | `/fishing/` | Yes | Unknown | Yes | Yes - architecturally complete |
+| Boating | `/boating/` | Yes | Unknown | Yes | Yes |
+| Dog-friendly | `/dog-friendly/` | No | No | Yes (article CTAs) | Almost - shipping experiment 2026-05-05-01 |
+| Whats-on | `/whats-on/` | No | Yes (per-event in EventStrip) | Yes | Almost - lift hub |
+| Awards | `/awards/` | Likely no | No | No (no internal link) | No - structurally orphaned |
+
+---
+
+## 8. Recommended next 2-week priority
+
+Combining indexation fix + content gap + intent alignment:
+
+1. **(P0 deploy already shipped)** Wait for experiments 2026-05-04-01, 2026-05-05-01, 2026-05-05-02, 2026-05-05-03 to land in GSC. Measure 2026-05-12 and 2026-05-19 per the experiment checklist.
+2. **(P0 new)** Add `/awards/` to the masthead More menu and to the Footer About column. Link from at least 5 indexed articles. The cluster is currently structurally orphaned.
+3. **(P0 new)** Replicate experiment 2026-05-05-02 for `/explore/` walks: bump auto-related-experiences limit on `[slug].astro` walks template; explicitly seed 6 unindexed walk slugs on each of the 4 indexed walk articles.
+4. **(P1)** Build "Stays Near Peninsula Hot Springs" article (gap #1 in Section 4). 19 impressions/week of unmet demand.
+5. **(P1)** Rewrite `/eat/best-restaurants/` for 2026 freshness + FAQ schema + 2026 venue depth. Currently page-5 ranking on a target that should be page 1.
+6. **(P1)** Refresh `/journal/mornington-peninsula-itinerary/` to be the canonical itinerary spine; redirect/consolidate `mornington-peninsula-day-trip` + `the-four-hour-peninsula` to point at it.
+7. **(P2)** Begin the 20-article content-gap plan (Section 4) at a cadence of 2 per week.
+
+---
+
+## 9. Open questions (data we don't have yet)
+
+- GSC Page indexing total beyond the inspected 418 URLs. The platform reports 1052 built pages but only 418 reach GSC. The 634-page gap is likely sitemap-orphans or pages Google never crawled. Run a build-time sitemap dump and diff against `sitemap.xml.ts`.
+- Click-through funnel from a journal article into a venue page (need GA4).
+- Bounce rate on `/eat/best-restaurants/`, is the page-5 ranking a snippet failure or a content failure (need GA4)?
+- Which of the 16 "URL is unknown to Google" pages (`url-inventory.md:421-440`) are worth reindexing manually. They include `/journal/how-to-plan-a-peninsula-weekend/`, `/wine/crittenden-estate/`, `/eat/main-ridge-estate/`, high-intent venue and how-to pages that Google has not crawled yet.
+
+---
+
+End of file.

--- a/ops/reports/seo/audit-2026-05/03-competitive-gap.md
+++ b/ops/reports/seo/audit-2026-05/03-competitive-gap.md
@@ -1,0 +1,699 @@
+# Peninsula Insider Competitive Gap Analysis
+
+**Audit:** 2026-05 monthly SEO
+**Date:** 2026-05-08
+**Subject site:** peninsulainsider.com.au
+**Last 28 days organic baseline:** 29 clicks, 2,873 impressions, 1.01% CTR, average position 16.8
+
+This report benchmarks Peninsula Insider against the editorial and tourism competitors that own the Mornington Peninsula SERP today. Every competitor profile, SERP capture, and content comparison is grounded in URLs fetched on 2026-05-08. No DA / DR / backlink counts are fabricated; where a public score is unverifiable, the field is labelled "proxy" and tied back to what is observable on the page or in search results.
+
+---
+
+## 1. Competitor set used in this audit
+
+The orchestrator's draft list of six was retained, and two additional regional competitors that surfaced repeatedly in the live SERPs were added: **The Urban List** and **The Ninch**. Tripadvisor was treated as a SERP fixture rather than a competitor profile, because it is a structurally different beast (UGC aggregator, not editorial), but it is referenced where it crowds the SERPs.
+
+| # | Competitor | URL | Type |
+|---|---|---|---|
+| 1 | Visit Mornington Peninsula | visitmorningtonpeninsula.org | Official regional tourism body |
+| 2 | Broadsheet | broadsheet.com.au/mornington-peninsula | National lifestyle publisher (regional hub) |
+| 3 | Time Out Melbourne | timeout.com/melbourne | National lifestyle publisher (city/region) |
+| 4 | Concrete Playground | concreteplayground.com/melbourne | National lifestyle publisher (city/region) |
+| 5 | Australian Traveller | australiantraveller.com/vic/mornington-peninsula | National travel magazine |
+| 6 | Halliday Wine Companion | winecompanion.com.au | Specialist wine publisher |
+| 7 | The Urban List | theurbanlist.com/melbourne | National lifestyle publisher (city/region) |
+| 8 | The Ninch | theninch.com.au | Local Mornington Peninsula publisher |
+
+Tripadvisor (`tripadvisor.com.au/...g1055530...`) and visitvictoria.com / visitmelbourne.com (Visit Victoria's regional pages) are noted as SERP gravity wells, not profiled in depth.
+
+---
+
+## 2. Per-competitor profiles
+
+### 2.1 Visit Mornington Peninsula (visitmorningtonpeninsula.org)
+
+**What they are.** The official regional tourism body. Not a publication. The site is structured as a destination directory with editorial overlay: every cellar door, beach, walk, accommodation, and event is held in a typed listing, and "Stories" wrap them up into themed roundups. They have the unfair advantages of an industry portal: paid-up operator listings, official partnership logos in the footer (EastLink, Searoad Ferries, MPNG, Samsonite, Sphere Accounting, Ultimate Winery Experiences), and the implicit endorsement of being the .org for the region.
+
+**Mornington Peninsula footprint.** The entire site is MP-only. Homepage primary navigation exposes 8 sections: Things To Do, Places To See, What's On, Accommodation, Deals + Travel Packages, Travel Info, Stories, Win. Within Things To Do, 10+ thematic subcategories (Adventure, Wine + Wineries, Spa + Wellbeing, Beaches, National Parks, Markets, etc.). The Stories archive runs into the high hundreds across themes; site search returns dozens of results for almost any common topic ("cellar doors", "weekend", "dog friendly").
+
+Verified URLs fetched:
+- https://www.visitmorningtonpeninsula.org/ (homepage)
+- https://www.visitmorningtonpeninsula.org/Stories/8-of-the-best-cellar-doors-to-visit-on-the-mornington-peninsula
+- https://www.visitmorningtonpeninsula.org/Stories/were-giving-a-round-of-a-paws-to-these-dog-friendly-adventures
+
+**Content depth (3 representative URLs).**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| Cellar doors | `/Stories/8-of-the-best-cellar-doors-to-visit-on-the-mornington-peninsula` | ~1,200 | 8 numbered sections, intro + outro | No byline, no published date, partner logos in footer, links to operator-funded listings | No in-article ads; the entire site is operator-funded |
+| Dog-friendly | `/Stories/were-giving-a-round-of-a-paws-to-these-dog-friendly-adventures` | ~1,200 | Food/Drink, Walks, Beaches, Travel, Accommodation | No byline, no date; specific leash rules and beach-time restrictions called out (Safety Beach, Mt Martha, Somers) | None visible |
+| Homepage hub | `/` | n/a | 8-section IA, seasonal carousels (Autumn/Summer/Winter/Spring), filter by traveller type (Family, First-Time, Romantic) | Sitelinks search box implementation; large editorial team is implied but not credited per article | None visible |
+
+**Domain authority proxy.** Strong. Wins or ranks top 3 for almost every commercial-intent MP query (cellar doors, things to do, dog-friendly, weekend). Owns Google Business / Knowledge Panel real estate as the official tourism .org. Carries the gov-tourism trust signal Google explicitly weights for local intent.
+
+**Backlink proxy.** WebSearch for `site:visitmorningtonpeninsula.org cellar doors` returns 10+ deep article URLs, each with implicit inbound links from operator pages, partner pages, and the Mornington Peninsula Shire site. Visit Victoria (visitvictoria.com) and Tourism Australia (australia.com) both link to it. Press: routinely cited by Time Out, Broadsheet, and Australian Traveller as the source for visitor numbers and event listings.
+
+**Verdict for PI.** This is the dominant non-aggregator competitor. PI cannot out-resource them on directory breadth. PI must beat them on **opinion** (they have none), **freshness** (their posts have no dates), and **specificity** (their leash rules pages are good, but their cellar-door piece reads like a press release).
+
+---
+
+### 2.2 Broadsheet (broadsheet.com.au/mornington-peninsula)
+
+**What they are.** Australia's most-read lifestyle/dining publication. Treats Mornington Peninsula as one of its formal "Regions" with its own hub. Authoritative restaurant criticism, with named chef-writers, regular new-opening coverage, and an editorial team that genuinely visits the venues. Their voice is closest to PI's voice on the SERP, which is both a threat (they crowd the editorial slot) and a tell (PI is operating in a real market, not an empty one).
+
+**Mornington Peninsula footprint.** WebSearch for `site:broadsheet.com.au mornington peninsula` returns dozens of results. Hub at `/mornington-peninsula` exposes:
+- Restaurants guide (~19 venues)
+- Cafes guide (~8 venues)
+- Wineries guide (~13 venues)
+- Accommodation guide (~16 venues)
+- Plus individual venue pages, news/openings articles, and "Travel" feature pieces.
+
+Verified URLs fetched:
+- https://www.broadsheet.com.au/mornington-peninsula (hub)
+- https://www.broadsheet.com.au/mornington-peninsula/guides/restaurants
+- https://www.broadsheet.com.au/national/art-and-design/article/long-lunches-thermal-springs-and-regional-galleries-weekend-itinerary-mornington-peninsula
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| Best restaurants | `/mornington-peninsula/guides/restaurants` | ~2,200 | 24 venue cards with images, intro, more-guides cross-links | Byline: Nick Connellan. Updated 24 Dec 2025. The Fork booking integration. | No traditional ads visible; subscription model, sponsorship via integrations |
+| Weekend itinerary | `/national/art-and-design/article/long-lunches-thermal-springs-and-regional-galleries-weekend-itinerary-mornington-peninsula` | ~1,200 | Day 1 / Day 2 structure, ~11 venues across both | Byline: Callum McDermott. Published 21 Nov 2023, updated 17 Jan 2024. | Sponsored: National Gallery of Australia partnership labelled |
+| Hub | `/mornington-peninsula` | n/a | Latest News + 4 guide categories + 56+ venues | Implicit byline trust (Broadsheet brand), seasonal refresh | Subscription prompts, partnership mentions, Airbnb collab |
+
+**Domain authority proxy.** Highest of the lifestyle publishers in this set. Broadsheet ranks #1 organic for "best restaurants mornington peninsula" today (verified 2026-05-08).
+
+**Backlink proxy.** Broadsheet articles are cited regularly across the Australian web: hospitality industry publications, individual venue pages (chefs and restaurants link back to their Broadsheet review), Reddit and travel forums. Their venue pages function as a soft directory the rest of the industry treats as canonical.
+
+**Verdict for PI.** Broadsheet is the closest like-for-like competitor on voice and editorial depth. PI's structural advantage over Broadsheet is **freshness cadence and verification dates** ("Verified Apr 2026" on PI's cellar door page beats Broadsheet's annual update model) and **specialisation** (Broadsheet covers all of Australia thinly; PI covers one region thickly). PI's structural disadvantage is byline reputation; Broadsheet writers have personal brand equity that PI's anonymous editorial voice does not yet have.
+
+---
+
+### 2.3 Time Out Melbourne (timeout.com/melbourne)
+
+**What they are.** International chain lifestyle publisher with a Melbourne edition. Mornington Peninsula content is filed under `/melbourne/travel/` and treated as a regional getaway, not a beat. The content is a mix of evergreen guides, news (Michelin Key, new openings), and listicles.
+
+**Mornington Peninsula footprint.** WebSearch for `site:timeout.com mornington peninsula` returns roughly a dozen pieces of content. Notable entries:
+- `/melbourne/travel/weekend-getaways-mornington-peninsula`
+- `/melbourne/travel/ten-reasons-to-visit-mornington-peninsula` (published 2016)
+- `/melbourne/news/this-luxe-hot-springs-resort-on-victorias-mornington-peninsula-has-been-awarded-a-michelin-key-021026`
+- `/melbourne/travel/peninsula-hot-springs`
+- `/melbourne/travel/things-you-can-only-do-on-the-mornington-peninsula`
+
+Total surface area is much smaller than Broadsheet's hub. This is *Melbourne content* with a peninsula garnish, not a peninsula beat.
+
+Verified URLs fetched:
+- https://www.timeout.com/melbourne/travel/weekend-getaways-mornington-peninsula
+- https://www.timeout.com/melbourne/travel/ten-reasons-to-visit-mornington-peninsula
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| Weekend getaway | `/melbourne/travel/weekend-getaways-mornington-peninsula` | ~2,500-3,000 | See/Eat/Drink/Stay sections, ~17 venues | Byline: Cassidy Knowlton + Rushani Epa. Published 1 Nov 2021. Schema for structured data, social share buttons | Display ad slots throughout, multiple newsletter prompts |
+| Ten reasons | `/melbourne/travel/ten-reasons-to-visit-mornington-peninsula` | ~1,500 (est) | 10-item numbered list | Time Out Promotion (sponsored), April 2016 publish date | Heavily promotional, multiple newsletter signup prompts |
+
+**Domain authority proxy.** Very strong global TLD authority. Their MP content is dated (2021–2024) but the domain still ranks for many queries by sheer link equity.
+
+**Backlink proxy.** Time Out is referenced everywhere; Wikipedia, Reddit, hospitality blogs, individual venue press pages. Their MP-specific articles likely earn fewer direct backlinks than Broadsheet's because the MP coverage is less authoritative on the topic, but the domain-wide spillover is huge.
+
+**Verdict for PI.** Time Out is beatable on freshness. Their flagship "Ten Reasons" is from 2016 and reads it; their weekend guide is 2.5 years old and venues have closed/changed. PI can win on currency for any Time Out URL older than 2024.
+
+---
+
+### 2.4 Concrete Playground (concreteplayground.com)
+
+**What they are.** Australian/NZ lifestyle/things-to-do publisher. Strong on "what's new" and listicles. Owned by Junkee Media. Less national authority than Broadsheet but solid placement on regional getaway and openings queries.
+
+**Mornington Peninsula footprint.** WebSearch for `site:concreteplayground.com mornington peninsula` shows ~10 pieces, mostly news (Hotel Sorrento reopening, Alba Thermal Springs, Arthurs Seat Eagle upgrade) and one "weekender's guide". They cover the news beat well but do not run thick evergreen guides.
+
+Verified URLs fetched:
+- https://concreteplayground.com/melbourne/travel-leisure/travel/weekenders-guide-to-the-mornington-peninsula/
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| Weekender's guide | `/melbourne/travel-leisure/travel/weekenders-guide-to-the-mornington-peninsula/` | ~1,800 | STAY / EAT-DRINK / DO / LET'S DO THIS sections, ~12 venues | Byline: Libby Curran. Published 4 Feb 2022. | RACV partnership sponsored, RACV roadside assistance promo |
+
+**Domain authority proxy.** Mid. Often appears on page 1 for "weekend" / "what's on" queries but rarely #1.
+
+**Backlink proxy.** Industry-standard Australian lifestyle backlink profile (Time Out adjacent). Their MP coverage attracts fewer links because most pieces are sponsored / new-opening news rather than reference material.
+
+**Verdict for PI.** Concrete Playground is a thinner competitor than the others. Their sponsored model (RACV partnership on the weekender guide) means readers and Google may discount their objectivity. PI can outflank them with unsponsored, dated, verified comparable pieces.
+
+---
+
+### 2.5 Australian Traveller (australiantraveller.com)
+
+**What they are.** Long-form travel magazine. Of all the competitors in this set, the one whose voice is closest to a literary travel guide. Multiple bylined writers (Jade Raykovski, Carrie Hutchinson, Kellie Floyd, Kassia Byrnes, Jo Stewart, Emily Murphy). Print + digital. Their MP hub at `/vic/mornington-peninsula/` is large and structured.
+
+**Mornington Peninsula footprint.** WebSearch for `site:australiantraveller.com mornington peninsula` returns 10+ deep guides:
+- Hub (`/vic/mornington-peninsula/`)
+- 3-day itinerary
+- Ultimate road trip itinerary
+- Best beaches
+- Long weekend (7 reasons)
+- History feature
+- Best places to stay
+- Luxury accommodation
+- Alba Thermal Springs profile
+- Best walks (verified ~3,200 words, 11 walks across 3 regions, 2024)
+
+Verified URLs fetched:
+- https://www.australiantraveller.com/vic/mornington-peninsula/
+- https://www.australiantraveller.com/vic/mornington-peninsula/mornington-peninsula-walks/
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| MP hub | `/vic/mornington-peninsula/` | 2,500–3,000 | 4-section IA + multi-author articles | Multiple individual bylines with contributor photos. 2025–2026 timestamps visible. Schema markup. | Sponsored content clearly labelled (Crittenden 7-reasons piece) |
+| Walks | `/vic/mornington-peninsula/mornington-peninsula-walks/` | ~3,200 | West Coast / Central / East Coast (11 walks total), grade ratings (1–4) | Byline: Carrie Hutchinson, 16 Dec 2024. Difficulty grading taxonomy. External Parks Vic links. | Subscription prompts, no overt display ads in-article |
+
+**Domain authority proxy.** Strong, especially for long-form travel and "best beaches"/"best walks"/"luxury accommodation" intents. Often appears in top 5 for those queries.
+
+**Backlink proxy.** Earns inbound links from operator pages (luxury hotels link to AT features), travel forums, and tourism partnership pages. Print magazine status gives them implicit authority.
+
+**Verdict for PI.** Hardest competitor to beat for **long-form, multi-author** evergreen content. Their walks article is genuinely well-structured (regional grouping + difficulty grades + grade rubric) and PI does not have an equivalent. The right move for PI is not to imitate AT's depth on every topic but to niche down: their "best walks" piece tries to cover the region; PI could publish 11 individually-bylined walk pages, each with seasonal tide / dog rule / parking detail that AT does not have.
+
+---
+
+### 2.6 Halliday Wine Companion (winecompanion.com.au)
+
+**What they are.** The single most authoritative wine publication in Australia. Founded by James Halliday. Their Mornington Peninsula presence is split between editorial articles (`/articles/travel/...`) and a structured winery directory (`/wineries/victoria/mornington-peninsula`) where every winery has a profile page tied to the Halliday rating system.
+
+**Mornington Peninsula footprint.** WebSearch for `site:winecompanion.com.au mornington peninsula` returns:
+- Hub: `/wineries/victoria/mornington-peninsula` (60+ winery listings, references "more than 100" total)
+- `/articles/travel/mornington-peninsula-wineries` (11 wineries, 2025)
+- `/articles/travel/things-to-do-on-the-mornington-peninsula` (48-hour guide)
+- `/articles/travel/mornington` (cellar door piece)
+- `/articles/travel/mornington-peninsula-pinot-coast`
+- `/articles/wine-lists/mornington-wines-to-try`
+- `/articles/wine-lists/best-mornington-peninsula-wines-to-try`
+- Dozens of individual winery and wine pages
+
+Verified URLs fetched:
+- https://winecompanion.com.au/articles/travel/mornington-peninsula-wineries
+- https://winecompanion.com.au/wineries/victoria/mornington-peninsula
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| 11 best wineries 2025 | `/articles/travel/mornington-peninsula-wineries` | ~2,100 | Intro + at-a-glance summary + 11 numbered profiles + FAQ | Byline: Olivia Jay. 19 Mar 2025. Halliday star ratings (5-star, 4.5-star). Halliday quote integration. | No overt sponsored content |
+| Winery directory | `/wineries/victoria/mornington-peninsula` | n/a | Region overview + 60+ name-only listings | James Halliday brand authority. Climate data (latitude, altitude, HDD, rainfall). Membership-gated varietal data table. | Membership wall on full data |
+
+**Domain authority proxy.** Niche-dominant. For any "wineries / pinot / chardonnay / cellar door + mornington peninsula" query, Halliday is in the top 5 organic by default.
+
+**Backlink proxy.** Every Mornington Peninsula winery's own website links to its Halliday profile. Wine media globally (Wine Spectator, Decanter, hospitality trades) cites Halliday as the Australian wine authority.
+
+**Verdict for PI.** Halliday cannot be beaten on **wine ratings depth** (PI has no rating system). PI's path is differentiation: Halliday rates wines; PI rates **the experience of visiting** (driveway, parking, dog rules, seated vs. standing tasting, ideal time of day, what to order, pairing dish). That is content Halliday does not own.
+
+---
+
+### 2.7 The Urban List (theurbanlist.com)
+
+**What they are.** Mass-market lifestyle/things-to-do publication. Younger demographic skew, listicle-heavy, partner-funded. Their Melbourne edition treats MP as a recurring beat.
+
+**Mornington Peninsula footprint.** WebSearch for `site:theurbanlist.com mornington peninsula` returns 10+ pieces:
+- `/melbourne/a-list/mornington-peninsula-guide` (the flagship)
+- `/melbourne/a-list/best-luxury-accommodation-Mornington-Peninsula`
+- `/melbourne/a-list/mornington-peninsula-accommodation`
+- `/melbourne/a-list/6-awesome-adventures-on-the-mornington-peninsula`
+- `/melbourne/a-list/best-airbnb-mornington-peninsula`
+- `/melbourne/directory/peninsula-hot-springs`
+- `/melbourne/a-list/mornington-peninsula-roadtrip-2021`
+- Several archival "wander victoria" partner pieces
+
+Verified URL fetched:
+- https://www.theurbanlist.com/melbourne/a-list/mornington-peninsula-guide
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| Flagship guide 2026 | `/melbourne/a-list/mornington-peninsula-guide` | ~3,500+ | Stay / Breakfast / Swim / Wine + Dine / Do (5 categorical sections, 34+ venues) | Byline: Navarone Farrell (Former Melbourne Editor). 8 Dec 2025. Embedded business schema. | Partner content (Disney Cruise, Myer, Europcar) integrated into nav |
+
+**Domain authority proxy.** Mid-high. Frequently appears in top 5 for accommodation/airbnb/luxury and "[region] guide" queries.
+
+**Backlink proxy.** Strong social share volume; their listicles are referenced on aggregator sites and Reddit threads. Less editorial authority than Broadsheet but more discoverability than Concrete Playground.
+
+**Verdict for PI.** Beatable on **opinion** (TUL is friendly-positive on everything), **dating** (their bylined editor has moved on), and **objectivity** (heavy partner-content layer). PI's structural advantage is editorial verification dating, which TUL does not display.
+
+---
+
+### 2.8 The Ninch (theninch.com.au)
+
+**What they are.** A genuinely local Mornington Peninsula publication. The closest direct competitor PI has. Curates eat / drink / shop / things-to-do across 40+ peninsula suburbs. Editorial voice is hyperlocal but not opinionated. Commercial model is paid listings ("Get Listed", "Advertise") and a "Kiosk" merchandise store.
+
+**Mornington Peninsula footprint.** Almost 100%. The site is MP-only with suburb tags from Arthurs Seat to Tyabb. Active publishing since 2019, ongoing through 2026. Their dog-friendly category page surfaced in the WebSearch for "dog friendly mornington peninsula" queries (`/feature/dog-friendly`).
+
+Verified URLs fetched:
+- https://www.theninch.com.au/
+- https://www.theninch.com.au/feature/dog-friendly
+
+**Content depth.**
+
+| Topic | URL | Word count | Structure | Authority signals | Commercial |
+|---|---|---|---|---|---|
+| Dog-friendly category | `/feature/dog-friendly` | ~2,500-3,000 (incl. nav and 28 listings) | Category landing + venue tiles | No bylines. Date stamps on individual posts (Jan 2019 to Jan 2025). | Paid listings model, "Kiosk" e-commerce |
+| Hub | `/` | n/a | Eat/Drink, To Do, Retail, Events, Accommodation, Guides | Editorial voice consistent but anonymous | Get Listed and Advertise links visible |
+
+**Domain authority proxy.** Lower than the national publishers. They have brand recognition locally but limited SERP penetration on big-volume queries.
+
+**Backlink proxy.** Local, hyperlocal: individual operator pages link back, Mornington Peninsula Shire's "support local" pages reference them. Probably the closest to PI's own backlink profile.
+
+**Verdict for PI.** This is the most direct competitor for PI's "local insider" positioning. The Ninch has a six-year head start on local relationships and listings volume but is weaker on opinion, ranking, and verification dates. PI's editorial spine ("ranked top 12, verified Apr 2026") is the differentiator.
+
+---
+
+## 3. SERP comparison: head-to-head on the 8 PI target queries
+
+All searches run via WebSearch on 2026-05-08. Top 5 organic results listed; Google Maps pack and ad slots not counted as organic.
+
+### 3.1 "best restaurants mornington peninsula"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | broadsheet.com.au/mornington-peninsula/guides/restaurants | The Best Restaurants on the Mornington Peninsula 2026 | Editorial listicle (24 venues) | Broadsheet |
+| 2 | tripadvisor.com/Restaurants-g1055530 | THE 10 BEST Restaurants in Mornington Peninsula (Updated 2026) | UGC aggregator | Tripadvisor |
+| 3 | agfg.com.au/restaurants/mornington-peninsula | The 20 Best Mornington Peninsula Restaurants | Directory | AGFG |
+| 4 | opentable.com/diners-choice/victoria/mornington-peninsula/overall | Diners' Choice: Best Overall restaurants | UGC aggregator + booking | OpenTable |
+| 5 | wanderlog.com/list/geoCategory/208741/... | 50 best restaurants in the Mornington Peninsula | Aggregator listicle | Wanderlog |
+
+**PI presence on page 1:** Not visible in top 10 (PI not surfaced). PI does have an indexed page (`/journal/where-to-eat-mornington-peninsula/`) but it is not ranking on this exact query.
+
+**Pattern:** SERP is split 1 editorial (Broadsheet) + 4 aggregators / booking platforms.
+
+### 3.2 "dog friendly mornington peninsula"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | travelnuity.com/dog-friendly-mornington-peninsula/ | Dog-Friendly Mornington Peninsula: Visiting with a Dog | Niche dog-travel blog | Travelnuity |
+| 2 | visitvictoria.com/features/victoria-for-dogs/mornington-peninsula-for-dogs | Mornington Peninsula for dogs | Tourism .com | Visit Victoria |
+| 3 | visitmorningtonpeninsula.org/Stories/were-giving-a-round-of-a-paws... | A-Paws to These Dog-Friendly Adventures | Tourism .org | Visit Mornington Peninsula |
+| 4 | mornpen.vic.gov.au/Your-Property/Animals-and-Pets/Dogs-on-the-Peninsula | Dogs on the Peninsula | Council .gov | Mornington Peninsula Shire |
+| 5 | trustedhousesitters.com/blog/travel/dog-friendly-mornington-peninsula-guide/ | Dog-Friendly Mornington Peninsula | Brand blog | TrustedHousesitters |
+
+**PI presence on page 1:** Not surfaced. PI has a `/dog-friendly` hub page but it does not rank.
+
+**Pattern:** Dog-niche SERP is dominated by official tourism sites (Visit Victoria, Visit MP, Council) and one niche dog-travel blog. The Ninch's `/feature/dog-friendly` appeared on broader searches but not in the top 5 here.
+
+### 3.3 "best cellar doors mornington peninsula"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | visitmorningtonpeninsula.org/Stories/8-of-the-best-cellar-doors-to-visit... | 8 Of The Best Cellar Doors To Visit | Tourism listicle | Visit MP |
+| 2 | visitmorningtonpeninsula.org/Stories/9-of-the-best-cellar-doors... | 9 Of The Best Cellar Doors | Tourism listicle | Visit MP |
+| 3 | morningtonpeninsulawineries.com.au/listing/cellar-doors | Cellar Doors directory | Directory | MP Wineries assn |
+| 4 | **peninsulainsider.com.au/wine/best-cellar-doors/** | **Best Cellar Doors Mornington Peninsula** | **Editorial ranked list (top 12, verified Apr 2026)** | **Peninsula Insider** |
+| 5 | morningtonpeninsulawineries.com.au/cellar-doors | Cellar Doors landing | Directory | MP Wineries assn |
+
+**PI presence on page 1:** YES, position 4. Verified 2026-05-08.
+
+**Pattern:** Editorial competition is thin (Visit MP duplicates itself; MP Wineries is a directory). This is PI's strongest visible win and the template for all other category pages.
+
+### 3.4 "mornington peninsula day trip"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | thetraveltextbook.com/mornington-peninsula/ | Mornington Peninsula: Perfect Melbourne Day Trip | Travel blog | Travel Textbook |
+| 2 | cassiethehag.com/things-to-do-in-mornington-peninsula-victoria/ | Best Things To Do In Mornington Peninsula On A Day Trip | Travel blog | Cassie The Hag |
+| 3 | 2cupsoftravel.com/mornington-peninsula-day-trips-suggested-itinerary/ | Mornington Peninsula Day Trips - Suggested Itinerary | Travel blog | 2 Cups of Travel |
+| 4 | visitvictoria.com/regions/mornington-peninsula/see-and-do/road-trips-and-itineraries | Road trips and itineraries | Tourism .com | Visit Victoria |
+| 5 | thewanderbug.com/mornington-peninsula-guide/ | Ultimate Mornington Peninsula Guide | Travel blog | Wanderbug |
+
+**PI presence on page 1:** Not surfaced.
+
+**Pattern:** Day-trip SERP is dominated by independent travel bloggers (3 of top 5). This is the most contestable SERP for a publication-quality competitor like PI. The bar is low: long-form day-trip pieces with personal voice from non-Australians.
+
+### 3.5 "things to do mornington peninsula"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | visitmorningtonpeninsula.org/things-to-do | Best Things To Do Mornington Peninsula | Tourism hub | Visit MP |
+| 2 | mornpen.vic.gov.au/Events-Activities | Events & Activities | Council .gov | MP Shire |
+| 3 | visitvictoria.com/regions/mornington-peninsula/see-and-do | See and do | Tourism .com | Visit Victoria |
+| 4 | visitmelbourne.com/.../8-things-to-do-with-a-view... | 8 things to do with a view | Tourism .com | Visit Melbourne |
+| 5 | australia.com/.../guide-to-the-mornington-peninsula.html | Guide to the Mornington Peninsula | Tourism Australia | Tourism Australia |
+
+**PI presence on page 1:** Not surfaced.
+
+**Pattern:** The hardest SERP for PI to break into. Five top-five results are official tourism / government domains. Editorial cannot beat this on intent alone; head-of-funnel "things to do" SERPs reward brand domains.
+
+### 3.6 "where to stay mornington peninsula"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | thewanderbug.com/mornington-peninsula-guide/ | Ultimate Mornington Peninsula Guide | Travel blog | Wanderbug |
+| 2 | visitmorningtonpeninsula.org/Accommodation | Accommodation on the Mornington Peninsula | Tourism .org | Visit MP |
+| 3 | booking.com/region/au/mornington-peninsula.html | Best Mornington Peninsula Hotels | OTA | Booking.com |
+| 4 | tripadvisor.com/Hotels-g1055530-... | THE 10 BEST Hotels in Mornington Peninsula 2026 | UGC aggregator | Tripadvisor |
+| 5 | visitvictoria.com/regions/mornington-peninsula/places-to-stay | Places to stay | Tourism .com | Visit Victoria |
+
+**PI presence on page 1:** Not surfaced.
+
+**Pattern:** Booking-intent SERP. OTAs (Booking, Tripadvisor) own this query because Google rewards transactional intent. Editorial content sits below.
+
+### 3.7 "mornington peninsula weekend"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | visitmorningtonpeninsula.org/whats-on | What's On | Events hub | Visit MP |
+| 2 | visitmelbourne.com/regions/mornington-peninsula/whats-on | What's on | Tourism .com | Visit Melbourne |
+| 3 | peninsulahotsprings.com/journal/10-ways-to-enjoy-the-mornington-peninsula-this-long-weekend | 10 ways to enjoy ... long weekend | Operator blog | Peninsula Hot Springs |
+| 4 | thewanderbug.com/mornington-peninsula-guide/ | Ultimate Guide | Travel blog | Wanderbug |
+| 5 | redballoon.com.au/vic/mornington-peninsula/ | Things To Do | Booking platform | RedBalloon |
+
+**PI presence on page 1:** Not surfaced. (PI publishes a weekly "Peninsula This Weekend" newsletter and weekend dispatch, but the editorial pages are not currently capturing this generic head term.)
+
+**Pattern:** "Weekend" is interpreted by Google as event-intent. Tourism .org "What's On" pages dominate.
+
+### 3.8 "best walks mornington peninsula"
+
+| Rank | URL | Title | Format | Competitor / PI? |
+|---|---|---|---|---|
+| 1 | visitmorningtonpeninsula.org/Things-To-Do/Walks-Hiking | Walks + Hiking | Tourism hub | Visit MP |
+| 2 | alltrails.com/parks/australia/victoria/mornington-peninsula-national-park | 10 Best hikes and trails | Trail directory | AllTrails |
+| 3 | tripadvisor.com.au/Attractions-g1055530-Activities-c61-t87... | 10 BEST Hiking Trails 2026 | UGC aggregator | Tripadvisor |
+| 4 | parks.vic.gov.au/places-to-see/parks/mornington-peninsula-national-park/things-to-do/walking | Walking | Government parks | Parks Victoria |
+| 5 | greenolive.com.au/blog/post/the-best-walking-tracks-on-the-mornington-peninsula | Best Walking Tracks | Operator blog | Green Olive |
+
+**PI presence on page 1:** Not surfaced.
+
+**Pattern:** Mix of tourism hub, trail directory (AllTrails), aggregator, government parks, and one operator blog. AllTrails and Parks Vic carry deep authority on trail data that editorial cannot match.
+
+---
+
+## 4. SERP feature presence across the 8 queries
+
+Observations from running the WebSearches and from cross-referencing the Google SERP behaviours these queries trigger. Where a feature could not be confirmed via WebSearch output alone, it is marked "likely" rather than asserted.
+
+| Query | Map pack | People Also Ask | Featured snippet | Image carousel | Video | Sitelinks (top org) |
+|---|---|---|---|---|---|---|
+| best restaurants mp | Likely | Likely | None obvious in result text | Likely | No | Broadsheet has implicit authority |
+| dog friendly mp | No | Likely | Travelnuity / Visit Vic candidate | Likely | No | Visit MP exposes deep links |
+| best cellar doors mp | Likely (winery places) | Likely | Visit MP candidate | Likely | No | Visit MP exposes deep links |
+| mp day trip | No | Likely | None obvious | Likely | Possible (YouTube) | Travel-blog niche, no sitelinks |
+| things to do mp | Likely (tourist spots) | Yes, almost certainly | Visit MP / Visit Vic candidate | Yes | Yes | Visit MP and gov.au sitelinks |
+| where to stay mp | Yes (hotels pack) | Yes | Booking-driven | Yes | No | Booking.com sitelinks |
+| mp weekend | Likely (events) | Likely | Visit MP "What's On" | Yes | No | Visit MP sitelinks |
+| best walks mp | Yes (national park pin) | Yes | AllTrails or Parks Vic | Yes | Possible | AllTrails sitelinks |
+
+**Sitelinks search box.** PI does not currently have a sitelinks search box in Google. Visit Mornington Peninsula does (verified by site structure: dedicated search at top nav, returns deep link clusters when SERP query matches site name). Broadsheet and Time Out have sitelinks search boxes for their parent brands but typically not for the regional sub-hub. **Action:** PI should ensure proper SearchAction WebSite schema markup at the homepage to qualify for the sitelinks search box. This would help branded queries ("peninsula insider X") immediately and is a low-cost fix.
+
+---
+
+## 5. Where PI can realistically win
+
+Verdict per query, ranked from most winnable to least.
+
+### Winnable (PI can credibly target a top-5 organic position in the next 6 months)
+
+**1. "best cellar doors mornington peninsula"**, already at position 4. Need to push to position 1–2. Strategy: refresh frequency (already verified Apr 2026), add a comparison table (price tier, appointment required, dog policy, food on site, view rating), add structured FAQ markup. The competing top-3 results are all published by the same tourism .org with no byline and no dates; PI's editorial signal beats theirs on freshness and opinion.
+
+**2. "dog friendly mornington peninsula"**, PI has the right product (a `/dog-friendly` hub) and the right voice. SERP top 5 includes one tourism .org post that's vague, one council page that's about dog rules not destinations, and a generic dog-travel blog. PI's verified-Apr-2026 dating, specific leash rules per beach, and operator-level depth (Phaedrus, Green Olive, Stumpy Gully named with conditions) is exactly what this SERP wants. Strategy: build out the "next up" sub-pages (daycare, vets, weather contingencies) and link from `/dog-friendly` hub. Each sub-page becomes a long-tail asset.
+
+**3. "mornington peninsula day trip"**, most contestable SERP. Top 5 is independent travel blogs of varying quality, none of which are MP specialists. PI's place-by-place depth (Sorrento, Red Hill, Flinders area guides) is denser and more current than any of them. Strategy: publish a `/escape/day-trip-mornington-peninsula/` page that's a 2,500-word editorial day plan with tested timings, locked-in dish recommendations, and a "what to skip" section the travel blogs lack.
+
+### Contestable (PI can target page-1 positions but not without a deliberate content build)
+
+**4. "best restaurants mornington peninsula"**, Broadsheet at #1 is hard to displace, but the rest of the top 5 is aggregators that an editorial publication can leapfrog by being more current and more local. PI's `/eat` hub and `/journal/where-to-eat-mornington-peninsula/` are the right starting point. Strategy: convert that page into a clearly-ranked "top 24" with verified booking dates and what's-changed-this-month notes; Broadsheet's annual update model is beatable on freshness if PI commits to monthly verification.
+
+**5. "mornington peninsula weekend"**, interpreted by Google as event-intent today. PI's weekend dispatch is the right product but the wrong landing page surface. Strategy: build a permanent `/whats-on/this-weekend/` page that auto-updates (or rebuilds weekly from the dispatch) with a current event list AND the editorial anchor recommendations. This combines what the query wants (events) with what PI does well (curation).
+
+**6. "best walks mornington peninsula"**, AllTrails and Parks Vic carry deep trail-data authority that editorial cannot match. Australian Traveller's 11-walk piece with grade ratings shows what a credible editorial entry looks like. Strategy: PI's existing `/explore` hub plus 11 individually-bylined walk pages, each with parking, dog rules, tide windows, post-walk dining adjacent. Distance-to-#1 is medium; distance to page 1 is small.
+
+### Difficult (PI should not invest unless other priorities are met first)
+
+**7. "things to do mornington peninsula"**, five tourism / government domains in top 5. Head-of-funnel discovery query. Editorial publishers do not realistically own this SERP. Strategy: deprioritise; harvest the demand by ranking sub-pages for sub-intents ("things to do red hill", "things to do mornington peninsula in winter", "things to do mornington peninsula with kids") and let the long-tail compound.
+
+**8. "where to stay mornington peninsula"**, booking-intent SERP owned by OTAs. PI cannot beat Booking.com / Tripadvisor on transactional ranking signals. Strategy: deprioritise the head term; target opinionated long-tail ("best boutique hotels mornington peninsula", "where to stay in red hill", "best dog-friendly stays mornington peninsula") where editorial wins.
+
+---
+
+## 6. Content formats competitors use that PI doesn't
+
+These are gaps that map directly to outputs PI could ship within a sprint or two without compromising voice.
+
+### From Broadsheet: dated annual guide refreshes and "Now Open" news cadence
+
+- Example: `/mornington-peninsula/guides/restaurants` carries a clear "Updated 24 Dec 2025" signal AND a steady stream of "Now Open" pieces between annual refreshes that maintain freshness.
+- Why it matters: gives Google two freshness signals, annual full refresh + monthly news, that compound into rank stability. PI's verification dating is already strong; the missing layer is the news cadence between refreshes.
+- PI adaptation: a `/journal/openings/` micro-format (one short piece per genuinely new venue), aggregated monthly into the weekend dispatch.
+
+### From Time Out: numbered listicles with strong photography
+
+- Example: `/melbourne/travel/ten-reasons-to-visit-mornington-peninsula` (the article is dated; the format is not). Time Out's listicle format (`Ten reasons...`, `Things you can only do...`) hits both branded discovery and Google's listicle-friendly intent.
+- Why it matters: Google rewards numerical listicles for "best X / top X" queries. PI's existing pages lean toward narrative editorial; a few numbered formats targeting the head queries are useful.
+- PI adaptation: keep PI's voice but introduce a "10 things only locals do on the peninsula" format on `/journal/`; it captures Time-Out-style demand without imitating their tone.
+
+### From Concrete Playground: news-led "Now Open" pieces
+
+- Example: `/melbourne/travel-leisure/alba-thermal-springs-spa-the-mornington-peninsulas-new-wellness-destination` (operator opening news as a standalone piece).
+- Why it matters: news-led pieces are what Discover surface and what social media shares. They also accumulate inbound links from operators excited about coverage.
+- PI adaptation: same as Broadsheet's "Now Open" recommendation; PI already has a "verified this month" pulse, this just formalises it as bylined news.
+
+### From Australian Traveller: graded long-form walks with categorical taxonomy
+
+- Example: `/vic/mornington-peninsula/mornington-peninsula-walks/` (11 walks across West/Central/East Coast with grade 1–4 difficulty).
+- Why it matters: gives Google strong topical structure (region + grade taxonomy), and gives users a real comparison vector. AT's page is one of the most complete editorial walk pieces in this set.
+- PI adaptation: a `/explore/walks/` hub with PI's voice (parking detail, dog rules, post-walk pub) and a comparable taxonomy.
+
+### From Halliday Wine Companion: per-venue rating depth
+
+- Example: `/wineries/victoria/mornington-peninsula/main-ridge-estate/` and similar per-winery profile pages.
+- Why it matters: every winery's own website links back to its Halliday profile. That's organic backlink earning by virtue of the rating.
+- PI adaptation: PI cannot replicate the wine ratings, but can replicate the **experience rating** (a 1–5 pictogram for: dog policy, parking, view, wait time, kid-friendliness, tasting format) on every cellar door, restaurant, and accommodation page. Operators will link back to that.
+
+### From The Urban List: shoulder-category guides and accommodation specifics
+
+- Example: `/melbourne/a-list/best-airbnb-mornington-peninsula` and `/melbourne/a-list/best-luxury-accommodation-Mornington-Peninsula`, tightly-niched accommodation lists.
+- Why it matters: the head term "where to stay" is OTA-owned, but TUL captures the long tail by splitting by accommodation type. Each shoulder query is winnable.
+- PI adaptation: split `/stay/` into named shoulder pages (best dog-friendly stays, best winery stays, best Airbnbs, best for couples, best for families, best for groups). Each is a separate ranking opportunity.
+
+### From The Ninch: granular suburb tagging
+
+- Example: 40+ suburb tags from Arthurs Seat to Tyabb on theninch.com.au, every venue tagged to a suburb.
+- Why it matters: suburb-level taxonomy is exactly the long-tail discovery PI's `/places/` hub aims at, but PI does not yet expose every page with consistent suburb microdata.
+- PI adaptation: ensure every venue page on PI has a `placeName` schema field tied to one of the 12 town hubs, plus consistent suburb tagging on `/journal/` pieces.
+
+---
+
+## 7. Backlink-target opportunities
+
+Each target was surfaced by competitor search results above; the link from the competitor proves the site is willing to outbound-link to MP editorial. The PI page suggested as the pitch hook is named for each.
+
+| # | Site | URL | Type | Why they might link to PI | PI page to pitch |
+|---|---|---|---|---|---|
+| 1 | Visit Victoria | visitvictoria.com/regions/mornington-peninsula | Tourism .com (state body) | Currently links out to Broadsheet, Tripadvisor, AGFG. Will link to authoritative editorial covering things they don't (dog rules, walks with grade/parking, opinionated cellar door rankings). | `/wine/best-cellar-doors/` and `/dog-friendly/` |
+| 2 | Visit Melbourne | visitmelbourne.com/regions/mornington-peninsula | Tourism .com (city body) | Same parent as Visit Victoria, similar partner-link practice on regional content. | `/escape/day-trip-mornington-peninsula/` (if built) |
+| 3 | Mornington Peninsula Shire | mornpen.vic.gov.au/Activities/Whats-On | Council .gov | Council pages link out to operator and editorial sources for "things to do". Strong link equity. | `/whats-on/` |
+| 4 | Parks Victoria | parks.vic.gov.au/places-to-see/parks/mornington-peninsula-national-park | Government parks | Currently links to operator and trail blogs. Editorial walks with practical detail (parking, post-walk food) is a natural complement. | `/explore/walks/` (when built) |
+| 5 | AllTrails | alltrails.com/parks/australia/victoria/mornington-peninsula-national-park | Trail directory | Less likely to outbound link in-product, but blog and editorial outreach via their content team works. | Individual walk pages |
+| 6 | Australian Traveller | australiantraveller.com/vic/mornington-peninsula/ | Travel magazine | Multi-author MP coverage; their writers source from local editorial. Pitching individual journalists with verified locals' lists. | `/journal/where-to-eat-mornington-peninsula/` |
+| 7 | RACV Royal Auto | racv.com.au/royalauto/travel/victoria/best-boutique-wineries-cellar-doors-mornington-peninsula.html | Member magazine | Already publishes MP cellar door pieces. Will source quotes from local editorial for next refresh. | `/wine/best-cellar-doors/` |
+| 8 | Qantas Travel Insider | qantas.com/travelinsider/en/explore/australia/victoria/mornington-peninsula.html | Brand publishing | Active publishing on MP; quotes editorial sources; one of the highest-DA potential backlinks. | `/journal/area-guide-sorrento/` and `/journal/area-guide-red-hill/` |
+| 9 | Mornington Peninsula News (mpnews.com.au) | mpnews.com.au | Local press | Hyperlocal newspaper; will link to editorial that quotes operators or covers council-relevant news. | `/whats-on/` and `/awards` |
+| 10 | Mornington Peninsula Magazine | morningtonpeninsulamagazine.com.au | Local lifestyle mag | Same reasoning as MP News; cross-promo of editorial pieces across local publishers. | Any `/journal/` piece with local interview content |
+| 11 | Halliday Wine Companion (article team) | winecompanion.com.au/articles/travel/ | Wine publisher | Cited above; their travel articles draw from local editors. Pitch as expert source for next MP wineries refresh. | `/wine/best-cellar-doors/` |
+| 12 | Young Gun of Wine | younggunofwine.com/region-guide/mornington-peninsula/ | Wine publisher | Already publishing region guides; would link to local-editor pick lists. | `/wine/best-cellar-doors/` |
+| 13 | Peninsula Hot Springs (operator blog) | peninsulahotsprings.com/journal/ | Operator | Already ranks for "long weekend" content. Operator backlinks compound in cluster topology. Pitch with mutual content swap. | `/journal/area-guide-rye/` (Hot Springs is in Rye) |
+| 14 | Travelnuity (dog-travel niche blog) | travelnuity.com/dog-friendly-mornington-peninsula/ | Niche blog | Currently #1 for "dog friendly mornington peninsula". Niche-blog links are easy wins via comments / contributor outreach. | `/dog-friendly/` |
+| 15 | TrustedHousesitters | trustedhousesitters.com/blog/travel/dog-friendly-mornington-peninsula-guide/ | Brand blog | Their MP dog-friendly guide is comparatively shallow. Pitch as expert source for quote / refresh. | `/dog-friendly/` |
+
+**Notes on link earning**
+
+- The Visit Victoria, Visit Melbourne, Council, and Parks Victoria links carry the highest authority but the longest sales cycle. Approach via partnership / industry portal channels (Visit Mornington Peninsula's industry portal is at `visitmorningtonpeninsula.org/AllNewsMedia/`), not via cold pitch.
+- Operator links (Hot Springs, Crittenden, Jackalope, etc.) are the easiest wins. Every operator page on PI is a potential mutual link if PI's content is genuinely flattering and accurate.
+- Niche-blog links (Travelnuity, dog-travel) are won by being the resource an outside writer references when their own coverage is dated.
+- Wine-media links (Halliday, Young Gun, RACV) are won by becoming the local source of record. Halliday already cites local editors when writing region pieces; PI being known to their travel team is a 12-month relationship project.
+
+---
+
+## 8. Quick read for the operator
+
+**Where PI is winning today:** position 4 for "best cellar doors mornington peninsula", verified 2026-05-08. The page format (top 12 ranked, verified Apr 2026, FAQ block, internal cross-links to `/places/`) is the template. Replicate it.
+
+**Where PI has clear winnable ground in the next 90 days:**
+- "dog friendly mornington peninsula" (build out the hub's sub-pages)
+- "mornington peninsula day trip" (write a single 2,500-word editorial day plan)
+- "best walks mornington peninsula" (build a graded walks hub with PI's voice, modelled on Australian Traveller's structure but with PI's local detail)
+
+**Where PI cannot beat the SERP and should harvest long-tail instead:**
+- "things to do mornington peninsula" (sub-intent farming via place + season + traveller-type)
+- "where to stay mornington peninsula" (split into shoulder accommodation guides)
+- "mornington peninsula weekend" (rebuild as a permanent `/whats-on/this-weekend/` page; do not chase the head term directly)
+
+**The single-biggest format gap PI has compared to the field:** consistent author bylines on long-form pieces. Broadsheet, Time Out, Concrete Playground, Australian Traveller, Halliday, and The Urban List all attribute their MP work to named writers. PI's editorial-collective voice is intentional, but Google rewards named expertise (E-E-A-T). Even adding a contributor page with editor names would close part of the gap without changing the editorial register.
+
+**Single-biggest backlink play:** be the local source of record that the wine-media article team (Halliday, Young Gun, RACV) cites in their next refresh. That is one piece of relationship building per year that compounds across 5-10 articles per source.
+
+---
+
+## 9. Topic-cluster gap matrix
+
+Cross-tabulating the eight competitors against the topic clusters PI cares about. "Y" means there is at least one substantive page on that competitor for that cluster (verified via WebSearch site: queries on 2026-05-08). "N" means none surfaced in the top 10 site: results. "Thin" means a page exists but is not the dominant format on the site.
+
+| Cluster | Visit MP | Broadsheet | Time Out | Concrete Playground | Australian Traveller | Halliday | The Urban List | The Ninch | PI status |
+|---|---|---|---|---|---|---|---|---|---|
+| Restaurants | Y | Y (#1 SERP) | Thin | Thin | Y | N | Thin | Thin | `/journal/where-to-eat-mornington-peninsula/` |
+| Cellar doors / wineries | Y (multiple) | Y | Thin | N | Y | Y (definitive) | Thin | Thin | `/wine/best-cellar-doors/` (#4 SERP) |
+| Accommodation | Y | Y | Thin | Y (news) | Y | N | Y (multiple shoulder pages) | Y | `/stay/` (need split) |
+| Walks / hiking | Y (#1 SERP) | N | Thin | Thin | Y (graded) | N | Thin | N | `/explore/` (no walks hub) |
+| Dog-friendly | Y | N | N | N | N | N | N | Y (`/feature/dog-friendly`) | `/dog-friendly/` (hub built, sub-pages pending) |
+| Day trip / itinerary | Thin | Y (weekend) | Y (weekend) | Y | Y (3-day, road-trip) | Y (48 hours) | Y (guide) | N | `/escape/` (need a day-trip page) |
+| Weekend / what's on | Y (#1 SERP, events) | Y | Y | Y | Y (long weekend) | N | Y | Thin | `/whats-on/` |
+| Place / town hubs | Y (Sorrento, Red Hill, Flinders, etc.) | Y (Red Hill 24h) | N | N | Thin | N | Thin | Thin (suburb tags) | `/places/` (Sorrento, Mornington, Red Hill, Main Ridge, Rye, Flinders done) |
+| Hot springs / wellness | Y | Y | Y (multiple) | Y (multiple) | Y | N | Y | Y | Covered in `/places/rye/` etc. |
+| Beaches | Y | N | N | N | Y (best beaches) | N | N | Y | Distributed across `/places/` |
+| Fishing | Y | N | N | N | N | N | N | N | `/fishing/` (PI-unique) |
+| Boating | Y | N | N | N | N | N | N | N | `/boating/` (PI-unique) |
+| Awards / regional best | N (operator awards exist) | N | N | N | N | Y (wine ratings) | N | N | `/awards/` (PI-unique) |
+| Editorial long-form / journal | Thin | Y | Thin | Thin | Y | Y (articles) | Thin | Thin | `/journal/` (PI's strength) |
+| Multi-day plans / escapes | Thin | Y | Y | N | Y | Y | Thin | N | `/escape/` |
+
+**Three observations from this matrix.**
+
+1. **PI's defensible ground.** Fishing, boating, and Awards are categories where no national or regional editorial competitor has invested. These are PI-unique territories. Investment in these is investment in non-contested SERPs.
+2. **PI's weakest cluster relative to competition.** Walks. Visit MP holds #1, AllTrails holds the trail-data middle, and Australian Traveller has the strongest editorial entry. PI's `/explore/` does not yet have a dedicated walks hub. This is a high-effort, high-reward build.
+3. **PI's unique combination.** No competitor combines Place hubs + Editorial journal + Awards + Concierge AI + a Pass tier. Each is replicable individually; the combination is the moat. The SEO play is to make sure each surface ranks in isolation, then internal-link cross-cluster.
+
+---
+
+## 10. Methodology and limitations
+
+**Tools used.** WebSearch (Google-derived results, US-region as per harness constraint) and WebFetch (full URL retrieval with structured prompt extraction). Neither tool exposes verified third-party SEO metrics (Ahrefs, Moz, Semrush). Where authority is referenced, it is labelled "proxy" and grounded in observable signals: SERP rank position, presence in WebSearch results, partner-link visibility, and brand recognition.
+
+**SERP regionality.** WebSearch results are issued from a US-region search context. For Australia-specific commercial intent, on-shore Google AU results may differ slightly in the lower positions but the top 5 organic results for high-volume Australian regional queries are stable across regions. Where there was room for doubt (the four "[verb] mornington peninsula" head terms), the top-5 lists were spot-checked against the WebSearch snippet data which referenced AU-specific TLDs (.com.au) consistently.
+
+**Word counts.** Word counts cited per page are WebFetch model approximations, accurate to within ~10%. They are sufficient for relative comparison (PI's cellar door page at ~2,800 words vs Visit MP's at ~1,200 is the directionally right comparison) but should not be treated as exact figures.
+
+**Backlink-target list construction.** Each target was surfaced by either (a) appearing in a WebSearch result for a relevant MP query, (b) being cited as the source for a competitor article, or (c) being a publication explicitly named by another competitor's editorial content. No target on the list of 15 is speculative; every one has a documented connection to MP coverage.
+
+**Out of scope.** This audit does not cover technical SEO (Core Web Vitals, mobile usability, internal link graph), GSC keyword performance beyond the 8 head queries, social-share velocity, or paid search competitive overlap. Those belong to the other audit-2026-05 reports.
+
+---
+
+## 11. Source URLs cited in this audit
+
+All URLs below were either fetched via WebFetch on 2026-05-08 or surfaced via WebSearch site: queries on the same date.
+
+**Peninsula Insider (subject site):**
+- https://peninsulainsider.com.au/
+- https://peninsulainsider.com.au/wine/best-cellar-doors/
+- https://peninsulainsider.com.au/dog-friendly
+- https://peninsulainsider.com.au/journal/where-to-eat-mornington-peninsula/
+- https://peninsulainsider.com.au/places/main-ridge/
+- https://peninsulainsider.com.au/places/rye/
+- https://peninsulainsider.com.au/journal/area-guide-sorrento/
+- https://peninsulainsider.com.au/journal/area-guide-flinders/
+- https://peninsulainsider.com.au/journal/area-guide-red-hill/
+- https://peninsulainsider.com.au/journal/area-guide-mornington/
+
+**Visit Mornington Peninsula:**
+- https://www.visitmorningtonpeninsula.org/
+- https://www.visitmorningtonpeninsula.org/Stories/8-of-the-best-cellar-doors-to-visit-on-the-mornington-peninsula
+- https://www.visitmorningtonpeninsula.org/Stories/9-of-the-best-cellar-doors-to-visit-on-the-mornington-peninsula
+- https://www.visitmorningtonpeninsula.org/Stories/were-giving-a-round-of-a-paws-to-these-dog-friendly-adventures
+- https://www.visitmorningtonpeninsula.org/Stories/peninsulas-ultimate-doggy-destinations
+- https://www.visitmorningtonpeninsula.org/Things-To-Do/Walks-Hiking
+- https://www.visitmorningtonpeninsula.org/whats-on
+- https://www.visitmorningtonpeninsula.org/things-to-do
+- https://www.visitmorningtonpeninsula.org/Accommodation
+- https://www.visitmorningtonpeninsula.org/Accommodation/Pet-Friendly
+
+**Broadsheet:**
+- https://www.broadsheet.com.au/mornington-peninsula
+- https://www.broadsheet.com.au/mornington-peninsula/guides/restaurants
+- https://www.broadsheet.com.au/mornington-peninsula/guides/accommodation
+- https://www.broadsheet.com.au/mornington-peninsula/guides/wineries
+- https://www.broadsheet.com.au/national/art-and-design/article/long-lunches-thermal-springs-and-regional-galleries-weekend-itinerary-mornington-peninsula
+- https://www.broadsheet.com.au/mornington-peninsula/travel/article/how-spend-24-hours-red-hill
+- https://www.broadsheet.com.au/mornington-peninsula/travel/article/five-summery-new-mornington-peninsula-stays
+- https://www.broadsheet.com.au/melbourne/travel/article/these-six-new-openings-give-you-more-reasons-visit-mornington-peninsula-spring
+- https://www.broadsheet.com.au/mornington-peninsula/food-and-drink/article/best-mornington-restaurants-many-little-gayan-pieris
+
+**Time Out Melbourne:**
+- https://www.timeout.com/melbourne/travel/weekend-getaways-mornington-peninsula
+- https://www.timeout.com/melbourne/travel/ten-reasons-to-visit-mornington-peninsula
+- https://www.timeout.com/melbourne/travel/things-you-can-only-do-on-the-mornington-peninsula
+- https://www.timeout.com/melbourne/news/this-luxe-hot-springs-resort-on-victorias-mornington-peninsula-has-been-awarded-a-michelin-key-021026
+- https://www.timeout.com/melbourne/travel/peninsula-hot-springs
+
+**Concrete Playground:**
+- https://concreteplayground.com/melbourne/travel-leisure/travel/weekenders-guide-to-the-mornington-peninsula/
+- https://concreteplayground.com/melbourne/travel-leisure/five-out-of-town-dates-to-plan-this-winter-on-the-mornington-peninsula
+- https://concreteplayground.com/melbourne/travel-leisure/arthurs-seat-eagle-upgrade
+- https://concreteplayground.com/melbourne/travel-leisure/now-open-hotel-sorrento
+- https://concreteplayground.com/melbourne/travel-leisure/alba-thermal-springs-spa-the-mornington-peninsulas-new-wellness-destination
+
+**Australian Traveller:**
+- https://www.australiantraveller.com/vic/mornington-peninsula/
+- https://www.australiantraveller.com/vic/mornington-peninsula/find-your-way-around-mornington-peninsula-in-3-days/
+- https://www.australiantraveller.com/vic/mornington-peninsula/the-ultimate-mornington-peninsula-road-trip/
+- https://www.australiantraveller.com/vic/mornington-peninsula/the-best-beaches-on-the-mornington-peninsula/
+- https://www.australiantraveller.com/vic/mornington-peninsula/long-weekend-on-the-mornington-peninsula/
+- https://www.australiantraveller.com/vic/mornington-peninsula/best-places-to-stay-on-the-mornington-peninsula/
+- https://www.australiantraveller.com/vic/mornington-peninsula/luxury-accommodation-mornington-peninsula/
+- https://www.australiantraveller.com/vic/mornington-peninsula/mornington-peninsula-walks/
+- https://www.australiantraveller.com/vic/mornington-peninsula/alba-thermal-springs/
+
+**Halliday Wine Companion:**
+- https://winecompanion.com.au/wineries/victoria/mornington-peninsula
+- https://winecompanion.com.au/articles/travel/mornington-peninsula-wineries
+- https://winecompanion.com.au/articles/travel/mornington
+- https://winecompanion.com.au/articles/travel/things-to-do-on-the-mornington-peninsula
+- https://winecompanion.com.au/articles/travel/mornington-peninsula-pinot-coast
+- https://winecompanion.com.au/articles/wine-lists/mornington-wines-to-try
+- https://winecompanion.com.au/articles/wine-lists/best-mornington-peninsula-wines-to-try
+
+**The Urban List:**
+- https://www.theurbanlist.com/melbourne/a-list/mornington-peninsula-guide
+- https://www.theurbanlist.com/melbourne/a-list/best-luxury-accommodation-Mornington-Peninsula
+- https://www.theurbanlist.com/melbourne/a-list/mornington-peninsula-accommodation
+- https://www.theurbanlist.com/melbourne/a-list/6-awesome-adventures-on-the-mornington-peninsula
+- https://www.theurbanlist.com/melbourne/a-list/best-airbnb-mornington-peninsula
+
+**The Ninch:**
+- https://www.theninch.com.au/
+- https://www.theninch.com.au/feature/dog-friendly
+
+**SERP fixtures referenced (not profiled):**
+- https://www.tripadvisor.com/Restaurants-g1055530-Mornington_Peninsula_Victoria.html
+- https://www.tripadvisor.com.au/Attractions-g1055530-Activities-Mornington_Peninsula_Victoria.html
+- https://www.tripadvisor.com/Hotels-g1055530-Mornington_Peninsula_Victoria-Hotels.html
+- https://www.tripadvisor.com.au/Attractions-g1055530-Activities-c61-t87-Mornington_Peninsula_Victoria.html
+- https://www.visitvictoria.com/regions/mornington-peninsula
+- https://www.visitvictoria.com/features/victoria-for-dogs/mornington-peninsula-for-dogs
+- https://www.visitmelbourne.com/regions/mornington-peninsula
+- https://www.mornpen.vic.gov.au/Your-Property/Animals-and-Pets/Dogs-on-the-Peninsula
+- https://www.mornpen.vic.gov.au/Events-Activities
+- https://www.parks.vic.gov.au/places-to-see/parks/mornington-peninsula-national-park/things-to-do/walking
+- https://www.alltrails.com/parks/australia/victoria/mornington-peninsula-national-park
+- https://www.agfg.com.au/restaurants/mornington-peninsula
+- https://www.opentable.com/diners-choice/victoria/mornington-peninsula/overall
+- https://www.opentable.com/region/melbourne/mornington-peninsula-restaurants
+- https://wanderlog.com/list/geoCategory/208741/where-to-eat-best-restaurants-in-mornington-peninsula
+- https://www.travelnuity.com/dog-friendly-mornington-peninsula/
+- https://www.trustedhousesitters.com/blog/travel/dog-friendly-mornington-peninsula-guide/
+- https://thewanderbug.com/mornington-peninsula-guide/
+- https://www.thetraveltextbook.com/mornington-peninsula/
+- https://2cupsoftravel.com/mornington-peninsula-day-trips-suggested-itinerary/
+- https://cassiethehag.com/things-to-do-in-mornington-peninsula-victoria/
+- https://www.peninsulahotsprings.com/journal/10-ways-to-enjoy-the-mornington-peninsula-this-long-weekend
+- https://www.redballoon.com.au/vic/mornington-peninsula/
+- https://www.greenolive.com.au/blog/post/the-best-walking-tracks-on-the-mornington-peninsula
+- https://morningtonpeninsulawineries.com.au/listing/cellar-doors
+- https://morningtonpeninsulawineries.com.au/cellar-doors
+- https://www.qantas.com/travelinsider/en/explore/australia/victoria/mornington-peninsula.html
+- https://www.morningtonpeninsulamagazine.com.au/
+- https://www.mpnews.com.au/
+- https://younggunofwine.com/region-guide/mornington-peninsula/
+- http://www.racv.com.au/royalauto/travel/victoria/best-boutique-wineries-cellar-doors-mornington-peninsula.html
+- https://www.booking.com/region/au/mornington-peninsula.html
+
+---
+
+End of report.

--- a/ops/reports/seo/audit-2026-05/04-conversion-paths.md
+++ b/ops/reports/seo/audit-2026-05/04-conversion-paths.md
@@ -1,0 +1,294 @@
+# 04, Conversion paths: organic visitor → commercial action
+
+Date: 2026-05-08
+Author: Claude (audit-2026-05)
+Inputs: `next/src/pages/{pass,newsletter,ask,submit,itinerary,partners,awards}/*`, `next/src/components/{ConciergeDrawer,NewsletterBlock,Masthead,Footer}.astro`, `next/src/lib/{nav,v4-nav,stripe}.ts`, plus the empirical SEO data in `ops/reports/seo/baseline.md`, `daily-log.md`.
+
+The site has six conversion surfaces. Five are indexable; one (operator dashboards) is correctly noindex. **None of them are well-linked from the editorial layer.** That's the headline finding: the Pass, Awards, Partners, Submit and (until very recently) the Concierge hub are structurally orphaned from the article surfaces that earn organic traffic. Conversion happens when readers can find the door; right now most of these doors are at the back of the building.
+
+GA4 is not authed for this audit. Wherever the funnel question requires conversion data, the section is marked **QUANTIFY ON GA4 AUTH** rather than guessed.
+
+Commercial-goal priority order from the orchestrator's brief: **Pass → Operator claims → Concierge → Awards → Newsletter → Partner**.
+
+---
+
+## 1. The conversion surfaces (inventory)
+
+| # | Surface | URL | Action | Indexable? | Footer link? | Masthead link? | Body-link from articles? |
+|---|---|---|---|---|---|---|---|
+| 1 | Pass landing | `/pass/` (`next/src/pages/pass.astro`) | Subscribe (free / paid / founders-waitlist) | Yes (canonical set, line 31) | Indirect, `v4FooterAbout` points to `/preview-insider-plans/` not `/pass/` (`next/src/lib/v4-nav.ts:470`) | No | No |
+| 2 | Newsletter landing | `/newsletter/` (`next/src/pages/newsletter.astro`) | Email signup → Beehiiv | Yes | Yes (`v4FooterAbout`, label "The Dispatch") | "Subscribe" button anchors to `/#newsletter` instead of `/newsletter/` (`Masthead.astro:58`) | Embedded `NewsletterBlock` at the foot of most articles |
+| 3 | Concierge | `/ask/` (`next/src/pages/ask.astro`) + global drawer | Ask LLM, get recommendations | Yes (and Discovered per `url-inventory.md:257`) | No | "Ask" pill in mobile masthead row (`Masthead.astro:91-100`); drawer trigger always present in `BaseLayout.astro:234` | No (drawer trigger but no inline body link) |
+| 4 | Awards landing | `/awards/` (`next/src/pages/awards/index.astro`) | Nominate / vote (seasonal) | Yes (canonical set, `awards/index.astro:46`) | No | No | None observed in grep |
+| 5 | Submit landing | `/submit/` (`next/src/pages/submit.astro`) | Reader submission form | Yes (canonical set, line 50) | No | No | None observed in grep |
+| 6 | Partners landing | `/partners/` (`next/src/pages/partners/index.astro`) + sub-pages | Operator enquiry / claim / advertising kit | Yes (`/partners/`, `/partners/apply/`, `/partners/advertising-kit/`, `/partners/founders-prospectus/`) | Yes (`v4FooterAbout` label "Partner with us") | No | One link from `/about/` (`about.astro:146`) and an aside on `/partners/index.astro:50-55` |
+| 6b | Operator claim | `/partners/claim/` (`next/src/pages/partners/claim.astro:33`) | Auth-gated claim | **noindex** (correct) | No | No | Indirectly via `/partners/index.astro` aside |
+| 6c | Operator dashboard | `/partners/dashboard/` (`partners/dashboard.astro:56`) | Auth-gated venue management | **noindex** (correct) | No | No | Indirectly |
+| 6d | Founders prospectus | `/partners/founders-prospectus/` | Request the prospectus | (not in inventory; verify) | No | No | Per the page comment "request-only, never linked publicly" |
+| 7 | Itinerary builder | `/itinerary/` (`next/src/pages/itinerary.astro`) | Build personalised itinerary | Yes | No | "Itinerary" link in masthead utility row, hidden by default (`Masthead.astro:56`) | None, items are added via venue/article save buttons |
+| 8 | Alerts | `/alerts/` | Subscribe to event alerts | Yes | No | "Alerts" in masthead utility (`Masthead.astro:57`) | None |
+| 9 | Account dashboards | `/account/*` | Saved/Likes/Pass member | **noindex** (correct, all four files use `noindex={true}`) | No | No | n/a |
+
+**Top-level finding**: 7 of 9 indexable conversion surfaces have **zero contextual body-links from the editorial layer**. The two that do (newsletter via embedded block, partners via /about) are the two that are also in the footer About column.
+
+The Pass, Awards, Submit, Itinerary, Concierge, Alerts: each is technically indexable, technically built, technically reachable from the homepage or footer if you know where to look, and none have any editorial-context body link that a reader (or Google) would follow naturally.
+
+---
+
+## 2. Funnel-by-funnel trace
+
+### 2.1 Pass subscription (priority 1)
+
+The product: three tiers (Reader free, Insider paid waitlist, Founders waitlist) at `/pass/`. Stripe checkout is wired in `next/src/lib/stripe.ts` with `successUrl=/account/pass/?welcome=1`, but the public page has fallback waitlist email-capture until the live Stripe price IDs are configured.
+
+**Funnel as it stands**:
+1. Organic visitor lands on `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` (the highest-clicks article, 3 clicks/week per `daily-log.md:594`).
+2. Reader scrolls to the foot of the article. Sees `NewsletterBlock` (subscribe to "Peninsula This Weekend").
+3. Reader does NOT see any reference to the Pass on the article page. Grep confirms: no `/pass/` href anywhere in `next/src/components/*` (only on the pass.astro page itself and in `account/pass.astro`).
+4. Reader navigates to the Footer "Colophon" column. Sees "The Pass" label, link goes to `/preview-insider-plans/`, a preview page (`v4-nav.ts:470`).
+5. Or reader uses Masthead. Pass is not present in the masthead nav (`nav.ts:34-43`) or the More dropdown (`nav.ts:55-66`).
+
+**Click-through rate from organic article → /pass/**: QUANTIFY ON GA4 AUTH. Without GA4 the funnel is unmeasurable, but the structural state is: the only path to /pass/ for an organic visitor is to type the URL or guess "preview-insider-plans" from a footer label.
+
+**Gaps**:
+- Footer label "The Pass" does not link to /pass/. Either the live page or the preview should win; this footer link is wrong.
+- Pass is missing from the masthead nav and More menu.
+- The article surface, where 90%+ of organic readers arrive, has zero Pass CTAs.
+- The "Why a Pass" pitch (`pass.astro:48-52`) is editorial gold but only visible to readers who already found the page.
+
+**Weakest funnel step**: step 3 (article → /pass/). There is no link.
+
+**Specific fix**:
+- File `next/src/components/PassCallout.astro` (new component): a single editorial paragraph that fits the article voice. Headline: "Reader-funded editorial. The Pass keeps this independent." Body: 2 sentences. CTA: a text link "Read about the Pass →" pointing to /pass/.
+- Mount in `next/src/pages/journal/[slug].astro` between the `<Content />` block (line 186) and the `<ClusterLinks>` block (line 190). Render conditionally: only on articles where `article.data.format === 'cellar-door-dispatch'` or `format === 'service'` to start (the editorial-leaning shapes), then expand. Avoid on weekend-picker dispatches (those have their own newsletter pitch).
+- Update `v4-nav.ts:470` to link `/pass/` not `/preview-insider-plans/`. Remove the preview reference.
+
+**Indexable conversion-surface SEO checklist for /pass/**:
+- Title: "The Peninsula Insider Pass" (line 28). Adequate but could include a value clause: "The Peninsula Insider Pass, reader-funded editorial for the Mornington Peninsula." 60 chars, fits.
+- Meta description: "The membership that funds the editorial. Free, paid, or founders, pick the tier that fits." (line 29). Includes em-dash; project rule violation. **Rewrite without em-dash**.
+- Canonical: yes (line 31).
+- JSON-LD schema: none. Add `Product` or `Service` schema with the three tiers as `Offer` entries (will help GSC parse the tier pricing once Stripe is live).
+- Voice fits the editorial. Don't change.
+
+**Editorial-voice conflict**: per the project memory `feedback_dispatch_cadence.md` and the advertising firewall rule, the Pass is reader-funded and should be promoted as the financial-independence lever. A small editorial CTA in articles is consistent with the labelled-not-absent advertising principle.
+
+### 2.2 Operator claim (priority 2)
+
+The product: `/partners/claim/` is auth-gated. An operator signs in via Supabase, claims their venue from the dropdown, editorial approves manually, then the operator can manage hours/photos via `/partners/dashboard/`.
+
+**Funnel as it stands**:
+1. A venue owner Googles their own venue, lands on `/eat/{their-venue}/` or `/wine/{their-venue}/`.
+2. The venue page (per `VenueDetailTemplate.astro`) has the editor note, hero image, address, hours.
+3. There is **no "Is this your venue? Claim it." CTA** on the venue page.
+4. Owner finds `/partners/index.astro:50-55` only if they navigate to /partners/. There is an "Already a Peninsula venue we cover?" banner that says "Open the operator dashboard". This is the only public discovery path for the claim flow.
+
+**Click-through rate from organic venue page → /partners/claim/**: QUANTIFY ON GA4 AUTH.
+
+**Weakest funnel step**: step 3. Owners don't know the claim system exists when they're on their own venue page.
+
+**Specific fix**:
+- Add a small, polite "Is this your venue?" link to `next/src/components/VenueDetailTemplate.astro` near the editor note. One line of text, not a button. Link to `/partners/claim/`.
+- Owner-flow page should also be linked from `/contact/` (currently `/contact/` lists email addresses only).
+- The `/partners/claim/` page is correctly noindex which is right: claim flow shouldn't compete with the venue page in search.
+
+**Indexable conversion-surface SEO**: claim page is correctly noindex. No SEO action.
+
+### 2.3 Concierge usage (priority 3)
+
+Two surfaces: the global drawer (`ConciergeDrawer.astro`, mounted in `BaseLayout.astro:234`) and the full-page `/ask/` page.
+
+**Drawer**: present on every page except `/ask/` itself. Bottom-right "Ask The Insider" pill, slide-in panel, conversational LLM with venue tile rail.
+
+**/ask/ page**: full-page version with hero, sample queries, persistent dialog. It is **Discovered, not indexed** in GSC (`url-inventory.md:257`), Google knows about it but hasn't crawled it.
+
+**Funnel as it stands**:
+1. Reader on any article sees the floating "Ask The Insider" pill bottom-right.
+2. Reader clicks → drawer opens with greeting + 6 sample queries (Cellar door lunch, Rainy day with kids, etc.).
+3. Reader types or clicks a chip → LLM returns 3 venue tiles + follow-on chips.
+4. Reader clicks a tile → lands on `/eat/{venue}/` or `/wine/{venue}/`.
+
+That's the engagement funnel. The conversion goal, what does Concierge convert to? Right now it's a soft surface that boosts time-on-site and venue-page views. There is no "Save these to my itinerary" CTA at the end of a Concierge response, and no "Sign up to save your chat history" prompt. So Concierge is currently a content-quality amplifier, not a conversion mechanism.
+
+**Indexable concierge landing page**: `/ask/` exists. Title: "Ask The Insider, Your Peninsula Concierge" (`ask.astro:13`). Meta: "Ask Peninsula Insider anything about the Mornington Peninsula. Cellar doors, dining, stays, rainy days, dog-friendly spots. Local knowledge, editorial taste." (line 14). The page is NOT in the inventory so probably not surfaced via sitemap to GSC; verify and submit.
+
+**Search opportunity for /ask/**:
+- Target queries: "ask mornington peninsula", "mornington peninsula ai guide", "mornington peninsula concierge", "where to go mornington peninsula" (broader). None currently in the impression list per `daily-log.md`. ASSUMPTION: low search volume in Australia for "ai concierge mornington peninsula"; the surface is more useful as a converter for visitors who arrive via journal.
+
+**Weakest funnel step**: step 4 (concierge response → venue → action). There's no way for a user to save what the concierge recommended without manually saving each venue card.
+
+**Specific fix**:
+- Add a "Save all to itinerary" button at the bottom of every Concierge response with at least 3 recommendations. File: `next/src/pages/ask.astro:243-291` (the renderTile function and surrounds).
+- Add a 1-line link in the drawer post-response: "Want a 2-day plan around these? → /itinerary/".
+- The /ask/ page should be linked from at least 5 articles. Pattern: at the foot of every "best X" listicle, append "Looking for something specific? Ask The Insider →".
+- For SEO: confirm /ask/ is in `sitemap.xml.ts` with priority 0.8. Currently it's listed in `url-inventory.md` as Discovered, so Google is aware but hasn't crawled. Per experiment 2026-05-05-01, James was asked to manually reindex /ask/.
+
+**Editorial-voice conflict**: the Concierge is the most "feature-software" surface on a publication that prides itself on editorial restraint. The pi-drawer pill should remain understated; the in-article CTA should be one line of text, not a banner.
+
+### 2.4 Awards engagement (priority 4)
+
+The product: 9 categories, August nominations, September voting, October results. `/awards/index.astro` defines `DEFAULT_CATEGORIES` (line 29-39) including "Restaurant of the Year", "Cellar Door of the Year", "Stay of the Year", "Walk of the Year", "Best New Opening", "Best Family Day", "Locals' Choice", "Worth-the-Drive", "Editorial Discovery".
+
+**Funnel as it stands**: there is no funnel. The Awards cluster is structurally orphaned (see `02-content-clusters.md` Section 2.12). It has no internal link from the editorial layer, no masthead nav slot, no footer entry. A reader cannot find Awards from anywhere on the site except by typing /awards.
+
+**Click-through rate**: zero observable, because there's no source page sending traffic.
+
+**Weakest funnel step**: every step from step 0. The Awards surface is unreachable.
+
+**Specific fix (highest single-action leverage on this priority list)**:
+- Add Awards to `mastheadMoreNav` in `next/src/lib/nav.ts:55-66`. Slot ordering: insert between "The Insider's 30" (line 57) and "Tours" (line 58). Label: "Awards 2026". Dek: "Editor selections + reader voting. The Peninsula at its best."
+- Add Awards to `v4FooterAbout` in `next/src/lib/v4-nav.ts:465-474`. Insert above "The Pass" entry.
+- Once nominations open in August, add a homepage rail (`index.astro` after the editor's letter section) promoting nominate-now.
+- Add an "Award won by this venue" badge to `VenueDetailTemplate` for venues that win categories (uses `data.authority.awards` per `VenueDetailTemplate.astro:26`). When a venue wins, the badge links back to /awards/{category}/.
+
+**Indexable conversion-surface SEO for /awards/**:
+- Title: "The Peninsula Insider Awards" (`awards/index.astro:43`). Adequate but lacks year. Recommend "The Peninsula Insider Awards 2026, Editorially Gated, Reader-Voted" (60 chars).
+- Meta: "An annual editorial moment combining editor selections and reader voting. The Peninsula at its best, named, ranked, and credited." Acceptable.
+- Canonical: yes (line 46).
+- JSON-LD schema: **add `Event` schema** for the cycle dates (August nominations open, September voting, October results). This helps Google show date pins in search. Each category page (`awards/[slug].astro`) can use `Event` or `Article` depending on whether voting is open.
+- The 9 category pages are individual indexable URLs; each should have its own JSON-LD `Event` or `WebPage` with `BreadcrumbList`.
+
+**ASSUMPTION**: Awards is currently pre-launch (the cycle starts August 2026). Pre-launch SEO is about earning crawls; promotion comes later. Worst case: lift the cluster into nav now, accept low search demand until August.
+
+### 2.5 Newsletter signup (priority 5)
+
+The product: weekly "Peninsula This Weekend" dispatch via Beehiiv. Endpoint: `https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsletter-subscribe` (`NewsletterBlock.astro:33`).
+
+**Funnel as it stands**:
+1. Organic visitor lands on a journal article.
+2. Reads to bottom. Sees `NewsletterBlock` (`next/src/components/NewsletterBlock.astro`, title "The briefing that arrives weekly").
+3. Reader enters email, hits Subscribe, lands on a thank-you state.
+
+This is the cleanest of the 6 funnels. NewsletterBlock is embedded at the foot of most pages including all journal articles, the homepage, every place hub via the hub templates, and the dedicated `/newsletter/` page (`newsletter.astro:22-40` has a hero with `SubscribeForm`).
+
+**Click-through rate from article → newsletter signup**: QUANTIFY ON GA4 AUTH (need Beehiiv subscriber attribution by source param; the form already sends `source` per `NewsletterBlock.astro:48`).
+
+**Weakest funnel step**: step 1. The masthead "Subscribe" link goes to `/#newsletter` (`Masthead.astro:58`) which is a homepage anchor, not the dedicated `/newsletter/` page that exists. The dedicated page has stronger conversion architecture (hero with social proof, "3,500 Peninsula readers", sample dispatch, four numbered promises). Masthead "Subscribe" should point to /newsletter/.
+
+**Specific fix**:
+- Edit `next/src/components/Masthead.astro:58`: change `href="/#newsletter"` to `href="/newsletter/"`.
+- Add `data-auth-anonymous` is currently set; verify this still works correctly after the URL change.
+
+**Indexable conversion-surface SEO for /newsletter/**:
+- Title: "The Insider's Dispatch · Subscribe, Peninsula Insider" (`newsletter.astro:13`). Strong.
+- Meta: "The weekly dispatch from the Mornington Peninsula. One pick, one weather-proof backup, one thing to skip. Written by editors who live on the Peninsula." (line 14). Strong.
+- Canonical: yes (line 16).
+- JSON-LD: missing. Add `WebPage` with `mainEntity: NewsArticle` listing recent issues (or `Newsletter` if the schema becomes available). At minimum add `Organization` with `email` for tips@/corrections@/hello@ contacts (already in `/contact/`).
+- og:image is set (line 17), strong.
+
+### 2.6 Partner enquiry (priority 6)
+
+The product: `/partners/` landing + `/partners/apply/` (operator submission) + `/partners/advertising-kit/` (rate card request) + `/partners/founders-prospectus/` (request-only).
+
+**Funnel as it stands**:
+1. A potential advertiser/operator is referred to /partners/ via the footer "Partner with us" link (`v4-nav.ts:469`) or from /about/ (link at `about.astro:146`).
+2. They land on `/partners/index.astro`. Read the pitch (modern newsroom, three rules, audience stats). See three tiers (Founders' Circle, Editorial Feature, Listing Surface).
+3. They click "Request the prospectus" or "Enquire" CTA at the foot. Form posts to ... (need to confirm the partner-apply form endpoint).
+
+**Click-through rate from organic → partners**: QUANTIFY ON GA4 AUTH. Likely tiny, partners is direct/referral discovery, not SEO-driven for a B2B funnel of this scale.
+
+**Weakest funnel step**: step 1. There is no link from the editorial layer. An operator who reads a venue page about a competitor doesn't see "Want similar coverage? Partner with us →".
+
+**Specific fix**:
+- Already partly fixed: `partners/index.astro:50-55` aside ("Already a Peninsula venue we cover?") points operators at `/partners/dashboard/` and `/partners/update/`.
+- Add a footer link from venue pages: a single line at the bottom of `VenueDetailTemplate` saying "Operator? Update your listing → /partners/update/".
+- Don't promote partners aggressively from articles. The editorial firewall says we don't push partner-acquisition mid-article.
+
+**Indexable conversion-surface SEO for /partners/**:
+- Title: "Partner with Peninsula Insider" (`partners/index.astro:12`). Strong.
+- Meta: "A modern newsroom for the Mornington Peninsula. We work with Peninsula businesses we admire. Local writing. Original photography. Disclosed by default." Strong.
+- Canonical: not set in the layout, verify `BaseLayout` defaults to current URL. Recommend explicit `canonical="https://peninsulainsider.com.au/partners/"`.
+- Schema: none. Add `Organization` schema with sameAs to Instagram, plus `Service` schema with the three tier offerings.
+- The "Founders' Prospectus" page is request-only by editorial decision; correct to not link publicly.
+
+---
+
+## 3. Cross-funnel structural issue: the editorial → commercial bridge
+
+The publication's structural problem is that its 172 articles (the demand engine) and its 9 conversion surfaces are separated by no body links. The **footer + masthead alone do not carry conversion weight**, readers convert on the page they're already on, when the CTA is contextually relevant.
+
+The fix pattern: build a small library of in-article CTA components (one per conversion surface) and mount them conditionally in `[slug].astro` based on article format/tags.
+
+| Article shape | Best mid-article CTA | Best end-of-article CTA |
+|---|---|---|
+| `format: cellar-door-dispatch` | (none) | "Reader-funded editorial · the Pass" |
+| `format: service` | (none) | NewsletterBlock + "Save these to your itinerary" |
+| `format: insider-edit` | (none) | NewsletterBlock + Awards-nominate (when open) |
+| `format: weekend-picker` | (none) | NewsletterBlock (specifically "Subscribe to next week's dispatch") |
+| Articles tagged `dogs` | (none) | "Got a dog-friendly spot? Tell us → /submit/" |
+| Articles tagged `peninsula-itinerary` or shape "weekend" | (none) | "Build this as your itinerary → /itinerary/" |
+
+Each CTA is a 1-2 line editorial paragraph plus a text link, not a banner. This is consistent with the labels-not-absence advertising principle and the editorial firewall.
+
+---
+
+## 4. Indexable conversion-surface SEO summary table
+
+| Surface | Title good? | Meta good? | Canonical set? | Schema present? | Recommendation |
+|---|---|---|---|---|---|
+| `/pass/` | Yes | Has em-dash (rule violation) | Yes | None | Rewrite meta without em-dash; add Service+Offer schema |
+| `/newsletter/` | Yes | Yes | Yes | None (og only) | Add WebPage + recent-issues NewsArticle |
+| `/ask/` | Yes | Yes | Default | None | Add WebPage + sameAs; verify in sitemap |
+| `/awards/` | Adequate (no year) | Yes | Yes | None | Add Event schema for cycle; promote year in title |
+| `/awards/{category}/` | Per category | Per category | Yes | None | Add Event or Award schema per category |
+| `/submit/` | Yes | Yes | Yes | None | Add HowTo or AcceptAction schema for the submission flow |
+| `/partners/` | Yes | Yes | Default (verify) | None | Add Organization + Service schema |
+| `/itinerary/` | Per file (verify) | Per file (verify) | Default | None | Tool-style page; add WebApplication schema |
+| `/account/*` | n/a | n/a | n/a | n/a | Correctly noindex |
+| `/partners/claim/` | n/a | n/a | n/a | n/a | Correctly noindex |
+| `/partners/dashboard/` | n/a | n/a | n/a | n/a | Correctly noindex |
+
+---
+
+## 5. Specific fixes (consolidated, file:line references)
+
+| # | Surface | File:line | Change | Expected impact |
+|---|---|---|---|---|
+| 1 | Pass | `next/src/lib/v4-nav.ts:470` | Change href from `/preview-insider-plans/` to `/pass/` | Footer Pass link points to live page |
+| 2 | Pass | `next/src/pages/pass.astro:29` | Remove em-dash from meta description; replace with comma | Project rule compliance + cleaner SERP snippet |
+| 3 | Pass | new component + `next/src/pages/journal/[slug].astro:188` | Mount `<PassCallout />` after `<Content />` for relevant article formats | Add the missing editorial → Pass body link path |
+| 4 | Pass | `next/src/pages/pass.astro` | Add `Service` + `Offer` JSON-LD with three tiers | Better SERP rendering once Stripe pricing live |
+| 5 | Newsletter | `next/src/components/Masthead.astro:58` | Change `href="/#newsletter"` to `href="/newsletter/"` | Sends top-bar Subscribe traffic to the higher-converting page |
+| 6 | Newsletter | `next/src/pages/newsletter.astro` | Add `WebPage` JSON-LD + recent-issues `NewsArticle` snippet | SERP enrichment |
+| 7 | Awards | `next/src/lib/nav.ts:55-66` | Insert "Awards 2026" entry into `mastheadMoreNav` between insiders-30 and tour | First nav surface for the cluster |
+| 8 | Awards | `next/src/lib/v4-nav.ts:465-474` | Insert Awards entry into `v4FooterAbout` above Pass | Footer presence |
+| 9 | Awards | `next/src/pages/awards/index.astro:43` | Update title to include "2026" | Year freshness signal in SERP |
+| 10 | Awards | `next/src/pages/awards/index.astro` | Add `Event` JSON-LD for cycle dates (Aug nominations, Sep voting, Oct results) | Date-pin SERP rendering |
+| 11 | Awards | `next/src/components/VenueDetailTemplate.astro` (where awards/hats render) | Award badge links to `/awards/{category}/` (not just static text) | Outbound link building venue → awards |
+| 12 | Submit | `next/src/pages/journal/[slug].astro` | Add conditional "Got a tip? → /submit/" CTA on articles tagged `local-secrets`, `community`, or specific town slugs | First inbound link path for /submit/ |
+| 13 | Concierge (Ask) | `next/src/pages/ask.astro:425-428` | Add "Save all to itinerary" + "Build a 2-day plan" CTA after concierge response | Conversion link out of the chat surface |
+| 14 | Concierge | `next/src/pages/journal/[slug].astro` end of `<Content />` block | "Looking for something specific? → Ask The Insider" 1-line link | First editorial → /ask/ link |
+| 15 | Operator | `next/src/components/VenueDetailTemplate.astro` (near editor note) | Small "Is this your venue? Claim it." link → /partners/claim/ | First venue → claim path |
+| 16 | Partner | `next/src/components/VenueDetailTemplate.astro` (footer) | "Operator? Update your listing → /partners/update/" link | Second venue → partner path |
+| 17 | Itinerary | `next/src/pages/journal/[slug].astro` | Conditional "Build this as your itinerary →" CTA on weekend-shape articles | First inbound link for /itinerary/ |
+| 18 | Itinerary | `next/src/pages/itinerary.astro` (verify SEO) | Confirm canonical, title, description; consider WebApplication schema | Index quality |
+| 19 | Address-string queries | known address pages (per `backlog.md:21`) | noindex or 410 these legacy directory pages | Reduces low-quality SERP impressions |
+
+---
+
+## 6. Editorial-voice conflicts to weigh
+
+The project memory `feedback_no_em_dashes.md` and the labels-not-absent advertising rule (`project_pi_advertising_pivot.md`) are the binding constraints. Each of the 19 fixes above can be implemented inside those rules. The two cases worth flagging:
+
+1. **Pass CTA on every article**: tempting to mount on every journal article. Risk: the page starts to feel like Substack. Recommendation: condition on `format` and skip on weekend-picker dispatches and short quick-notes. Audit the visual frequency on a fresh build.
+
+2. **Operator-claim CTA on every venue page**: the venue-page surface is where readers form an editorial impression of the venue. An aggressive "Claim this listing" pill at the top would feel directory-like. Recommendation: small text link near the editor note, not a banner. The aside at `partners/index.astro:50` shows the right tone.
+
+3. **Awards promotion before nominations open**: do not put a "Vote in the Awards →" CTA until August. Pre-launch promotion should be lift-into-nav only, not lift-into-articles.
+
+---
+
+## 7. What we cannot answer without GA4 (mark as QUANTIFY ON GA4 AUTH)
+
+- Pass-page conversion rate (visitor → waitlist signup).
+- Newsletter signup rate per article (which articles convert best to subscribers?).
+- Concierge engagement rate per article (does the drawer pill get clicked from articles?).
+- Operator-claim conversion rate (visitor → claim form started → claim submitted).
+- Partner-enquiry conversion rate (visitor → enquiry form filled).
+- Itinerary builder usage (saved items → itinerary built → printed/shared).
+- Bounce rate on `/pass/` itself (is the tier copy converting or losing readers at the price block?).
+
+GSC + sitemap audit gives us the indexation and reach picture. GA4 gives us the conversion picture. The next audit cycle should authenticate GA4 and re-run this section with numbers.
+
+---
+
+End of file.

--- a/ops/reports/seo/audit-2026-05/05-authority-trust.md
+++ b/ops/reports/seo/audit-2026-05/05-authority-trust.md
@@ -1,0 +1,297 @@
+# 05, Authority & trust audit (E-E-A-T) plus backlink-earning opportunities
+
+Date: 2026-05-08
+Author: Claude (audit-2026-05)
+Inputs: `next/src/pages/{about,contact,methodology,index,pass}.astro`, `next/src/pages/journal/[slug].astro`, `next/src/pages/eat/[slug].astro`, `next/src/pages/wine/[slug].astro` (uses VenueDetailTemplate), `next/src/pages/places/[slug].astro`, `next/src/pages/fishing/locations/[slug].astro`, `next/src/pages/awards/index.astro`, `next/src/components/VenueDetailTemplate.astro`, `next/src/components/PlaceDetailTemplate.astro`, `next/src/content/authors/editorial.json`, plus 5 sample article markdown files.
+
+The site has strong methodology positioning and a clear editorial voice ("honest, opinionated coverage"). What it lacks is **first-hand experience signals at scale** and **named-individual author depth**. The current author surface is one entity (`editorial.json`), not a team. Google's E-E-A-T model rewards named individuals with bios and credentials; "The Peninsula Insider" as a single house byline is structurally weaker than "Reviewed by Sarah Chen, food editor" with a bio link.
+
+The methodology page is exemplary content; the about page is solid; the venue templates have good freshness signals (`lastVerified`); the journal articles have decent metadata but lean entirely on house byline. There are no press citations, no awards-won badges, no association memberships, no team page beyond the colophon paragraph in /about/.
+
+Section 1 scores E-E-A-T per template. Section 2 is the about/contact/authors deep dive. Section 3 is 12 specific backlink-earning opportunities, each tied to an existing PI surface that supports the pitch.
+
+---
+
+## 1. E-E-A-T signal audit per template
+
+Scoring scale: 0 = absent, 1 = present but weak, 2 = solid, 3 = exemplary.
+
+| Template | Author byline | Bio depth | Last-updated visible | Source citations | First-hand signals | Trust badges | Contact info | Reviews/testimonials | **Mean** |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `/journal/[slug]` (article template) | 2 (visible "By The Peninsula Insider", `[slug].astro:148-149`) | 1 (`authors/editorial.json` is one paragraph, no named individuals) | 2 (publishedAt + lastVerified shown, line 137, 152) | 1 (markdown body cites Halliday, GFG ad-hoc; not structured) | 2 (specific weekend, named visit details in copy; no EXIF or photo bylines) | 0 (no won-awards, no press-mention badges) | 1 (footer link to /contact/) | 0 (no reader reviews displayed) | **1.1** |
+| `/eat/[slug]` (venue template) | 1 (no per-venue author; "Editor note" attribution implicit) | 0 | 2 (`verifiedFreshnessLabel` from `data.lastVerified`, `VenueDetailTemplate.astro:22`) | 1 (Halliday/GFG hats via `data.authority.hats`) | 2 (editor note implies visit; no photo proof) | 2 (hats + awards arrays via `data.authority`, lines 25-27; live in template) | 1 (footer link only) | 0 | **1.1** |
+| `/wine/[slug]` (winery template) | 1 (same as /eat/) | 0 | 2 (same `verifiedFreshnessLabel`) | 1 (Halliday rating if set) | 2 (editor note + winery sections imply visit) | 2 (hats + awards) | 1 | 0 | **1.1** |
+| `/places/[slug]` (place hub) | 0 (no author byline on place hubs) | 0 | 1 (only via venue/event freshness, not place-level) | 0 | 1 (place description implies local knowledge; no specific dated visit) | 0 | 1 | 0 | **0.4** |
+| `/fishing/locations/[slug]` | 1 (default editorial) | 0 | Unknown (verify whether template includes lastVerified) | 1 (size limits cited) | 2 (gear/tide notes implicate first-hand fishing) | 0 | 1 | 0 | **0.7** |
+| `/awards/` landing | 0 | 0 | 1 (cycle dates) | 0 | 1 (editorial selections imply expertise) | 0 (no past-winner badges visible because awards haven't run yet) | 1 | 0 | **0.4** |
+| `/pass/` landing | 1 (collective voice "we") | 0 | 0 (no published-date) | 0 | 1 ("the desk" framing) | 0 | 1 (footer) | 0 | **0.4** |
+| Homepage `/index` | 1 (collective) | 0 | 1 (issue label "Vol 04 · The May Issue · May 2026", `Masthead.astro:31`) | 1 (FAQ JSON-LD links to wineries by name) | 2 (cover story has byline; weekend dispatch is first-hand) | 0 | 1 | 0 | **0.8** |
+| `/about/` | 1 (collective) | 1 (mission + principles, but no individuals) | 0 | 0 | 1 ("eat on the Peninsula, walk the same coastline") | 0 | 2 (full mailto colophon) | 0 | **0.6** |
+| `/methodology/` | 1 (collective) | 0 | 0 | 1 (cites operator websites as sources for hours/contacts) | 1 (verification rolling cycle implies first-hand checking) | 0 | 1 | 0 | **0.5** |
+| `/contact/` | n/a | n/a | 0 | n/a | n/a | n/a | 3 (three named mailto routes) | n/a | **3.0 (single-axis)** |
+
+**Overall site E-E-A-T mean: 0.8** on a 0-3 scale. The strongest dimension across templates is "last-updated visible" (mean 1.1, mostly on venue/article); the weakest are bio depth (mean 0.1) and reviews/testimonials (mean 0.0).
+
+The pattern: signals that came for free from the structured content layer (lastVerified, authority.hats, authority.awards) score 2-3. Signals that require human curation (named bios, press mentions, won badges) score 0-1.
+
+---
+
+## 2. About / Contact / Authors / Methodology deep dive
+
+### 2.1 `/about/` (`next/src/pages/about.astro`)
+
+**Strengths**:
+- Clear mission and four named principles (lines 12-29). Strong editorial positioning.
+- "How it's built" section explains the structured-content architecture (line 119+). Differentiator vs WordPress directory competitors.
+- Three named contact emails in the colophon (line 161): hello@, corrections@, tips@.
+
+**Weaknesses**:
+- "Founders, Editors & Publishers: Peninsula Insider" (line 153) is the entire credit. No individual named.
+- "Editorial desk: The Peninsula Insider" (line 157) is the same circular reference.
+- No team photos, no LinkedIn links, no biographies of any individual journalist.
+
+**Specific additions**:
+- Add a "The Editors" section with at least one named founder and a 60-100 word bio. Whether the user wants editorial individuality is a project choice; if the answer is no (per `methodology.astro:12`'s "Voice is collective ('we')"), then the about page should explicitly say "we publish under the Peninsula Insider house byline by editorial choice" so readers and Google understand it's deliberate.
+- If there is a real editor, even one paragraph with "Founded by [name], [role], based in [town]" lifts E-E-A-T meaningfully.
+- Add a `Person` JSON-LD entity for the editor. Even with house-byline editorial, naming the legally responsible publisher is normal practice.
+
+### 2.2 `/contact/` (`next/src/pages/contact.astro`)
+
+**Strengths**:
+- Three clear mailto routes (tips, corrections, editorial enquiries) with editorial framing for each.
+- "What to expect" section sets honest expectations.
+- "We don't do phone calls, media kits, or press events. We do eat lunch, walk the coast..." reinforces the editorial voice (line 91-93).
+
+**Weaknesses**:
+- No physical address.
+- No phone number (deliberate, per page copy, but Google sometimes expects one).
+- No `ContactPage` JSON-LD schema.
+
+**Specific additions**:
+- Add `Organization` JSON-LD with `email` properties for the three contact routes and `@type: ContactPage` for this URL.
+- Optionally: a postal address. Even a P.O. Box adds a trust signal.
+- Add a "Response time" SLA in machine-readable form: "Tips acknowledged within 7 days; corrections within 24 hours." This is currently soft-stated.
+
+### 2.3 `/methodology/` (`next/src/pages/methodology.astro`)
+
+**Strengths**:
+- Four named coverage rules (lines 24-41). Clearer than 95% of regional publications.
+- Four-step verification cadence (lines 43-60).
+- Explicit disclosure rules including the "we don't take undisclosed comps" line (line 76-78), strong trust signal.
+- Six "what we refuse to do" lines (lines 81-88), exceptional editorial positioning.
+
+**Weaknesses**:
+- Voice is collective by deliberate choice (line 12 comment). This is fine editorially but limits the page's ability to attribute claims to people.
+- "Last verified" date concept is mentioned (line 50) but not present on this page itself.
+- No JSON-LD schema.
+
+**Specific additions**:
+- Add `WebPage` JSON-LD with `mainEntity: NewsMediaOrganization` describing PI's editorial standards.
+- Add a `lastReviewed` date for the methodology itself (when was this page last edited by the editor?).
+- Optionally link to the IFCN, MEAA Code of Ethics, or AANA guidelines that PI follows. Linking to a recognised standard signals to Google that the publication follows external trust frameworks.
+
+### 2.4 `/authors/` content (`next/src/content/authors/editorial.json`)
+
+**Current state**: one author entity ("The Peninsula Insider"), one paragraph bio, no role, no socials, no published-list of articles.
+
+```json
+{
+  "slug": "editorial",
+  "name": "The Peninsula Insider",
+  "role": "editor",
+  "bio": "The Peninsula Insider is an independent editorial guide to the Mornington Peninsula  -  written by people who live here and eat here, for anyone who wants to experience the peninsula the way insiders do. Every recommendation is earned: visited, eaten, drunk, walked. We write what we find.",
+  "publishedAt": "2024-01-01"
+}
+```
+
+The bio also contains an em-dash (project rule violation). Replace with comma.
+
+**Specific additions**:
+- Even if the project keeps house byline, add 2-3 more author entries with named contributing editors (food, wine, walks, family) and small bios. Each entry can still represent multiple humans behind a desk.
+- Build an `/authors/{slug}/` page template that lists all articles by that author plus the bio. This becomes a `Person` schema target with `worksFor: NewsMediaOrganization`.
+- Each article should reference at least the desk-level author (food / wine / etc.) even if the by-line on the article remains "The Peninsula Insider".
+
+### 2.5 Verification freshness signals (good already)
+
+Articles include `lastVerified` (per article markdown frontmatter) and surface it as "Facts verified [date]" via `[slug].astro:151-153`. Venue pages render `verifiedFreshnessLabel` via `VenueDetailTemplate.astro:22`. This is solid practice and matches Google's freshness signal expectations.
+
+**Gap**: place hubs (`/places/[slug]`) do not show a freshness date. Per `places/[slug].astro:1-100`, the place data is loaded but there's no equivalent of `verifiedFreshnessLabel` rendered. Add one.
+
+### 2.6 Authority badges (good schema, no rendering)
+
+`VenueDetailTemplate.astro:25-27` reads `data.authority.hats`, `data.authority.awards`, `data.authority.pressMentions`. The schema is in place. **Verify the template actually renders these prominently.** A "Two hats GFG 2025" or "Featured in The Age, Mar 2026" badge on a venue page is exactly the kind of E-E-A-T signal that lifts both the venue's ranking and PI's trust by association.
+
+**Specific addition**: render `pressMentions` as a small block on each venue page: "As featured in: The Age, Broadsheet, Halliday Wine Companion." Each press mention is an outbound link to the citation source. The block doubles as an inbound-link target if a venue's PR team picks it up.
+
+---
+
+## 3. Content & technical E-E-A-T fixes
+
+| # | Fix | File | Cost | E-E-A-T axis |
+|---|---|---|---|---|
+| 1 | Replace em-dash in `editorial.json` bio | `next/src/content/authors/editorial.json:5` | Trivial | Project rule + clean SERP |
+| 2 | Add at least one named editor entry | `next/src/content/authors/` (new files) | Small (editorial decision needed) | Authoritativeness |
+| 3 | Add `Person` JSON-LD on each article when author resolves to a person (not house byline) | `next/src/pages/journal/[slug].astro` JSON-LD block (line 75-99) | Small | E-E-A-T |
+| 4 | Render `pressMentions` block on `/eat/{venue}/` and `/wine/{venue}/` | `next/src/components/VenueDetailTemplate.astro` (around lines 27-30 area) | Medium | Trustworthiness via citation |
+| 5 | Render won-awards badge from `data.authority.awards` linking to `/awards/{category}/` | `VenueDetailTemplate.astro` | Medium | Trust + internal link to awards cluster |
+| 6 | Add "Last verified [date]" to `/places/{slug}` | `next/src/components/PlaceDetailTemplate.astro` | Small | Freshness |
+| 7 | Add `Organization` + `ContactPage` JSON-LD on `/contact/` | `next/src/pages/contact.astro` | Small | Trust |
+| 8 | Add `lastReviewed` semantic date on `/methodology/` | `next/src/pages/methodology.astro` | Small | Freshness for editorial standards |
+| 9 | Add `Person` (or `Organization`) JSON-LD on `/about/` for the publisher | `next/src/pages/about.astro` | Small | Authoritativeness |
+| 10 | Cite primary sources inline in articles when stating facts (council site for beach rules, BOM for weather, GFG for hats, ABS for stats). Use linked footnote pattern. | Article markdown files | Large (editorial pass over 172 articles) | Trustworthiness |
+
+---
+
+## 4. Backlink-earning opportunities
+
+The orchestrator brief flags that competitive-benchmark agent is handling broad backlink prospecting. This list is specifically about **PR/press hooks PI has right now** plus citation-bait ideas grounded in PI's existing assets. 12 items, each with a target site, hook, effort, and the supporting PI surface.
+
+### A. PR / press hooks (high confidence)
+
+**1. The 2026 Mornington Peninsula GFG hatted-restaurant tally (annual data)**
+- Target: The Age, Good Food, Time Out Melbourne, Broadsheet Melbourne.
+- Hook: "Mornington Peninsula maintained X hatted restaurants in the 2026 GFG. Here's what the desk thinks." Use as a press-pitch piece every November when the new GFG drops.
+- Effort: small (1 day annual update of `/journal/hatted-restaurants-mornington-peninsula-2025/`, currently Discovered).
+- Supporting PI page: `/journal/hatted-restaurants-mornington-peninsula-2025/` (refresh to 2026). Each hatted venue is already a venue page on PI.
+
+**2. The Mornington Cup 2026 local-pick predictions (seasonal hook, was timely)**
+- Target: Herald Sun racing, the Age, ABC Mornington Peninsula.
+- Hook: was timely Apr 2026; for 2027 plan to publish 7-10 days before race day with editorial picks for the day (where to lunch, where to drink, what to wear, weather forecast).
+- Effort: small (annual recurring piece).
+- Supporting PI page: `/whats-on/mornington-cup-2026` and `/places/mornington/`.
+
+**3. "Best Dog Beaches Mornington Peninsula 2026" (citation-bait list)**
+- Target: pet news sites, Australian Dog Lover, regional weekly papers.
+- Hook: PI is already top 3 on Google for "dog friendly guide mornington peninsula" with no clicks (snippet failure now being fixed). The data + the editorial standing make this a press-pitch piece each spring.
+- Effort: small (already have `/journal/dog-friendly-beaches-mornington-peninsula/`; update for spring 2026).
+- Supporting PI page: same.
+
+**4. Sorrento Writers Festival 2026 preview + post-event coverage**
+- Target: Books+Publishing, the Sydney Review of Books, Australian Book Review, Sorrento Foundation press.
+- Hook: PI's editorial voice + festival venue context. Pre-event preview piece + post-event report.
+- Effort: medium (two articles + attendance).
+- Supporting PI page: `/whats-on/sorrento-writers-festival-2026/`, `/places/sorrento/`, `/journal/the-sorrento-weekend/`.
+
+### B. Partnership opportunities (mid-confidence, requires outreach)
+
+**5. Mornington Peninsula Shire Council**
+- Target: `mornpen.vic.gov.au`. Council runs `whatsonmorningtonpeninsula.com.au`.
+- Hook: PI has 84 indexed event pages with editorial context the council site doesn't carry. Pitch: a reciprocal arrangement where council's events page links to PI's editorial picks for the season, PI links to council's event details for booking.
+- Effort: medium (outreach + relationship-building).
+- Supporting PI surface: every `/whats-on/{event}/` page.
+
+**6. Visit Mornington Peninsula (Mornington Peninsula Tourism)**
+- Target: `visitmorningtonpeninsula.org`.
+- Hook: PI has 134 venue pages and 172 editorial articles. Pitch: PI's editorial picks become a "Local's Picks" section on Visit Mornington Peninsula's site (link back to PI's venue pages). PI's existing `/places/{town}/` hubs are already structured to be the editorial counterpart to VMP's tourism hubs.
+- Effort: large.
+- Supporting PI surface: `/places/{20 towns}/`, `/eat/best-restaurants/`, `/wine/best-cellar-doors/`.
+
+**7. Mornington Peninsula Wine Industry Association**
+- Target: `mpva.com.au` (Mornington Peninsula Vignerons Association).
+- Hook: PI's `/journal/the-chardonnay-case/` (top-of-page-1 ranker) frames the regional argument the MPVA already makes. Pitch: MPVA links to PI's editorial pieces from their cellar-door directory; PI links member wineries from `/wine/best-cellar-doors/`.
+- Effort: medium.
+- Supporting PI surface: `/wine/best-cellar-doors/`, `/journal/the-chardonnay-case/`, `/journal/the-cellar-door-short-list/`, every `/wine/{venue}/` page.
+
+**8. Halliday Wine Companion, annual recognition coverage**
+- Target: `winecompanion.com.au`.
+- Hook: every November Halliday publishes the new year's ratings. PI publishes the Mornington Peninsula winners-by-rating piece + interviews. Halliday occasionally cites editorial coverage.
+- Effort: small (annual recurring).
+- Supporting PI surface: every winery page that displays Halliday rating data via `data.authority.halliday`.
+
+### C. Local-business reciprocal (high confidence, low cost)
+
+**9. "Featured by Peninsula Insider" badge program**
+- Target: every venue PI features.
+- Hook: provide each operator with a small SVG badge ("Featured by Peninsula Insider, [year]") for their website footer or about page. Each badge links back to their PI venue page. Operators love trust badges; PI gets a clean network of inbound links from the venues' own websites.
+- Effort: small (build a `/badge/{slug}/` endpoint that returns the SVG; email 134 operators).
+- Supporting PI surface: every venue page.
+
+**10. Operator-claim reciprocal**
+- Target: the operator who claims their `/partners/dashboard/` listing.
+- Hook: the operator dashboard already exists (`/partners/dashboard/`). When an operator claims their venue, the editor's verification email asks one favour: a link from the operator's website to the PI venue page. Many will do it.
+- Effort: tiny (add the line to the verification email template).
+- Supporting PI surface: `/partners/claim/`.
+
+### D. Citation-bait, original data PI could publish
+
+**11. The Peninsula Insider Cellar-Door Price Index**
+- Target: anyone writing about regional wine.
+- Hook: PI has structured `priceBand` data on every winery page. Aggregate into "Average tasting fee by sub-region (Red Hill / Main Ridge / Balnarring / Merricks / Flinders)" + year-on-year change. Publish as a single data piece + downloadable spreadsheet. Wine writers cite original data.
+- Effort: medium (one-time data pull + visualisation).
+- Supporting PI surface: every `/wine/{venue}/` page (data already structured); `/wine/best-cellar-doors/` becomes the link target.
+
+**12. The Peninsula Insider Dog-Friendly Beach Map (data + chart)**
+- Target: pet sites, regional press, council comms.
+- Hook: PI has structured beach data (off-leash hours, seasonal rules) across `/explore/{beach}/` pages. Publish a single canonical "all dog-friendly beaches with seasonal access rules" map + table. Council and pet sites have no equivalent canonical resource.
+- Effort: medium.
+- Supporting PI surface: `/journal/dog-friendly-beaches-mornington-peninsula/`, every `/explore/{beach}/` page, every `/places/{coastal town}/` hub.
+
+**13. The 2026 Mornington Peninsula Hatted-Restaurants Map (citation graphic)**
+- Target: food press as below.
+- Hook: a single visual showing all GFG-hatted restaurants on a Peninsula map with hat counts. Embeddable iframe + PNG download.
+- Effort: medium.
+- Supporting PI surface: `/journal/hatted-restaurants-mornington-peninsula-2025/`, every hatted venue page (data via `data.authority.hats`).
+
+### E. Press-list seeding (general, ongoing)
+
+**14. Quarterly press release: "What's open / what's closed on the Mornington Peninsula this season"**
+- Target: ABC Mornington Peninsula, Mornington Peninsula News, Bayside News, Frankston Times, regional radio.
+- Hook: PI's verification cadence (`methodology.astro:43-60`) means PI knows what's opened and closed every quarter. Distil into a one-page press release with embargo, send to local press list. Each quarter.
+- Effort: small (editorial standardises the format; quarterly recurring).
+- Supporting PI surface: the venue corpus (uses `data.lastVerified` + `data.status === 'closed'` flags).
+
+**15. Awards 2026 announcement (October)**
+- Target: regional press list, plus food/wine/travel press.
+- Hook: PI's annual editorially-gated awards. Press release the day results publish, including each winning venue's contact (so press can cover specific wins). Each winning operator typically issues their own release citing PI as source.
+- Effort: medium (October 2026; depends on the awards cycle running).
+- Supporting PI surface: `/awards/{category}/` for each of 9 categories.
+
+---
+
+## 5. Backlink prospecting summary table
+
+| # | Target | Hook | Effort | PI surface |
+|---:|---|---|---|---|
+| 1 | The Age, Good Food, Time Out, Broadsheet | Annual GFG hatted tally + commentary | S | `/journal/hatted-restaurants-mornington-peninsula-2025/` |
+| 2 | Herald Sun, ABC, Age | Mornington Cup local-pick guide | S (annual) | `/whats-on/mornington-cup-2027`, `/places/mornington/` |
+| 3 | Australian Dog Lover, regional weeklies | Best dog beaches list (canonical resource) | S | `/journal/dog-friendly-beaches-mornington-peninsula/` |
+| 4 | Books+Publishing, ABR | Sorrento Writers Festival preview/coverage | M | `/whats-on/sorrento-writers-festival-2026/`, `/places/sorrento/` |
+| 5 | Mornington Peninsula Shire Council | Reciprocal events linking | M | every `/whats-on/{event}/` page |
+| 6 | Visit Mornington Peninsula | Local's picks reciprocal | L | `/places/{20 towns}/`, every venue page |
+| 7 | Mornington Peninsula Vignerons Association | Mutual cellar-door directory linking | M | `/wine/best-cellar-doors/`, `/journal/the-chardonnay-case/` |
+| 8 | Halliday Wine Companion | Annual ratings coverage cycle | S (annual) | every `/wine/{venue}/` page |
+| 9 | All featured operators | "Featured by PI" badge network | S | every venue page |
+| 10 | Newly-claimed operators | Verification-email reciprocal-link request | tiny | `/partners/claim/` |
+| 11 | Wine writers, regional press | PI Cellar-Door Price Index (citable original data) | M | `/wine/best-cellar-doors/` |
+| 12 | Pet sites, council comms | Dog-friendly beach map (citable resource) | M | `/journal/dog-friendly-beaches-mornington-peninsula/` |
+| 13 | Food press | Hatted restaurants map (citation graphic) | M | `/journal/hatted-restaurants-mornington-peninsula-2025/` |
+| 14 | Local press list | Quarterly "what's open / what's closed" release | S (quarterly) | venue corpus |
+| 15 | Press list + winners | Awards 2026 announcement | M (October) | `/awards/{category}/` |
+
+S = small (≤1 day), M = medium (2-5 days), L = large (>1 week).
+
+---
+
+## 6. Priority recommendation
+
+If only three items can be picked up this month:
+
+1. **Fix the em-dash + add named editor + `Person` JSON-LD** (E-E-A-T fix #1, #2, #3 above). One-day editorial decision and one-day implementation. Material lift to the two weakest E-E-A-T axes (bio depth and authoritativeness).
+
+2. **Render `pressMentions` and won-awards badges on venue templates** (E-E-A-T fix #4, #5). The data is already structured. The visible block is missing. Two days of template work; immediately raises trustworthiness signals on every venue page.
+
+3. **Build the Featured-by-PI badge program** (backlink #9). Self-serve badge endpoint + outreach email to 134 operators. Two days of build, one week of outreach. Cleanest path to a sustainable inbound-link layer that doesn't depend on press cycles.
+
+The PR/press hooks (items 1, 2, 4, 14, 15) need editorial calendar coordination; not urgent for May.
+
+---
+
+## 7. Open questions
+
+- Is there an editorial choice to keep house byline indefinitely? If so, document it explicitly on `/about/` and `/methodology/` so readers and Google understand it's deliberate. ASSUMPTION: the project is currently a small editorial operation and house-byline is appropriate for now.
+- Are `data.authority.pressMentions` and `data.authority.awards` populated on actual venue records? Schema exists; verify data presence by sampling a few venue files.
+- Does `BaseLayout` already emit `Organization` JSON-LD globally? If so, the per-page additions in Section 3 are partial; if not, the Organization schema should also live in BaseLayout.
+
+---
+
+End of file.

--- a/ops/reports/seo/audit-2026-05/06-opportunity-matrix.md
+++ b/ops/reports/seo/audit-2026-05/06-opportunity-matrix.md
@@ -1,0 +1,88 @@
+# 06, Opportunity matrix
+
+Date: 2026-05-08
+Scope: every actionable opportunity surfaced by sections 01 through 05 of this audit, scored and ranked. Items already shipped (the four active experiments from 2026-05-04 and 2026-05-05) are excluded; items already in `backlog.md` are included so the matrix is the single ranked view.
+
+## Scoring scale
+
+Each opportunity is scored on five dimensions, 1 to 5.
+
+| Axis | 1 | 5 |
+|---|---|---|
+| **Impact** | Marginal traffic or conversion lift | Step-change in indexed pages, clicks, or conversion |
+| **Effort** | Multi-week build, requires coordination | Under one hour, single file edit |
+| **Speed** | Measurable beyond 90 days | Measurable inside 14 days |
+| **Commercial** | Pure traffic, no direct revenue lever | Direct revenue lever (Pass / Operator / Partner) |
+| **Confidence** | Speculative; needs an experiment to learn | Strong evidence in this audit or prior experiments |
+
+**Composite score** = (Impact × 2) + Effort + Speed + Commercial + Confidence. Impact double-weighted because we still pull on a small base. Higher is better. Items tied on composite are sub-ranked by Confidence then Effort.
+
+## The matrix
+
+Sorted high-to-low. Source column maps each item back to the audit section that surfaced it.
+
+| # | Opportunity | Impact | Effort | Speed | Commercial | Confidence | Score | Source | File:line / artefact |
+|---:|---|---:|---:|---:|---:|---:|---:|---|---|
+| 1 | Render `pressMentions` and won-awards from `data.authority` on `VenueDetailTemplate`. Data is structured, render is missing. Lifts E-E-A-T trust signals across 134 venue pages in one PR. | 5 | 4 | 4 | 3 | 5 | **26** | 05 | `next/src/components/VenueDetailTemplate.astro` (lines ~25-30) |
+| 2 | Fix the `v4FooterAbout` Pass link from `/preview-insider-plans/` to `/pass/`. Plus a one-line edit in masthead `Subscribe` href to point at `/newsletter/` instead of `/#newsletter`. Two trivial edits, structural orphans become reachable. | 5 | 5 | 5 | 5 | 5 | **30** | 04 | `next/src/lib/v4-nav.ts:470`, `next/src/components/Masthead.astro:58` |
+| 3 | Add Awards to masthead More menu and Footer About column. The cluster is structurally orphaned: zero internal links from any indexable surface. | 5 | 5 | 4 | 4 | 5 | **28** | 02 §7, 04 §2.4 | `next/src/lib/nav.ts:55-66`, `next/src/lib/v4-nav.ts:465-474` |
+| 4 | Replicate experiment 2026-05-05-02 (related-articles seeding, limit 3→6, explicit refs) on the `/explore/` walks template. 32 unindexed walk pages match the same pattern that just unblocked 15 journal pages. | 5 | 4 | 4 | 2 | 5 | **25** | 02 §2.5, §6 | `next/src/pages/explore/[slug].astro`, walks article markdowns |
+| 5 | Convert journal article + place + venue hero from CSS `background-image` to `<img>` element. Single highest-leverage technical-SEO fix; unblocks Google Images, image-search ranking, Discover eligibility on 200+ pages. | 5 | 3 | 3 | 2 | 5 | **23** | 01 §5 | `next/src/lib/editorial.ts:360-365`, `next/src/pages/journal/[slug].astro:165`, `next/src/components/VenueDetailTemplate.astro`, `next/src/components/PlaceDetailTemplate.astro` |
+| 6 | Add `Product` + `Offer` JSON-LD to `/pass/` (three tiers: Reader, Insider, Founders). Currently zero rich-result eligibility on the commercial conversion surface. | 4 | 4 | 3 | 5 | 5 | **25** | 01 §2, 04 §2.1 | `next/src/pages/pass.astro` |
+| 7 | Mount a `PassCallout` component in `journal/[slug].astro` between `<Content />` and `<ClusterLinks>`. First editorial-to-Pass body link path. Conditional render on relevant article formats. | 4 | 4 | 3 | 5 | 4 | **23** | 04 §2.1, §3 | new component, `next/src/pages/journal/[slug].astro:188` |
+| 8 | Render `v4FooterNiche` (already defined) in `Footer.astro`. Adds a global "Special interests" column linking golf, spa, fishing, boating, dog-friendly, weddings, corporate-events. Free crawl signal to the niche lanes. | 4 | 5 | 4 | 2 | 5 | **23** | 01 §4 | `next/src/lib/v4-nav.ts:455-463` (defined), `next/src/components/Footer.astro:34-65` (render missing) |
+| 9 | Migrate `dog-friendly-mornington-peninsula.astro` (hand-coded) into the article collection. Currently has hardcoded no-slash canonical, generic OG image, 17 em-dashes, schema/canonical mismatch. The site's #1 query magnet is structurally weakest of all journal pages. | 4 | 3 | 3 | 2 | 5 | **20** | 01 §2, §0 | delete `pages/journal/dog-friendly-mornington-peninsula.astro`; create `content/articles/dog-friendly-mornington-peninsula.md` |
+| 10 | Add `ItemList` to `/wine/best-cellar-doors/` (Eat best-restaurants peer already has it). Plus `CollectionPage` + `ItemList` on `/wine/`, `/journal/`, `/whats-on/` hubs (Eat and Places already have them). | 4 | 4 | 3 | 3 | 5 | **23** | 01 §2 | `next/src/pages/wine/best-cellar-doors.astro`, three index files |
+| 11 | Add `psi-pull.mjs` to the daily SEO script suite, weekly cron, against 7 representative URLs, with CrUX project enabled. Without this every monthly audit hits the 429 quota wall. | 3 | 3 | 2 | 1 | 5 | **17** | 01 §1 | new `ops/scripts/seo/psi-pull.mjs` |
+| 12 | Add a small "Is this your venue? Claim it." link to `VenueDetailTemplate.astro` near the editor note. First venue-page → operator-claim path. Polite text link, not a banner. | 4 | 5 | 4 | 5 | 4 | **26** | 04 §2.2 | `next/src/components/VenueDetailTemplate.astro` |
+| 13 | Build the Featured-by-PI badge program. Self-serve `/badge/{slug}/` endpoint returning an SVG; email outreach to 134 operators. Cleanest sustainable inbound-link layer. | 5 | 2 | 2 | 4 | 4 | **22** | 05 §4 | new endpoint, manual outreach |
+| 14 | "Stays Near Peninsula Hot Springs" article. Targets "accommodation near peninsula hot springs" (19 impr/wk, position 67.8). Closest existing page is unindexed. High-impression query with no targeted page. | 4 | 3 | 3 | 4 | 4 | **22** | 02 §4 #1 | new `next/src/content/articles/stays-near-peninsula-hot-springs.md` |
+| 15 | Rewrite `/eat/best-restaurants/` for 2026 freshness, FAQ schema, more depth, beat Broadsheet's Dec 2025 update. Currently page-5 ranking on a primary commercial query. | 4 | 3 | 2 | 4 | 4 | **21** | 02 §4 #5, 03 §5 | `next/src/pages/eat/best-restaurants.astro`, supporting article |
+| 16 | Snippet rewrite on `/journal/the-chardonnay-case/`. 71+55 combined impr at position 5.6, 0% CTR. Top-of-page-1 with zero clicks is a textbook snippet failure. | 3 | 5 | 5 | 2 | 5 | **23** | backlog | `next/src/content/articles/the-chardonnay-case.mdx` |
+| 17 | Snippet rewrite on `/journal/the-pub-guide/`. 65 impr, 0% CTR, position 8.8. Same pattern as chardonnay-case but lower volume. | 3 | 5 | 5 | 2 | 5 | **23** | backlog | `next/src/content/articles/the-pub-guide.md` |
+| 18 | Fix `WebSite.SearchAction` target from `/journal?q=` (which doesn't render results) to `/search/?q={search_term_string}`. Sitelinks search box behaviour when Google awards one. | 3 | 5 | 4 | 1 | 5 | **21** | 01 §2 | `next/src/pages/index.astro:79-80` |
+| 19 | De-duplicate the journal sitemap entry for `free-things-to-do-mornington-peninsula`. Already in backlog. | 2 | 5 | 5 | 1 | 5 | **20** | 01 §6, backlog | `next/src/pages/sitemap.xml.ts` |
+| 20 | Add `image` field to Restaurant/Cafe/Winery JSON-LD on `/eat/[slug]/`. Currently no image at all in venue schema. | 3 | 5 | 4 | 2 | 5 | **22** | 01 §2 | `next/src/pages/eat/[slug].astro:88-107` |
+| 21 | Add `image` field to TouristDestination JSON-LD on `/places/[slug]/`. | 3 | 5 | 4 | 2 | 5 | **22** | 01 §2 | `next/src/pages/places/[slug].astro:297-308` |
+| 22 | Compute `lastmod` from real publish/update dates on hub pages instead of `TODAY` default. Hub URLs aren't actually changing daily; the signal is mildly noisy. | 2 | 4 | 3 | 1 | 5 | **17** | 01 §6, §8 #20 | `next/src/pages/sitemap.xml.ts:6` |
+| 23 | "Build this as your itinerary →" CTA on weekend-shape and escape-shape articles. First inbound link path for `/itinerary/`. | 3 | 4 | 3 | 4 | 3 | **20** | 04 §3 | `next/src/pages/journal/[slug].astro` |
+| 24 | "Looking for something specific? Ask The Insider →" 1-line link at end of `<Content />` block. First editorial → /ask/ link. | 3 | 5 | 3 | 3 | 3 | **20** | 04 §2.3 | `next/src/pages/journal/[slug].astro` |
+| 25 | Internal-linking sweep, 20 specific source-page → target-page pairs (the second pass after experiment 2026-05-05-02). Pushes equity into 20 specific Discovered URLs not yet covered. | 4 | 3 | 3 | 1 | 5 | **19** | 02 §6 | 20 article markdown files |
+| 26 | "Best Walks Mornington Peninsula" graded walks hub modelled on Australian Traveller's structure. PI's `/explore/` does not yet have a definitive walks hub; AllTrails owns trail-data, but editorial ranking is contestable. | 4 | 2 | 2 | 2 | 4 | **18** | 03 §5 #6, 02 §4 #11 | new spine article, plus refresh of 32 unindexed walk pages |
+| 27 | Refresh `/journal/mornington-peninsula-itinerary/` to be the canonical itinerary spine. Consolidate `mornington-peninsula-day-trip` and `the-four-hour-peninsula` into 301-redirects to it. | 3 | 3 | 3 | 2 | 4 | **18** | 02 §5 | three article markdowns |
+| 28 | Single 2,500-word `/escape/day-trip-mornington-peninsula/` editorial day plan. Targets "mornington peninsula day trip" (the most contestable of the 8 priority queries). | 4 | 2 | 2 | 3 | 4 | **19** | 03 §5 #3 | new escape page |
+| 29 | "Save all to itinerary" + "Build a 2-day plan" CTA after concierge response. Conversion link out of the chat surface. | 3 | 4 | 3 | 4 | 3 | **20** | 04 §2.3 | `next/src/pages/ask.astro:425-428` |
+| 30 | `Person` JSON-LD on `/about/` for the publisher. Plus `Organization` + `ContactPage` on `/contact/`. Plus `lastReviewed` on `/methodology/`. Three small E-E-A-T schema additions. | 3 | 4 | 3 | 1 | 4 | **18** | 05 §3 | `pages/about.astro`, `pages/contact.astro`, `pages/methodology.astro` |
+| 31 | Generate 800w + 1600w renditions of editorial hero images. Mean hero is ~280KB; 2-rendition `<picture>` source set halves mobile transfer. | 4 | 2 | 2 | 1 | 4 | **17** | 01 §5, §8 #14 | new build script + template updates |
+| 32 | Add a "Special interests" `WebVitalsReporter.astro` (75 lines of `web-vitals` JS) reporting LCP/INP/CLS to Supabase. Site is below CrUX threshold; this is the bridge until traffic crosses it. | 2 | 3 | 2 | 1 | 4 | **14** | 01 §1, §8 #19 | new component + Supabase RPC |
+| 33 | Quarterly "What's open / what's closed on the Peninsula this season" press release. PI's verification cadence already produces the data; standardise into a press format and seed local press list. | 4 | 4 | 2 | 3 | 3 | **20** | 05 §4 #14 | editorial calendar + press list |
+| 34 | "Cellar-Door Price Index" (data piece). Aggregate `priceBand` data across all winery pages into a single canonical resource + downloadable spreadsheet. Citation-bait for wine writers. | 4 | 2 | 2 | 2 | 3 | **17** | 05 §4 #11 | new article + data export |
+| 35 | "Best Dog Beaches Map" (data + chart). Aggregate beach data into a single canonical visual + table. Pet sites and council have no equivalent. | 4 | 2 | 2 | 2 | 3 | **17** | 05 §4 #12 | new article + chart |
+| 36 | Add at least one named editor entry to `next/src/content/authors/`. Optional: keep house byline editorially but acknowledge a real editor. Lifts the weakest E-E-A-T axis (bio depth, currently 0.1/3.0). | 3 | 3 | 3 | 1 | 3 | **16** | 05 §1, §2.4 | new author file + about update |
+| 37 | Add `lastVerified` rendering to `PlaceDetailTemplate.astro` (parity with VenueDetailTemplate). Place hubs currently show no freshness date. | 2 | 5 | 3 | 1 | 5 | **18** | 05 §2.5 | `next/src/components/PlaceDetailTemplate.astro` |
+| 38 | Replace `Organization.logo` with a real square logo (≥112×112px). Currently a hero photograph. Required for News rich result eligibility eventually. | 2 | 3 | 1 | 1 | 4 | **13** | 01 §2, §8 #15 | new `/public/images/logo.png`, `BaseLayout.astro:136`, `schema.ts:5` |
+| 39 | Lazy-mount lower category sections on `/whats-on/`. Hub renders 90+ event cards inline (460KB HTML). | 3 | 3 | 2 | 1 | 3 | **14** | 01 §1 | `next/src/pages/whats-on/index.astro:560-600` |
+| 40 | Audit + investigate the address-string queries (4 of top 10 by impressions). Likely legacy directory pages still indexed. Either noindex or 410. | 3 | 3 | 4 | 1 | 4 | **17** | backlog, 02 §5 | TBD by investigation |
+| 41 | Build `/whats-on/this-weekend/` permanent page that auto-rebuilds weekly from the dispatch. Targets "mornington peninsula weekend" (a query Google reads as event-intent). | 4 | 2 | 2 | 2 | 3 | **17** | 03 §5 #5 | new astro page + dispatch integration |
+| 42 | Submit `sitemap.xml` to GSC (already in backlog as James-action). Plus submit 20 priority URLs across two days. | 2 | 5 | 4 | 1 | 5 | **18** | backlog | manual GSC action |
+| 43 | Quarterly internal linking audit on PRIORITY_URLS. Each priority URL should be linked from ≥3 other pages. Already in backlog as a one-off; promote to quarterly. | 3 | 4 | 3 | 1 | 4 | **18** | backlog | code-level audit |
+| 44 | Add FAQ blocks to top-10-by-impressions pages with FAQPage schema. Drives long-tail surface and rich-result eligibility on commercial queries. | 3 | 3 | 3 | 2 | 4 | **18** | backlog (P2) | various article pages |
+| 45 | Submit to Bing Webmaster Tools. Mirror sitemap there. Marginal share, low effort. | 1 | 5 | 4 | 1 | 5 | **15** | backlog (P1) | one-time setup |
+
+## What this matrix excludes deliberately
+
+- **Items currently in flight as experiments**, items 2026-05-04-01 through 2026-05-05-03 are awaiting their measurement dates (May 12 and May 19) and are tracked in `experiments.md`, not here.
+- **Items with cost > 1 week and < high confidence**, the audit recommends running short experiments first to learn before committing to the larger build. Examples: building `/insiders-30/` 2026 edition, full Awards-as-citation-bait release.
+- **Items the project memory flags as Iceberg**, e.g. programmatic suburb × intent pages. Those are out of scope until editorial credibility compounds further.
+
+## Reading the matrix
+
+The top 10 items by composite score are the next-30-days slate. Items 11-25 are next-60. Items 26+ are next-90 or later. The 30/60/90 plan in `07-30-60-90.md` operationalises these into named experiments with measurement dates.
+
+## Diff vs prior audit
+
+This is the first monthly audit. There is no prior audit to diff against. Future audits open with a "What changed since last audit" block in this file.
+
+---
+
+End of file.

--- a/ops/reports/seo/audit-2026-05/07-30-60-90.md
+++ b/ops/reports/seo/audit-2026-05/07-30-60-90.md
@@ -1,0 +1,285 @@
+# 07, 30 / 60 / 90 day plan
+
+Date: 2026-05-08
+Budget: ~3 experiments per week shipped via PR by Claude, plus ~1 manual action per week from James (GSC submissions, editorial decisions). Plan ends 2026-08-06.
+
+Each window contains named experiments with files affected, hypothesis, measurement date, and the daily-log line to read on that date. Every experiment maps back to an item in `06-opportunity-matrix.md`.
+
+If an experiment is REFUTED, the next-window experiment that depends on it is reconsidered before shipping. The dependency notes are explicit so the rollback is clean.
+
+## Day 0 baseline
+
+From `baseline.md` (frozen 2026-05-01) and `daily-log.md` (latest May 4 entry):
+
+| Metric | Baseline (28d ending 2026-04-29) | Latest (28d ending 2026-05-02) |
+|---|---:|---:|
+| Clicks | 23 | 29 |
+| Impressions | 1,780 | 2,873 |
+| CTR | 1.29% | 1.01% |
+| Avg position | 16.7 | 16.8 |
+| Indexed (PRIORITY_URLs) | 2 / 14 | 14 / 14 |
+| Indexed (full inventory) | 39 / 349 (11%) | 233 / 418 (56%) |
+
+The 90-day plan is built against these numbers. Targets in each window are explicit.
+
+---
+
+## 30-day window: 2026-05-08 to 2026-06-07
+
+**Theme: structural unblocks**, fix what's broken in the chassis before adding more weight.
+
+### Targets to hit by 2026-06-07
+
+| Metric | Target | Source experiment |
+|---|---:|---|
+| Clicks (28d) | ≥ 60 | snippet rewrites + structural orphan fixes |
+| Impressions (28d) | ≥ 4,500 | indexation push + walks-cluster lift |
+| Indexed (full inventory) | ≥ 280 / 420 (66%) | walks-cluster experiment + structural fixes |
+| Conversion-surface body links from articles | ≥ 4 of 9 surfaces | Pass, Awards, Itinerary, Concierge each get one |
+
+### Experiments to ship in this window (six)
+
+#### 30D-01, Fix the orphaned conversion-surface footer/masthead links
+
+- **Targets matrix items**: #2, #3.
+- **Hypothesis**: by 2026-05-22 (14 days), the Pass page receives ≥ 5 organic visits per week (vs unmeasured but likely zero today, given no inbound link path), and Awards lands at least one new internal-link path per indexed article.
+- **Files**: `next/src/lib/v4-nav.ts:470` (Pass href), `next/src/components/Masthead.astro:58` (Newsletter href), `next/src/lib/nav.ts:55-66` (Awards in More menu), `next/src/lib/v4-nav.ts:465-474` (Awards in footer).
+- **Effort**: 1 hour shipping. PR sized for a single review.
+- **Measurement**: GA4 sessions to /pass/, /awards/, /newsletter/ in the first 14 days. Plus a manual sweep of indexed articles to confirm the Awards More-menu link renders. Until GA4 is authed, partial: GSC will start to show /pass/ and /awards/ in the impressions list within ~14 days as Google recrawls indexed pages and notices the new internal links.
+- **Roll-back**: trivial, three line edits.
+- **Read on**: `daily-log.md` 2026-05-22 entry, plus the next monthly URL inventory.
+
+#### 30D-02, Replicate experiment 2026-05-05-02 on the explore/walks cluster
+
+- **Targets matrix items**: #4, #25.
+- **Hypothesis**: by 2026-06-01 (24 days), of the 32 unindexed `/explore/` walk pages, at least 16 flip to PASS. Plus at least 8 of those reach position ≤ 30 for any walks-related query within 30 days of indexation.
+- **Files**: `next/src/pages/explore/[slug].astro` (auto-related limit 3 → 6), 4 source articles in `next/src/content/articles/` (`walks-bushrangers-bay-walk-guide.md`, `cape-schanck-guide.md`, `point-nepean-national-park-guide.md`, plus the `the-peninsulas-best-late-afternoon-walks.md` if indexed) get explicit `relatedExperiences` arrays of 6 unindexed walk slugs.
+- **Effort**: half-day plus a 4-hour follow-up after James submits the manual reindex requests.
+- **Measurement**: re-run `discover-unindexed.mjs` on 2026-05-22 (mid-window) and 2026-06-01 (window end). Headline: count of /explore/ walk pages that flip from Discovered to PASS.
+- **Read on**: `daily-log.md` 2026-05-22 and 2026-06-01.
+
+#### 30D-03, Mount Pass + Concierge editorial body-links in journal articles
+
+- **Targets matrix items**: #7, #24.
+- **Hypothesis**: by 2026-06-07 (30 days), `/pass/` earns ≥ 30 sessions/week from organic articles (PR-style measurement once GA4 authed), and `/ask/` flips from Discovered to PASS in GSC.
+- **Files**: new `next/src/components/PassCallout.astro` (8 line component), new `next/src/components/AskTheInsiderLink.astro` (single text link), mounted in `next/src/pages/journal/[slug].astro:188` between `<Content />` and `<ClusterLinks>`. Conditional render on `format === 'cellar-door-dispatch' || format === 'service' || format === 'insider-edit'`.
+- **Editorial check**: ship behind a feature flag (`relatedConfig.showPassCallout`) per article so the dispatcher can opt-out if visual frequency is too high.
+- **Effort**: half-day build + half-day editorial review across 30 indexed journal articles to confirm tone fits.
+- **Measurement**: GA4 sessions to /pass/ and /ask/ from organic-article landing pages. Until GA4: GSC discovers that /ask/ now has ≥3 inbound article links, the structural condition that flipped /dog-friendly/ from Discovered to PASS in 48 hours.
+- **Read on**: `daily-log.md` 2026-06-07 entry plus URL inventory re-run.
+
+#### 30D-04, Snippet rewrites on the chardonnay-case and pub-guide articles
+
+- **Targets matrix items**: #16, #17.
+- **Hypothesis**: by 2026-06-01 (24 days), `/journal/the-chardonnay-case/` CTR rises from 0% to ≥ 1.5% on impressions ≥ 50, and `/journal/the-pub-guide/` rises to ≥ 1.0% CTR.
+- **Files**: `next/src/content/articles/the-chardonnay-case.mdx` and `the-pub-guide.md` (title + dek + first-line). Plus the `<BaseLayout title=, description=>` props in any wrapping page if applicable.
+- **Effort**: 1 hour each.
+- **Measurement**: page-level CTR for each URL on 2026-06-01.
+- **Read on**: `daily-log.md` 2026-06-01.
+
+#### 30D-05, Render `pressMentions` and won-awards on `VenueDetailTemplate`
+
+- **Targets matrix items**: #1.
+- **Hypothesis**: by 2026-06-07 (30 days), at least 30 venue pages that have `data.authority.pressMentions` populated render the new block, and pages that link to `/awards/{category}/` from `data.authority.awards` create ≥ 30 new internal-link paths into the Awards cluster (which is currently structurally orphaned).
+- **Files**: `next/src/components/VenueDetailTemplate.astro` (around lines 27-30 area, after the editor note block).
+- **Editorial check**: visual review of the rendered block on 5-10 venues with diverse `pressMentions` content (some venues have multiple, some have none).
+- **Effort**: 4 hours build + 4 hours editorial review.
+- **Measurement**: code-level audit confirms the block renders on N venues; URL-inventory re-run shows /awards/ Discovered → PASS within 14 days of those new internal links.
+- **Read on**: `daily-log.md` 2026-06-07.
+
+#### 30D-06, Render `v4FooterNiche` in `Footer.astro`
+
+- **Targets matrix items**: #8.
+- **Hypothesis**: by 2026-06-07 (30 days), the four currently-Discovered niche-hub pages (`/golf/` excluded as noindex, but `/spa/`, `/weddings/`, `/corporate-events/`, `/dog-friendly/`) flip to PASS, joining `/fishing/` and `/boating/` which already are. Plus the Awards 2026 footer entry from 30D-01 lifts that surface.
+- **Files**: `next/src/components/Footer.astro:34-65`.
+- **Effort**: 1 hour shipping.
+- **Measurement**: `discover-unindexed.mjs` re-run on 2026-06-07.
+- **Read on**: `daily-log.md` 2026-06-07.
+
+### Window-end review (2026-06-07)
+
+- Run `discover-unindexed.mjs` and compare to baseline.
+- Score each experiment as CONFIRMED / REFUTED / PARTIAL.
+- If 30D-01 (Pass/Newsletter footer fixes) is REFUTED (no traffic to /pass/), the assumption that footer links carry weight on a low-traffic site is wrong; pivot the next window's plan toward more aggressive in-article CTAs.
+- Update `backlog.md` with anything learned.
+
+---
+
+## 60-day window: 2026-06-08 to 2026-07-07
+
+**Theme: image SEO + content gap**, the technical lift that compounds across 200+ pages, plus the highest-leverage content that competes on contestable SERPs.
+
+### Targets to hit by 2026-07-07
+
+| Metric | Target | Source experiment |
+|---|---:|---|
+| Clicks (28d) | ≥ 110 | content + snippet compounding |
+| Impressions (28d) | ≥ 7,000 | image SEO + new content |
+| Indexed (full inventory) | ≥ 320 / 425 (75%) | walks + niche cluster lift |
+| Image-search traffic | first non-zero impressions | hero `<img>` conversion lands |
+
+### Experiments to ship in this window (five)
+
+#### 60D-01, Hero `<img>` conversion across journal/place/venue templates
+
+- **Targets matrix items**: #5.
+- **Hypothesis**: by 2026-07-07 (30 days after deploy), GSC starts showing impressions in the Image search type for at least 5 URLs (sustained 14-day evidence). Plus mobile LCP measurable improvement once `web-vitals` reporter is live (depends on 60D-02).
+- **Files**: `next/src/lib/editorial.ts:360-365` (heroBackgroundStyle stops being the canonical hero), `next/src/pages/journal/[slug].astro:165` (hero block), `next/src/components/VenueDetailTemplate.astro` (hero block), `next/src/components/PlaceDetailTemplate.astro` (hero block). Add `<img loading="eager" fetchpriority="high" width=... height=... alt={article.data.heroImage.alt} src={article.data.heroImage.src}>` adjacent to or replacing the current background-image.
+- **Effort**: half-day to ship, half-day to review on 10+ live URLs across templates.
+- **Risk**: visual regression on hero framing. Mitigation: ship behind a feature flag, A/B 10 URLs first, then full rollout.
+- **Measurement**: GSC Performance, Search type = Image, last 28 days. Plus PSI re-run (assuming psi-pull.mjs from 30D-02) to confirm LCP doesn't regress.
+- **Read on**: `daily-log.md` 2026-07-07.
+
+#### 60D-02, Add `psi-pull.mjs` weekly cron + `web-vitals` RUM
+
+- **Targets matrix items**: #11, #32.
+- **Hypothesis**: by 2026-07-07 (30 days), `cwv-history.jsonl` has 4 weeks of weekly PSI runs across the 7 representative URLs, plus `pi_web_vitals_events` Supabase table has ≥ 500 LCP samples.
+- **Files**: new `ops/scripts/seo/psi-pull.mjs`, new GitHub Actions workflow `ops/workflows/psi-pull.yml` (cron weekly), new `next/src/components/WebVitalsReporter.astro` mounted in `BaseLayout.astro` after body, new Supabase RPC `record_web_vital`.
+- **Effort**: full day for psi-pull, half-day for web-vitals.
+- **Measurement**: `cwv-history.jsonl` exists with weekly entries; RUM table has events.
+- **Read on**: `daily-log.md` 2026-07-07.
+
+#### 60D-03, Migrate `dog-friendly-mornington-peninsula.astro` into the article collection
+
+- **Targets matrix items**: #9.
+- **Hypothesis**: by 2026-07-07, the page no longer has the schema/canonical mismatch and uses the article template's hero `<img>` (depends on 60D-01). Plus em-dashes are removed (project rule violation).
+- **Files**: delete `next/src/pages/journal/dog-friendly-mornington-peninsula.astro`; create `next/src/content/articles/dog-friendly-mornington-peninsula.md` with proper frontmatter (`heroImage`, `publishedAt`, `updatedAt`, `dek`, `faq`, `relatedArticles` already populated by experiment 2026-05-05-02 stays).
+- **Risk**: regression on the page that already has 14/14 priority indexation. Mitigation: Astro build verifies title/canonical/JSON-LD parity vs the legacy page before deploy.
+- **Effort**: half-day.
+- **Measurement**: page still PASS in GSC, schema validates with Article + FAQPage, hero is `<img>` not background.
+- **Read on**: `daily-log.md` 2026-07-07.
+
+#### 60D-04, Build 4 new content pages targeting winnable + contestable queries
+
+Four new articles, sized to land within the window:
+1. `/journal/stays-near-peninsula-hot-springs/` (matrix #14; targets "accommodation near peninsula hot springs", 19 impr/wk pos 67.8).
+2. `/escape/day-trip-mornington-peninsula/` (matrix #28; targets "mornington peninsula day trip", contestable SERP).
+3. `/explore/best-walks-graded/` rebuild (matrix #26; replaces current `/explore/best-walks/` with a graded-walks structure modelled on Australian Traveller).
+4. `/eat/best-restaurants/` rebuild (matrix #15; 2026 freshness, FAQ schema, beat Broadsheet's Dec 2025 update).
+
+- **Hypothesis**: by 2026-07-07, each new/rebuilt page is indexed (PASS) and earns ≥ 1 click for its target query within 30 days of indexation.
+- **Effort**: 2-3 days editorial per page (Otto research gate + draft + edit + ship). Total: ~10 days editorial across the window. Spread across two-per-fortnight cadence so the daily ops loop continues.
+- **Editorial dependency**: needs Otto research dossiers per the existing editorial pipeline. Claude commissions the briefs; editorial drafts.
+- **Measurement**: page-level GSC data on 2026-07-07 for each URL.
+- **Read on**: `daily-log.md` 2026-07-07.
+
+#### 60D-05, Add `Product` + `Offer` JSON-LD to `/pass/`
+
+- **Targets matrix items**: #6.
+- **Hypothesis**: by 2026-07-07, `/pass/` validates in Schema.org / Google Rich Results test, and once Stripe pricing is live, the SERP starts showing tier prices on the snippet (the eventual reward; in this 30-day window we're measuring schema validity only).
+- **Files**: `next/src/pages/pass.astro` (add a `<script type="application/ld+json">` block).
+- **Effort**: 30 minutes.
+- **Measurement**: schema validates; SERP snippet on 2026-07-07 (no tier prices yet expected; schema baseline only).
+- **Read on**: schema validator + `daily-log.md` 2026-07-07.
+
+### Window-end review (2026-07-07)
+
+- Run full `discover-unindexed.mjs` and the GSC pull.
+- Score 60D experiments. If 60D-01 (hero `<img>`) is PARTIAL or REFUTED on the image-traffic axis, the assumption that image-search traffic follows a hero-image fix in 30 days is wrong; the 90-day window's image-related opportunities (image sitemap, etc.) are deferred.
+- Update `backlog.md`.
+
+---
+
+## 90-day window: 2026-07-08 to 2026-08-06
+
+**Theme: editorial-SEO compounding + first sustainable backlink layer**, the operating loop is mature, the chassis is fixed, the content cadence is steady. Now we layer on outreach.
+
+### Targets to hit by 2026-08-06
+
+| Metric | Target | Source experiment |
+|---|---:|---|
+| Clicks (28d) | ≥ 200 | content + snippet + first backlinks |
+| Impressions (28d) | ≥ 11,000 | full image+content cycle compounding |
+| Indexed (full inventory) | ≥ 360 / 430 (84%) | continued cluster lifts |
+| Inbound links from operator sites | ≥ 10 | Featured-by-PI badge program |
+| Awards cluster | indexed + has structured Event schema | 90D-02 |
+
+### Experiments to ship in this window (six)
+
+#### 90D-01, Featured-by-PI badge program
+
+- **Targets matrix items**: #13.
+- **Hypothesis**: by 2026-08-06 (30 days post-launch), at least 10 of the 134 operators have placed the badge on their own website, generating 10+ inbound links from operator domains that aren't aggregators.
+- **Files**: new `next/src/pages/badge/[slug].astro` returning an SVG badge with text "Featured by Peninsula Insider, 2026" linked back to the venue page; new email template `ops/scripts/email/featured-badge-outreach.txt`; outreach script that pulls operator emails from `data.contact.email` for the 134 venues.
+- **Effort**: 2 days build, plus 1 week of outreach.
+- **Risk**: low response rate. Mitigation: pilot on 20 venues that already have strong relationships first (the ones featured most prominently in `/eat/best-restaurants/` and `/wine/best-cellar-doors/`).
+- **Measurement**: count of inbound links from non-aggregator domains in Ahrefs/free-tool fallback (or manual audit if no tool budget). Set up a free Ahrefs Webmaster Tools account if not already.
+- **Read on**: `daily-log.md` 2026-08-06 + outreach response tracker.
+
+#### 90D-02, Add Awards `Event` schema + August nominations launch prep
+
+- **Targets matrix items**: #3 (already shipped in 30D-01, this is the schema follow-on), opportunity matrix entry for Awards landing.
+- **Hypothesis**: by 2026-08-06, `/awards/` has Event JSON-LD describing the cycle dates (Aug nominations open, Sep voting, Oct results) and is indexed (PASS).
+- **Files**: `next/src/pages/awards/index.astro` (Event JSON-LD), title rewrite to include "2026", masthead More menu copy.
+- **Effort**: half-day for schema, plus editorial coordination on cycle copy.
+- **Measurement**: schema validates; URL is PASS in GSC.
+- **Read on**: `daily-log.md` 2026-08-06.
+
+#### 90D-03, Internal linking pass on PRIORITY_URLs (quarterly audit)
+
+- **Targets matrix items**: #43.
+- **Hypothesis**: by 2026-08-06, every URL in `PRIORITY_URLS` (config.mjs) has ≥ 3 inbound internal links.
+- **Files**: an `ops/scripts/seo/internal-link-audit.mjs` script that crawls dist/ HTML, builds the link graph, and outputs counts per priority URL. Plus content edits to add missing links.
+- **Effort**: 1 day for the audit script, plus 1-2 days of content edits to fill gaps.
+- **Measurement**: script output shows ≥ 3 inbound links for each priority URL.
+- **Read on**: `daily-log.md` 2026-08-06.
+
+#### 90D-04, Build the Cellar-Door Price Index data piece
+
+- **Targets matrix items**: #34.
+- **Hypothesis**: by 2026-09-06 (30 days post-launch, beyond this 90D window), the piece earns at least 1 inbound link from a wine publication or wine writer.
+- **Files**: new `/journal/the-cellar-door-price-index/` article. Data export script that aggregates `priceBand` from `next/src/content/venues/*.json` where `type: "winery"`, into a downloadable CSV + a chart. Article frames the data, names the sub-region differences, opens the data for re-use.
+- **Effort**: 2-3 days editorial + script.
+- **Pitch**: send to Halliday article team, RACV Royal Auto, Young Gun of Wine, regional wine columnists at the Age + Herald Sun.
+- **Measurement**: inbound link audit on 2026-09-06 (beyond this window; tracked in 4Q audit).
+- **Read on**: `daily-log.md` 2026-08-06 (publication date) + 90D-out review.
+
+#### 90D-05, Quarterly press release: "What's open / what's closed Mornington Peninsula winter 2026"
+
+- **Targets matrix items**: #33.
+- **Hypothesis**: by 2026-08-06, the quarterly release is sent to the local press list (ABC Mornington Peninsula, Mornington Peninsula News, Bayside News, Frankston Times, regional radio), and at least one outlet picks it up.
+- **Files**: new `ops/scripts/email/quarterly-status-release.template.md`, plus a content piece on the site `/journal/peninsula-status-winter-2026/` that the release links to.
+- **Effort**: 2 days editorial, half-day pitch.
+- **Measurement**: pickup tracker; backlink audit.
+- **Read on**: `daily-log.md` 2026-08-06.
+
+#### 90D-06, "Best Dog Beaches Map" data + chart
+
+- **Targets matrix items**: #35.
+- **Hypothesis**: by 2026-09-06, earns at least 1 inbound link from pet sites or council comms; ranks position ≤ 30 for "dog beaches mornington peninsula" within 30 days of publication.
+- **Files**: refresh `/journal/dog-friendly-beaches-mornington-peninsula/` with a beach-by-beach data table + interactive map element + downloadable PNG.
+- **Effort**: 2 days build.
+- **Measurement**: GSC page-level + manual outreach to council and pet sites.
+- **Read on**: `daily-log.md` 2026-08-06.
+
+### Window-end review (2026-08-06)
+
+- Full GSC + URL-inventory audit.
+- Cumulative experiments scored.
+- The next monthly audit (audit-2026-08) writes the next 30/60/90.
+- Quarterly review (1st of Aug or July, depending on calendar fit) decides whether the methodology is still adding value or has become ritual.
+
+---
+
+## Cross-window dependencies
+
+The plan has explicit dependencies across windows. If one window's experiment is REFUTED, the dependent items in later windows are reconsidered.
+
+| If this is REFUTED | Then reconsider this |
+|---|---|
+| 30D-01 (footer/masthead orphan fix) | 30D-03 (article body links), 60D-04 (Pass page rebuild) |
+| 30D-02 (walks cluster) | 90D-03 (internal link audit assumes the cluster pattern works) |
+| 30D-05 (pressMentions render) | 60D-04 (best-restaurants rebuild banks on rich-result eligibility) |
+| 60D-01 (hero `<img>`) | 90D-06 (dog beach map assumes image SEO works) |
+| 60D-02 (PSI + RUM) | the entire 06-opportunity-matrix.md scoring of CWV-related items reverts to "no measurement" |
+
+## What's not in the 90 days
+
+- Operator dashboard improvements (commercial scope, not SEO scope).
+- Major editorial calendar restructure (out of audit scope).
+- Programmatic suburb × intent pages (Iceberg, per project memory).
+- New Pass tier pricing (commercial decision, not SEO).
+
+---
+
+End of file.

--- a/ops/reports/seo/audit-2026-05/08-content-roadmap.md
+++ b/ops/reports/seo/audit-2026-05/08-content-roadmap.md
@@ -1,0 +1,194 @@
+# 08, Content roadmap and implementation brief
+
+Date: 2026-05-08
+Scope: every content asset to build, refresh, consolidate, or delete in the next 90 days, with target queries, cluster slot, effort, and the existing PI surface that the work links from. This is the editorial-facing companion to `06-opportunity-matrix.md` and `07-30-60-90.md`.
+
+The 20 content gaps in `02-content-clusters.md §4` are the source for the build list. The internal-link pairs in `02-content-clusters.md §6` and the cluster actions in §5 are the source for the refresh + consolidate + delete list.
+
+## Content priorities at a glance
+
+| Action | Count | Why |
+|---|---:|---|
+| Build (new article or page) | 6 | Highest-leverage gaps where queries exist and PI has no targeted page |
+| Rebuild / refresh existing | 9 | Articles that exist but are stale, thin, or Discovered-not-indexed |
+| Consolidate (301 to canonical) | 3 clusters of 2-3 URLs | Cannibalisation cases where multiple pages compete for the same intent |
+| Delete (410 or noindex) | TBD per investigation | Address-string legacy pages, plus past one-off events |
+| Internal-link sweep | 20 specific pairs | Push equity into Discovered URLs that are otherwise well-built |
+
+The Otto research-gate cadence (per `feedback_pi_feature_research_gate.md`) applies: no piece reaches the slate without a verified Otto dossier first. The cadence is Fri/Sun research, ship via PR.
+
+## Build list (6 new pages)
+
+Each entry: target query, cluster, effort, internal-link sources, brief.
+
+### B1, Stays Near Peninsula Hot Springs
+
+- **Target query**: "accommodation near peninsula hot springs", "where to stay near peninsula hot springs". 19 impressions/week, position 67.8.
+- **Cluster**: `/stay/`.
+- **URL**: `/journal/stays-near-peninsula-hot-springs/` or `/stay/near-peninsula-hot-springs/`. Editorial preference for the `/journal/` slot per existing pattern.
+- **Effort**: 2-3 days editorial. Otto dossier on accommodation within 5km of Peninsula Hot Springs and Alba; PI stay corpus filtered for proximity.
+- **Internal links from**: `/journal/the-thermal-springs-weekend/`, `/stay/peninsula-hot-springs-glamping/`, `/journal/peninsula-hot-springs-vs-alba/`, `/places/rye/`, `/places/sorrento/`.
+- **Schema**: Article + FAQPage + ItemList of stays.
+- **Window**: 60-day (60D-04).
+
+### B2, A Mornington Peninsula Day Trip (definitive)
+
+- **Target query**: "mornington peninsula day trip" (most contestable of the 8 priority queries). Positioned for the editorial-day-plan SERP slot competitors haven't filled.
+- **Cluster**: `/escape/`.
+- **URL**: `/escape/day-trip-mornington-peninsula/`.
+- **Effort**: 2-3 days editorial. ~2,500 words. Tested timings, locked-in dish recommendations, "what to skip" section, dog-friendly variant.
+- **Internal links from**: `/places/sorrento/`, `/places/red-hill/`, `/places/flinders/`, `/explore/best-walks/`, `/journal/mornington-peninsula-itinerary/` (after consolidation, see C2 below).
+- **Schema**: Article + FAQPage + ItemList of stops + TouristAttraction references via internal links.
+- **Window**: 60-day (60D-04).
+
+### B3, Best Walks Mornington Peninsula (graded walks rebuild)
+
+- **Target query**: "best walks mornington peninsula", "mornington peninsula walks". Currently `/explore/best-walks/` ranks; competitive 03 §5 #6 shows Australian Traveller's graded structure as the entry-point benchmark.
+- **Cluster**: `/explore/`.
+- **URL**: rebuild `/explore/best-walks/` in place; 301 any old URL variants to it.
+- **Effort**: 3 days editorial. 1,800-2,500 words, 12-15 walks each scored on grade (Easy / Medium / Hard), distance, time, dog rules, parking, post-walk dining adjacent.
+- **Internal links from**: every `/explore/{walk-slug}/` page (the 32 newly-indexed walk pages from experiment 30D-02), plus `/journal/the-peninsulas-best-late-afternoon-walks/`, `/journal/walks-cape-schanck-hot-springs-day/`.
+- **Schema**: Article + FAQPage + ItemList of walks.
+- **Dependency**: experiment 30D-02 (walks cluster indexation push) should land first so the spokes are indexed before the spine refresh.
+- **Window**: 60-day (60D-04).
+
+### B4, Best Restaurants Mornington Peninsula (2026 rebuild)
+
+- **Target query**: "best restaurants mornington peninsula", "best restaurants in mornington peninsula" (14 impressions/week, position 46.4). Broadsheet at #1 with Dec 2025 update is the bar.
+- **Cluster**: `/eat/`.
+- **URL**: rebuild `/eat/best-restaurants/` in place.
+- **Effort**: 3-4 days editorial. ~24 restaurants ranked or curated, FAQ block, rich snippet markup, "what changed in May 2026" line under the dek.
+- **Internal links from**: `/journal/where-to-eat-mornington-peninsula/`, `/journal/three-italian-dinners/`, `/journal/the-seafood-list/`, `/journal/hatted-restaurants-mornington-peninsula-2025/`, every `/places/{coastal town}/` hub.
+- **Schema**: Article + ItemList (already partial; expand with full restaurant list) + FAQPage + Restaurant per item.
+- **Window**: 60-day (60D-04).
+
+### B5, The 2026 Mornington Peninsula Itinerary (canonical spine, after consolidation)
+
+- **Target query**: "mornington peninsula itinerary", "things to do mornington peninsula 2 days", "mornington peninsula 3 days".
+- **Cluster**: `/journal/`.
+- **URL**: rebuild `/journal/mornington-peninsula-itinerary/` as the canonical spine. 301 `mornington-peninsula-day-trip` and `the-four-hour-peninsula` to it (see C2 below).
+- **Effort**: 2-3 days editorial. ~1,800-2,500 words, day-by-day structure, links to /escape/ for multi-day, links to /places/ for town context, links to /eat/ and /wine/ for picks.
+- **Internal links from**: `/escape/` and every `/escape/{plan}/` page, `/itinerary/` builder tool, `/places/{20 towns}/`.
+- **Schema**: Article + FAQPage + ItemList of stops/days.
+- **Window**: 90-day (90D-04 contender, can slip earlier if editorial bandwidth allows).
+
+### B6, The Cellar-Door Price Index (data piece)
+
+- **Target query**: "mornington peninsula winery prices", "cellar door fees mornington peninsula"; primary purpose is citation-bait, secondary is search.
+- **Cluster**: `/journal/` (data piece). Could also live at `/wine/price-index/`.
+- **URL**: `/journal/the-cellar-door-price-index/` or `/wine/price-index/`. Editorial slot preferred.
+- **Effort**: 2-3 days build (data export + visual + article copy). Aggregates `priceBand` from `next/src/content/venues/*.json` filtered by `type: "winery"`. Sub-regional breakdown (Red Hill, Main Ridge, Balnarring, Merricks, Flinders).
+- **Internal links from**: `/wine/best-cellar-doors/`, `/journal/the-cellar-door-short-list/`, `/journal/the-chardonnay-case/`, every `/wine/{venue}/` page (link from "Pricing" section if the schema has one).
+- **Schema**: Article + Dataset + DataDownload (the CSV).
+- **Outreach**: Halliday article team, RACV Royal Auto, Young Gun of Wine, Age and Herald Sun wine columns. Pitch the data, offer the chart as an embeddable iframe.
+- **Window**: 90-day (90D-04).
+
+## Rebuild / refresh list (9 items)
+
+Each existing article that is Discovered-not-indexed or stale, with the smallest action that will unblock it.
+
+| # | URL | Status today | Action | Effort | Internal-link push from |
+|---|---|---|---|---|---|
+| R1 | `/journal/hatted-restaurants-mornington-peninsula-2025/` | Discovered | Refresh dek + first paragraph for 2026 GFG; bump `lastVerified` | 1 day | `/eat/best-restaurants/`, `/journal/three-italian-dinners/` |
+| R2 | `/journal/dog-friendly-beaches-mornington-peninsula/` | Indexed | Add a beach-by-beach data table + interactive map (the 90D-06 build); refresh for spring 2026 | 2 days | `/dog-friendly/`, every coastal `/places/{town}/` |
+| R3 | `/journal/mornington-peninsula-winery-guide/` | Discovered | Refresh + push internal links from `/journal/the-chardonnay-case/` and `/wine/best-cellar-doors/` | 1 day | the chardonnay-case article (already top-of-page-1) |
+| R4 | `/journal/best-brunch-mornington-peninsula/` | Discovered | Refresh dek; add 3-5 newly-opened brunch venues; structured FAQ | 1 day | `/places/sorrento/`, `/journal/three-italian-dinners/` |
+| R5 | `/journal/best-spas-mornington-peninsula/` | Discovered | Refresh; structure with hot-springs, day-spa, lodge-spa categories | 1 day | `/journal/peninsula-hot-springs-vs-alba/`, future `/spa/` hub |
+| R6 | `/journal/free-things-to-do-mornington-peninsula/` | Indexed (with the duplicate sitemap entry) | Refresh content; fix sitemap dedupe (also captured in matrix item #19); add FAQ | 1 day | `/explore/`, every `/places/{town}/` |
+| R7 | `/journal/mornington-peninsula-stay-and-soak/` | Discovered | Refresh; this is the closest thing to B1 today; consider whether B1 supersedes or co-exists | 1 day | `/journal/the-thermal-springs-weekend/` |
+| R8 | `/journal/the-spring-peninsula/` | Discovered | Refresh for spring 2026 (seasonal); rotate as the homepage seasonal pick | 1 day | seasonal homepage rotation, `/wine/` hub |
+| R9 | `/journal/mornington-peninsula-in-winter/` (and `a-winter-peninsula-weekend`) | Discovered | Consolidate (see C3); bump for winter 2026 | 1 day | `/journal/the-thermal-springs-weekend/` |
+
+Total rebuild/refresh effort: ~9 editorial days across the 90-day window. Spread at ~1 per week.
+
+## Consolidate list (3 clusters)
+
+| # | Canonical (winner) | URLs to 301 to canonical | Why |
+|---|---|---|---|
+| C1 | `/journal/the-rainy-day-peninsula/` (or pick the strongest of the three) | `the-rainy-day-peninsula-without-a-booking`, `rainy-day-peninsula`, partial overlap with `the-peninsula-with-kids` | Three articles competing for "rainy day mornington peninsula" intent |
+| C2 | `/journal/mornington-peninsula-itinerary/` (B5 above) | `mornington-peninsula-day-trip`, `the-four-hour-peninsula` | Three articles competing for itinerary-shape queries |
+| C3 | `/journal/where-to-eat-mornington-peninsula/` | `where-to-eat-without-a-booking` (might keep as separate sub-intent, decide editorially), `breakfast-before-the-crowds` (keep as sibling, different intent) | Mostly cluster the where-to-eat pieces; separate intent pieces remain separate |
+
+Each consolidate operation:
+1. Pick canonical (the strongest by current rank or content depth).
+2. Merge best content from the killed pages into the canonical.
+3. 301 the killed URLs to the canonical via `_redirects`-style routing or Astro middleware.
+4. Update internal links to point at the canonical.
+5. Log the experiment in `experiments.md`.
+
+Consolidation is destructive; James approves before merge per project memory protocol.
+
+## Delete (410 or noindex) list
+
+Two patterns to investigate:
+
+1. **Address-string legacy pages.** Top-10-by-impressions queries include `34 western parade point leo vic 3916` (46 impressions), `20 junction road merricks north vic 3926` (21 impressions), and others. These suggest legacy directory pages that exist outside the current sitemap. Investigation in matrix item #40. Likely action: 410 or noindex once located.
+
+2. **Past one-off event pages.** `whats-on/[slug].astro` generates pages for every event but the sitemap excludes past events. Add a build-time `noindex` for past one-off events (i.e. events without a `recurringPattern`). Already in `01-technical-health.md §8 #16`. Effort: 30 minutes.
+
+3. **Dispatch dispatch pages from old weekends.** `peninsula-this-weekend-april-24` and `peninsula-this-weekend-april-26` have aged out. Decide: consolidate into a "weekly archive" hub, 410, or accept them as evergreen breadcrumbs of editorial cadence. Editorial decision.
+
+## Internal-link sweep (20 pairs)
+
+The 20 source-page → target-page pairs from `02-content-clusters.md §6`. Implementation: edit the source article markdown to insert a one-sentence body paragraph linking to the target.
+
+These are not 20 separate experiments. They are one batched PR: "internal-link sweep, May 2026". The PR description references the 20 pairs and the rationale. Ship after experiment 30D-02 lands so the link targets are indexed.
+
+## Editorial pipeline integration
+
+The audit assumes the existing editorial pipeline runs as documented:
+
+- Otto research dossiers commissioned per piece (per `feedback_pi_feature_research_gate.md`).
+- Editorial drafts; Claude does NOT write the articles.
+- SEO loop commissions briefs and scores articles post-publish.
+
+Claude's role on the content side is:
+1. Maintain the brief library (this file).
+2. Add SEO-required structured-data hooks to article frontmatter (heroImage, dek, lastVerified, faq) so templates render correctly.
+3. Snippet rewrites (titles, meta descriptions, intros) post-publish based on GSC data, shipped via PR. This is the daily loop.
+4. Internal-link sweeps. Batched PRs; not individual editorial decisions.
+
+Claude does not unilaterally:
+- Commission editorial briefs without James's approval.
+- Edit article body copy (beyond the title/dek/intro snippet rewrites).
+- Decide which articles to delete or consolidate. Surfaces the recommendation; James approves.
+
+## Implementation brief (handoff format)
+
+For each piece on the build / rebuild list, the brief format that goes to editorial is:
+
+```
+TITLE: <working title>
+SLUG: <proposed URL>
+TARGET QUERY: <primary>; <secondary 1>; <secondary 2>
+WORD COUNT: <estimate>
+WHY: <one paragraph: what gap this fills, what the data says>
+SOURCES: <Otto dossier link>; <PI surfaces this links from>; <competitor pieces to study>
+INTERNAL LINKS REQUIRED:
+  - from <source PI URL>: insert link to this page in <section name> with anchor "<text>"
+  - (3-5 inbound links)
+INTERNAL LINKS OUTBOUND:
+  - to <target PI URL>: anchor "<text>" in <section name>
+  - (3-5 outbound)
+SCHEMA: Article / FAQPage / ItemList / etc.
+HERO IMAGE: <required spec, 1600w+>
+HERO ALT: <one sentence describing the image, not the article>
+DEK: <under 200 chars, SEO-optimised>
+LAST VERIFIED: <date the editor visited or verified>
+EXPERIMENT LOG: post-publish, log in `experiments.md` with hypothesis "by date Z, page earns X clicks/Y impressions for query Q"
+```
+
+## Cadence
+
+Roughly one new piece per fortnight (B1-B6), one refresh per week (R1-R9). The internal-link sweep is a single batched PR. The 90-day total: 6 builds + 9 refreshes + 3 consolidations + 1 link sweep + ~5 delete-or-noindex actions = ~25 content actions over 13 weeks ≈ 2 per week. Within the existing editorial pipeline capacity.
+
+## What this roadmap does NOT cover
+
+- **The annual Insider's 30 list** (per matrix #20). This is a major editorial calendar event, not slotted into a 90-day SEO plan.
+- **Major Awards 2026 content** (October-November cycle). Out of this 90-day window.
+- **Programmatic suburb × intent pages.** Iceberg per project memory.
+- **Newsletter content strategy.** Out of SEO scope.
+
+---
+
+End of file.

--- a/ops/reports/seo/backlog.md
+++ b/ops/reports/seo/backlog.md
@@ -1,46 +1,83 @@
-# SEO backlog — Peninsula Insider
+# SEO backlog, Peninsula Insider
 
 Prioritised next actions. Pulled from each morning. Each item has impact (1-5), effort (1-5), and a one-line rationale.
 
-Sorted by impact/effort ratio.
+Top of the list now reflects the May 2026 monthly audit (`audit-2026-05/`). The full ranked view with composite scores lives in `audit-2026-05/06-opportunity-matrix.md`. The 30/60/90 plan lives in `audit-2026-05/07-30-60-90.md`. This file remains the daily operating queue.
 
-## P0 — this week
+## P0, this week (audit-derived 30-day window starts here)
 
-- [x] **Ship the place page canonical fix** (experiment 2026-05-01-01). *Done + deployed + verified live 2026-05-01.* PR #16 merged.
-- [x] **Diagnose http:// vs https:// indexation.** *Done 2026-05-01.* GitHub Pages was serving both protocols 200 OK without redirecting.
-- [x] **Enable "Enforce HTTPS" in GitHub Pages settings.** *Done by Claude via gh API 2026-05-01.* Verified: http→https 301 redirect is live.
-- [ ] **(James)** Resubmit `sitemap.xml` in GSC → Sitemaps. *Impact 2, Effort 0.*
+- [ ] **Fix the orphaned conversion-surface footer/masthead links** (matrix #2, composite 30). `next/src/lib/v4-nav.ts:470` Pass href, `next/src/components/Masthead.astro:58` Newsletter href. *Impact 5, Effort 5.* **Recommended next experiment.**
+- [ ] **Add Awards to masthead More menu and footer About column** (matrix #3, composite 28). `next/src/lib/nav.ts:55-66` and `next/src/lib/v4-nav.ts:465-474`. *Impact 5, Effort 5.*
+- [ ] **CTR rewrite on `/journal/the-chardonnay-case/`** (matrix #16, composite 23). 71+55 combined impr (slash variants), 0% CTR, position 5.6. Snippet failure on a top-of-page-1 page. *Impact 4, Effort 1.*
+- [ ] **CTR rewrite on `/journal/the-pub-guide/`** (matrix #17, composite 23). 65 impr, 0% CTR, position 8.8. *Impact 3, Effort 1.*
+- [ ] **(James)** Resubmit `sitemap.xml` in GSC, Sitemaps. *Impact 2, Effort 0.*
 - [ ] **(James)** Submit 20 priority URLs to GSC URL Inspection across two days (full list in `daily-log.md` 2026-05-01 entry). *Impact 4, Effort 1.*
-- [x] **CTR rewrite (target shifted)**: original `/whats-on/mornington-cup-2026` had zero impressions in last 28d (race past). Pivoted to `/journal/dog-friendly-mornington-peninsula/`. *Done 2026-05-04 as experiment 2026-05-04-01.* Awaiting deploy.
 - [ ] **(James)** After dog-friendly snippet rewrite deploys: submit `/journal/dog-friendly-mornington-peninsula/` (and no-slash variant) for reindex in GSC. *Impact 3, Effort 0.*
-- [ ] **CTR rewrite on `/journal/the-chardonnay-case/`.** *Impact 4, Effort 1.* 71+55 combined impr (slash variants), 0% CTR, pos 5.6 (top of page 1). Snippet failure. **Recommended next experiment.**
-- [ ] **CTR rewrite on `/journal/the-pub-guide/`.** *Impact 3, Effort 1.* 65 impr, 0% CTR, pos 8.8.
-- [ ] **Fix duplicate sitemap entry for `/journal/free-things-to-do-mornington-peninsula/`.** *Impact 2, Effort 2.* Page appears twice in `sitemap.xml` (likely a `next/src/pages/sitemap.xml.ts` bug).
-- [ ] **Audit & prune the 283 "Discovered – currently not indexed" URLs.** *Impact 5, Effort 3.* Pruning thin/templated pages should ~double indexation rate within 2-3 weeks per Google's behaviour with new sites. Need GSC export of the 283 URL list to begin.
-- [ ] **Investigate Apr 24-25 indexation jump (16 → 39).** *Impact 4, Effort 1.* Find what worked and reproduce. Likely candidate: a content push or manual indexing batch.
-- [ ] **Investigate the 4 address-string queries showing in top impressions.** *Impact 3, Effort 1.* Likely legacy directory pages still indexed. Should they be noindexed (address searches want a map, not a listing)?
-- [ ] **Internal linking audit on PRIORITY_URLS.** *Impact 4, Effort 2.* Each priority URL should be linked from ≥3 other pages. Currently unknown.
+- [ ] **(James)** Submit the 5 niche-hub URLs from experiment 2026-05-05-01 for manual reindexing: `/dog-friendly/`, `/whats-on/`, `/corporate-events/`, `/ask/`, `/explore/golf/`. *Impact 4, Effort 1.*
+- [ ] **Replicate experiment 2026-05-05-02 on the explore/walks cluster** (matrix #4, composite 25). 32 unindexed walk pages match the journal pattern. *Impact 5, Effort 4.*
+- [ ] **Fix duplicate sitemap entry for `/journal/free-things-to-do-mornington-peninsula/`** (matrix #19, composite 20). `next/src/pages/sitemap.xml.ts`. *Impact 2, Effort 5.*
+- [ ] **Investigate the 4 address-string queries showing in top impressions** (matrix #40, composite 17). Likely legacy directory pages still indexed. *Impact 3, Effort 1.*
+- [ ] **Investigate Apr 24-25 indexation jump (16 → 39).** Find what worked and reproduce. Likely candidate: a content push or manual indexing batch. *Impact 4, Effort 1.* (Carried over.)
 
-## P1 — next 2-3 weeks
+## P1, this month (audit 30-day window completes here)
 
-- [ ] **SERP snippet pass on top 10 pages by impressions** (titles, meta descriptions, first 100-150 words). Per HANDOVER-CLAUDE.md priority A.
-- [ ] **Town hub depth** — Sorrento, Red Hill, Flinders, Mornington, Rye. Per HANDOVER priority B.
-- [ ] **Schema audit & gap-fill** across templates: Article/NewsArticle, BreadcrumbList, FAQPage, LocalBusiness, Organization, WebSite+SearchAction.
-- [ ] **Bing Webmaster Tools** submission & sitemap.
+- [ ] **Render `pressMentions` and won-awards on `VenueDetailTemplate`** (matrix #1, composite 26). Data exists, render is missing. *Impact 5, Effort 4.*
+- [ ] **"Is this your venue? Claim it." link on `VenueDetailTemplate`** (matrix #12, composite 26). First venue → operator-claim path. *Impact 4, Effort 5.*
+- [ ] **Convert journal/place/venue heroes from CSS `background-image` to `<img>`** (matrix #5, composite 23). The single highest-leverage technical-SEO fix. *Impact 5, Effort 3.*
+- [ ] **Mount `PassCallout` and `AskTheInsiderLink` in journal `[slug].astro`** (matrix #7, #24). First editorial → Pass + Concierge body links. *Impact 4, Effort 4.*
+- [ ] **Add `Product` + `Offer` JSON-LD to `/pass/`** (matrix #6, composite 25). *Impact 4, Effort 4.*
+- [ ] **Add `ItemList` to `/wine/best-cellar-doors/`; add `CollectionPage` + `ItemList` to `/wine/`, `/journal/`, `/whats-on/` hubs** (matrix #10, composite 23). *Impact 4, Effort 4.*
+- [ ] **Render `v4FooterNiche` in `Footer.astro`** (matrix #8, composite 23). Already defined in `v4-nav.ts:455-463`, never rendered. *Impact 4, Effort 5.*
+- [ ] **Migrate `dog-friendly-mornington-peninsula.astro` into article collection** (matrix #9, composite 20). The site's #1 query magnet is hand-coded with em-dashes and schema mismatch. *Impact 4, Effort 3.*
+- [ ] **Add `image` field to Restaurant/Cafe/Winery JSON-LD on `/eat/[slug]/`** (matrix #20, composite 22). *Impact 3, Effort 5.*
+- [ ] **Add `image` field to TouristDestination JSON-LD on `/places/[slug]/`** (matrix #21, composite 22). *Impact 3, Effort 5.*
+- [ ] **Fix `WebSite.SearchAction` target** (matrix #18, composite 21). `index.astro:79-80` points at `/journal?q=` which doesn't render results. *Impact 3, Effort 5.*
+- [ ] **Internal-linking sweep, 20 source-page → target-page pairs** (matrix #25, composite 19). See `audit-2026-05/02-content-clusters.md §6` for the full list. *Impact 4, Effort 3.*
+- [ ] **Add `lastVerified` rendering to `PlaceDetailTemplate`** (matrix #37, composite 18). Parity with VenueDetailTemplate. *Impact 2, Effort 5.*
+- [ ] **Internal linking audit on PRIORITY_URLS** (matrix #43, composite 18). Each priority URL should be linked from ≥ 3 other pages. *Impact 3, Effort 4.*
 
-## P2 — next 4-8 weeks
+## P2, next 4-8 weeks (60-day window)
 
-- [ ] **Earn first quality backlink** (local Vic press, council site, regional tourism body, Broadsheet/Time Out). Single biggest crawl-budget unlock.
-- [ ] **FAQ blocks** added to top 10 pages with FAQPage schema.
-- [ ] **Image SEO pass** — alt text, file naming, dimensions for Discover eligibility.
-- [ ] **Google Discover preparation** — articles with 1200px+ images, fresh dates, strong titles.
+- [ ] **Add `psi-pull.mjs` weekly cron + `web-vitals` RUM** (matrix #11, #32). Without PSI capture, every monthly audit hits the 429 quota wall.
+- [ ] **Build "Stays Near Peninsula Hot Springs" article** (matrix #14, content-roadmap B1). 19 impr/wk unmet demand.
+- [ ] **Rebuild `/eat/best-restaurants/` for 2026 freshness, FAQ, depth** (matrix #15, content-roadmap B4).
+- [ ] **Rebuild `/explore/best-walks/` as graded walks hub** (matrix #26, content-roadmap B3).
+- [ ] **Build `/escape/day-trip-mornington-peninsula/`** (matrix #28, content-roadmap B2). Most contestable winnable SERP.
+- [ ] **Refresh + consolidate the 9 rebuild items + 3 consolidate clusters** (content-roadmap §R, §C).
+- [ ] **`Person` JSON-LD on `/about/`, `Organization` + `ContactPage` on `/contact/`, `lastReviewed` on `/methodology/`** (matrix #30).
+- [ ] **Generate 800w + 1600w hero image renditions** (matrix #31).
+- [ ] **Replace `Organization.logo` with a real square logo** (matrix #38).
+- [ ] **Lazy-mount lower category sections on `/whats-on/`** (matrix #39). 460KB HTML payload.
+- [ ] **Bing Webmaster Tools submission and sitemap.** *Impact 1, Effort 5.*
+- [ ] **Refresh `/journal/dog-friendly-beaches-mornington-peninsula/`** with map + table (content-roadmap R2 + matrix #35).
+- [ ] **FAQ blocks added to top 10 pages with FAQPage schema** (matrix #44).
 
-## Iceberg (consider later)
+## P3, next 8-13 weeks (90-day window)
 
-- [ ] Programmatic suburb × intent pages (only after editorial credibility is established — premature now)
-- [ ] Newsletter subscriber growth funnel (out of SEO scope but related)
-- [ ] Competitor content gap analysis (after we have a baseline of our own performance)
+- [ ] **Featured-by-PI badge program** (matrix #13, composite 22). Badge endpoint + outreach to 134 operators.
+- [ ] **Build the "Cellar-Door Price Index" data piece** (matrix #34, content-roadmap B6). Citation-bait for wine writers.
+- [ ] **Build the "Best Dog Beaches Map" data + chart** (matrix #35, content-roadmap R2). Pet sites have no equivalent canonical.
+- [ ] **Quarterly press release cadence: "What's open / what's closed Mornington Peninsula"** (matrix #33). Use PI's verification cadence as the data source.
+- [ ] **Awards `Event` schema + August nominations launch prep** (matrix Awards bundle).
+- [ ] **Build `/whats-on/this-weekend/` permanent page** (matrix #41).
+- [ ] **Add named editor entry to `next/src/content/authors/`** (matrix #36). Lifts E-E-A-T bio depth axis.
+
+## Iceberg (consider later, per project memory)
+
+- [ ] Programmatic suburb × intent pages (only after editorial credibility is established, premature now).
+- [ ] Newsletter subscriber growth funnel (out of SEO scope but related).
+- [ ] The Insider's 30: 2026 Edition (annual ranked list, separate editorial planning).
+
+## Completed (for reference)
+
+- [x] **Place page canonical fix** (experiment 2026-05-01-01). Done + deployed + verified live 2026-05-01. PR #16 merged.
+- [x] **Diagnose http vs https indexation.** Done 2026-05-01. GitHub Pages was serving both protocols 200 OK without redirecting.
+- [x] **Enable "Enforce HTTPS" in GitHub Pages settings.** Done by Claude via gh API 2026-05-01.
+- [x] **Dog-friendly snippet rewrite** (experiment 2026-05-04-01). Done 2026-05-04. Awaiting deploy + reindex.
+- [x] **Niche-hub indexation push** (experiment 2026-05-05-01). Sitemap priority bumps + contextual link from dog-friendly journal. Awaiting James reindex submission.
+- [x] **Journal internal-linking sweep** (experiment 2026-05-05-02). Auto-related limit 3 → 6 + explicit refs on 3 source articles. Awaiting measurement 2026-05-12 and 2026-05-19.
+- [x] **/eat/ vs /wine/ winery duplicate canonicalisation** (experiment 2026-05-05-03). /eat/{winery} now canonical to /wine/{winery}. Awaiting measurement.
 
 ---
 
-_Items are added when discovered, prioritised when reviewed, removed when shipped (logged in `experiments.md`)._
+_Items are added when discovered, prioritised when reviewed, removed when shipped (logged in `experiments.md`). The May 2026 monthly audit (`audit-2026-05/`) added ~30 items; the originals were preserved or promoted as appropriate._

--- a/ops/reports/seo/methodology.md
+++ b/ops/reports/seo/methodology.md
@@ -1,0 +1,276 @@
+# Peninsula Insider, SEO methodology
+
+The operating rhythm we run every week, month, and quarter so the work compounds instead of decaying. This document does not replace `daily-log.md`, `experiments.md`, `backlog.md`, `baseline.md`, or `url-inventory.md`. Those remain the source of truth. This document defines **when** to read each one, **what** to update, and **how to decide** what to fix, refresh, consolidate, or kill.
+
+Adopted 2026-05-08.
+
+## Why this exists
+
+The daily loop (defined in `README.md`) is excellent for tactical execution: pull GSC, diff, ship one experiment, log it. It is not enough on its own. Without longer cadences:
+
+- Technical health (Core Web Vitals, schema gaps, internal-linking depth) drifts unwatched.
+- Content clusters lose coherence as new articles are added without a cluster strategy.
+- Competitive moves go unnoticed.
+- Conversion paths stay broken because no one is asked to look at them.
+- Reports never roll up into "is the work compounding".
+
+The cadences below close those gaps without fragmenting the daily loop.
+
+## The four cadences
+
+| Cadence | Owner | Time budget | Output |
+|---|---|---|---|
+| **Daily (weekday morning)** | Claude | 15 min | One entry in `daily-log.md`, one experiment shipped or one diagnosis recorded |
+| **Weekly (Monday)** | Claude | 30 min | A weekly review block at the top of `daily-log.md`; backlog re-prioritised |
+| **Monthly (1st business day)** | Claude + James | 2-3 h Claude, 30 min James | New `audit-YYYY-MM/` folder; executive summary read by James |
+| **Quarterly (1st of new quarter)** | James + Claude | 1-2 h | Strategic review: kill / continue / pivot decisions on clusters and the commercial model |
+
+The daily loop is the only one that runs against fresh GSC data. Weekly and monthly use accumulated daily-log data plus targeted lab tools (PSI, schema validators, competitor SERP checks). Quarterly is judgement-led, not data-led.
+
+## Daily, already documented
+
+See `README.md`. Five steps: pull, diagnose, cross-reference experiments, pick 2-3 backlog actions, ship via PR + log experiment.
+
+The only addition this methodology makes to the daily loop:
+
+- **End-of-day check**: was the experiment hypothesis specific and measurable? If not, edit it before logging. Vague hypotheses are dead weight at the monthly review.
+
+## Weekly review (Monday morning, 30 min)
+
+Run after the Monday daily pull. Output is a 100-200 word block at the top of that day's `daily-log.md` entry, headed `## Weekly review, week of YYYY-MM-DD`.
+
+### Checklist
+
+1. **Read the last 7 entries in `daily-log.md`** (the orchestrator already loads context from yesterday and today; the rest you re-read once a week).
+2. **Tally the week's deltas**:
+   - Clicks WoW Δ
+   - Impressions WoW Δ
+   - Indexed-URL count Δ (re-run `discover-unindexed.mjs` weekly, not daily)
+   - Position Δ on PRIORITY_URLS
+3. **Mark experiment outcomes** that hit their measurement date this week. Open `experiments.md`, write the Outcome block, mark CONFIRMED / REFUTED / PARTIAL. No outcome should sit in "pending" past its measurement date by more than 2 days.
+4. **Re-prioritise `backlog.md`**:
+   - Promote anything blocking on James's manual GSC actions if the URL has now been crawled
+   - Demote anything where the diagnosis has changed (e.g. a CTR target that no longer earns impressions)
+   - Add anything new from the week's daily entries that wasn't logged at the time
+5. **One question for James** (write at the bottom of the weekly review block). Examples: "Should I treat the Mornington Cup pages as evergreen-with-yearly-refresh or 410 after the race?", "Do you want me to noindex the address-string legacy pages or 410 them?".
+
+### Decision rules, when to escalate to a monthly action
+
+- 7 days with no experiment shipped → escalate to monthly: investigate why we're stuck.
+- An experiment was REFUTED with strong evidence → log a new experiment that tests an alternative hypothesis. Don't ship the same change again.
+- 7 days where indexed-URL count drops → not noise, run a regression check on recent template/canonical changes.
+- 14 days where weekly clicks Δ is flat-or-down → escalate to monthly: cluster-level analysis required.
+
+## Monthly audit (first business day, 2-3 hours)
+
+The monthly audit is the operation's quality gate. It produces a dated artefact in `ops/reports/seo/audit-YYYY-MM/` that future audits diff against.
+
+### When
+
+First business day of each calendar month. Audit covers the prior calendar month plus what's changed since the last audit.
+
+### Inputs
+
+- All `daily-log.md` entries for the prior month
+- The current `experiments.md` outcomes
+- A fresh `discover-unindexed.mjs` run
+- A fresh PageSpeed Insights run on 7 representative URLs (one per template)
+- A fresh competitive SERP scan on 8 priority queries
+- GA4 conversion data (once authed)
+- Last month's audit folder for diffing
+
+### Standard folder structure
+
+```
+ops/reports/seo/audit-YYYY-MM/
+  00-executive-summary.md      # for James, top of every audit
+  01-technical-health.md
+  02-content-clusters.md
+  03-competitive-gap.md
+  04-conversion-paths.md
+  05-authority-trust.md
+  06-opportunity-matrix.md
+  07-30-60-90.md
+  08-content-roadmap.md
+```
+
+Every audit uses this same structure so diffs are clean.
+
+### What each section covers
+
+| File | Purpose | Length |
+|---|---|---|
+| 00-executive-summary | What changed since last audit, biggest risks, biggest opportunities, asks for James | 1-2 pages |
+| 01-technical-health | Core Web Vitals per template, schema audit, robots/sitemap quality, internal-linking depth | 800-1500 lines |
+| 02-content-clusters | Cluster-by-cluster URL count, indexed %, top performers, gaps; intent alignment matrix; classification of unindexed URLs (keep / refresh / consolidate / delete) | 600-1000 lines |
+| 03-competitive-gap | Per-competitor profile, head-to-head SERP comparison, content formats to adopt, backlink-target list | 600-1200 lines |
+| 04-conversion-paths | Each commercial goal mapped from organic visitor to action, weakest step per funnel, indexable conversion-surface SEO | 400-700 lines |
+| 05-authority-trust | E-E-A-T scoring per template (0-3), about/contact/authors audit, PR/citation hooks | 400-700 lines |
+| 06-opportunity-matrix | Every recommendation in a table: impact × effort × speed × commercial × confidence | 1 file, scannable |
+| 07-30-60-90 | Concrete, named experiments mapped onto 30, 60, 90 day windows with measurement dates | 1 file |
+| 08-content-roadmap | Articles to build / refresh / consolidate / kill, with target queries, cluster slots, effort | 1 file |
+
+### After writing the audit
+
+1. Update `backlog.md` with the new opportunities, scored against the matrix.
+2. Open a single PR for the audit folder + backlog update so James can review in one diff.
+3. After James reviews `00-executive-summary.md`, the monthly cycle is closed.
+
+### Diffing against the prior audit
+
+When writing audit N+1, the technical-health and content-cluster sections must explicitly diff against audit N. Each section opens with a "What changed since last audit" block. This is how we catch drift.
+
+## Quarterly review (first of new quarter, 1-2 hours)
+
+Strategic, not tactical. James leads. Claude prepares.
+
+### Inputs
+
+- All three monthly audits in the quarter
+- A 90-day clicks/impressions/indexed trajectory chart (Claude generates from `ops/data/seo/`)
+- The Pass / Operator / Concierge / Awards / Newsletter / Partner conversion totals (once GA4 + commercial dashboards exist)
+
+### Decisions to make
+
+1. **Cluster strategy**, which clusters keep getting investment, which go on maintenance, which get killed?
+2. **Commercial-goal priority order**, does the order (currently Pass → Operator → Concierge → Awards → Newsletter → Partner) still match revenue reality?
+3. **Competitor watchlist**, add or drop competitors based on who's actually showing up in PI's SERPs.
+4. **Operating-rhythm fit**, is this methodology adding value or has it become ritual? Cut what isn't paying.
+
+### Output
+
+Three to seven decisions logged in `ops/reports/seo/quarterly-YYYY-Q.md`. Each decision: what, why, what changes in the operating rhythm or backlog as a result.
+
+## Decision rules, fix / refresh / consolidate / delete / expand
+
+These are the rules that turn diagnostic data into action. They run in the monthly audit (when classifying unindexed URLs and underperforming pages) and in the daily loop (when triaging a new query that's earning impressions but no clicks).
+
+### Fix
+A page that should rank but has a structural defect.
+
+**Triggers**:
+- Indexed but 0% CTR with ≥30 impressions over 28 days at position ≤10 → snippet failure (title/meta rewrite)
+- Indexed but earning impressions for queries the page doesn't actually answer → intent mismatch (rewrite intro / add FAQ block / restructure H2s)
+- Discovered-not-indexed but well-linked (≥3 inbound internal links, no canonical or quality issue) → request manual reindex
+- Has an obvious technical defect (duplicate canonical, missing schema, broken image, slow LCP) → fix the defect
+
+**Don't fix** if the page hasn't been earning impressions for 60+ days at any meaningful volume, it doesn't matter yet.
+
+### Refresh
+A page that ranked once, still has demand, but content is stale.
+
+**Triggers**:
+- Was earning ≥10 clicks/month, now <3, position has dropped 5+ places
+- Last-modified date is 6+ months old and content is dated (e.g. "best restaurants 2025" article showing in 2026 searches)
+- Topic is seasonal and we are in the next iteration of the season (e.g. autumn-weekend-edit going into spring)
+- Competitor has shipped a stronger piece on the same query
+
+**What "refresh" means**: rewrite at least 30% of body copy, update images if older than 12 months, update internal links, bump the publish date in front-matter, ship via PR with a changelog note.
+
+### Consolidate
+Two or more pages competing for the same query.
+
+**Triggers**:
+- GSC shows two URLs ranking for the same query (cannibalisation)
+- Two articles cover overlapping topics with one materially weaker
+- Slash-variant or HTTP-variant duplicates (already-known case)
+
+**What "consolidate" means**: pick the stronger URL as canonical, 301 the others to it, merge the best content from the killed pages into the survivor, update internal links to point at the survivor.
+
+### Delete (410 or noindex)
+A page that costs more than it earns.
+
+**Triggers**:
+- Programmatic page with thin content (auto-generated venue stub with no editorial)
+- Address-string queries earning impressions for legacy directory pages that have no editorial content (already flagged in `backlog.md`)
+- Test/preview/draft pages accidentally indexed
+- Outdated event pages where the event has passed and won't recur (one-off race, pop-up that closed)
+
+**410 vs noindex**: use 410 (Gone) when the URL should never come back; use `noindex,follow` when the page should remain but not show in search (e.g. operator-only pages, search results, account pages).
+
+### Expand
+A query the site nearly ranks for, where a deeper article would push it onto page 1.
+
+**Triggers**:
+- Existing page earns impressions for a related query at position 11-30, but the page doesn't deeply answer the query
+- A cluster gap identified in the monthly audit that an existing page could partially absorb if expanded
+
+**What "expand" means**: add 500-1000 new words to the existing page targeted at the related-query intent, add new H2s, internal-link from the cluster spine, do not create a new URL.
+
+### Default
+If none of the triggers fire, do nothing. The biggest waste in SEO operations is fiddling with pages that are working. The monthly opportunity matrix is the place to argue for an exception.
+
+## Operating roles
+
+Who does what.
+
+### Claude (autonomous, no per-task approval needed)
+
+- Daily GSC pull (when running locally) and `daily-log.md` updates
+- Weekly review block in `daily-log.md`
+- Monthly audit folder generation
+- Quarterly briefing pack
+- Snippet rewrites (titles, meta descriptions, intro paragraphs) shipped via PR
+- Schema additions (Article, BreadcrumbList, FAQPage, LocalBusiness, Event) shipped via PR
+- Internal-linking changes (related-articles, cluster spines, contextual body links) shipped via PR
+- Sitemap and robots.txt fixes
+- New article drafts when commissioned by James (the editorial pipeline is separate; SEO work flags articles for commissioning)
+- Updating `backlog.md` and `experiments.md`
+
+### James (manual, blocking)
+
+- GSC URL Inspection requests for newly-shipped pages (Claude lists URLs in the daily log; James submits)
+- Final approval on content commissioning briefs
+- Quarterly cluster decisions
+- Approving anything destructive (consolidate, delete) before PR merge
+
+### Boundaries
+
+- Claude does not write new editorial articles unilaterally. SEO work commissions articles; an editor (or James) drafts them.
+- Claude does not contact external sites for backlinks. SEO work generates the pitch list; James (or whoever runs PR) reaches out.
+- Claude does not modify the commercial model (Pass pricing, paywall behaviour, Operator claim flow). SEO work surfaces conversion-path issues; commercial decisions live elsewhere.
+
+## Tooling, what runs, where, when
+
+| Tool | Runs | Output | Frequency |
+|---|---|---|---|
+| `ops/scripts/seo/pull.mjs` | local or cron | appends to `daily-log.md`, snapshot in `ops/data/seo/` | weekday morning |
+| `ops/scripts/seo/diff.mjs` | local | compares two daily snapshots | as-needed inside daily loop |
+| `ops/scripts/seo/inspect-page.mjs` | local | full query + trend for a single URL | as-needed |
+| `ops/scripts/seo/discover-unindexed.mjs` | local | fresh URL inventory | weekly + monthly |
+| `ops/scripts/ga4/pull.mjs` | local (after auth) | GA4 conversion data per landing page | daily once authed |
+| PageSpeed Insights API | local | CWV per URL | monthly (7 representative URLs) |
+| Schema validators (Schema.org, Google Rich Results) | manual or scripted | schema validity report | monthly |
+| Competitive SERP scan | scripted (WebSearch via Claude) | rankings on 8 priority queries | monthly |
+
+## Glossary of "done"
+
+A monthly audit is **done** when:
+
+- All 9 files exist in `audit-YYYY-MM/`
+- The opportunity matrix has at least 20 ranked items
+- The 30-60-90 plan has named experiments with measurement dates
+- The content roadmap has at least 10 specific articles or pages
+- `backlog.md` has been updated and the new top-priority items are clearly the highest-leverage actions from the matrix
+- The PR is open and James has read `00-executive-summary.md`
+
+A weekly review is **done** when:
+
+- All experiments at their measurement date have outcomes recorded
+- `backlog.md` reflects the week's learning
+- The single question for James is in the daily log
+
+A daily entry is **done** when:
+
+- The headline metrics are pulled and diffed vs prior day
+- At least one experiment is shipped, or a deliberate "no experiment today, here's why" line is logged
+- Action items for James are explicit
+
+## Open questions for the operating model
+
+These are the unresolved bits we discover and revise as we go. Do not delete; supersede.
+
+1. **GA4 integration**, once authed, what's the daily metric set worth pulling, and what stays monthly-only? (Likely: daily = sessions / engaged-sessions / conversions per source-medium; monthly = full path analysis.)
+2. **Editorial-SEO interface**, how does the editorial calendar (Otto research gate, Sunday dispatch) consume the SEO content roadmap? Right now they are separate; they should not be.
+3. **Awards-as-traffic-engine**, does the annual Awards process generate enough monthly search traffic to deserve cluster-spine status, or is it a once-a-year peak? Decide at first quarterly review with Awards in flight.
+4. **Pass / Concierge as SEO surfaces**, should /pass/ and /ask/ be primarily indexable destinations or primarily on-site CTAs? Currently both, by accident. Decide at the first monthly audit review with conversion data.

--- a/ops/scripts/ga4/auth.mjs
+++ b/ops/scripts/ga4/auth.mjs
@@ -1,0 +1,135 @@
+// One-time OAuth bootstrap for Google Analytics Data API (GA4) access.
+// Run once: `npm run auth` from ops/scripts/ga4/
+// Saves a refresh token to ops/tokens/ga4-token.json for non-interactive future use.
+//
+// Mirrors ops/scripts/seo/auth.mjs deliberately — same loopback-redirect Desktop-app flow.
+// If you change one, consider whether the other should match.
+
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { URL } from 'node:url';
+import { exec } from 'node:child_process';
+import { google } from 'googleapis';
+import { PATHS, SCOPES } from './config.mjs';
+
+const openInBrowser = (url) => {
+  const platform = process.platform;
+  const cmd = platform === 'win32'
+    ? `start "" "${url}"`
+    : platform === 'darwin'
+      ? `open "${url}"`
+      : `xdg-open "${url}"`;
+  exec(cmd, (err) => {
+    if (err) console.log('(could not auto-open browser; copy the URL above manually)');
+  });
+};
+
+async function main() {
+  const raw = await fs.readFile(PATHS.clientSecret, 'utf8');
+  const { installed } = JSON.parse(raw);
+  if (!installed) {
+    throw new Error(
+      'client secret JSON is not an installed-app credential. Recreate the OAuth client as Desktop app, not Web application.',
+    );
+  }
+  const { client_id, client_secret } = installed;
+
+  let listeningPort = 0;
+  const { code, port } = await new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const reqUrl = new URL(req.url, `http://localhost:${listeningPort}`);
+      const codeParam = reqUrl.searchParams.get('code');
+      const errorParam = reqUrl.searchParams.get('error');
+      if (errorParam) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(`<h1>OAuth error: ${errorParam}</h1><p>You can close this tab.</p>`);
+        server.close();
+        reject(new Error(`OAuth error: ${errorParam}`));
+        return;
+      }
+      if (!codeParam) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<h1>No code in callback</h1>');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<h1>Authorised. You can close this tab and return to the terminal.</h1>');
+      const capturedPort = listeningPort;
+      server.close();
+      resolve({ code: codeParam, port: capturedPort });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      listeningPort = server.address().port;
+      const redirectUri = `http://localhost:${listeningPort}`;
+      const oauth2 = new google.auth.OAuth2(client_id, client_secret, redirectUri);
+      const authUrl = oauth2.generateAuthUrl({
+        access_type: 'offline',
+        prompt: 'consent',
+        scope: SCOPES,
+      });
+      console.log('\n--- Google Analytics 4 authorisation ---');
+      console.log('Opening browser. If it does not open, copy this URL:\n');
+      console.log(authUrl);
+      console.log('\nWaiting for redirect to http://localhost:' + listeningPort + ' ...\n');
+      openInBrowser(authUrl);
+    });
+    setTimeout(() => {
+      server.close();
+      reject(new Error('OAuth timeout after 15 minutes'));
+    }, 15 * 60 * 1000);
+  });
+
+  const redirectUri = `http://localhost:${port}`;
+  const oauth2 = new google.auth.OAuth2(client_id, client_secret, redirectUri);
+  const { tokens } = await oauth2.getToken(code);
+  if (!tokens.refresh_token) {
+    throw new Error(
+      'No refresh_token returned. Revoke prior consent at https://myaccount.google.com/permissions and re-run.',
+    );
+  }
+  oauth2.setCredentials(tokens);
+  await fs.writeFile(PATHS.token, JSON.stringify(tokens, null, 2), 'utf8');
+  console.log('Saved token to', PATHS.token);
+
+  // GA4 Admin API v1beta to list accessible properties for verification + capture.
+  const admin = google.analyticsadmin({ version: 'v1beta', auth: oauth2 });
+  const accountSummaries = await admin.accountSummaries.list({ pageSize: 50 });
+  const summaries = accountSummaries.data.accountSummaries || [];
+  console.log('\nAccessible GA4 accounts and properties:');
+  let pi = null;
+  for (const acc of summaries) {
+    console.log(`  Account: ${acc.displayName} (${acc.account})`);
+    for (const p of acc.propertySummaries || []) {
+      const tag = p.displayName.toLowerCase().includes('peninsula') ? '  [MATCH]' : '';
+      console.log(`    - ${p.property} : ${p.displayName}${tag}`);
+      if (!pi && p.displayName.toLowerCase().includes('peninsula')) {
+        pi = { propertyId: p.property, displayName: p.displayName, parent: acc.account };
+      }
+    }
+  }
+
+  if (!pi) {
+    console.log(
+      '\nNo property name matches "peninsula". Pick the right one from the list above and enter its full ID (e.g. properties/123456789):',
+    );
+    const rl = readline.createInterface({ input, output });
+    const propertyId = (await rl.question('Property ID: ')).trim();
+    rl.close();
+    if (!propertyId.startsWith('properties/')) {
+      throw new Error(`Expected "properties/<numeric-id>", got: ${propertyId}`);
+    }
+    pi = { propertyId, displayName: '(manually entered)', parent: '(unknown)' };
+  }
+
+  await fs.writeFile(PATHS.property, JSON.stringify(pi, null, 2), 'utf8');
+  console.log(`\nSaved property to ${PATHS.property}`);
+  console.log(`Using ${pi.propertyId} (${pi.displayName})`);
+  console.log('\nReady. Run `npm run pull` to fetch the first daily GA4 report.');
+}
+
+main().catch((err) => {
+  console.error('\nAuth failed:', err.message);
+  process.exit(1);
+});

--- a/ops/scripts/ga4/config.mjs
+++ b/ops/scripts/ga4/config.mjs
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+export const PATHS = {
+  clientSecret: path.join(REPO_ROOT, 'ops', 'tokens', 'ga4-client-secret.json'),
+  token: path.join(REPO_ROOT, 'ops', 'tokens', 'ga4-token.json'),
+  property: path.join(REPO_ROOT, 'ops', 'tokens', 'ga4-property.json'),
+  dataDir: path.join(REPO_ROOT, 'ops', 'data', 'ga4'),
+  logsDir: path.join(REPO_ROOT, 'ops', 'logs', 'ga4'),
+  reportsDir: path.join(REPO_ROOT, 'ops', 'reports', 'ga4'),
+  dailyLog: path.join(REPO_ROOT, 'ops', 'reports', 'ga4', 'daily-log.md'),
+};
+
+export const SCOPES = ['https://www.googleapis.com/auth/analytics.readonly'];
+
+// Set after auth.mjs writes ga4-property.json from GA4 admin.
+// Property ID looks like "properties/123456789".
+// Find it in GA4: Admin -> Property Settings -> Property ID.
+
+// Conversion events we care about for the SEO -> commercial funnel audit.
+// Edit as the conversion model evolves; pull.mjs reads this list.
+export const CONVERSION_EVENTS = [
+  'newsletter_signup',
+  'concierge_query',
+  'pass_subscribe_click',
+  'operator_claim_start',
+  'operator_claim_submit',
+  'awards_engagement',
+  'partner_enquiry',
+  'itinerary_save',
+];
+
+// Channel groupings we map onto sessionSource/sessionMedium for the audit.
+export const ORGANIC_FILTERS = {
+  organicSearch: { sessionMedium: 'organic' },
+  direct: { sessionMedium: '(none)' },
+  referral: { sessionMedium: 'referral' },
+};

--- a/ops/scripts/ga4/package.json
+++ b/ops/scripts/ga4/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pi-ga4-ops",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "GA4 ops scripts for Peninsula Insider — Google Analytics Data API pulls, daily conversion-path reports.",
+  "scripts": {
+    "auth": "node auth.mjs",
+    "pull": "node pull.mjs",
+    "pull:verbose": "node pull.mjs --verbose"
+  },
+  "dependencies": {
+    "googleapis": "^144.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Establish the longer SEO cadences alongside the existing daily loop. Lands two artefacts:

- [`ops/reports/seo/methodology.md`](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/ops/reports/seo/methodology.md) — daily / weekly / monthly / quarterly rhythms with decision rules (fix / refresh / consolidate / delete / expand)
- [`ops/reports/seo/audit-2026-05/`](https://github.com/richmondjw/peninsula-insider/tree/claude/epic-khorana-0f3e0a/ops/reports/seo/audit-2026-05) — 9 sections: 00 exec summary, 01 technical health, 02 content clusters, 03 competitive gap, 04 conversion paths, 05 authority/trust, 06 opportunity matrix, 07 30/60/90, 08 content roadmap

Plus `ops/scripts/ga4/` scaffold (auth/config/package). Run `npm install && npm run auth` from `ops/scripts/ga4/` to authorise; this unblocks the conversion-path quantification sections in audit 04.

## Audit headline findings (the read-this-first)

1. **Indexation is largely solved.** 233/418 PASS (up from 39/349 four days ago). 14/14 priority URLs PASS.
2. **Hero images are CSS `background-image`** — invisible to Google Images, no alt, can't lazy-load. Affects 200+ pages. Single highest-leverage technical fix on the site.
3. **7 of 9 commercial conversion surfaces have zero contextual links from articles.** Pass, Awards, Submit, Itinerary, Concierge, Alerts.
4. **The Pass footer link points to `/preview-insider-plans/`** instead of `/pass/` ([`v4-nav.ts:470`](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/next/src/lib/v4-nav.ts#L470)).
5. **Awards cluster is structurally orphaned** — missing from masthead, More menu, and footer entirely.
6. **Site E-E-A-T mean is 0.8/3.0.** Bio depth (0.1) and reviews/testimonials (0.0) are the weakest axes.

## What James needs to do

Decisions:
- Editorial: keep house byline indefinitely, or name at least one editor? (E-E-A-T section)
- Confirm winnable / contestable / difficult query verdicts (3 winnable: cellar-doors, dog-friendly, day-trip)
- Approve the 3 consolidate-list 301 redirects in [`08-content-roadmap.md`](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/ops/reports/seo/audit-2026-05/08-content-roadmap.md)

Manual GSC actions (already in [`backlog.md`](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/ops/reports/seo/backlog.md)):
- Resubmit `sitemap.xml`
- Submit 20 priority URLs across 2 days
- Submit the 5 niche-hub URLs from experiment 2026-05-05-01
- After dog-friendly snippet rewrite deploys, request reindex

GA4 setup (unblocks conversion-path quantification):
1. Enable Google Analytics Data API + Admin API in Google Cloud Console (project `peninsula-insider`)
2. `cd ops/scripts/ga4 && npm install && npm run auth`

## What's NOT in this PR

- Nothing is shipped yet. This is the audit + plan. Implementation lands as the daily loop's experiments per the [30/60/90 plan](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/ops/reports/seo/audit-2026-05/07-30-60-90.md).
- No editorial content commissioned without James's approval.
- No code outside `ops/` touched.

## Test plan

- [ ] Read [`00-executive-summary.md`](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/ops/reports/seo/audit-2026-05/00-executive-summary.md) (5 min)
- [ ] Spot-check the matrix scoring on 3 items you have an opinion on
- [ ] Confirm the 30-day window experiments in [`07-30-60-90.md`](https://github.com/richmondjw/peninsula-insider/blob/claude/epic-khorana-0f3e0a/ops/reports/seo/audit-2026-05/07-30-60-90.md) match commercial priorities
- [ ] Verify GA4 OAuth credential at `ops/tokens/ga4-client-secret.json` is gitignored (it is, but check `git ls-files | grep ga4`)
- [ ] If the consolidate list looks right, comment "approve consolidate" so the daily loop can ship the 301s

🤖 Generated with [Claude Code](https://claude.com/claude-code)