### PR TITLE
feat(images): 'Photograph by jem' credit tag convention

### DIFF
--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -1,5 +1,5 @@
 ---
-import { placeLabel, typeLabel, routeSlug, titleize, venueHrefPrefix, heroBackgroundStyle } from '../lib/editorial';
+import { placeLabel, typeLabel, routeSlug, titleize, venueHrefPrefix, heroBackgroundStyle, formatHeroCredit } from '../lib/editorial';
 import { resolveLiveStatusUrl, verifiedFreshnessLabel } from '../lib/venues';
 import Breadcrumbs from './Breadcrumbs.astro';
 import NewsletterBlock from './NewsletterBlock.astro';
@@ -93,6 +93,9 @@ const isClosed = data.status === 'closed';
       <div class="venue-detail__hero-fog"></div>
       <span class="venue-detail__hero-label">{heroLabel}</span>
     </div>
+    {data.heroImage?.credit && (
+      <p class="venue-detail__hero-credit">{formatHeroCredit(data.heroImage.credit)}</p>
+    )}
 
     <div class="venue-detail__grid">
       <div>

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -74,6 +74,10 @@ const coordinates = z.object({
 const imageRef = z.object({
   src: z.string(),
   alt: z.string(),
+  // Free-form attribution string. Set to the literal "jem" for any photo
+  // taken by James and Emma; templates (lib/editorial.formatHeroCredit)
+  // render that sentinel as "Photograph by jem". Anything else renders
+  // as "Photo · {credit}".
   credit: z.string(),
   license: imageLicense.default('venue-media-kit'),
   caption: z.string().optional(),

--- a/next/src/content/venues/epicurean-red-hill.json
+++ b/next/src/content/venues/epicurean-red-hill.json
@@ -53,7 +53,7 @@
   "heroImage": {
     "src": "/images/sourced/eat-epicurean-red-hill-01.webp",
     "alt": "The Epicurean Red Hill restaurant exterior with autumn ivy on the corrugated-iron facade, Mornington Peninsula",
-    "credit": "Peninsula Insider",
+    "credit": "jem",
     "license": "other-licensed"
   },
   "gallery": [],

--- a/next/src/lib/editorial.ts
+++ b/next/src/lib/editorial.ts
@@ -366,6 +366,23 @@ export function heroBackgroundStyle(data: any): string {
 }
 
 /**
+ * Format a hero-image credit string for display under the hero.
+ *
+ * Convention: when the photo is taken by James and Emma, set the
+ * heroImage `credit` field to the literal string "jem". This template
+ * then renders the byline as "Photograph by jem" instead of the default
+ * "Photo · {credit}" prefix used for everyone else.
+ *
+ * Opt in by setting `credit: "jem"` on a venue, place, or article
+ * heroImage. Anything else passes through unchanged.
+ */
+export function formatHeroCredit(credit: string | undefined | null): string {
+  if (!credit) return '';
+  if (credit.trim().toLowerCase() === 'jem') return 'Photograph by jem';
+  return `Photo · ${credit}`;
+}
+
+/**
  * Return the current Southern-Hemisphere season from a Date.
  * Used for seasonal hooks on index pages.
  */

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -12,7 +12,7 @@ import SaveButton from '../../components/v2/SaveButton.astro';
 import ClusterLinks from '../../components/ClusterLinks.astro';
 import ItineraryCard from '../../components/ItineraryCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
-import { formatLabel, routeSlug, venueHrefPrefix, titleize, heroBackgroundStyle } from '../../lib/editorial';
+import { formatLabel, routeSlug, venueHrefPrefix, titleize, heroBackgroundStyle, formatHeroCredit } from '../../lib/editorial';
 import { pickRelatedArticles, resolveRefs } from '../../lib/related';
 
 export async function getStaticPaths() {
@@ -164,7 +164,7 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
           <figure class="article-hero__figure">
             <div class="article-hero__image" role="img" aria-label={article.data.heroImage.alt} style={articleHeroStyle}></div>
             {article.data.heroImage.credit && (
-              <figcaption class="article-hero__credit">Photo · {article.data.heroImage.credit}</figcaption>
+              <figcaption class="article-hero__credit">{formatHeroCredit(article.data.heroImage.credit)}</figcaption>
             )}
           </figure>
         </div>

--- a/next/src/pages/journal/local-secrets/[slug].astro
+++ b/next/src/pages/journal/local-secrets/[slug].astro
@@ -12,6 +12,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import VenueCard from '../../../components/VenueCard.astro';
 import PlaceCard from '../../../components/PlaceCard.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import { formatHeroCredit } from '../../../lib/editorial';
 
 export async function getStaticPaths() {
   const secrets = await getCollection('localSecrets');
@@ -59,7 +60,7 @@ const breadcrumbItems = [
       {data.heroImage?.src && (
         <figure class="local-secret-detail__hero">
           <img src={data.heroImage.src} alt={data.heroImage.alt} loading="lazy" />
-          {data.heroImage.credit && <figcaption>{data.heroImage.credit}</figcaption>}
+          {data.heroImage.credit && <figcaption>{formatHeroCredit(data.heroImage.credit)}</figcaption>}
         </figure>
       )}
 

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -1960,6 +1960,15 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   text-transform: uppercase;
   font-weight: 500;
 }
+.venue-detail__hero-credit {
+  margin: -2.4rem 0 1.6rem 0;
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--soft);
+  text-align: right;
+}
 
 .venue-detail__grid {
   display: grid;


### PR DESCRIPTION
## Summary

Adds a credit-tag rule for photos taken by James and Emma. Any `heroImage.credit` set to the literal string `"jem"` renders as **Photograph by jem** on the live page, in the same subtle placement as the existing journal photo credits. All other credit values continue to render as `Photo · {credit}` per the established journal-article pattern.

## How to opt in

In any heroImage block, set:

```json
"heroImage": {
  ...
  "credit": "jem",
  ...
}
```

That single field controls when the JEM byline appears. Documented inline in [`content.config.ts`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/content.config.ts) at the schema level, and in the JSDoc of [`formatHeroCredit`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/lib/editorial.ts) which all templates use.

## What was changed

- **New helper** `formatHeroCredit(credit)` in [`next/src/lib/editorial.ts`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/lib/editorial.ts).
- **Journal article template** ([`journal/[slug].astro`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/pages/journal/%5Bslug%5D.astro)) now uses the helper instead of a hardcoded prefix.
- **Local-secrets template** ([`local-secrets/[slug].astro`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/pages/journal/local-secrets/%5Bslug%5D.astro)) now also uses the helper (was previously rendering raw credit with no prefix).
- **Venue template** ([`VenueDetailTemplate.astro`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/components/VenueDetailTemplate.astro)) now renders a credit caption beneath the hero. Previously absent. Style matches the journal pattern: 0.62rem, soft, uppercase, right-aligned.
- **CSS** for `.venue-detail__hero-credit` added to [`global.css`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/styles/global.css).
- **Epicurean Red Hill venue file** flips its `credit` from `"Peninsula Insider"` to `"jem"` (the existing JEM photo from PR #84). This is the rule's first live use.

## Test plan

- [ ] After deploy, visit https://peninsulainsider.com.au/eat/epicurean-red-hill/ and confirm the byline reads **Photograph by jem** beneath the hero
- [ ] Visit any journal article that has `credit` set to something else (e.g. an Unsplash credit) and confirm it still reads **Photo · {credit}**
- [ ] Subjective: is the placement subtle enough? CSS is at [`global.css:.venue-detail__hero-credit`](https://github.com/richmondjw/peninsula-insider/blob/feat/jem-photo-credit/next/src/styles/global.css) if you want it tighter or further from the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)