### PR TITLE
feat(cms): admin hybrid scaffold + editable wrappers + Supabase server helpers + migrations

### DIFF
--- a/next/astro.config.mjs
+++ b/next/astro.config.mjs
@@ -2,19 +2,39 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
-// Peninsula Insider — Astro config (Phase 1 scaffold).
+// Peninsula Insider — Astro config.
 // Decisions locked in roadmap-2026-04-09.md § 4 and § 9:
 //   • Astro + JSON content collections as the source of truth
-//   • Static output — no SSR in Phase 1
+//   • Static output by default — the public site is fully prerendered
 //   • Content-first: zero-JS by default on content pages
-//   • Islands will be added later for map, search, wizard
+//   • Islands are added per-need (map, search, wizard, admin)
 //
-// Do not add integrations (Tailwind, MDX, etc.) until they earn their place.
-// Intentionally minimal so a human dev can pick this up and see the bones.
+// Admin hybrid cutover (see next/docs/pi-cms-hybrid-cutover-2026-05-10.md):
+// when PI_ADMIN_HYBRID=1, switch to server output and load a Vercel adapter so
+// `src/middleware.ts` runs at request time and `/admin/api/*` becomes real
+// serverless. Without that env var, behaviour is unchanged. The adapter is
+// loaded dynamically so the static build does not need it installed.
 
 // Preview builds to /V2/ on GitHub Pages set ASTRO_BASE=/V2/.
 // Production (root-served) builds leave it unset.
 const base = process.env.ASTRO_BASE || undefined;
+
+const adminHybrid = process.env.PI_ADMIN_HYBRID === '1';
+
+let adapter;
+if (adminHybrid) {
+  try {
+    const mod = await import('@astrojs/vercel');
+    adapter = mod.default({});
+  } catch (err) {
+    // The adapter is intentionally optional. If hybrid mode is requested but
+    // the adapter is not installed, fail loud rather than silently producing a
+    // static build that cannot run middleware or admin endpoints.
+    throw new Error(
+      'PI_ADMIN_HYBRID=1 but @astrojs/vercel is not installed. Run `npm install @astrojs/vercel` in next/ and retry.'
+    );
+  }
+}
 
 export default defineConfig({
   site: 'https://peninsulainsider.com.au',
@@ -26,8 +46,8 @@ export default defineConfig({
   integrations: [
     mdx(), // hub-guide, trail-guide, venue-guide articles use AlertBlock + ClusterLinks components
   ],
-  // Output: pure static. Vercel/Netlify adapters come in the cutover week.
-  output: 'static',
+  output: adminHybrid ? 'server' : 'static',
+  adapter,
   // Redirects are handled by custom src/pages/*.astro files using the
   // Redirect component (src/components/Redirect.astro). This gives flash-free
   // JS redirects instead of Astro's meta-refresh HTML which flashes body content.

--- a/next/docs/pi-cms-hybrid-cutover-2026-05-10.md
+++ b/next/docs/pi-cms-hybrid-cutover-2026-05-10.md
@@ -1,0 +1,55 @@
+# PI CMS Hybrid Cutover Plan — 2026-05-10
+
+## Why this exists
+
+The CMS/admin layer now has three real parts:
+- editable UI seams in the Astro source
+- structured content backing for homepage admin surfaces
+- schema + migration plan for content, media, revisions, and admin allowlist
+
+What it still does **not** have is honest server-side protection.
+
+As long as the app is pure static output, `/admin` can only be cosmetic. Real route protection, session checks, and write endpoints require server execution.
+
+## Recommended cutover shape
+
+### 1. Keep public rendering mostly static in practice
+Use Astro server output on Vercel, but preserve `prerender = true` for public-first pages wherever we want static characteristics.
+
+### 2. Turn on hybrid admin mode behind an env flag
+Use `PI_ADMIN_HYBRID=1` to activate:
+- Astro server output via Vercel adapter
+- `src/middleware.ts` admin route protection
+- redirect unauthenticated users to `/admin/login`
+- 401 on protected admin API routes
+
+### 3. Keep the public site stable during cutover
+The admin rollout should not force a full app re-architecture in one shot. The switch should be deployment-gated and reversible.
+
+## What has already been scaffolded
+- `src/middleware.ts`
+- `src/pages/admin/login.astro`
+- env-gated hybrid config in `astro.config.mjs`
+- route helpers in `src/lib/admin.ts`
+
+## Next secure step
+The current admin gate still relies on the existing admin hint (`?admin=1` / cookie seam). That is fine as a transitional scaffold, but not good enough for production.
+
+Production-grade next step:
+1. Validate Supabase user session server-side
+2. Check `pi.profiles.is_editor = true`
+3. Check explicit allowlist / publish rights in CMS admin table
+4. Set a short-lived server cookie or session contract for admin routes
+5. Reject all writes that do not pass server validation
+
+## Suggested implementation order
+1. Enable `PI_ADMIN_HYBRID=1` in a preview environment only
+2. Confirm `/admin/login` and middleware behaviour on preview
+3. Add server-side Supabase session validation
+4. Upgrade admin API routes from scaffold to real reads/writes
+5. Connect homepage fields to CMS tables instead of JSON-only backing
+6. Extend editable coverage from homepage to hero components on `eat`, `stay`, `whats-on`
+
+## Principle
+The admin layer should feel small, elegant, and deliberate.
+The shift to hybrid/server mode is infrastructure work in service of trust — not a reason to bloat the product.

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "5.0.3",
+        "@astrojs/vercel": "^10.0.6",
         "@supabase/supabase-js": "^2.105.1",
         "lenis": "^1.3.23",
         "potrace": "^2.1.8"
@@ -184,6 +185,71 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/vercel": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-10.0.6.tgz",
+      "integrity": "sha512-Ubd1M77QWqXXluFNL8/ynmfyZCfIUVuL6QRpPXGYOIQ8Dv3QBXM34e0CMig3OgmihSIWNv9sqQHzEHDyDJV9QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@vercel/analytics": "^1.6.1",
+        "@vercel/functions": "^3.4.3",
+        "@vercel/nft": "^1.3.2",
+        "@vercel/routing-utils": "^5.3.3",
+        "esbuild": "^0.27.3",
+        "tinyglobby": "^0.2.15"
+      },
+      "peerDependencies": {
+        "astro": "^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/vercel/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@astrojs/vercel/node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/yaml2ts": {
@@ -1254,6 +1320,18 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jimp/bmp": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
@@ -1711,6 +1789,27 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
@@ -2525,6 +2624,113 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vercel/functions": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.1.tgz",
+      "integrity": "sha512-ndh5v+uhWqGA8033oD0i0KHvqUHcLlLCOaLOw5L+xx5zVsWUSQcZPKEYk2nm51aisnKhcnTylxnOmhx+w4UCRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/nft": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
+      "integrity": "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@rollup/pluginutils": "^5.1.3",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^13.0.0",
+        "graceful-fs": "^4.2.9",
+        "node-gyp-build": "^4.2.2",
+        "picomatch": "^4.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/nft/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/routing-utils": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@vercel/routing-utils/-/routing-utils-5.3.3.tgz",
+      "integrity": "sha512-KYm2sLNUD48gDScv8ob4ejc3Gww2jcJyW80hTdYlenAPz/5BQar1Gyh38xrUuZ532TUwSb5mV1uRbAuiykq0EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0"
+      },
+      "optionalDependencies": {
+        "ajv": "^6.12.3"
+      }
+    },
+    "node_modules/@vercel/routing-utils/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@vercel/routing-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
@@ -2623,6 +2829,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2633,6 +2848,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -2648,7 +2872,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2911,6 +3134,12 @@
         "vfile": "^6.0.3"
       }
     },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+      "license": "MIT"
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2943,6 +3172,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bare-events": {
@@ -3072,6 +3310,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
@@ -3083,6 +3330,18 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -3212,6 +3471,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
@@ -3331,6 +3599,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/cookie": {
@@ -3543,7 +3820,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4047,7 +4323,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -4056,6 +4332,13 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
@@ -4133,6 +4416,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -4255,6 +4544,23 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/global": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
@@ -4264,6 +4570,12 @@
         "min-document": "^2.19.0",
         "process": "^0.11.10"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -4554,7 +4866,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6035,6 +6346,21 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -6042,6 +6368,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -6135,17 +6482,63 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
       "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6458,6 +6851,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp-updated": {
+      "name": "path-to-regexp",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6654,6 +7076,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
@@ -7396,6 +7828,22 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -7495,6 +7943,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -7892,6 +8346,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/utif": {
@@ -8310,6 +8774,22 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -8428,6 +8908,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yaml": {

--- a/next/package.json
+++ b/next/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "5.0.3",
+    "@astrojs/vercel": "^10.0.6",
     "@supabase/supabase-js": "^2.105.1",
     "lenis": "^1.3.23",
     "potrace": "^2.1.8"

--- a/next/src/components/EditableImage.astro
+++ b/next/src/components/EditableImage.astro
@@ -1,0 +1,69 @@
+---
+import { getEditableAttrs } from './editable';
+
+export interface Props {
+  id: string;
+  src: string;
+  alt?: string;
+  mode?: 'public' | 'admin';
+  label?: string;
+  class?: string;
+  imgClass?: string;
+  loading?: 'eager' | 'lazy';
+  decoding?: 'sync' | 'async' | 'auto';
+}
+
+const {
+  id,
+  src,
+  alt = '',
+  mode = 'public',
+  label,
+  class: className,
+  imgClass,
+  loading = 'lazy',
+  decoding = 'async',
+} = Astro.props;
+
+const attrs = getEditableAttrs({ id, mode, label });
+---
+
+<div
+  class:list={['editable-slot', 'editable-slot--image', mode === 'admin' && 'editable-slot--admin', className]}
+  {...attrs}
+>
+  <img src={src} alt={alt} class={imgClass} loading={loading} decoding={decoding} />
+</div>
+
+<style>
+  .editable-slot--image {
+    position: relative;
+  }
+
+  .editable-slot--image :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .editable-slot--admin.editable-slot--image {
+    outline: 1px dashed rgba(160, 84, 31, 0.45);
+    outline-offset: 0.2rem;
+  }
+
+  .editable-slot--admin.editable-slot--image::before {
+    content: attr(data-editable-label);
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    font: 600 0.6rem/1 'Outfit', system-ui, sans-serif;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #8b4e3b;
+    background: rgba(250, 247, 240, 0.92);
+    padding: 0.15rem 0.35rem;
+    border-radius: 999px;
+    pointer-events: none;
+    z-index: 2;
+  }
+</style>

--- a/next/src/components/EditableText.astro
+++ b/next/src/components/EditableText.astro
@@ -1,0 +1,58 @@
+---
+import { getEditableAttrs } from './editable';
+
+export interface Props {
+  id: string;
+  text?: string;
+  html?: string;
+  mode?: 'public' | 'admin';
+  as?: keyof HTMLElementTagNameMap;
+  class?: string;
+  label?: string;
+}
+
+const {
+  id,
+  text,
+  html,
+  mode = 'public',
+  as = 'div',
+  class: className,
+  label,
+} = Astro.props;
+
+const Tag = as;
+const attrs = getEditableAttrs({ id, mode, label });
+const content = html ?? text ?? '';
+---
+
+<Tag
+  class:list={['editable-slot', 'editable-slot--text', mode === 'admin' && 'editable-slot--admin', className]}
+  {...attrs}
+>
+  {html ? <Fragment set:html={content} /> : content}
+</Tag>
+
+<style>
+  .editable-slot--admin[data-editable-id] {
+    outline: 1px dashed rgba(160, 84, 31, 0.45);
+    outline-offset: 0.18rem;
+    position: relative;
+  }
+
+  .editable-slot--admin[data-editable-id]::before {
+    content: attr(data-editable-label);
+    position: absolute;
+    top: -0.8rem;
+    left: 0;
+    font: 600 0.6rem/1 'Outfit', system-ui, sans-serif;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #8b4e3b;
+    background: rgba(250, 247, 240, 0.92);
+    padding: 0.15rem 0.35rem;
+    border-radius: 999px;
+    pointer-events: none;
+    z-index: 2;
+  }
+</style>

--- a/next/src/components/admin/Editable.astro
+++ b/next/src/components/admin/Editable.astro
@@ -1,0 +1,28 @@
+---
+import { toEditableAttr, type AdminCollection } from '../../lib/admin';
+
+export interface Props {
+  collection: AdminCollection;
+  slug: string;
+  field?: string;
+  label?: string;
+  as?: keyof HTMLElementTagNameMap;
+  enabled?: boolean;
+}
+
+const {
+  collection,
+  slug,
+  field,
+  label,
+  as = 'div',
+  enabled = false,
+} = Astro.props;
+
+const Tag = as;
+const editable = enabled ? toEditableAttr({ collection, slug, field, label }) : null;
+---
+
+<Tag class:list={[enabled && 'pi-editable']} data-pi-editable={editable ?? undefined}>
+  <slot />
+</Tag>

--- a/next/src/components/editable.ts
+++ b/next/src/components/editable.ts
@@ -1,0 +1,21 @@
+export type EditableMode = 'public' | 'admin';
+
+export interface EditableBaseProps {
+  id: string;
+  mode?: EditableMode;
+  label?: string;
+  as?: string;
+  class?: string;
+}
+
+export function getEditableAttrs({
+  id,
+  mode = 'public',
+  label,
+}: Pick<EditableBaseProps, 'id' | 'mode' | 'label'>) {
+  return {
+    'data-editable-id': id,
+    'data-editable-label': label ?? id,
+    'data-editable-mode': mode,
+  };
+}

--- a/next/src/lib/admin.ts
+++ b/next/src/lib/admin.ts
@@ -1,0 +1,63 @@
+export const ADMIN_COOKIE = 'pi_admin';
+export const ADMIN_QUERY_PARAM = 'admin';
+export const ADMIN_LOGIN_PATH = '/admin/login';
+export const ADMIN_HOME_PATH = '/admin';
+export const ADMIN_HYBRID_ENV = 'PI_ADMIN_HYBRID';
+
+export type AdminCollection =
+  | 'articles'
+  | 'venues'
+  | 'experiences'
+  | 'places'
+  | 'itineraries'
+  | 'events'
+  | 'editorial_blocks';
+
+export type EditablePayload = {
+  collection: AdminCollection;
+  slug: string;
+  field?: string;
+  label?: string;
+};
+
+export function isAdminPath(pathname: string): boolean {
+  return pathname === ADMIN_HOME_PATH || pathname.startsWith(`${ADMIN_HOME_PATH}/`);
+}
+
+export function isAdminLoginPath(pathname: string): boolean {
+  return pathname === ADMIN_LOGIN_PATH || pathname.startsWith(`${ADMIN_LOGIN_PATH}/`);
+}
+
+export function isAdminApiPath(pathname: string): boolean {
+  return pathname.startsWith('/admin/api/') || pathname.startsWith('/api/admin/');
+}
+
+export function isAdminEnabledFromUrl(url: URL): boolean {
+  return url.searchParams.get(ADMIN_QUERY_PARAM) === '1';
+}
+
+export function isAdminEnabledFromCookie(cookieHeader?: string | null): boolean {
+  if (!cookieHeader) return false;
+  return cookieHeader
+    .split(';')
+    .map((part) => part.trim())
+    .some((part) => part === `${ADMIN_COOKIE}=1`);
+}
+
+export function canAccessAdmin(url: URL, cookieHeader?: string | null): boolean {
+  return isAdminEnabledFromUrl(url) || isAdminEnabledFromCookie(cookieHeader);
+}
+
+export function buildAdminLoginHref(nextPath?: string): string {
+  const login = new URL(ADMIN_LOGIN_PATH, 'https://peninsulainsider.com.au');
+  if (nextPath) login.searchParams.set('next', nextPath);
+  return `${login.pathname}${login.search}`;
+}
+
+export function isAdminHybridEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return env[ADMIN_HYBRID_ENV] === '1';
+}
+
+export function toEditableAttr(payload: EditablePayload): string {
+  return JSON.stringify(payload).replace(/"/g, '&quot;');
+}

--- a/next/src/lib/admin.ts
+++ b/next/src/lib/admin.ts
@@ -3,6 +3,7 @@ export const ADMIN_QUERY_PARAM = 'admin';
 export const ADMIN_LOGIN_PATH = '/admin/login';
 export const ADMIN_HOME_PATH = '/admin';
 export const ADMIN_HYBRID_ENV = 'PI_ADMIN_HYBRID';
+export const ADMIN_LEGACY_GATE_ENV = 'PI_ADMIN_LEGACY_GATE';
 
 export type AdminCollection =
   | 'articles'
@@ -56,6 +57,16 @@ export function buildAdminLoginHref(nextPath?: string): string {
 
 export function isAdminHybridEnabled(env: Record<string, string | undefined> = process.env): boolean {
   return env[ADMIN_HYBRID_ENV] === '1';
+}
+
+/**
+ * When `PI_ADMIN_LEGACY_GATE=1` the middleware additionally honours the
+ * transitional `?admin=1` query / `pi_admin=1` cookie seam from Phase 1, so
+ * local QA without a Supabase session can keep working. Production deploys
+ * leave this unset, and the only path in is a real Supabase session.
+ */
+export function isAdminLegacyGateEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return env[ADMIN_LEGACY_GATE_ENV] === '1';
 }
 
 export function toEditableAttr(payload: EditablePayload): string {

--- a/next/src/lib/cms/api.ts
+++ b/next/src/lib/cms/api.ts
@@ -1,0 +1,451 @@
+/**
+ * Peninsula Insider — CMS data access.
+ *
+ * Thin functional layer over Supabase that returns typed results in the shape
+ * defined by `./schema.ts`. Both the admin server (with a per-request JWT
+ * client) and the build-time anon-key reader use the same helpers.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  CMS_EDITABLE_ENTITY_TYPES,
+  CMS_ENTRY_STATUSES,
+  CMS_FIELD_KINDS,
+  CMS_IMAGE_SLOT_PURPOSES,
+  CMS_REVISION_ACTIONS,
+  type CmsEditableEntityType,
+  type CmsEditableImageSlot,
+  type CmsEditableTextField,
+  type CmsEntryStatus,
+  type CmsFieldKind,
+  type CmsImageSlotPurpose,
+  type CmsRevisionAction,
+  type CmsRevisionPatch,
+  type CmsRevisionRecord,
+} from './schema.ts';
+
+// ---- row shape coming back from Postgres -----------------------------------
+
+interface TextFieldRow {
+  id: string;
+  entity_type: string;
+  entity_slug: string;
+  field_path: string;
+  label: string;
+  field_kind: string;
+  locale: string | null;
+  value: string | null;
+  status: string;
+  updated_by: string | null;
+  updated_at: string;
+}
+
+interface ImageSlotRow {
+  id: string;
+  entity_type: string;
+  entity_slug: string;
+  field_path: string;
+  label: string;
+  purpose: string;
+  storage_bucket: string;
+  storage_path: string | null;
+  public_url: string | null;
+  alt_text: string | null;
+  caption: string | null;
+  credit: string | null;
+  mime_type: string | null;
+  status: string;
+  updated_by: string | null;
+  updated_at: string;
+}
+
+interface RevisionRow {
+  id: string;
+  entity_type: string;
+  entity_slug: string;
+  action: string;
+  status: string;
+  summary: string | null;
+  patch: unknown;
+  created_by: string | null;
+  restored_from_revision_id: string | null;
+  created_at: string;
+}
+
+// ---- conversion ------------------------------------------------------------
+
+function asEntityType(v: string): CmsEditableEntityType {
+  return (CMS_EDITABLE_ENTITY_TYPES as readonly string[]).includes(v)
+    ? (v as CmsEditableEntityType)
+    : 'page';
+}
+function asStatus(v: string): CmsEntryStatus {
+  return (CMS_ENTRY_STATUSES as readonly string[]).includes(v) ? (v as CmsEntryStatus) : 'draft';
+}
+function asTextKind(v: string): Exclude<CmsFieldKind, 'image'> {
+  return v === 'markdown' || v === 'richtext' || v === 'text' ? v : 'text';
+}
+function asImagePurpose(v: string): CmsImageSlotPurpose {
+  return (CMS_IMAGE_SLOT_PURPOSES as readonly string[]).includes(v)
+    ? (v as CmsImageSlotPurpose)
+    : 'hero';
+}
+function asAction(v: string): CmsRevisionAction {
+  return (CMS_REVISION_ACTIONS as readonly string[]).includes(v)
+    ? (v as CmsRevisionAction)
+    : 'update';
+}
+
+function rowToTextField(row: TextFieldRow): CmsEditableTextField {
+  return {
+    id: row.id,
+    entityType: asEntityType(row.entity_type),
+    entitySlug: row.entity_slug,
+    fieldPath: row.field_path,
+    label: row.label,
+    kind: asTextKind(row.field_kind),
+    value: row.value,
+    status: asStatus(row.status),
+    locale: row.locale,
+    updatedAt: row.updated_at,
+    updatedBy: row.updated_by,
+  };
+}
+
+function rowToImageSlot(row: ImageSlotRow): CmsEditableImageSlot {
+  return {
+    id: row.id,
+    entityType: asEntityType(row.entity_type),
+    entitySlug: row.entity_slug,
+    fieldPath: row.field_path,
+    label: row.label,
+    purpose: asImagePurpose(row.purpose),
+    storageBucket: row.storage_bucket,
+    storagePath: row.storage_path,
+    publicUrl: row.public_url,
+    altText: row.alt_text,
+    caption: row.caption,
+    credit: row.credit,
+    mimeType: row.mime_type,
+    status: asStatus(row.status),
+    updatedAt: row.updated_at,
+    updatedBy: row.updated_by,
+  };
+}
+
+function rowToRevision(row: RevisionRow): CmsRevisionRecord {
+  const rawPatch = Array.isArray(row.patch) ? row.patch : [];
+  const patch: CmsRevisionPatch[] = rawPatch
+    .filter((p): p is Record<string, unknown> => typeof p === 'object' && p !== null)
+    .map((p) => {
+      const op = p.op === 'unset' ? 'unset' : 'set';
+      const target = typeof p.target === 'string' ? p.target : '';
+      const value = typeof p.value === 'string' || p.value === null ? p.value : undefined;
+      const out: CmsRevisionPatch = { op, target };
+      if (value !== undefined) out.value = value;
+      return out;
+    })
+    .filter((p) => p.target.length > 0);
+
+  return {
+    id: row.id,
+    entityType: asEntityType(row.entity_type),
+    entitySlug: row.entity_slug,
+    action: asAction(row.action),
+    status: asStatus(row.status),
+    summary: row.summary,
+    patch,
+    createdAt: row.created_at,
+    createdBy: row.created_by,
+    restoredFromRevisionId: row.restored_from_revision_id,
+  };
+}
+
+// ---- queries ---------------------------------------------------------------
+
+export interface FetchEntryOptions {
+  status?: CmsEntryStatus | 'any';
+}
+
+export async function listTextFieldsForEntry(
+  client: SupabaseClient,
+  entityType: CmsEditableEntityType,
+  entitySlug: string,
+  options: FetchEntryOptions = {},
+): Promise<CmsEditableTextField[]> {
+  let query = client
+    .from('cms_text_fields')
+    .select('*')
+    .eq('entity_type', entityType)
+    .eq('entity_slug', entitySlug)
+    .order('field_path', { ascending: true });
+  if (options.status && options.status !== 'any') {
+    query = query.eq('status', options.status);
+  }
+  const { data, error } = await query;
+  if (error || !data) return [];
+  return (data as TextFieldRow[]).map(rowToTextField);
+}
+
+export async function listImageSlotsForEntry(
+  client: SupabaseClient,
+  entityType: CmsEditableEntityType,
+  entitySlug: string,
+  options: FetchEntryOptions = {},
+): Promise<CmsEditableImageSlot[]> {
+  let query = client
+    .from('cms_image_slots')
+    .select('*')
+    .eq('entity_type', entityType)
+    .eq('entity_slug', entitySlug)
+    .order('field_path', { ascending: true });
+  if (options.status && options.status !== 'any') {
+    query = query.eq('status', options.status);
+  }
+  const { data, error } = await query;
+  if (error || !data) return [];
+  return (data as ImageSlotRow[]).map(rowToImageSlot);
+}
+
+export async function listRevisionsForEntry(
+  client: SupabaseClient,
+  entityType: CmsEditableEntityType,
+  entitySlug: string,
+  limit = 25,
+): Promise<CmsRevisionRecord[]> {
+  const { data, error } = await client
+    .from('cms_revisions')
+    .select('*')
+    .eq('entity_type', entityType)
+    .eq('entity_slug', entitySlug)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (error || !data) return [];
+  return (data as RevisionRow[]).map(rowToRevision);
+}
+
+// ---- writes ---------------------------------------------------------------
+
+export interface UpsertTextFieldInput {
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  fieldPath: string;
+  label: string;
+  kind: Exclude<CmsFieldKind, 'image'>;
+  value: string | null;
+  status: CmsEntryStatus;
+  locale?: string | null;
+}
+
+export async function upsertTextField(
+  client: SupabaseClient,
+  input: UpsertTextFieldInput,
+  actorId: string | null,
+): Promise<CmsEditableTextField | null> {
+  const payload = {
+    entity_type: input.entityType,
+    entity_slug: input.entitySlug,
+    field_path: input.fieldPath,
+    label: input.label,
+    field_kind: input.kind,
+    value: input.value,
+    status: input.status,
+    locale: input.locale ?? null,
+    updated_by: actorId,
+  };
+  const { data, error } = await client
+    .from('cms_text_fields')
+    .upsert(payload, { onConflict: 'entity_type,entity_slug,field_path,locale' })
+    .select('*')
+    .maybeSingle();
+  if (error || !data) return null;
+  return rowToTextField(data as TextFieldRow);
+}
+
+export interface UpsertImageSlotInput {
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  fieldPath: string;
+  label: string;
+  purpose: CmsImageSlotPurpose;
+  storageBucket: string;
+  storagePath: string | null;
+  publicUrl: string | null;
+  altText?: string | null;
+  caption?: string | null;
+  credit?: string | null;
+  mimeType?: string | null;
+  status: CmsEntryStatus;
+}
+
+export async function upsertImageSlot(
+  client: SupabaseClient,
+  input: UpsertImageSlotInput,
+  actorId: string | null,
+): Promise<CmsEditableImageSlot | null> {
+  const payload = {
+    entity_type: input.entityType,
+    entity_slug: input.entitySlug,
+    field_path: input.fieldPath,
+    label: input.label,
+    purpose: input.purpose,
+    storage_bucket: input.storageBucket,
+    storage_path: input.storagePath,
+    public_url: input.publicUrl,
+    alt_text: input.altText ?? null,
+    caption: input.caption ?? null,
+    credit: input.credit ?? null,
+    mime_type: input.mimeType ?? null,
+    status: input.status,
+    updated_by: actorId,
+  };
+  const { data, error } = await client
+    .from('cms_image_slots')
+    .upsert(payload, { onConflict: 'entity_type,entity_slug,field_path' })
+    .select('*')
+    .maybeSingle();
+  if (error || !data) return null;
+  return rowToImageSlot(data as ImageSlotRow);
+}
+
+export interface RecordRevisionInput {
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  action: CmsRevisionAction;
+  status: CmsEntryStatus;
+  summary?: string | null;
+  patch: CmsRevisionPatch[];
+}
+
+export async function recordRevision(
+  client: SupabaseClient,
+  input: RecordRevisionInput,
+  actorId: string | null,
+): Promise<CmsRevisionRecord | null> {
+  const payload = {
+    entity_type: input.entityType,
+    entity_slug: input.entitySlug,
+    action: input.action,
+    status: input.status,
+    summary: input.summary ?? null,
+    patch: input.patch,
+    created_by: actorId,
+  };
+  const { data, error } = await client
+    .from('cms_revisions')
+    .insert(payload)
+    .select('*')
+    .maybeSingle();
+  if (error || !data) return null;
+  return rowToRevision(data as RevisionRow);
+}
+
+// ---- aggregate read for an editor session ---------------------------------
+
+export interface CmsEntrySnapshot {
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  textFields: CmsEditableTextField[];
+  imageSlots: CmsEditableImageSlot[];
+  revisions: CmsRevisionRecord[];
+}
+
+export async function getCmsEntrySnapshot(
+  client: SupabaseClient,
+  entityType: CmsEditableEntityType,
+  entitySlug: string,
+  options: FetchEntryOptions = { status: 'any' },
+): Promise<CmsEntrySnapshot> {
+  const [textFields, imageSlots, revisions] = await Promise.all([
+    listTextFieldsForEntry(client, entityType, entitySlug, options),
+    listImageSlotsForEntry(client, entityType, entitySlug, options),
+    listRevisionsForEntry(client, entityType, entitySlug, 25),
+  ]);
+  return { entityType, entitySlug, textFields, imageSlots, revisions };
+}
+
+// ---- public/build-time read for a published page --------------------------
+
+export async function getPublishedPageOverrides(
+  client: SupabaseClient,
+  entitySlug: string,
+): Promise<{ textFields: CmsEditableTextField[]; imageSlots: CmsEditableImageSlot[] }> {
+  const [textFields, imageSlots] = await Promise.all([
+    listTextFieldsForEntry(client, 'page', entitySlug, { status: 'published' }),
+    listImageSlotsForEntry(client, 'page', entitySlug, { status: 'published' }),
+  ]);
+  return { textFields, imageSlots };
+}
+
+// ---- collection inventory for the admin dashboard -------------------------
+
+export interface CmsCollectionSummaryRow {
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  textFieldCount: number;
+  imageSlotCount: number;
+  draftCount: number;
+  publishedCount: number;
+  lastUpdatedAt: string | null;
+}
+
+/**
+ * Aggregate summary across both text and image rows. Cheap enough for the
+ * scale we expect in v1 — pulls all rows readable to the caller and groups in
+ * memory. RLS already filters to admin-readable rows.
+ */
+export async function listCmsEntries(
+  client: SupabaseClient,
+): Promise<CmsCollectionSummaryRow[]> {
+  const [textRes, imageRes] = await Promise.all([
+    client
+      .from('cms_text_fields')
+      .select('entity_type, entity_slug, status, updated_at'),
+    client
+      .from('cms_image_slots')
+      .select('entity_type, entity_slug, status, updated_at'),
+  ]);
+
+  type Bucket = CmsCollectionSummaryRow;
+  const byKey = new Map<string, Bucket>();
+
+  function bump(
+    entityType: string,
+    entitySlug: string,
+    status: string,
+    updatedAt: string,
+    kind: 'text' | 'image',
+  ) {
+    const key = `${entityType}::${entitySlug}`;
+    const current = byKey.get(key) ?? {
+      entityType: asEntityType(entityType),
+      entitySlug,
+      textFieldCount: 0,
+      imageSlotCount: 0,
+      draftCount: 0,
+      publishedCount: 0,
+      lastUpdatedAt: null as string | null,
+    };
+    if (kind === 'text') current.textFieldCount += 1;
+    if (kind === 'image') current.imageSlotCount += 1;
+    if (status === 'draft') current.draftCount += 1;
+    if (status === 'published') current.publishedCount += 1;
+    if (!current.lastUpdatedAt || updatedAt > current.lastUpdatedAt) {
+      current.lastUpdatedAt = updatedAt;
+    }
+    byKey.set(key, current);
+  }
+
+  for (const row of (textRes.data ?? []) as TextFieldRow[]) {
+    bump(row.entity_type, row.entity_slug, row.status, row.updated_at, 'text');
+  }
+  for (const row of (imageRes.data ?? []) as ImageSlotRow[]) {
+    bump(row.entity_type, row.entity_slug, row.status, row.updated_at, 'image');
+  }
+
+  return [...byKey.values()].sort((a, b) => {
+    const aT = a.lastUpdatedAt ?? '';
+    const bT = b.lastUpdatedAt ?? '';
+    return bT.localeCompare(aT);
+  });
+}

--- a/next/src/lib/cms/schema.ts
+++ b/next/src/lib/cms/schema.ts
@@ -1,0 +1,82 @@
+export const CMS_EDITABLE_ENTITY_TYPES = ['article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary'] as const;
+
+export type CmsEditableEntityType = (typeof CMS_EDITABLE_ENTITY_TYPES)[number];
+
+export const CMS_FIELD_KINDS = ['text', 'markdown', 'richtext', 'image'] as const;
+export type CmsFieldKind = (typeof CMS_FIELD_KINDS)[number];
+
+export const CMS_ENTRY_STATUSES = ['draft', 'published'] as const;
+export type CmsEntryStatus = (typeof CMS_ENTRY_STATUSES)[number];
+
+export const CMS_REVISION_ACTIONS = ['create', 'update', 'publish', 'unpublish', 'restore'] as const;
+export type CmsRevisionAction = (typeof CMS_REVISION_ACTIONS)[number];
+
+export const CMS_IMAGE_SLOT_PURPOSES = ['hero', 'card', 'gallery', 'inline', 'seo'] as const;
+export type CmsImageSlotPurpose = (typeof CMS_IMAGE_SLOT_PURPOSES)[number];
+
+export type CmsFieldPath = string;
+
+export interface CmsEditableTextField {
+  id: string;
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  fieldPath: CmsFieldPath;
+  label: string;
+  kind: Exclude<CmsFieldKind, 'image'>;
+  value: string | null;
+  status: CmsEntryStatus;
+  locale: string | null;
+  updatedAt: string;
+  updatedBy: string | null;
+}
+
+export interface CmsEditableImageSlot {
+  id: string;
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  fieldPath: CmsFieldPath;
+  label: string;
+  purpose: CmsImageSlotPurpose;
+  storageBucket: string;
+  storagePath: string | null;
+  publicUrl: string | null;
+  altText: string | null;
+  caption: string | null;
+  credit: string | null;
+  mimeType: string | null;
+  status: CmsEntryStatus;
+  updatedAt: string;
+  updatedBy: string | null;
+}
+
+export interface CmsRevisionPatch {
+  op: 'set' | 'unset';
+  target: CmsFieldPath;
+  value?: string | null;
+}
+
+export interface CmsRevisionRecord {
+  id: string;
+  entityType: CmsEditableEntityType;
+  entitySlug: string;
+  action: CmsRevisionAction;
+  status: CmsEntryStatus;
+  summary: string | null;
+  patch: CmsRevisionPatch[];
+  createdAt: string;
+  createdBy: string | null;
+  restoredFromRevisionId: string | null;
+}
+
+export interface CmsEditorIdentity {
+  userId: string;
+  email: string | null;
+  isEditor: boolean;
+}
+
+export interface CmsAdminAccess {
+  identity: CmsEditorIdentity;
+  canRead: boolean;
+  canWrite: boolean;
+  canPublish: boolean;
+}

--- a/next/src/lib/cms/server.ts
+++ b/next/src/lib/cms/server.ts
@@ -1,0 +1,205 @@
+/**
+ * Peninsula Insider — CMS server-side helpers.
+ *
+ * Used by:
+ *   - src/middleware.ts (when PI_ADMIN_HYBRID=1) to gate admin paths
+ *   - src/pages/admin/api/* routes to authorise reads/writes
+ *
+ * The browser/client uses src/lib/auth.ts for the public-facing Supabase
+ * client. This file is the *server* counterpart: it inspects the request
+ * cookie for a Supabase session token, calls auth.getUser(token) to confirm
+ * identity with the auth server, then looks up admin access through the same
+ * RLS-protected views the migration wires up.
+ *
+ * Importantly, every Supabase call here passes the user's JWT in the
+ * Authorization header so RLS evaluates as that user — never the service-role
+ * key. RLS is the security boundary; this helper is the auditable path to it.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { CmsAdminAccess, CmsEditorIdentity } from './schema.ts';
+
+const SUPABASE_URL =
+  (import.meta.env.PUBLIC_SUPABASE_URL as string | undefined) ||
+  process.env.PUBLIC_SUPABASE_URL ||
+  'https://tjjhpvslpysfklwpqmgz.supabase.co';
+
+const SUPABASE_ANON_KEY =
+  (import.meta.env.PUBLIC_SUPABASE_ANON_KEY as string | undefined) ||
+  process.env.PUBLIC_SUPABASE_ANON_KEY;
+
+export const PI_AUTH_COOKIE_PREFIX = 'sb-';
+export const PI_AUTH_TOKEN_COOKIE = 'pi-sb-access-token';
+export const PI_AUTH_REFRESH_COOKIE = 'pi-sb-refresh-token';
+
+export function isCmsServerConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+}
+
+/**
+ * Read a single cookie value out of a raw `Cookie` header.
+ * Returns null when missing or empty. Whitespace tolerant.
+ */
+export function readCookie(header: string | null | undefined, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const [k, ...rest] = part.split('=');
+    if (!k) continue;
+    if (k.trim() === name) {
+      const v = rest.join('=').trim();
+      return v.length > 0 ? decodeURIComponent(v) : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Best-effort token extraction. Prefers our explicit `pi-sb-access-token`
+ * cookie (set by the admin login page after a successful Supabase sign-in)
+ * and falls back to scanning for any `sb-*-access-token` cookie that the
+ * Supabase client may have written into shared state.
+ */
+export function readSupabaseAccessToken(cookieHeader: string | null | undefined): string | null {
+  const direct = readCookie(cookieHeader, PI_AUTH_TOKEN_COOKIE);
+  if (direct) return direct;
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(';')) {
+    const [k, ...rest] = part.split('=');
+    if (!k) continue;
+    const name = k.trim();
+    if (name.startsWith(PI_AUTH_COOKIE_PREFIX) && name.endsWith('-access-token')) {
+      const v = rest.join('=').trim();
+      if (v.length > 0) return decodeURIComponent(v);
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a Supabase client scoped to the request user's JWT. All queries it
+ * issues will pass the JWT in the Authorization header, so RLS evaluates as
+ * that user. The session is *not* persisted on the server.
+ */
+export function createCmsClientForToken(token: string): SupabaseClient | null {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return null;
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+    db: { schema: 'pi' },
+    global: {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  });
+}
+
+/**
+ * Build a Supabase client with the public anon key only. Used for build-time
+ * reads of *published* CMS content (which the public-read RLS migration
+ * exposes). Never use this client for writes.
+ */
+export function createCmsAnonClient(): SupabaseClient | null {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return null;
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    db: { schema: 'pi' },
+  });
+}
+
+export interface ResolvedCmsAccess {
+  ok: boolean;
+  reason?: 'no-token' | 'invalid-token' | 'not-editor' | 'not-configured' | 'error';
+  access?: CmsAdminAccess;
+  client?: SupabaseClient;
+  token?: string;
+}
+
+/**
+ * Resolve admin access for a request. Returns a populated access object plus
+ * a request-scoped Supabase client when the requester is an approved editor.
+ *
+ * The chain is:
+ *   1. Read access token cookie
+ *   2. supabase.auth.getUser(token) — verifies signature with the auth server
+ *   3. profiles.select(is_editor)
+ *   4. admin_user_allowlist.select(role, can_publish)
+ */
+export async function resolveCmsAccess(
+  cookieHeader: string | null | undefined,
+): Promise<ResolvedCmsAccess> {
+  if (!isCmsServerConfigured()) return { ok: false, reason: 'not-configured' };
+
+  const token = readSupabaseAccessToken(cookieHeader);
+  if (!token) return { ok: false, reason: 'no-token' };
+
+  const client = createCmsClientForToken(token);
+  if (!client) return { ok: false, reason: 'not-configured' };
+
+  const { data: userData, error: userErr } = await client.auth.getUser(token);
+  if (userErr || !userData?.user) return { ok: false, reason: 'invalid-token', token };
+
+  const user = userData.user;
+
+  const { data: profile, error: profileErr } = await client
+    .from('profiles')
+    .select('is_editor')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (profileErr) return { ok: false, reason: 'error', token };
+
+  const identity: CmsEditorIdentity = {
+    userId: user.id,
+    email: user.email ?? null,
+    isEditor: Boolean(profile?.is_editor),
+  };
+  if (!identity.isEditor) return { ok: false, reason: 'not-editor', token };
+
+  const { data: allow } = await client
+    .from('admin_user_allowlist')
+    .select('role, can_publish')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  const role = (allow?.role as string | undefined) ?? 'editor';
+  const canPublish = Boolean(allow?.can_publish) || role === 'publisher' || role === 'admin';
+
+  const access: CmsAdminAccess = {
+    identity,
+    canRead: true,
+    canWrite: true,
+    canPublish,
+  };
+
+  return { ok: true, access, client, token };
+}
+
+export function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+export function unauthorized(message = 'Unauthorized'): Response {
+  return jsonResponse({ ok: false, error: message }, { status: 401 });
+}
+
+export function forbidden(message = 'Forbidden'): Response {
+  return jsonResponse({ ok: false, error: message }, { status: 403 });
+}
+
+export function badRequest(message: string): Response {
+  return jsonResponse({ ok: false, error: message }, { status: 400 });
+}
+
+export function internalError(message = 'Internal error'): Response {
+  return jsonResponse({ ok: false, error: message }, { status: 500 });
+}

--- a/next/src/lib/cms/validators.ts
+++ b/next/src/lib/cms/validators.ts
@@ -1,0 +1,117 @@
+import {
+  CMS_EDITABLE_ENTITY_TYPES,
+  CMS_ENTRY_STATUSES,
+  CMS_FIELD_KINDS,
+  CMS_IMAGE_SLOT_PURPOSES,
+  CMS_REVISION_ACTIONS,
+  type CmsAdminAccess,
+  type CmsEditableImageSlot,
+  type CmsEditableTextField,
+  type CmsEditorIdentity,
+  type CmsRevisionRecord,
+} from './schema.ts';
+
+const hasOwn = <T extends object>(value: T, key: PropertyKey): key is keyof T =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === 'string';
+}
+
+function isIsoDateString(value: unknown): value is string {
+  return isString(value) && !Number.isNaN(Date.parse(value));
+}
+
+function isEnumValue<T extends readonly string[]>(value: unknown, values: T): value is T[number] {
+  return isString(value) && (values as readonly string[]).includes(value);
+}
+
+export function isCmsEditorIdentity(value: unknown): value is CmsEditorIdentity {
+  return (
+    isRecord(value) &&
+    isString(value.userId) &&
+    isNullableString(value.email) &&
+    typeof value.isEditor === 'boolean'
+  );
+}
+
+export function isCmsAdminAccess(value: unknown): value is CmsAdminAccess {
+  return (
+    isRecord(value) &&
+    hasOwn(value, 'identity') &&
+    isCmsEditorIdentity(value.identity) &&
+    typeof value.canRead === 'boolean' &&
+    typeof value.canWrite === 'boolean' &&
+    typeof value.canPublish === 'boolean'
+  );
+}
+
+export function isCmsEditableTextField(value: unknown): value is CmsEditableTextField {
+  return (
+    isRecord(value) &&
+    isString(value.id) &&
+    isEnumValue(value.entityType, CMS_EDITABLE_ENTITY_TYPES) &&
+    isString(value.entitySlug) &&
+    isString(value.fieldPath) &&
+    isString(value.label) &&
+    isEnumValue(value.kind, CMS_FIELD_KINDS) &&
+    value.kind !== 'image' &&
+    isNullableString(value.value) &&
+    isEnumValue(value.status, CMS_ENTRY_STATUSES) &&
+    isNullableString(value.locale) &&
+    isIsoDateString(value.updatedAt) &&
+    isNullableString(value.updatedBy)
+  );
+}
+
+export function isCmsEditableImageSlot(value: unknown): value is CmsEditableImageSlot {
+  return (
+    isRecord(value) &&
+    isString(value.id) &&
+    isEnumValue(value.entityType, CMS_EDITABLE_ENTITY_TYPES) &&
+    isString(value.entitySlug) &&
+    isString(value.fieldPath) &&
+    isString(value.label) &&
+    isEnumValue(value.purpose, CMS_IMAGE_SLOT_PURPOSES) &&
+    isString(value.storageBucket) &&
+    isNullableString(value.storagePath) &&
+    isNullableString(value.publicUrl) &&
+    isNullableString(value.altText) &&
+    isNullableString(value.caption) &&
+    isNullableString(value.credit) &&
+    isNullableString(value.mimeType) &&
+    isEnumValue(value.status, CMS_ENTRY_STATUSES) &&
+    isIsoDateString(value.updatedAt) &&
+    isNullableString(value.updatedBy)
+  );
+}
+
+export function isCmsRevisionRecord(value: unknown): value is CmsRevisionRecord {
+  return (
+    isRecord(value) &&
+    isString(value.id) &&
+    isEnumValue(value.entityType, CMS_EDITABLE_ENTITY_TYPES) &&
+    isString(value.entitySlug) &&
+    isEnumValue(value.action, CMS_REVISION_ACTIONS) &&
+    isEnumValue(value.status, CMS_ENTRY_STATUSES) &&
+    isNullableString(value.summary) &&
+    Array.isArray(value.patch) &&
+    value.patch.every((item) =>
+      isRecord(item) &&
+      (item.op === 'set' || item.op === 'unset') &&
+      isString(item.target) &&
+      (!hasOwn(item, 'value') || isNullableString(item.value))
+    ) &&
+    isIsoDateString(value.createdAt) &&
+    isNullableString(value.createdBy) &&
+    isNullableString(value.restoredFromRevisionId)
+  );
+}

--- a/next/src/lib/cms/validators.ts
+++ b/next/src/lib/cms/validators.ts
@@ -5,9 +5,13 @@ import {
   CMS_IMAGE_SLOT_PURPOSES,
   CMS_REVISION_ACTIONS,
   type CmsAdminAccess,
+  type CmsEditableEntityType,
   type CmsEditableImageSlot,
   type CmsEditableTextField,
   type CmsEditorIdentity,
+  type CmsEntryStatus,
+  type CmsFieldKind,
+  type CmsImageSlotPurpose,
   type CmsRevisionRecord,
 } from './schema.ts';
 
@@ -92,6 +96,68 @@ export function isCmsEditableImageSlot(value: unknown): value is CmsEditableImag
     isIsoDateString(value.updatedAt) &&
     isNullableString(value.updatedBy)
   );
+}
+
+// ---- input validators (write-path payloads) -------------------------------
+//
+// These differ from the record validators above: incoming payloads do not
+// carry server-assigned fields like `id`, `updatedAt`, `updatedBy`, so we
+// validate just the editor-supplied subset.
+
+export interface UpsertTextFieldPayload {
+  fieldPath: string;
+  label: string;
+  kind: Exclude<CmsFieldKind, 'image'>;
+  value: string | null;
+  status: CmsEntryStatus;
+  locale?: string | null;
+}
+
+export interface UpsertImageSlotPayload {
+  fieldPath: string;
+  label: string;
+  purpose: CmsImageSlotPurpose;
+  storageBucket?: string;
+  storagePath: string | null;
+  publicUrl: string | null;
+  altText?: string | null;
+  caption?: string | null;
+  credit?: string | null;
+  mimeType?: string | null;
+  status: CmsEntryStatus;
+}
+
+export function isCmsCollection(value: unknown): value is CmsEditableEntityType {
+  return isEnumValue(value, CMS_EDITABLE_ENTITY_TYPES);
+}
+
+export function isUpsertTextFieldPayload(value: unknown): value is UpsertTextFieldPayload {
+  if (!isRecord(value)) return false;
+  if (!isString(value.fieldPath) || value.fieldPath.length === 0) return false;
+  if (!isString(value.label) || value.label.length === 0) return false;
+  if (!isEnumValue(value.kind, CMS_FIELD_KINDS) || value.kind === 'image') return false;
+  if (!isNullableString(value.value)) return false;
+  if (!isEnumValue(value.status, CMS_ENTRY_STATUSES)) return false;
+  if (hasOwn(value, 'locale') && !(value.locale === undefined || isNullableString(value.locale))) {
+    return false;
+  }
+  return true;
+}
+
+export function isUpsertImageSlotPayload(value: unknown): value is UpsertImageSlotPayload {
+  if (!isRecord(value)) return false;
+  if (!isString(value.fieldPath) || value.fieldPath.length === 0) return false;
+  if (!isString(value.label) || value.label.length === 0) return false;
+  if (!isEnumValue(value.purpose, CMS_IMAGE_SLOT_PURPOSES)) return false;
+  if (!isNullableString(value.storagePath)) return false;
+  if (!isNullableString(value.publicUrl)) return false;
+  if (!isEnumValue(value.status, CMS_ENTRY_STATUSES)) return false;
+  for (const key of ['storageBucket', 'altText', 'caption', 'credit', 'mimeType'] as const) {
+    if (hasOwn(value, key) && !(value[key] === undefined || isNullableString(value[key]))) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function isCmsRevisionRecord(value: unknown): value is CmsRevisionRecord {

--- a/next/src/lib/content/homepage.ts
+++ b/next/src/lib/content/homepage.ts
@@ -1,0 +1,205 @@
+import homepageData from '../../data/homepage.json';
+import type { CmsEditableImageSlot, CmsEditableTextField } from '../cms/schema';
+
+export interface HomepageCoverContent {
+  label: string;
+  hours: string;
+  image: string;
+  imageAlt: string;
+  caption: string;
+  headline: string;
+  dispatch: string;
+  primaryHref: string;
+  primaryLabel: string;
+}
+
+export interface HomepageSectionHeading {
+  label: string;
+  title: string;
+  sub?: string;
+}
+
+export interface HomepageEditorsLetterContent {
+  eyebrow: string;
+  title: string;
+  paragraphs: string[];
+  pullQuote?: string;
+  signatureName: string;
+  signatureRole: string;
+  image?: string;
+  imageAlt?: string;
+  imageCaption?: string;
+}
+
+export interface HomepageNewsletterContent {
+  title: string;
+  body: string;
+  issueNumber?: string;
+  issueDate?: string;
+  previewHeadline?: string;
+  previewItems?: string[];
+}
+
+export interface HomepageAdminContent {
+  cover: HomepageCoverContent;
+  mobile: Pick<HomepageCoverContent, 'label' | 'hours' | 'headline' | 'dispatch'>;
+  places: HomepageSectionHeading;
+  picks: Pick<HomepageSectionHeading, 'label' | 'title'>;
+  editorsLetter: HomepageEditorsLetterContent;
+  newsletter: HomepageNewsletterContent;
+}
+
+type HomepageDataShape = typeof homepageData & {
+  admin?: Partial<HomepageAdminContent>;
+};
+
+const HOMEPAGE_DATA = homepageData as HomepageDataShape;
+
+const DEFAULT_HOMEPAGE_ADMIN_CONTENT: HomepageAdminContent = {
+  cover: {
+    label: 'THE COVER STORY',
+    hours: '9 MIN READ',
+    image: '/images/sourced/home-cover-bay-umbrella-01.webp',
+    imageAlt: 'A wide sandy bay beach with dune grass in the foreground, a bright red umbrella and chair to the right, and calm water under a blue sky.',
+    caption: 'Bay beach, Mornington Peninsula',
+    headline: 'The Hatted Restaurants of the <em>Peninsula.</em>',
+    dispatch: 'Four two-hat restaurants. Seven one-hat tables. Barragunda is the debut, Tedesca took Regional Restaurant of the Year, and Laura is still where the long lunch happens. The complete list, with booking realities.',
+    primaryHref: '/journal/hatted-restaurants-mornington-peninsula-2025/',
+    primaryLabel: 'Read the cover story',
+  },
+  mobile: {
+    label: 'THE COVER STORY',
+    hours: '9 MIN READ',
+    headline: 'The Hatted Restaurants of the <em>Peninsula.</em>',
+    dispatch: 'Four two-hat restaurants. Seven one-hat tables. Barragunda is the debut, Tedesca took Regional Restaurant of the Year, and Laura is still where the long lunch happens. The complete list, with booking realities.',
+  },
+  places: {
+    label: 'Know the terrain',
+    title: 'The Peninsula, place by place',
+    sub: 'Six towns that organise the region — ridge, coast, and bay.',
+  },
+  picks: {
+    label: "This week's edit",
+    title: 'Three reasons to go',
+  },
+  editorsLetter: {
+    eyebrow: "Editor's Letter",
+    title: 'On the <em>quiet authority</em> of a good autumn.',
+    paragraphs: [
+      'Autumn is the season the Peninsula stops performing. The weekend crowds thin, the vintage trucks finish their last runs, and the ridge takes on the colour it has for about six weeks a year.',
+      "We've rebuilt the cellar-door shortlist from scratch this season, visited every restaurant on the long-lunch list at least twice, and walked every beach on the ranking.",
+      "If this is your first issue with us, welcome. If you're returning, thanks for the patience through the refit.",
+    ],
+    pullQuote: 'This issue is built for the six weeks where the Peninsula is at its most itself, before winter settles in and the coast goes quiet.',
+    signatureName: 'The Editors',
+    signatureRole: 'Peninsula Insider',
+    image: '/images/sourced/place-red-hill-01.webp',
+    imageAlt: 'Vine rows in late-season colour, Red Hill',
+    imageCaption: 'The last weekend of vintage, Red Hill, <em>the quietest a working winery ever gets.</em>',
+  },
+  newsletter: {
+    title: 'The briefing that <em>arrives weekly.</em>',
+    body: "One email. The weekend's pick, the tables that have opened up, the cellar doors with windows this week, and the walk worth doing before it's too cold. Read in five minutes, used all weekend.",
+    issueNumber: '№ 214',
+    issueDate: 'Issue 04',
+    previewHeadline: 'A <em>quiet</em> autumn weekend — the post-Easter reset.',
+    previewItems: [
+      'The cellar-door shortlist lands — five producers, ranked.',
+      'Laura opens three extra Sunday lunches for autumn.',
+      'The long-lunch piece — three Italian rooms that actually matter.',
+      'Weather brief: dry, cool, best light of the year.',
+      'One walk worth doing: Bushrangers Bay before sunset.',
+    ],
+  },
+};
+
+function mergeHomepageAdminContent(base: HomepageAdminContent, patch?: Partial<HomepageAdminContent>): HomepageAdminContent {
+  return {
+    cover: { ...base.cover, ...(patch?.cover ?? {}) },
+    mobile: { ...base.mobile, ...(patch?.mobile ?? {}) },
+    places: { ...base.places, ...(patch?.places ?? {}) },
+    picks: { ...base.picks, ...(patch?.picks ?? {}) },
+    editorsLetter: {
+      ...base.editorsLetter,
+      ...(patch?.editorsLetter ?? {}),
+      paragraphs: patch?.editorsLetter?.paragraphs ?? base.editorsLetter.paragraphs,
+    },
+    newsletter: {
+      ...base.newsletter,
+      ...(patch?.newsletter ?? {}),
+      previewItems: patch?.newsletter?.previewItems ?? base.newsletter.previewItems,
+    },
+  };
+}
+
+export function getHomepageAdminContent(): HomepageAdminContent {
+  return mergeHomepageAdminContent(DEFAULT_HOMEPAGE_ADMIN_CONTENT, HOMEPAGE_DATA.admin);
+}
+
+export function applyHomepageCmsOverrides(
+  content: HomepageAdminContent,
+  textFields: CmsEditableTextField[] = [],
+  imageSlots: CmsEditableImageSlot[] = [],
+): HomepageAdminContent {
+  const next = structuredClone(content);
+
+  for (const field of textFields) {
+    if (field.entityType !== 'page' || field.entitySlug !== 'home' || !field.value) continue;
+    switch (field.fieldPath) {
+      case 'cover.label': next.cover.label = field.value; break;
+      case 'cover.hours': next.cover.hours = field.value; break;
+      case 'cover.caption': next.cover.caption = field.value; break;
+      case 'cover.headline': next.cover.headline = field.value; break;
+      case 'cover.dispatch': next.cover.dispatch = field.value; break;
+      case 'mobile.label': next.mobile.label = field.value; break;
+      case 'mobile.hours': next.mobile.hours = field.value; break;
+      case 'mobile.headline': next.mobile.headline = field.value; break;
+      case 'mobile.dispatch': next.mobile.dispatch = field.value; break;
+      case 'places.label': next.places.label = field.value; break;
+      case 'places.title': next.places.title = field.value; break;
+      case 'places.sub': next.places.sub = field.value; break;
+      case 'picks.label': next.picks.label = field.value; break;
+      case 'picks.title': next.picks.title = field.value; break;
+      case 'editors-letter.eyebrow': next.editorsLetter.eyebrow = field.value; break;
+      case 'editors-letter.title': next.editorsLetter.title = field.value; break;
+      case 'editors-letter.pullQuote': next.editorsLetter.pullQuote = field.value; break;
+      case 'editors-letter.signatureName': next.editorsLetter.signatureName = field.value; break;
+      case 'editors-letter.signatureRole': next.editorsLetter.signatureRole = field.value; break;
+      case 'newsletter.title': next.newsletter.title = field.value; break;
+      case 'newsletter.body': next.newsletter.body = field.value; break;
+      case 'newsletter.previewHeadline': next.newsletter.previewHeadline = field.value; break;
+      default:
+        if (field.fieldPath.startsWith('editors-letter.paragraphs.')) {
+          const index = Number(field.fieldPath.split('.').pop());
+          if (!Number.isNaN(index) && next.editorsLetter.paragraphs[index] !== undefined) next.editorsLetter.paragraphs[index] = field.value;
+        }
+        if (field.fieldPath.startsWith('newsletter.previewItems.')) {
+          const index = Number(field.fieldPath.split('.').pop());
+          if (!Number.isNaN(index) && next.newsletter.previewItems?.[index] !== undefined) next.newsletter.previewItems[index] = field.value;
+        }
+        break;
+    }
+  }
+
+  for (const slot of imageSlots) {
+    if (slot.entityType !== 'page' || slot.entitySlug !== 'home') continue;
+    const src = slot.publicUrl ?? slot.storagePath;
+    if (!src) continue;
+    switch (slot.fieldPath) {
+      case 'cover.image':
+        next.cover.image = src;
+        if (slot.altText) next.cover.imageAlt = slot.altText;
+        if (slot.caption) next.cover.caption = slot.caption;
+        break;
+      case 'editors-letter.image':
+        next.editorsLetter.image = src;
+        if (slot.altText) next.editorsLetter.imageAlt = slot.altText;
+        if (slot.caption) next.editorsLetter.imageCaption = slot.caption;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return next;
+}

--- a/next/src/lib/content/homepage.ts
+++ b/next/src/lib/content/homepage.ts
@@ -160,6 +160,44 @@ export async function loadHomepageContentWithCmsOverrides(): Promise<HomepageAdm
   }
 }
 
+export interface HomepageOverrides {
+  textFieldsByPath: Record<string, string>;
+  imageSlotsByPath: Record<string, { src: string | null; alt: string | null; caption: string | null; credit: string | null }>;
+}
+
+/**
+ * Lower-level companion to loadHomepageContentWithCmsOverrides — returns the
+ * raw published CMS rows keyed by fieldPath. Useful when a page wants
+ * per-field "use override only if explicitly set" semantics, so dynamic
+ * seasonal/runtime values aren't overwritten by the JSON defaults.
+ */
+export async function loadPublishedHomepageOverrides(): Promise<HomepageOverrides> {
+  const empty: HomepageOverrides = { textFieldsByPath: {}, imageSlotsByPath: {} };
+  const client = createCmsAnonClient();
+  if (!client) return empty;
+  try {
+    const { textFields, imageSlots } = await getPublishedPageOverrides(client, 'home');
+    const textFieldsByPath: Record<string, string> = {};
+    for (const f of textFields) {
+      if (typeof f.value === 'string' && f.value.length > 0) textFieldsByPath[f.fieldPath] = f.value;
+    }
+    const imageSlotsByPath: HomepageOverrides['imageSlotsByPath'] = {};
+    for (const s of imageSlots) {
+      const src = s.publicUrl ?? s.storagePath;
+      if (!src) continue;
+      imageSlotsByPath[s.fieldPath] = {
+        src,
+        alt: s.altText,
+        caption: s.caption,
+        credit: s.credit,
+      };
+    }
+    return { textFieldsByPath, imageSlotsByPath };
+  } catch {
+    return empty;
+  }
+}
+
 export function applyHomepageCmsOverrides(
   content: HomepageAdminContent,
   textFields: CmsEditableTextField[] = [],

--- a/next/src/lib/content/homepage.ts
+++ b/next/src/lib/content/homepage.ts
@@ -1,5 +1,7 @@
 import homepageData from '../../data/homepage.json';
 import type { CmsEditableImageSlot, CmsEditableTextField } from '../cms/schema';
+import { createCmsAnonClient } from '../cms/server';
+import { getPublishedPageOverrides } from '../cms/api';
 
 export interface HomepageCoverContent {
   label: string;
@@ -134,6 +136,28 @@ function mergeHomepageAdminContent(base: HomepageAdminContent, patch?: Partial<H
 
 export function getHomepageAdminContent(): HomepageAdminContent {
   return mergeHomepageAdminContent(DEFAULT_HOMEPAGE_ADMIN_CONTENT, HOMEPAGE_DATA.admin);
+}
+
+/**
+ * Build-time hook: fetch any published CMS overrides for entity_slug='home'
+ * and return a fully merged HomepageAdminContent. Falls back to the
+ * JSON-backed defaults when Supabase is not configured or returns no rows.
+ *
+ * Safe to call from `astro build` — uses the public anon key, gated by the
+ * `cms_*_public_read_published` RLS policies in
+ * ops/migrations/2026-05-10-pi-cms-public-read.sql.
+ */
+export async function loadHomepageContentWithCmsOverrides(): Promise<HomepageAdminContent> {
+  const base = getHomepageAdminContent();
+  const client = createCmsAnonClient();
+  if (!client) return base;
+  try {
+    const { textFields, imageSlots } = await getPublishedPageOverrides(client, 'home');
+    if (textFields.length === 0 && imageSlots.length === 0) return base;
+    return applyHomepageCmsOverrides(base, textFields, imageSlots);
+  } catch {
+    return base;
+  }
 }
 
 export function applyHomepageCmsOverrides(

--- a/next/src/middleware.ts
+++ b/next/src/middleware.ts
@@ -4,27 +4,60 @@ import {
   canAccessAdmin,
   isAdminApiPath,
   isAdminHybridEnabled,
+  isAdminLegacyGateEnabled,
   isAdminLoginPath,
   isAdminPath,
 } from './lib/admin';
+import { resolveCmsAccess } from './lib/cms/server';
 
+/**
+ * Hybrid admin gate.
+ *
+ * Default (production): a request can only reach `/admin` or `/admin/api/*`
+ * when the user has a valid Supabase session AND is flagged as an editor
+ * (RLS-backed `pi.profiles.is_editor` check inside `resolveCmsAccess`).
+ *
+ * Legacy fallback (Phase 1 QA): when `PI_ADMIN_LEGACY_GATE=1` is set, the
+ * transitional `?admin=1` / `pi_admin=1` cookie seam still grants access.
+ * This lets local development keep working without a real Supabase session
+ * during the cutover, but is intentionally off by default.
+ */
 export const onRequest = defineMiddleware(async (context, next) => {
   if (!isAdminHybridEnabled()) {
     return next();
   }
 
   const pathname = context.url.pathname;
-  const allowed = canAccessAdmin(context.url, context.request.headers.get('cookie'));
+  const isAdminRoute = isAdminPath(pathname) || isAdminApiPath(pathname);
+  const isLogin = isAdminLoginPath(pathname);
 
-  if (isAdminLoginPath(pathname) && allowed) {
+  // Cheap exit: nothing here we have to gate.
+  if (!isAdminRoute && !isLogin) {
+    return next();
+  }
+
+  const cookieHeader = context.request.headers.get('cookie');
+
+  // Real session validation by default. We only run the (slightly more
+  // expensive) Supabase calls for routes that actually care.
+  const access = await resolveCmsAccess(cookieHeader);
+  let allowed = access.ok;
+
+  // Optional legacy fallback for Phase 1 QA.
+  if (!allowed && isAdminLegacyGateEnabled()) {
+    allowed = canAccessAdmin(context.url, cookieHeader);
+  }
+
+  // If they're already signed in and hit the login page, send them home.
+  if (isLogin && allowed) {
     return context.redirect('/admin/');
   }
 
-  if ((isAdminPath(pathname) || isAdminApiPath(pathname)) && !allowed) {
+  if (isAdminRoute && !allowed) {
     if (isAdminApiPath(pathname)) {
       return new Response(JSON.stringify({ ok: false, error: 'Unauthorized' }), {
         status: 401,
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json; charset=utf-8' },
       });
     }
 

--- a/next/src/middleware.ts
+++ b/next/src/middleware.ts
@@ -1,0 +1,36 @@
+import { defineMiddleware } from 'astro:middleware';
+import {
+  buildAdminLoginHref,
+  canAccessAdmin,
+  isAdminApiPath,
+  isAdminHybridEnabled,
+  isAdminLoginPath,
+  isAdminPath,
+} from './lib/admin';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  if (!isAdminHybridEnabled()) {
+    return next();
+  }
+
+  const pathname = context.url.pathname;
+  const allowed = canAccessAdmin(context.url, context.request.headers.get('cookie'));
+
+  if (isAdminLoginPath(pathname) && allowed) {
+    return context.redirect('/admin/');
+  }
+
+  if ((isAdminPath(pathname) || isAdminApiPath(pathname)) && !allowed) {
+    if (isAdminApiPath(pathname)) {
+      return new Response(JSON.stringify({ ok: false, error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    const nextPath = `${pathname}${context.url.search}`;
+    return context.redirect(buildAdminLoginHref(nextPath));
+  }
+
+  return next();
+});

--- a/next/src/pages/admin/api/content/[collection]/[slug].ts
+++ b/next/src/pages/admin/api/content/[collection]/[slug].ts
@@ -41,7 +41,15 @@ import {
  * RLS evaluates as the editor — never the service-role key.
  */
 
-export const prerender = false;
+// Hybrid-only route. When PI_ADMIN_HYBRID is unset, prerender = true and
+// getStaticPaths returns [], so the static build excludes this endpoint
+// entirely. When PI_ADMIN_HYBRID=1, the @astrojs/vercel adapter is loaded and
+// the endpoint runs at request time.
+const PI_ADMIN_HYBRID = (import.meta.env.PI_ADMIN_HYBRID as string | undefined) === '1';
+export const prerender = !PI_ADMIN_HYBRID;
+export async function getStaticPaths() {
+  return [];
+}
 
 interface ParsedParams {
   collection: CmsEditableEntityType;

--- a/next/src/pages/admin/api/content/[collection]/[slug].ts
+++ b/next/src/pages/admin/api/content/[collection]/[slug].ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+import { canAccessAdmin } from '../../../../../lib/admin';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, request }) => {
+  if (!canAccessAdmin(new URL(request.url), request.headers.get('cookie'))) {
+    return new Response(JSON.stringify({ ok: false, error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({
+    ok: true,
+    collection: params.collection,
+    slug: params.slug,
+    message: 'Content API scaffold only. Wire file-backed reads/writes next.',
+  }), {
+    headers: { 'content-type': 'application/json' },
+  });
+};

--- a/next/src/pages/admin/api/content/[collection]/[slug].ts
+++ b/next/src/pages/admin/api/content/[collection]/[slug].ts
@@ -1,22 +1,229 @@
 import type { APIRoute } from 'astro';
-import { canAccessAdmin } from '../../../../../lib/admin';
+
+import {
+  getCmsEntrySnapshot,
+  listImageSlotsForEntry,
+  listTextFieldsForEntry,
+  recordRevision,
+  upsertImageSlot,
+  upsertTextField,
+} from '../../../../../lib/cms/api';
+import {
+  badRequest,
+  forbidden,
+  internalError,
+  jsonResponse,
+  resolveCmsAccess,
+  unauthorized,
+} from '../../../../../lib/cms/server';
+import type { CmsEditableEntityType } from '../../../../../lib/cms/schema';
+import {
+  isCmsCollection,
+  isUpsertImageSlotPayload,
+  isUpsertTextFieldPayload,
+} from '../../../../../lib/cms/validators';
+
+/**
+ * Admin content API.
+ *
+ * Routes:
+ *   GET    /admin/api/content/:collection/:slug              → snapshot for an entry
+ *   GET    /admin/api/content/:collection/:slug?field=foo    → just that text/image field
+ *   PUT    /admin/api/content/:collection/:slug              → upsert text or image (replace)
+ *   PATCH  /admin/api/content/:collection/:slug              → upsert (alias of PUT)
+ *
+ * Body shape for PUT/PATCH:
+ *   { kind: 'text', payload: UpsertTextFieldPayload, summary?: string }
+ *   { kind: 'image', payload: UpsertImageSlotPayload, summary?: string }
+ *
+ * All requests are authorised by `resolveCmsAccess` against the request's
+ * Supabase JWT cookie. Writes go through the per-request user-JWT client so
+ * RLS evaluates as the editor — never the service-role key.
+ */
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ params, request }) => {
-  if (!canAccessAdmin(new URL(request.url), request.headers.get('cookie'))) {
-    return new Response(JSON.stringify({ ok: false, error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'content-type': 'application/json' },
-    });
+interface ParsedParams {
+  collection: CmsEditableEntityType;
+  slug: string;
+}
+
+function parseParams(params: Record<string, string | undefined>): ParsedParams | { error: string } {
+  const rawCollection = params.collection;
+  const rawSlug = params.slug;
+  if (!rawCollection || !isCmsCollection(rawCollection)) {
+    return { error: `Unknown collection "${rawCollection ?? ''}"` };
+  }
+  if (!rawSlug || rawSlug.length === 0 || rawSlug.length > 200) {
+    return { error: 'Missing or invalid slug' };
+  }
+  return { collection: rawCollection, slug: rawSlug };
+}
+
+export const GET: APIRoute = async ({ params, request, url }) => {
+  const parsed = parseParams(params);
+  if ('error' in parsed) return badRequest(parsed.error);
+
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok || !access.client || !access.access) {
+    if (access.reason === 'not-editor') return forbidden('Not an editor');
+    return unauthorized();
   }
 
-  return new Response(JSON.stringify({
-    ok: true,
-    collection: params.collection,
-    slug: params.slug,
-    message: 'Content API scaffold only. Wire file-backed reads/writes next.',
-  }), {
-    headers: { 'content-type': 'application/json' },
-  });
+  const fieldFilter = url.searchParams.get('field');
+
+  try {
+    if (fieldFilter) {
+      // Filter snapshot down to this single field (could be text or image).
+      const [textFields, imageSlots] = await Promise.all([
+        listTextFieldsForEntry(access.client, parsed.collection, parsed.slug, { status: 'any' }),
+        listImageSlotsForEntry(access.client, parsed.collection, parsed.slug, { status: 'any' }),
+      ]);
+      const text = textFields.find((f) => f.fieldPath === fieldFilter) ?? null;
+      const image = imageSlots.find((f) => f.fieldPath === fieldFilter) ?? null;
+      return jsonResponse({
+        ok: true,
+        data: {
+          entityType: parsed.collection,
+          entitySlug: parsed.slug,
+          field: fieldFilter,
+          text,
+          image,
+        },
+      });
+    }
+
+    const snapshot = await getCmsEntrySnapshot(
+      access.client,
+      parsed.collection,
+      parsed.slug,
+      { status: 'any' },
+    );
+    return jsonResponse({ ok: true, data: snapshot });
+  } catch (err) {
+    return internalError((err as Error).message || 'Read failed');
+  }
 };
+
+const handleWrite: APIRoute = async ({ params, request }) => {
+  const parsed = parseParams(params);
+  if ('error' in parsed) return badRequest(parsed.error);
+
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok || !access.client || !access.access) {
+    if (access.reason === 'not-editor') return forbidden('Not an editor');
+    return unauthorized();
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return badRequest('Body must be valid JSON');
+  }
+
+  if (!body || typeof body !== 'object') {
+    return badRequest('Body must be a JSON object');
+  }
+
+  const { kind, payload, summary } = body as {
+    kind?: unknown;
+    payload?: unknown;
+    summary?: unknown;
+  };
+
+  const actorId = access.access.identity.userId;
+  const summaryText = typeof summary === 'string' ? summary : null;
+
+  try {
+    if (kind === 'text') {
+      if (!isUpsertTextFieldPayload(payload)) {
+        return jsonResponse(
+          { ok: false, error: 'Invalid text field payload' },
+          { status: 422 },
+        );
+      }
+      const saved = await upsertTextField(
+        access.client,
+        {
+          entityType: parsed.collection,
+          entitySlug: parsed.slug,
+          fieldPath: payload.fieldPath,
+          label: payload.label,
+          kind: payload.kind,
+          value: payload.value,
+          status: payload.status,
+          locale: payload.locale ?? null,
+        },
+        actorId,
+      );
+      if (!saved) return internalError('Failed to upsert text field');
+
+      await recordRevision(
+        access.client,
+        {
+          entityType: parsed.collection,
+          entitySlug: parsed.slug,
+          action: 'update',
+          status: payload.status,
+          summary: summaryText,
+          patch: [{ op: 'set', target: payload.fieldPath, value: payload.value }],
+        },
+        actorId,
+      );
+
+      return jsonResponse({ ok: true, data: saved });
+    }
+
+    if (kind === 'image') {
+      if (!isUpsertImageSlotPayload(payload)) {
+        return jsonResponse(
+          { ok: false, error: 'Invalid image slot payload' },
+          { status: 422 },
+        );
+      }
+      const saved = await upsertImageSlot(
+        access.client,
+        {
+          entityType: parsed.collection,
+          entitySlug: parsed.slug,
+          fieldPath: payload.fieldPath,
+          label: payload.label,
+          purpose: payload.purpose,
+          storageBucket: payload.storageBucket ?? 'cms-assets',
+          storagePath: payload.storagePath,
+          publicUrl: payload.publicUrl,
+          altText: payload.altText ?? null,
+          caption: payload.caption ?? null,
+          credit: payload.credit ?? null,
+          mimeType: payload.mimeType ?? null,
+          status: payload.status,
+        },
+        actorId,
+      );
+      if (!saved) return internalError('Failed to upsert image slot');
+
+      await recordRevision(
+        access.client,
+        {
+          entityType: parsed.collection,
+          entitySlug: parsed.slug,
+          action: 'update',
+          status: payload.status,
+          summary: summaryText,
+          patch: [{ op: 'set', target: payload.fieldPath, value: payload.publicUrl }],
+        },
+        actorId,
+      );
+
+      return jsonResponse({ ok: true, data: saved });
+    }
+
+    return badRequest('Body must include kind: "text" | "image" and a payload');
+  } catch (err) {
+    return internalError((err as Error).message || 'Write failed');
+  }
+};
+
+export const PUT: APIRoute = handleWrite;
+export const PATCH: APIRoute = handleWrite;

--- a/next/src/pages/admin/entry.astro
+++ b/next/src/pages/admin/entry.astro
@@ -1,0 +1,746 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Admin', href: '/admin/' },
+  { label: 'Edit entry' },
+];
+---
+
+<BaseLayout
+  title="Edit entry · Peninsula Insider"
+  description="Edit a CMS entry."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="entry-editor" data-entry-root>
+    <div class="container entry-editor__container">
+      <header class="entry-editor__head">
+        <p class="entry-editor__eyebrow" data-entry-type>—</p>
+        <h1 class="entry-editor__title" data-entry-slug>Loading…</h1>
+        <p class="entry-editor__status" data-entry-status>Loading…</p>
+      </header>
+
+      <div class="entry-editor__layout">
+        <main class="entry-editor__main">
+          <section class="entry-editor__group" data-section="text">
+            <header class="entry-editor__group-head">
+              <h2>Text fields</h2>
+              <button type="button" class="entry-editor__btn" data-action="add-text">+ Add field</button>
+            </header>
+            <div class="entry-editor__rows" data-text-rows>
+              <p class="entry-editor__hint">Loading…</p>
+            </div>
+          </section>
+
+          <section class="entry-editor__group" data-section="image">
+            <header class="entry-editor__group-head">
+              <h2>Image slots</h2>
+              <button type="button" class="entry-editor__btn" data-action="add-image">+ Add slot</button>
+            </header>
+            <div class="entry-editor__rows" data-image-rows>
+              <p class="entry-editor__hint">Loading…</p>
+            </div>
+          </section>
+        </main>
+
+        <aside class="entry-editor__aside">
+          <h2>Recent revisions</h2>
+          <ol class="entry-editor__revisions" data-revisions>
+            <li class="entry-editor__hint">Loading…</li>
+          </ol>
+          <h3>Quick links</h3>
+          <ul class="entry-editor__quick" data-quick-links></ul>
+        </aside>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled } from '../../lib/auth';
+
+  const COOKIE_ACCESS = 'pi-sb-access-token';
+  const COOKIE_REFRESH = 'pi-sb-refresh-token';
+  const LOGIN_PATH = '/admin/login/';
+
+  type TextRow = {
+    id: string;
+    entity_type: string;
+    entity_slug: string;
+    field_path: string;
+    label: string;
+    field_kind: 'text' | 'markdown' | 'richtext';
+    locale: string | null;
+    value: string | null;
+    status: 'draft' | 'published';
+    updated_at: string;
+  };
+  type ImageRow = {
+    id: string;
+    entity_type: string;
+    entity_slug: string;
+    field_path: string;
+    label: string;
+    purpose: 'hero' | 'card' | 'gallery' | 'inline' | 'seo';
+    storage_path: string | null;
+    public_url: string | null;
+    alt_text: string | null;
+    caption: string | null;
+    credit: string | null;
+    status: 'draft' | 'published';
+    updated_at: string;
+  };
+  type RevisionRow = {
+    id: string;
+    action: string;
+    status: string;
+    summary: string | null;
+    created_at: string;
+  };
+
+  const ALLOWED_TYPES = ['article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary'];
+
+  function setCookie(name: string, value: string, maxAgeSeconds: number) {
+    const secure = location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent(value)}; Path=/; Max-Age=${Math.max(60, Math.floor(maxAgeSeconds))}; SameSite=Lax${secure}`;
+  }
+  function clearCookie(name: string) {
+    document.cookie = `${name}=; Path=/; Max-Age=0; SameSite=Lax`;
+  }
+
+  async function syncCookies() {
+    const c = getSupabase();
+    if (!c) return null;
+    const { data } = await c.auth.getSession();
+    const session = data.session;
+    if (!session) {
+      clearCookie(COOKIE_ACCESS);
+      clearCookie(COOKIE_REFRESH);
+      return null;
+    }
+    const expiresIn = (session.expires_in as number | undefined) ?? 3600;
+    setCookie(COOKIE_ACCESS, session.access_token, expiresIn);
+    if (session.refresh_token) setCookie(COOKIE_REFRESH, session.refresh_token, 60 * 60 * 24 * 30);
+    return session;
+  }
+
+  function setStatus(text: string, tone: 'idle' | 'ok' | 'err' = 'idle') {
+    const el = document.querySelector<HTMLElement>('[data-entry-status]');
+    if (!el) return;
+    el.textContent = text;
+    el.dataset.tone = tone;
+  }
+
+  function escapeHtml(s: string) {
+    return s.replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c] as string));
+  }
+
+  function getParams(): { entityType: string; entitySlug: string } | null {
+    const sp = new URLSearchParams(location.search);
+    const t = (sp.get('type') || '').trim();
+    const s = (sp.get('slug') || '').trim();
+    if (!t || !s) return null;
+    if (!ALLOWED_TYPES.includes(t)) return null;
+    return { entityType: t, entitySlug: s };
+  }
+
+  function renderHead(entityType: string, entitySlug: string) {
+    const t = document.querySelector<HTMLElement>('[data-entry-type]');
+    const s = document.querySelector<HTMLElement>('[data-entry-slug]');
+    if (t) t.textContent = entityType;
+    if (s) s.textContent = entitySlug;
+    const links = document.querySelector<HTMLElement>('[data-quick-links]');
+    if (links) {
+      const livePath = entityType === 'page' && entitySlug === 'home' ? '/' : `/${entitySlug}/`;
+      links.innerHTML = `
+        <li><a href="/admin/">Back to admin home</a></li>
+        <li><a href="${livePath}" target="_blank" rel="noopener">View live</a></li>
+      `;
+    }
+  }
+
+  function renderTextRows(rows: TextRow[]) {
+    const host = document.querySelector<HTMLElement>('[data-text-rows]');
+    if (!host) return;
+    if (rows.length === 0) {
+      host.innerHTML = '<p class="entry-editor__hint">No text fields yet. Use “Add field” to register one.</p>';
+      return;
+    }
+    host.innerHTML = rows
+      .map((row) => {
+        const value = row.value ?? '';
+        return `
+          <div class="entry-editor__row" data-text-row data-row-id="${row.id}">
+            <div class="entry-editor__row-meta">
+              <span class="entry-editor__row-label">${escapeHtml(row.label || row.field_path)}</span>
+              <span class="entry-editor__row-tag">${escapeHtml(row.field_path)}</span>
+              <span class="entry-editor__row-tag">${row.field_kind}</span>
+              <span class="entry-editor__row-tag entry-editor__row-tag--${row.status}">${row.status}</span>
+            </div>
+            <textarea class="entry-editor__input" data-field="value">${escapeHtml(value)}</textarea>
+            <div class="entry-editor__row-actions">
+              <button type="button" class="entry-editor__btn entry-editor__btn--save" data-action="save-text" data-row-id="${row.id}">Save draft</button>
+              <button type="button" class="entry-editor__btn entry-editor__btn--publish" data-action="publish-text" data-row-id="${row.id}">Publish</button>
+              <button type="button" class="entry-editor__btn entry-editor__btn--ghost" data-action="delete-text" data-row-id="${row.id}">Delete</button>
+            </div>
+          </div>
+        `;
+      })
+      .join('');
+  }
+
+  function renderImageRows(rows: ImageRow[]) {
+    const host = document.querySelector<HTMLElement>('[data-image-rows]');
+    if (!host) return;
+    if (rows.length === 0) {
+      host.innerHTML = '<p class="entry-editor__hint">No image slots yet. Use “Add slot” to register a hero or card image.</p>';
+      return;
+    }
+    host.innerHTML = rows
+      .map((row) => {
+        return `
+          <div class="entry-editor__row" data-image-row data-row-id="${row.id}">
+            <div class="entry-editor__row-meta">
+              <span class="entry-editor__row-label">${escapeHtml(row.label || row.field_path)}</span>
+              <span class="entry-editor__row-tag">${escapeHtml(row.field_path)}</span>
+              <span class="entry-editor__row-tag">${row.purpose}</span>
+              <span class="entry-editor__row-tag entry-editor__row-tag--${row.status}">${row.status}</span>
+            </div>
+            <div class="entry-editor__image-grid">
+              <label>Public URL or storage path
+                <input class="entry-editor__input" data-field="public_url" value="${escapeHtml(row.public_url ?? '')}" />
+              </label>
+              <label>Alt text
+                <input class="entry-editor__input" data-field="alt_text" value="${escapeHtml(row.alt_text ?? '')}" />
+              </label>
+              <label>Caption
+                <input class="entry-editor__input" data-field="caption" value="${escapeHtml(row.caption ?? '')}" />
+              </label>
+              <label>Credit
+                <input class="entry-editor__input" data-field="credit" value="${escapeHtml(row.credit ?? '')}" />
+              </label>
+            </div>
+            <div class="entry-editor__row-actions">
+              <button type="button" class="entry-editor__btn entry-editor__btn--save" data-action="save-image" data-row-id="${row.id}">Save draft</button>
+              <button type="button" class="entry-editor__btn entry-editor__btn--publish" data-action="publish-image" data-row-id="${row.id}">Publish</button>
+              <button type="button" class="entry-editor__btn entry-editor__btn--ghost" data-action="delete-image" data-row-id="${row.id}">Delete</button>
+            </div>
+          </div>
+        `;
+      })
+      .join('');
+  }
+
+  function renderRevisions(rows: RevisionRow[]) {
+    const host = document.querySelector<HTMLElement>('[data-revisions]');
+    if (!host) return;
+    if (rows.length === 0) {
+      host.innerHTML = '<li class="entry-editor__hint">No revisions yet.</li>';
+      return;
+    }
+    host.innerHTML = rows
+      .map((row) => {
+        const ts = new Date(row.created_at).toLocaleString();
+        const summary = row.summary ?? `${row.action} (${row.status})`;
+        return `
+          <li>
+            <span class="entry-editor__rev-action">${row.action}</span>
+            <span class="entry-editor__rev-summary">${escapeHtml(summary)}</span>
+            <span class="entry-editor__rev-time">${ts}</span>
+          </li>
+        `;
+      })
+      .join('');
+  }
+
+  async function loadAll(entityType: string, entitySlug: string) {
+    const c = getSupabase();
+    if (!c) return;
+    const [textRes, imageRes, revRes] = await Promise.all([
+      c.from('cms_text_fields')
+        .select('*')
+        .eq('entity_type', entityType)
+        .eq('entity_slug', entitySlug)
+        .order('field_path', { ascending: true }),
+      c.from('cms_image_slots')
+        .select('*')
+        .eq('entity_type', entityType)
+        .eq('entity_slug', entitySlug)
+        .order('field_path', { ascending: true }),
+      c.from('cms_revisions')
+        .select('*')
+        .eq('entity_type', entityType)
+        .eq('entity_slug', entitySlug)
+        .order('created_at', { ascending: false })
+        .limit(25),
+    ]);
+    if (textRes.error || imageRes.error) {
+      setStatus('Could not read CMS rows. Check your editor permissions.', 'err');
+      return;
+    }
+    const textRows = (textRes.data ?? []) as TextRow[];
+    const imageRows = (imageRes.data ?? []) as ImageRow[];
+    const revRows = (revRes.data ?? []) as RevisionRow[];
+    renderTextRows(textRows);
+    renderImageRows(imageRows);
+    renderRevisions(revRows);
+    setStatus(`${textRows.length} text · ${imageRows.length} image · ${revRows.length} revisions`, 'ok');
+  }
+
+  async function getActorId(): Promise<string | null> {
+    const c = getSupabase();
+    if (!c) return null;
+    const { data } = await c.auth.getUser();
+    return data.user?.id ?? null;
+  }
+
+  async function recordRevision(
+    entityType: string,
+    entitySlug: string,
+    action: 'create' | 'update' | 'publish' | 'unpublish' | 'restore',
+    status: 'draft' | 'published',
+    summary: string,
+    patch: { op: 'set' | 'unset'; target: string; value?: string | null }[],
+  ) {
+    const c = getSupabase();
+    if (!c) return;
+    const actorId = await getActorId();
+    await c.from('cms_revisions').insert({
+      entity_type: entityType,
+      entity_slug: entitySlug,
+      action,
+      status,
+      summary,
+      patch,
+      created_by: actorId,
+    });
+  }
+
+  /**
+   * RLS-gated CRUD against the pi schema. Returns { ok } regardless of whether
+   * the row was returned — Postgres errors are surfaced to the editor via
+   * setStatus rather than thrown.
+   */
+  async function callApi(
+    entityType: string,
+    entitySlug: string,
+    method: 'POST' | 'PATCH' | 'DELETE',
+    payload: Record<string, unknown>,
+  ) {
+    const c = getSupabase();
+    if (!c) {
+      setStatus('Supabase client is not available.', 'err');
+      return null;
+    }
+    const actorId = await getActorId();
+    const kind = payload.kind as 'text' | 'image';
+    const status = (payload.status as 'draft' | 'published' | undefined) ?? 'draft';
+
+    try {
+      if (method === 'POST') {
+        if (kind === 'text') {
+          const fieldPath = String(payload.fieldPath || '').trim();
+          if (!fieldPath) { setStatus('Field path is required.', 'err'); return null; }
+          const insert = {
+            entity_type: entityType,
+            entity_slug: entitySlug,
+            field_path: fieldPath,
+            label: String(payload.label || fieldPath),
+            field_kind: String(payload.textKind || 'text'),
+            value: typeof payload.value === 'string' ? payload.value : null,
+            status,
+            updated_by: actorId,
+            locale: null,
+          };
+          const { error } = await c.from('cms_text_fields').insert(insert);
+          if (error) { setStatus(`Insert failed: ${error.message}`, 'err'); return null; }
+          await recordRevision(entityType, entitySlug, 'create', status, `create text ${fieldPath}`, [
+            { op: 'set', target: fieldPath, value: insert.value ?? null },
+          ]);
+          return { ok: true };
+        }
+        if (kind === 'image') {
+          const fieldPath = String(payload.fieldPath || '').trim();
+          if (!fieldPath) { setStatus('Field path is required.', 'err'); return null; }
+          const insert = {
+            entity_type: entityType,
+            entity_slug: entitySlug,
+            field_path: fieldPath,
+            label: String(payload.label || fieldPath),
+            purpose: String(payload.purpose || 'hero'),
+            storage_bucket: 'cms-assets',
+            storage_path: null,
+            public_url: typeof payload.publicUrl === 'string' && payload.publicUrl.length > 0 ? String(payload.publicUrl) : null,
+            alt_text: null, caption: null, credit: null, mime_type: null,
+            status,
+            updated_by: actorId,
+          };
+          const { error } = await c.from('cms_image_slots').insert(insert);
+          if (error) { setStatus(`Insert failed: ${error.message}`, 'err'); return null; }
+          await recordRevision(entityType, entitySlug, 'create', status, `create image ${fieldPath}`, [
+            { op: 'set', target: `${fieldPath}.public_url`, value: insert.public_url ?? null },
+          ]);
+          return { ok: true };
+        }
+      }
+
+      if (method === 'PATCH') {
+        const id = String(payload.id || '');
+        if (!id) { setStatus('Missing id.', 'err'); return null; }
+        if (kind === 'text') {
+          const update: Record<string, unknown> = {
+            value: typeof payload.value === 'string' ? payload.value : null,
+            status,
+            updated_by: actorId,
+          };
+          const { error } = await c.from('cms_text_fields').update(update).eq('id', id);
+          if (error) { setStatus(`Update failed: ${error.message}`, 'err'); return null; }
+          const action = status === 'published' ? 'publish' : 'update';
+          await recordRevision(entityType, entitySlug, action, status, `${action} text ${id}`, [
+            { op: 'set', target: 'value', value: typeof payload.value === 'string' ? payload.value : null },
+          ]);
+          return { ok: true };
+        }
+        if (kind === 'image') {
+          const update: Record<string, unknown> = {
+            public_url: typeof payload.publicUrl === 'string' && payload.publicUrl.length > 0 ? payload.publicUrl : null,
+            alt_text: typeof payload.altText === 'string' && payload.altText.length > 0 ? payload.altText : null,
+            caption: typeof payload.caption === 'string' && payload.caption.length > 0 ? payload.caption : null,
+            credit: typeof payload.credit === 'string' && payload.credit.length > 0 ? payload.credit : null,
+            status,
+            updated_by: actorId,
+          };
+          const { error } = await c.from('cms_image_slots').update(update).eq('id', id);
+          if (error) { setStatus(`Update failed: ${error.message}`, 'err'); return null; }
+          const action = status === 'published' ? 'publish' : 'update';
+          await recordRevision(entityType, entitySlug, action, status, `${action} image ${id}`, [
+            { op: 'set', target: 'public_url', value: typeof payload.publicUrl === 'string' ? payload.publicUrl : null },
+          ]);
+          return { ok: true };
+        }
+      }
+
+      if (method === 'DELETE') {
+        const id = String(payload.id || '');
+        if (!id) { setStatus('Missing id.', 'err'); return null; }
+        const table = kind === 'text' ? 'cms_text_fields' : 'cms_image_slots';
+        const { error } = await c.from(table).delete().eq('id', id);
+        if (error) { setStatus(`Delete failed: ${error.message}`, 'err'); return null; }
+        await recordRevision(entityType, entitySlug, 'update', 'draft', `delete ${kind} ${id}`, [
+          { op: 'unset', target: id },
+        ]);
+        return { ok: true };
+      }
+
+      setStatus('Unsupported operation.', 'err');
+      return null;
+    } catch (err) {
+      setStatus(`Request failed: ${(err as Error).message}`, 'err');
+      return null;
+    }
+  }
+
+  function rowFromButton(btn: HTMLElement, kind: 'text' | 'image') {
+    const row = btn.closest<HTMLElement>(kind === 'text' ? '[data-text-row]' : '[data-image-row]');
+    if (!row) return null;
+    const id = row.dataset.rowId!;
+    const inputs = row.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>('[data-field]');
+    const fields: Record<string, string | null> = {};
+    inputs.forEach((el) => { fields[el.dataset.field!] = el.value; });
+    return { id, fields };
+  }
+
+  function bindEvents(entityType: string, entitySlug: string) {
+    const root = document.querySelector<HTMLElement>('[data-entry-root]');
+    if (!root) return;
+
+    root.addEventListener('click', async (event) => {
+      const target = event.target as HTMLElement;
+      if (!target?.dataset?.action) return;
+
+      if (target.dataset.action === 'add-text') {
+        const fieldPath = window.prompt('Field path (e.g. cover.headline)?');
+        if (!fieldPath) return;
+        const label = window.prompt('Editor label?', fieldPath) ?? fieldPath;
+        const kind = (window.prompt('Kind: text | markdown | richtext', 'text') ?? 'text').toLowerCase();
+        const safeKind = ['text', 'markdown', 'richtext'].includes(kind) ? kind : 'text';
+        const value = window.prompt('Initial value (leave blank to set later)') ?? '';
+        setStatus('Saving new field…');
+        const res = await callApi(entityType, entitySlug, 'POST', {
+          kind: 'text',
+          fieldPath, label, textKind: safeKind, value, status: 'draft',
+        });
+        if (res?.ok) { setStatus('Field added.', 'ok'); await loadAll(entityType, entitySlug); }
+        return;
+      }
+
+      if (target.dataset.action === 'add-image') {
+        const fieldPath = window.prompt('Field path (e.g. cover.image)?');
+        if (!fieldPath) return;
+        const label = window.prompt('Editor label?', fieldPath) ?? fieldPath;
+        const purpose = (window.prompt('Purpose: hero | card | gallery | inline | seo', 'hero') ?? 'hero').toLowerCase();
+        const safe = ['hero', 'card', 'gallery', 'inline', 'seo'].includes(purpose) ? purpose : 'hero';
+        const publicUrl = window.prompt('Public URL (or leave blank)') ?? '';
+        setStatus('Saving new slot…');
+        const res = await callApi(entityType, entitySlug, 'POST', {
+          kind: 'image',
+          fieldPath, label, purpose: safe, publicUrl, status: 'draft',
+        });
+        if (res?.ok) { setStatus('Slot added.', 'ok'); await loadAll(entityType, entitySlug); }
+        return;
+      }
+
+      if (target.dataset.action === 'save-text' || target.dataset.action === 'publish-text') {
+        const data = rowFromButton(target, 'text');
+        if (!data) return;
+        const status = target.dataset.action === 'publish-text' ? 'published' : 'draft';
+        setStatus(status === 'published' ? 'Publishing…' : 'Saving…');
+        const res = await callApi(entityType, entitySlug, 'PATCH', {
+          kind: 'text', id: data.id, value: data.fields.value ?? null, status,
+        });
+        if (res?.ok) { setStatus(status === 'published' ? 'Published.' : 'Saved draft.', 'ok'); await loadAll(entityType, entitySlug); }
+        return;
+      }
+
+      if (target.dataset.action === 'save-image' || target.dataset.action === 'publish-image') {
+        const data = rowFromButton(target, 'image');
+        if (!data) return;
+        const status = target.dataset.action === 'publish-image' ? 'published' : 'draft';
+        setStatus(status === 'published' ? 'Publishing…' : 'Saving…');
+        const res = await callApi(entityType, entitySlug, 'PATCH', {
+          kind: 'image',
+          id: data.id,
+          publicUrl: data.fields.public_url ?? null,
+          altText: data.fields.alt_text ?? null,
+          caption: data.fields.caption ?? null,
+          credit: data.fields.credit ?? null,
+          status,
+        });
+        if (res?.ok) { setStatus(status === 'published' ? 'Published.' : 'Saved draft.', 'ok'); await loadAll(entityType, entitySlug); }
+        return;
+      }
+
+      if (target.dataset.action === 'delete-text' || target.dataset.action === 'delete-image') {
+        const id = target.dataset.rowId;
+        if (!id) return;
+        if (!window.confirm('Delete this entry? This cannot be undone.')) return;
+        const kind = target.dataset.action === 'delete-text' ? 'text' : 'image';
+        setStatus('Deleting…');
+        const res = await callApi(entityType, entitySlug, 'DELETE', { kind, id });
+        if (res?.ok) { setStatus('Deleted.', 'ok'); await loadAll(entityType, entitySlug); }
+        return;
+      }
+    });
+  }
+
+  async function init() {
+    if (!isAuthEnabled()) {
+      setStatus('Auth is not configured in this environment.', 'err');
+      return;
+    }
+    const params = getParams();
+    if (!params) {
+      setStatus('Missing or invalid ?type and ?slug — go back to /admin/.', 'err');
+      return;
+    }
+    renderHead(params.entityType, params.entitySlug);
+
+    const session = await syncCookies();
+    if (!session) {
+      const next = `${location.pathname}${location.search}`;
+      location.replace(`${LOGIN_PATH}?next=${encodeURIComponent(next)}`);
+      return;
+    }
+    const c = getSupabase();
+    if (!c) return;
+    const { data: profile } = await c
+      .from('profiles')
+      .select('is_editor')
+      .eq('id', session.user.id)
+      .maybeSingle();
+    if (!profile?.is_editor) {
+      setStatus('Your account does not have editor rights.', 'err');
+      return;
+    }
+
+    bindEvents(params.entityType, params.entitySlug);
+    await loadAll(params.entityType, params.entitySlug);
+
+    c.auth.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_OUT') {
+        clearCookie(COOKIE_ACCESS);
+        clearCookie(COOKIE_REFRESH);
+        location.replace(LOGIN_PATH);
+      }
+      if (event === 'TOKEN_REFRESHED') {
+        await syncCookies();
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    void init();
+  });
+</script>
+
+<style is:global>
+  .entry-editor {
+    padding: clamp(2rem, 5vw, 4rem) 0 clamp(4rem, 8vw, 6rem);
+  }
+  .entry-editor__container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .entry-editor__head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .entry-editor__eyebrow {
+    margin: 0;
+    font: 700 0.7rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ochre, #A0541F);
+  }
+  .entry-editor__title {
+    margin: 0;
+    font-family: var(--serif, 'Newsreader', Georgia, serif);
+    font-size: clamp(1.6rem, 4vw, 2.4rem);
+    line-height: 1;
+    letter-spacing: -0.02em;
+    word-break: break-all;
+  }
+  .entry-editor__status {
+    margin: 0.5rem 0 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.4rem;
+    background: rgba(23, 20, 19, 0.05);
+    font: 500 0.86rem/1.4 var(--sans, 'Inter', system-ui, sans-serif);
+  }
+  .entry-editor__status[data-tone='ok'] { background: rgba(46, 125, 50, 0.08); color: #2e7d32; }
+  .entry-editor__status[data-tone='err'] { background: rgba(176, 0, 32, 0.08); color: #b00020; }
+  .entry-editor__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+  @media (min-width: 60rem) {
+    .entry-editor__layout { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); }
+  }
+  .entry-editor__group {
+    background: var(--paper, #FAF7F0);
+    border: 1px solid rgba(23, 20, 19, 0.08);
+    padding: 1.25rem;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .entry-editor__group-head {
+    display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;
+  }
+  .entry-editor__group-head h2 {
+    margin: 0;
+    font: 700 0.85rem/1.2 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .entry-editor__rows { display: flex; flex-direction: column; gap: 0.85rem; }
+  .entry-editor__row {
+    border: 1px solid rgba(23, 20, 19, 0.08);
+    background: rgba(255, 255, 255, 0.6);
+    padding: 0.85rem; border-radius: 0.4rem;
+    display: flex; flex-direction: column; gap: 0.5rem;
+  }
+  .entry-editor__row-meta { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+  .entry-editor__row-label { font: 700 0.85rem/1.2 var(--sans, 'Inter', system-ui, sans-serif); }
+  .entry-editor__row-tag {
+    padding: 0.1rem 0.5rem; border-radius: 999px;
+    font: 700 0.66rem/1.4 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.06em; text-transform: uppercase;
+    background: rgba(23, 20, 19, 0.06); color: var(--ink-soft, #3A3531);
+  }
+  .entry-editor__row-tag--draft { background: rgba(176, 0, 32, 0.08); color: #b00020; }
+  .entry-editor__row-tag--published { background: rgba(46, 125, 50, 0.1); color: #2e7d32; }
+  .entry-editor__input {
+    width: 100%; box-sizing: border-box;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid rgba(23, 20, 19, 0.18);
+    border-radius: 0.35rem;
+    font: 500 0.95rem/1.4 var(--sans, 'Inter', system-ui, sans-serif);
+    color: var(--ink, #171413);
+    background: var(--paper, #FAF7F0);
+    resize: vertical; min-height: 2.4rem;
+  }
+  textarea.entry-editor__input {
+    min-height: 6rem;
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 0.9rem;
+  }
+  .entry-editor__image-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: 0.6rem;
+  }
+  .entry-editor__image-grid label {
+    display: flex; flex-direction: column; gap: 0.25rem;
+    font: 600 0.74rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--ink-soft, #3A3531);
+  }
+  .entry-editor__row-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+  .entry-editor__btn {
+    border: 0; border-radius: 999px;
+    padding: 0.5rem 0.9rem;
+    font: 700 0.7rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.14em; text-transform: uppercase;
+    cursor: pointer;
+  }
+  .entry-editor__btn--save { background: rgba(23, 20, 19, 0.06); color: var(--ink, #171413); }
+  .entry-editor__btn--publish { background: var(--ink, #171413); color: var(--paper, #FAF7F0); }
+  .entry-editor__btn--ghost {
+    background: transparent;
+    border: 1px solid rgba(176, 0, 32, 0.32);
+    color: #b00020;
+  }
+  .entry-editor__hint { margin: 0; color: var(--ink-soft, #3A3531); }
+  .entry-editor__aside {
+    background: var(--paper, #FAF7F0);
+    border: 1px solid rgba(23, 20, 19, 0.08);
+    padding: 1.25rem; border-radius: 0.5rem;
+    align-self: start; position: sticky; top: 1rem;
+  }
+  .entry-editor__aside h2 {
+    margin: 0 0 0.6rem;
+    font: 700 0.78rem/1.2 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.12em; text-transform: uppercase;
+  }
+  .entry-editor__aside h3 {
+    margin: 1rem 0 0.5rem;
+    font: 700 0.74rem/1.2 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--ink-soft, #3A3531);
+  }
+  .entry-editor__revisions {
+    margin: 0; padding-left: 1rem; line-height: 1.6;
+    font: 500 0.86rem/1.5 var(--sans, 'Inter', system-ui, sans-serif);
+  }
+  .entry-editor__revisions li {
+    margin-bottom: 0.6rem;
+    display: flex; flex-direction: column;
+  }
+  .entry-editor__rev-action {
+    font-weight: 700; text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.08em;
+    color: var(--ochre, #A0541F);
+  }
+  .entry-editor__rev-summary { color: var(--ink, #171413); }
+  .entry-editor__rev-time { color: var(--ink-soft, #3A3531); font-size: 0.78rem; }
+  .entry-editor__quick { margin: 0; padding-left: 1rem; line-height: 1.7; }
+</style>

--- a/next/src/pages/admin/index.astro
+++ b/next/src/pages/admin/index.astro
@@ -1,0 +1,495 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Admin' },
+];
+---
+
+<BaseLayout
+  title="Admin · Peninsula Insider"
+  description="Peninsula Insider editorial admin surface."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="admin-shell" data-admin-root>
+    <div class="container admin-shell__container">
+      <header class="admin-shell__header">
+        <p class="admin-shell__eyebrow">Editorial admin</p>
+        <h1 class="admin-shell__title">What needs your eye today.</h1>
+        <p class="admin-shell__subtitle">
+          Edit CMS-managed fields, publish what's ready, see who changed what.
+        </p>
+      </header>
+
+      <div class="admin-shell__topline" data-admin-topline>
+        <div class="admin-shell__topline-cell">
+          <span class="admin-shell__topline-label">Editor</span>
+          <span class="admin-shell__topline-value" data-admin-identity>Checking session…</span>
+        </div>
+        <div class="admin-shell__topline-cell">
+          <span class="admin-shell__topline-label">Publish rights</span>
+          <span class="admin-shell__topline-value" data-admin-publish>—</span>
+        </div>
+        <div class="admin-shell__topline-cell">
+          <span class="admin-shell__topline-label">Entries</span>
+          <span class="admin-shell__topline-value" data-admin-entry-count>—</span>
+        </div>
+        <div class="admin-shell__topline-cell">
+          <button type="button" class="admin-shell__signout" data-action="signout">Sign out</button>
+        </div>
+      </div>
+
+      <div class="admin-shell__body">
+        <div class="admin-shell__panel">
+          <div class="admin-shell__panel-head">
+            <h2 class="admin-shell__panel-title">CMS entries</h2>
+            <div class="admin-shell__panel-controls">
+              <input
+                type="search"
+                placeholder="Filter by slug…"
+                class="admin-shell__search"
+                data-admin-search
+                aria-label="Filter entries"
+              />
+              <button type="button" class="admin-shell__refresh" data-action="refresh">Refresh</button>
+            </div>
+          </div>
+          <div class="admin-shell__entries" data-admin-entries>
+            <p class="admin-shell__hint">Loading entries…</p>
+          </div>
+        </div>
+
+        <aside class="admin-shell__aside">
+          <h2 class="admin-shell__panel-title">Quick links</h2>
+          <ul class="admin-shell__quick-links">
+            <li><a href="/admin/entry/page/home/">Edit homepage</a></li>
+            <li><a href="/admin/login/">Login screen</a></li>
+            <li><a href="/" target="_blank" rel="noopener">View live site</a></li>
+          </ul>
+          <h3 class="admin-shell__panel-subtitle">Notes</h3>
+          <ul class="admin-shell__notes">
+            <li>Published changes go live on next build.</li>
+            <li>Unsigned visitors hit the login screen automatically.</li>
+            <li>All writes are logged to <code>pi.cms_revisions</code>.</li>
+          </ul>
+        </aside>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled, signOut } from '../../lib/auth';
+
+  const LOGIN_PATH = '/admin/login/';
+  const COOKIE_ACCESS = 'pi-sb-access-token';
+  const COOKIE_REFRESH = 'pi-sb-refresh-token';
+
+  type EntryRow = {
+    entityType: string;
+    entitySlug: string;
+    textFieldCount: number;
+    imageSlotCount: number;
+    draftCount: number;
+    publishedCount: number;
+    lastUpdatedAt: string | null;
+  };
+
+  function setCookie(name: string, value: string, maxAgeSeconds: number) {
+    const secure = location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent(value)}; Path=/; Max-Age=${Math.max(60, Math.floor(maxAgeSeconds))}; SameSite=Lax${secure}`;
+  }
+
+  function clearCookie(name: string) {
+    document.cookie = `${name}=; Path=/; Max-Age=0; SameSite=Lax`;
+  }
+
+  async function syncCookiesFromSession() {
+    const c = getSupabase();
+    if (!c) return null;
+    const { data } = await c.auth.getSession();
+    const session = data.session;
+    if (!session) {
+      clearCookie(COOKIE_ACCESS);
+      clearCookie(COOKIE_REFRESH);
+      return null;
+    }
+    const expiresIn = (session.expires_in as number | undefined) ?? 3600;
+    setCookie(COOKIE_ACCESS, session.access_token, expiresIn);
+    if (session.refresh_token) {
+      setCookie(COOKIE_REFRESH, session.refresh_token, 60 * 60 * 24 * 30);
+    }
+    return session;
+  }
+
+  function redirectToLogin() {
+    const next = `${location.pathname}${location.search}`;
+    location.replace(`${LOGIN_PATH}?next=${encodeURIComponent(next)}`);
+  }
+
+  async function loadEntries(): Promise<EntryRow[]> {
+    const c = getSupabase();
+    if (!c) return [];
+    const [text, image] = await Promise.all([
+      c.from('cms_text_fields').select('entity_type, entity_slug, status, updated_at'),
+      c.from('cms_image_slots').select('entity_type, entity_slug, status, updated_at'),
+    ]);
+    if (text.error || image.error) return [];
+
+    const buckets = new Map<string, EntryRow>();
+    function bump(entityType: string, entitySlug: string, status: string, updatedAt: string, kind: 'text' | 'image') {
+      const key = `${entityType}::${entitySlug}`;
+      const cur = buckets.get(key) ?? {
+        entityType,
+        entitySlug,
+        textFieldCount: 0,
+        imageSlotCount: 0,
+        draftCount: 0,
+        publishedCount: 0,
+        lastUpdatedAt: null as string | null,
+      };
+      if (kind === 'text') cur.textFieldCount += 1;
+      if (kind === 'image') cur.imageSlotCount += 1;
+      if (status === 'draft') cur.draftCount += 1;
+      if (status === 'published') cur.publishedCount += 1;
+      if (!cur.lastUpdatedAt || updatedAt > cur.lastUpdatedAt) cur.lastUpdatedAt = updatedAt;
+      buckets.set(key, cur);
+    }
+    for (const row of text.data ?? []) bump(row.entity_type, row.entity_slug, row.status, row.updated_at, 'text');
+    for (const row of image.data ?? []) bump(row.entity_type, row.entity_slug, row.status, row.updated_at, 'image');
+
+    return [...buckets.values()].sort((a, b) => (b.lastUpdatedAt ?? '').localeCompare(a.lastUpdatedAt ?? ''));
+  }
+
+  function renderEntries(rows: EntryRow[], filter: string) {
+    const host = document.querySelector<HTMLElement>('[data-admin-entries]');
+    const counter = document.querySelector<HTMLElement>('[data-admin-entry-count]');
+    if (!host) return;
+    const filtered = rows.filter((r) => r.entitySlug.toLowerCase().includes(filter));
+    if (counter) counter.textContent = `${filtered.length} of ${rows.length}`;
+    if (filtered.length === 0) {
+      host.innerHTML = `<p class="admin-shell__hint">${rows.length === 0 ? 'No CMS entries yet. Add fields by editing a page from the live site or running a seed.' : 'No matches for that filter.'}</p>`;
+      return;
+    }
+    host.innerHTML = filtered
+      .map((row) => {
+        const updated = row.lastUpdatedAt ? new Date(row.lastUpdatedAt).toLocaleString() : '—';
+        const href = `/admin/entry/${encodeURIComponent(row.entityType)}/${encodeURIComponent(row.entitySlug)}/`;
+        return `
+          <a class="admin-shell__entry" href="${href}">
+            <span class="admin-shell__entry-type">${row.entityType}</span>
+            <span class="admin-shell__entry-slug">${row.entitySlug}</span>
+            <span class="admin-shell__entry-meta">
+              <span>${row.textFieldCount} text</span>
+              <span>${row.imageSlotCount} img</span>
+              <span class="admin-shell__pill admin-shell__pill--draft">${row.draftCount} draft</span>
+              <span class="admin-shell__pill admin-shell__pill--pub">${row.publishedCount} pub</span>
+            </span>
+            <span class="admin-shell__entry-time">${updated}</span>
+          </a>
+        `;
+      })
+      .join('');
+  }
+
+  async function init() {
+    if (!isAuthEnabled()) {
+      const host = document.querySelector<HTMLElement>('[data-admin-entries]');
+      if (host) host.innerHTML = '<p class="admin-shell__hint">Auth is not configured in this environment.</p>';
+      return;
+    }
+    const session = await syncCookiesFromSession();
+    if (!session) {
+      redirectToLogin();
+      return;
+    }
+    const c = getSupabase();
+    if (!c) return;
+
+    const { data: profile } = await c
+      .from('profiles')
+      .select('display_name, is_editor')
+      .eq('id', session.user.id)
+      .maybeSingle();
+
+    if (!profile?.is_editor) {
+      const host = document.querySelector<HTMLElement>('[data-admin-entries]');
+      if (host) host.innerHTML = '<p class="admin-shell__hint">This account is signed in but does not have editor rights.</p>';
+      const id = document.querySelector<HTMLElement>('[data-admin-identity]');
+      if (id) id.textContent = session.user.email ?? session.user.id;
+      const pub = document.querySelector<HTMLElement>('[data-admin-publish]');
+      if (pub) pub.textContent = 'No';
+      return;
+    }
+
+    const idEl = document.querySelector<HTMLElement>('[data-admin-identity]');
+    if (idEl) idEl.textContent = profile.display_name || session.user.email || session.user.id;
+
+    const { data: allow } = await c
+      .from('admin_user_allowlist')
+      .select('role, can_publish')
+      .eq('user_id', session.user.id)
+      .maybeSingle();
+    const canPublish = Boolean(allow?.can_publish) || allow?.role === 'publisher' || allow?.role === 'admin';
+    const pubEl = document.querySelector<HTMLElement>('[data-admin-publish]');
+    if (pubEl) pubEl.textContent = canPublish ? 'Yes' : 'No (drafts only)';
+
+    let rows = await loadEntries();
+    let filter = '';
+
+    renderEntries(rows, filter);
+
+    const search = document.querySelector<HTMLInputElement>('[data-admin-search]');
+    search?.addEventListener('input', () => {
+      filter = (search.value || '').toLowerCase().trim();
+      renderEntries(rows, filter);
+    });
+
+    document.querySelector('[data-action="refresh"]')?.addEventListener('click', async () => {
+      rows = await loadEntries();
+      renderEntries(rows, filter);
+    });
+
+    document.querySelector('[data-action="signout"]')?.addEventListener('click', async () => {
+      await signOut();
+      clearCookie(COOKIE_ACCESS);
+      clearCookie(COOKIE_REFRESH);
+      location.replace(LOGIN_PATH);
+    });
+
+    c.auth.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_OUT') {
+        clearCookie(COOKIE_ACCESS);
+        clearCookie(COOKIE_REFRESH);
+        location.replace(LOGIN_PATH);
+      }
+      if (event === 'TOKEN_REFRESHED') {
+        await syncCookiesFromSession();
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    void init();
+  });
+</script>
+
+<style is:global>
+  .admin-shell {
+    padding: clamp(2rem, 6vw, 4.5rem) 0 clamp(4rem, 8vw, 6rem);
+    color: var(--ink, #171413);
+  }
+  .admin-shell__container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+  .admin-shell__header {
+    max-width: 50rem;
+  }
+  .admin-shell__eyebrow {
+    margin: 0 0 0.5rem;
+    font: 700 0.7rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ochre, #A0541F);
+  }
+  .admin-shell__title {
+    margin: 0 0 0.25rem;
+    font-family: var(--serif, 'Newsreader', Georgia, serif);
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    line-height: 1;
+    letter-spacing: -0.025em;
+  }
+  .admin-shell__subtitle {
+    margin: 0;
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-shell__topline {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 0.75rem;
+    background: var(--paper, #FAF7F0);
+    border: 1px solid rgba(23, 20, 19, 0.08);
+    padding: 1rem 1.25rem;
+    border-radius: 0.5rem;
+  }
+  .admin-shell__topline-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .admin-shell__topline-label {
+    font: 700 0.62rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-shell__topline-value {
+    font: 600 1rem/1.3 var(--sans, 'Inter', system-ui, sans-serif);
+    color: var(--ink, #171413);
+  }
+  .admin-shell__signout {
+    align-self: start;
+    background: transparent;
+    border: 1px solid rgba(23, 20, 19, 0.18);
+    padding: 0.5rem 0.85rem;
+    font: 700 0.7rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    border-radius: 999px;
+    cursor: pointer;
+  }
+  .admin-shell__body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+  @media (min-width: 60rem) {
+    .admin-shell__body {
+      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    }
+  }
+  .admin-shell__panel,
+  .admin-shell__aside {
+    background: var(--paper, #FAF7F0);
+    border: 1px solid rgba(23, 20, 19, 0.08);
+    padding: 1.25rem;
+    border-radius: 0.5rem;
+  }
+  .admin-shell__panel-head {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .admin-shell__panel-title {
+    margin: 0;
+    font: 700 0.95rem/1.2 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .admin-shell__panel-subtitle {
+    margin: 1.25rem 0 0.5rem;
+    font: 700 0.78rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-shell__panel-controls {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .admin-shell__search {
+    padding: 0.5rem 0.7rem;
+    border: 1px solid rgba(23, 20, 19, 0.18);
+    border-radius: 0.35rem;
+    font: 500 0.9rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    min-width: 12rem;
+    background: rgba(255, 255, 255, 0.6);
+  }
+  .admin-shell__refresh {
+    background: transparent;
+    border: 1px solid rgba(23, 20, 19, 0.18);
+    padding: 0.5rem 0.85rem;
+    font: 700 0.7rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    border-radius: 999px;
+    cursor: pointer;
+  }
+  .admin-shell__entries {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+  .admin-shell__entry {
+    display: grid;
+    grid-template-columns: 6rem minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    gap: 0.15rem 0.75rem;
+    padding: 0.75rem 0.9rem;
+    border: 1px solid rgba(23, 20, 19, 0.06);
+    border-radius: 0.4rem;
+    text-decoration: none;
+    color: var(--ink, #171413);
+    background: rgba(255, 255, 255, 0.5);
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .admin-shell__entry:hover {
+    border-color: rgba(160, 84, 31, 0.6);
+    background: rgba(255, 255, 255, 0.85);
+  }
+  .admin-shell__entry-type {
+    grid-column: 1;
+    font: 700 0.65rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ochre, #A0541F);
+    align-self: center;
+  }
+  .admin-shell__entry-slug {
+    grid-column: 2;
+    font: 600 0.95rem/1.3 var(--sans, 'Inter', system-ui, sans-serif);
+    word-break: break-all;
+  }
+  .admin-shell__entry-meta {
+    grid-column: 2;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.85rem;
+    font: 500 0.78rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-shell__entry-time {
+    grid-column: 1 / -1;
+    font: 500 0.72rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    color: var(--ink-soft, #3A3531);
+    margin-top: 0.25rem;
+  }
+  .admin-shell__pill {
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font: 700 0.66rem/1.4 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .admin-shell__pill--draft {
+    background: rgba(176, 0, 32, 0.08);
+    color: #b00020;
+  }
+  .admin-shell__pill--pub {
+    background: rgba(46, 125, 50, 0.1);
+    color: #2e7d32;
+  }
+  .admin-shell__hint {
+    margin: 0;
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-shell__quick-links {
+    margin: 0.25rem 0 0;
+    padding-left: 1.1rem;
+    line-height: 1.8;
+  }
+  .admin-shell__notes {
+    margin: 0.25rem 0 0;
+    padding-left: 1.1rem;
+    line-height: 1.6;
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-shell__notes code {
+    font: 500 0.85em/1 var(--mono, ui-monospace, SFMono-Regular, monospace);
+    background: rgba(23, 20, 19, 0.06);
+    padding: 0.05rem 0.35rem;
+    border-radius: 0.25rem;
+  }
+</style>

--- a/next/src/pages/admin/index.astro
+++ b/next/src/pages/admin/index.astro
@@ -68,7 +68,7 @@ const breadcrumbItems = [
         <aside class="admin-shell__aside">
           <h2 class="admin-shell__panel-title">Quick links</h2>
           <ul class="admin-shell__quick-links">
-            <li><a href="/admin/entry/page/home/">Edit homepage</a></li>
+            <li><a href="/admin/entry/?type=page&amp;slug=home">Edit homepage</a></li>
             <li><a href="/admin/login/">Login screen</a></li>
             <li><a href="/" target="_blank" rel="noopener">View live site</a></li>
           </ul>
@@ -180,7 +180,7 @@ const breadcrumbItems = [
     host.innerHTML = filtered
       .map((row) => {
         const updated = row.lastUpdatedAt ? new Date(row.lastUpdatedAt).toLocaleString() : '—';
-        const href = `/admin/entry/${encodeURIComponent(row.entityType)}/${encodeURIComponent(row.entitySlug)}/`;
+        const href = `/admin/entry/?type=${encodeURIComponent(row.entityType)}&slug=${encodeURIComponent(row.entitySlug)}`;
         return `
           <a class="admin-shell__entry" href="${href}">
             <span class="admin-shell__entry-type">${row.entityType}</span>

--- a/next/src/pages/admin/login.astro
+++ b/next/src/pages/admin/login.astro
@@ -1,0 +1,288 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+
+const nextPath = Astro.url.searchParams.get('next') || '/admin/';
+const hybridEnabled = import.meta.env.PI_ADMIN_HYBRID === '1';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Admin login' },
+];
+---
+
+<BaseLayout
+  title="Admin Login · Peninsula Insider"
+  description="Sign in to the Peninsula Insider admin layer."
+  section="home"
+  noindex={true}
+  searchExclude={true}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="admin-login" data-next-path={nextPath}>
+    <div class="container admin-login__container">
+      <div class="admin-login__card">
+        <p class="admin-login__eyebrow">Peninsula Insider admin</p>
+        <h1 class="admin-login__title">Sign in to edit the site.</h1>
+        <p class="admin-login__body">
+          Admin access is granted only to approved editor accounts. Sign in with your editor email and you'll be redirected back automatically.
+        </p>
+
+        <div class="admin-login__actions">
+          <button type="button" class="admin-login__primary" data-action="google">Continue with Google</button>
+        </div>
+
+        <form class="admin-login__magic" data-action="magic-link" novalidate>
+          <label class="admin-login__label" for="admin-login-email">Or use a magic link</label>
+          <div class="admin-login__row">
+            <input
+              id="admin-login-email"
+              type="email"
+              name="email"
+              autocomplete="email"
+              required
+              placeholder="you@example.com"
+              class="admin-login__input"
+            />
+            <button type="submit" class="admin-login__secondary">Send link</button>
+          </div>
+        </form>
+
+        <div class="admin-login__status" data-admin-login-status role="status" aria-live="polite">
+          {hybridEnabled
+            ? 'Hybrid admin mode is enabled. Approved editors will land on the admin home after sign-in.'
+            : 'Static admin mode. Editor sessions are validated client-side against Supabase RLS until the hybrid cutover ships.'}
+        </div>
+
+        <ul class="admin-login__notes">
+          <li>Public site stays fast and static by default.</li>
+          <li>Write access is gated by Supabase RLS policies — only approved editors can save changes.</li>
+          <li>Lost access? Ask another editor to add your account to <code>pi.admin_user_allowlist</code>.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled, signInWithGoogle, signInWithMagicLink } from '../../lib/auth';
+
+  const ADMIN_HOME = '/admin/';
+  const COOKIE_ACCESS = 'pi-sb-access-token';
+  const COOKIE_REFRESH = 'pi-sb-refresh-token';
+
+  function setCookie(name: string, value: string, maxAgeSeconds: number) {
+    const secure = location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent(value)}; Path=/; Max-Age=${Math.max(60, Math.floor(maxAgeSeconds))}; SameSite=Lax${secure}`;
+  }
+
+  function clearCookie(name: string) {
+    document.cookie = `${name}=; Path=/; Max-Age=0; SameSite=Lax`;
+  }
+
+  function setStatus(text: string, tone: 'idle' | 'ok' | 'err' = 'idle') {
+    const el = document.querySelector<HTMLElement>('[data-admin-login-status]');
+    if (!el) return;
+    el.textContent = text;
+    el.dataset.tone = tone;
+  }
+
+  function readNextPath(): string {
+    const wrap = document.querySelector<HTMLElement>('.admin-login');
+    const v = wrap?.dataset.nextPath || ADMIN_HOME;
+    if (!v.startsWith('/')) return ADMIN_HOME;
+    return v;
+  }
+
+  async function syncCookiesFromSession() {
+    const c = getSupabase();
+    if (!c) return null;
+    const { data } = await c.auth.getSession();
+    const session = data.session;
+    if (!session) {
+      clearCookie(COOKIE_ACCESS);
+      clearCookie(COOKIE_REFRESH);
+      return null;
+    }
+    const expiresIn = (session.expires_in as number | undefined) ?? 3600;
+    setCookie(COOKIE_ACCESS, session.access_token, expiresIn);
+    if (session.refresh_token) {
+      // Refresh tokens are long-lived; cap at 30 days.
+      setCookie(COOKIE_REFRESH, session.refresh_token, 60 * 60 * 24 * 30);
+    }
+    return session;
+  }
+
+  async function checkAlreadySignedIn() {
+    if (!isAuthEnabled()) {
+      setStatus('Auth is not configured in this environment. Contact the site admin.', 'err');
+      return;
+    }
+    const session = await syncCookiesFromSession();
+    if (!session) return;
+    setStatus('You are already signed in. Redirecting…', 'ok');
+    location.replace(readNextPath());
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    void checkAlreadySignedIn();
+
+    document.querySelector('[data-action="google"]')?.addEventListener('click', async () => {
+      try {
+        setStatus('Opening Google sign-in…');
+        await signInWithGoogle(`${location.origin}${readNextPath()}`);
+      } catch (err) {
+        setStatus((err as Error).message || 'Could not start sign-in.', 'err');
+      }
+    });
+
+    const form = document.querySelector<HTMLFormElement>('[data-action="magic-link"]');
+    form?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const email = (form.elements.namedItem('email') as HTMLInputElement | null)?.value?.trim();
+      if (!email) {
+        setStatus('Enter the email associated with your editor account.', 'err');
+        return;
+      }
+      setStatus('Sending magic link…');
+      const result = await signInWithMagicLink(email, `${location.origin}${readNextPath()}`);
+      if (result.ok) {
+        setStatus('Check your inbox — the link expires in 60 minutes.', 'ok');
+      } else {
+        setStatus(result.error || 'Could not send link.', 'err');
+      }
+    });
+
+    const c = getSupabase();
+    if (!c) return;
+    c.auth.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        const session = await syncCookiesFromSession();
+        if (session) {
+          setStatus('Signed in. Redirecting…', 'ok');
+          location.replace(readNextPath());
+        }
+      }
+      if (event === 'SIGNED_OUT') {
+        clearCookie(COOKIE_ACCESS);
+        clearCookie(COOKIE_REFRESH);
+      }
+    });
+  });
+</script>
+
+<style is:global>
+  .admin-login {
+    padding: clamp(4rem, 10vw, 7rem) 0;
+  }
+  .admin-login__container {
+    display: flex;
+    justify-content: center;
+  }
+  .admin-login__card {
+    width: min(100%, 42rem);
+    background: var(--paper, #FAF7F0);
+    border: 1px solid rgba(23, 20, 19, 0.08);
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+    box-shadow: 0 20px 60px -40px rgba(0, 0, 0, 0.4);
+  }
+  .admin-login__eyebrow {
+    margin: 0 0 0.75rem;
+    font: 700 0.72rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ochre, #A0541F);
+  }
+  .admin-login__title {
+    margin: 0 0 0.75rem;
+    font-family: var(--serif, 'Newsreader', Georgia, serif);
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+    color: var(--ink, #171413);
+  }
+  .admin-login__body,
+  .admin-login__status,
+  .admin-login__notes {
+    color: var(--ink-soft, #3A3531);
+    line-height: 1.6;
+  }
+  .admin-login__actions {
+    display: flex;
+    gap: 0.9rem;
+    flex-wrap: wrap;
+    margin: 1.5rem 0 1rem;
+  }
+  .admin-login__primary,
+  .admin-login__secondary {
+    appearance: none;
+    border: 0;
+    border-radius: 999px;
+    padding: 0.9rem 1.2rem;
+    font: 700 0.76rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .admin-login__primary {
+    background: var(--ink, #171413);
+    color: var(--paper, #FAF7F0);
+  }
+  .admin-login__secondary {
+    background: rgba(23, 20, 19, 0.06);
+    color: var(--ink, #171413);
+  }
+  .admin-login__magic {
+    margin: 1rem 0 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .admin-login__label {
+    font: 600 0.7rem/1 var(--sans, 'Inter', system-ui, sans-serif);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-soft, #3A3531);
+  }
+  .admin-login__row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .admin-login__input {
+    flex: 1 1 14rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid rgba(23, 20, 19, 0.18);
+    background: var(--paper, #FAF7F0);
+    font: 500 1rem/1.4 var(--sans, 'Inter', system-ui, sans-serif);
+    color: var(--ink, #171413);
+    border-radius: 0.4rem;
+  }
+  .admin-login__status {
+    margin-top: 1rem;
+    padding: 0.6rem 0.8rem;
+    border-radius: 0.4rem;
+    background: rgba(23, 20, 19, 0.04);
+    font: 500 0.92rem/1.5 var(--sans, 'Inter', system-ui, sans-serif);
+  }
+  .admin-login__status[data-tone='ok'] {
+    background: rgba(46, 125, 50, 0.08);
+    color: #2e7d32;
+  }
+  .admin-login__status[data-tone='err'] {
+    background: rgba(176, 0, 32, 0.08);
+    color: #b00020;
+  }
+  .admin-login__notes {
+    margin: 1rem 0 0;
+    padding-left: 1.2rem;
+  }
+  .admin-login__notes code {
+    font: 500 0.85em/1 var(--mono, ui-monospace, SFMono-Regular, monospace);
+    background: rgba(23, 20, 19, 0.06);
+    padding: 0.05rem 0.35rem;
+    border-radius: 0.25rem;
+  }
+</style>

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -27,6 +27,15 @@ import PlaceCard from '../components/PlaceCard.astro';
 import WeekendPickerBlock from '../components/WeekendPickerBlock.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
 import { formatLabel, routeSlug, stayTypes, currentSeason, seasonBlurb, dispatchWeekend, resolveHeroSrc } from '../lib/editorial';
+import { loadPublishedHomepageOverrides } from '../lib/content/homepage';
+
+// CMS-driven overrides for editor-controlled fields on the homepage. Empty
+// when Supabase is unconfigured or no rows are published; falls through to
+// the inline defaults below in that case. Per-field use only — dynamic
+// seasonal copy still wins when nothing is published.
+const cmsOverrides = await loadPublishedHomepageOverrides();
+const cmsText = cmsOverrides.textFieldsByPath;
+const cmsImage = cmsOverrides.imageSlotsByPath;
 
 const venues      = await getCollection('venues');
 const articles    = (await getCollection('articles', ({ data }) => data.status === 'published'))
@@ -98,18 +107,22 @@ interface Scene {
   primaryLabel: string;
 }
 
+// Cover scene fields are editor-controlled. CMS overrides (when present)
+// win over the inline defaults; the inline values are the canonical fallback
+// so the homepage renders identically when no CMS rows are published.
+const coverImageOverride = cmsImage['cover.image'];
 const scenes: Scene[] = [
   {
     id: 'cover',
-    label: 'THE COVER STORY',
-    hours: '9 MIN READ',
-    image: '/images/sourced/home-cover-bay-umbrella-01.webp',
-    imageAlt: 'A wide sandy bay beach with dune grass in the foreground, a bright red umbrella and chair to the right, and calm water under a blue sky.',
-    caption: 'Bay beach, Mornington Peninsula',
-    headline: 'The Hatted Restaurants of the <em>Peninsula.</em>',
-    dispatch: 'Four two-hat restaurants. Seven one-hat tables. Barragunda is the debut, Tedesca took Regional Restaurant of the Year, and Laura is still where the long lunch happens. The complete list, with booking realities.',
-    primaryHref: '/journal/hatted-restaurants-mornington-peninsula-2025/',
-    primaryLabel: 'Read the cover story',
+    label: cmsText['cover.label'] ?? 'THE COVER STORY',
+    hours: cmsText['cover.hours'] ?? '9 MIN READ',
+    image: coverImageOverride?.src ?? '/images/sourced/home-cover-bay-umbrella-01.webp',
+    imageAlt: coverImageOverride?.alt ?? 'A wide sandy bay beach with dune grass in the foreground, a bright red umbrella and chair to the right, and calm water under a blue sky.',
+    caption: coverImageOverride?.caption ?? cmsText['cover.caption'] ?? 'Bay beach, Mornington Peninsula',
+    headline: cmsText['cover.headline'] ?? 'The Hatted Restaurants of the <em>Peninsula.</em>',
+    dispatch: cmsText['cover.dispatch'] ?? 'Four two-hat restaurants. Seven one-hat tables. Barragunda is the debut, Tedesca took Regional Restaurant of the Year, and Laura is still where the long lunch happens. The complete list, with booking realities.',
+    primaryHref: cmsText['cover.primaryHref'] ?? '/journal/hatted-restaurants-mornington-peninsula-2025/',
+    primaryLabel: cmsText['cover.primaryLabel'] ?? 'Read the cover story',
   },
 ];
 
@@ -354,21 +367,36 @@ const ssrScene = scenes[0];
     />
   )}
 
-  <EditorsLetter
-    eyebrow="Editor's Letter"
-    title={`On the <em>quiet authority</em> of a good ${seasonBlurbData.label?.toLowerCase() ?? 'autumn'}.`}
-    paragraphs={[
-      `${seasonBlurbData.label ?? 'Autumn'} is the season the Peninsula stops performing. The weekend crowds thin, the vintage trucks finish their last runs, and the ridge takes on the colour it has for about six weeks a year.`,
-      `We've rebuilt the cellar-door shortlist from scratch this season, visited every restaurant on the long-lunch list at least twice, and walked every beach on the ranking.`,
-      `If this is your first issue with us, welcome. If you're returning, thanks for the patience through the refit.`,
-    ]}
-    pullQuote="This issue is built for the six weeks where the Peninsula is at its most itself, before winter settles in and the coast goes quiet."
-    signatureName="The Editors"
-    signatureRole="Peninsula Insider"
-    image="/images/sourced/place-red-hill-01.webp"
-    imageAlt="Vine rows in late-season colour, Red Hill"
-    imageCaption="The last weekend of vintage, Red Hill, <em>the quietest a working winery ever gets.</em>"
-  />
+  {/* Editor's Letter — title and paragraphs keep their seasonal interpolation
+      because the JSON-default copy is autumn-specific; CMS overrides apply
+      only when an editor explicitly sets that field. Other fields fall
+      through to the inline defaults when no override is published. */}
+  {(() => {
+    const elImage = cmsImage['editors-letter.image'];
+    const editorsLetterTitle = cmsText['editors-letter.title']
+      ?? `On the <em>quiet authority</em> of a good ${seasonBlurbData.label?.toLowerCase() ?? 'autumn'}.`;
+    const editorsLetterParagraphs = [
+      cmsText['editors-letter.paragraphs.0']
+        ?? `${seasonBlurbData.label ?? 'Autumn'} is the season the Peninsula stops performing. The weekend crowds thin, the vintage trucks finish their last runs, and the ridge takes on the colour it has for about six weeks a year.`,
+      cmsText['editors-letter.paragraphs.1']
+        ?? `We've rebuilt the cellar-door shortlist from scratch this season, visited every restaurant on the long-lunch list at least twice, and walked every beach on the ranking.`,
+      cmsText['editors-letter.paragraphs.2']
+        ?? `If this is your first issue with us, welcome. If you're returning, thanks for the patience through the refit.`,
+    ];
+    return (
+      <EditorsLetter
+        eyebrow={cmsText['editors-letter.eyebrow'] ?? "Editor's Letter"}
+        title={editorsLetterTitle}
+        paragraphs={editorsLetterParagraphs}
+        pullQuote={cmsText['editors-letter.pullQuote'] ?? "This issue is built for the six weeks where the Peninsula is at its most itself, before winter settles in and the coast goes quiet."}
+        signatureName={cmsText['editors-letter.signatureName'] ?? "The Editors"}
+        signatureRole={cmsText['editors-letter.signatureRole'] ?? "Peninsula Insider"}
+        image={elImage?.src ?? "/images/sourced/place-red-hill-01.webp"}
+        imageAlt={elImage?.alt ?? "Vine rows in late-season colour, Red Hill"}
+        imageCaption={elImage?.caption ?? "The last weekend of vintage, Red Hill, <em>the quietest a working winery ever gets.</em>"}
+      />
+    );
+  })()}
 
   <NewsletterBlock />
 </BaseLayout>

--- a/ops/migrations/2026-05-09-pi-cms-admin.sql
+++ b/ops/migrations/2026-05-09-pi-cms-admin.sql
@@ -1,0 +1,215 @@
+-- Migration: PI CMS admin layer v1
+-- Date: 2026-05-09
+-- Purpose: minimal editable-field CMS primitives for Supabase Auth + Postgres + Storage.
+-- Scope: editor allowlist, editable text fields, editable image slots, revision history,
+--        and draft/publish status. No browser-side service-role assumptions.
+
+create schema if not exists pi;
+
+-- Editors are still identified primarily through pi.profiles.is_editor.
+-- This allowlist adds an explicit audit-friendly table for admin access control.
+create table if not exists pi.admin_user_allowlist (
+  user_id        uuid primary key references auth.users(id) on delete cascade,
+  email          text,
+  role           text not null default 'editor' check (role in ('editor', 'publisher', 'admin')),
+  can_publish    boolean not null default false,
+  invited_by     uuid references auth.users(id) on delete set null,
+  notes          text,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now()
+);
+
+comment on table pi.admin_user_allowlist is 'Explicit CMS admin allowlist layered on top of Supabase Auth users.';
+
+create or replace function pi.admin_user_allowlist_set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists admin_user_allowlist_set_updated_at on pi.admin_user_allowlist;
+create trigger admin_user_allowlist_set_updated_at
+  before update on pi.admin_user_allowlist
+  for each row execute function pi.admin_user_allowlist_set_updated_at();
+
+create table if not exists pi.cms_text_fields (
+  id              uuid primary key default gen_random_uuid(),
+  entity_type     text not null check (entity_type in ('article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary')),
+  entity_slug     text not null,
+  field_path      text not null,
+  label           text not null,
+  field_kind      text not null check (field_kind in ('text', 'markdown', 'richtext')),
+  locale          text,
+  value           text,
+  status          text not null default 'draft' check (status in ('draft', 'published')),
+  updated_by      uuid references auth.users(id) on delete set null,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  unique (entity_type, entity_slug, field_path, coalesce(locale, ''))
+);
+
+comment on table pi.cms_text_fields is 'Canonical editable text primitives for the CMS.';
+
+create table if not exists pi.cms_image_slots (
+  id              uuid primary key default gen_random_uuid(),
+  entity_type     text not null check (entity_type in ('article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary')),
+  entity_slug     text not null,
+  field_path      text not null,
+  label           text not null,
+  purpose         text not null default 'hero' check (purpose in ('hero', 'card', 'gallery', 'inline', 'seo')),
+  storage_bucket  text not null default 'cms-assets',
+  storage_path    text,
+  public_url      text,
+  alt_text        text,
+  caption         text,
+  credit          text,
+  mime_type       text,
+  status          text not null default 'draft' check (status in ('draft', 'published')),
+  updated_by      uuid references auth.users(id) on delete set null,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  unique (entity_type, entity_slug, field_path)
+);
+
+comment on table pi.cms_image_slots is 'Canonical editable image slot registry for the CMS.';
+
+create table if not exists pi.cms_revisions (
+  id                       uuid primary key default gen_random_uuid(),
+  entity_type              text not null check (entity_type in ('article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary')),
+  entity_slug              text not null,
+  action                   text not null check (action in ('create', 'update', 'publish', 'unpublish', 'restore')),
+  status                   text not null check (status in ('draft', 'published')),
+  summary                  text,
+  patch                    jsonb not null default '[]'::jsonb,
+  created_by               uuid references auth.users(id) on delete set null,
+  restored_from_revision_id uuid references pi.cms_revisions(id) on delete set null,
+  created_at               timestamptz not null default now()
+);
+
+comment on table pi.cms_revisions is 'Append-only revision log for CMS-managed field changes.';
+
+create index if not exists cms_text_fields_entity_idx
+  on pi.cms_text_fields (entity_type, entity_slug, status, updated_at desc);
+create index if not exists cms_image_slots_entity_idx
+  on pi.cms_image_slots (entity_type, entity_slug, status, updated_at desc);
+create index if not exists cms_revisions_entity_idx
+  on pi.cms_revisions (entity_type, entity_slug, created_at desc);
+
+create or replace function pi.cms_set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists cms_text_fields_set_updated_at on pi.cms_text_fields;
+create trigger cms_text_fields_set_updated_at
+  before update on pi.cms_text_fields
+  for each row execute function pi.cms_set_updated_at();
+
+drop trigger if exists cms_image_slots_set_updated_at on pi.cms_image_slots;
+create trigger cms_image_slots_set_updated_at
+  before update on pi.cms_image_slots
+  for each row execute function pi.cms_set_updated_at();
+
+alter table pi.admin_user_allowlist enable row level security;
+alter table pi.cms_text_fields enable row level security;
+alter table pi.cms_image_slots enable row level security;
+alter table pi.cms_revisions enable row level security;
+
+create or replace function pi.is_cms_admin()
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pi.profiles p
+    left join pi.admin_user_allowlist a on a.user_id = p.id
+    where p.id = auth.uid()
+      and p.is_editor = true
+      and (a.user_id is null or a.role in ('editor', 'publisher', 'admin'))
+  );
+$$;
+
+create or replace function pi.can_publish_cms()
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pi.profiles p
+    join pi.admin_user_allowlist a on a.user_id = p.id
+    where p.id = auth.uid()
+      and p.is_editor = true
+      and (a.can_publish = true or a.role in ('publisher', 'admin'))
+  );
+$$;
+
+drop policy if exists "cms_admin_allowlist_self_or_editor_select" on pi.admin_user_allowlist;
+create policy "cms_admin_allowlist_self_or_editor_select"
+  on pi.admin_user_allowlist for select
+  using (user_id = auth.uid() or pi.is_cms_admin());
+
+drop policy if exists "cms_admin_allowlist_editor_all" on pi.admin_user_allowlist;
+create policy "cms_admin_allowlist_editor_all"
+  on pi.admin_user_allowlist for all
+  using (pi.is_cms_admin())
+  with check (pi.is_cms_admin());
+
+drop policy if exists "cms_text_fields_editor_all" on pi.cms_text_fields;
+create policy "cms_text_fields_editor_all"
+  on pi.cms_text_fields for all
+  using (pi.is_cms_admin())
+  with check (pi.is_cms_admin());
+
+drop policy if exists "cms_image_slots_editor_all" on pi.cms_image_slots;
+create policy "cms_image_slots_editor_all"
+  on pi.cms_image_slots for all
+  using (pi.is_cms_admin())
+  with check (pi.is_cms_admin());
+
+drop policy if exists "cms_revisions_editor_select" on pi.cms_revisions;
+create policy "cms_revisions_editor_select"
+  on pi.cms_revisions for select
+  using (pi.is_cms_admin());
+
+drop policy if exists "cms_revisions_editor_insert" on pi.cms_revisions;
+create policy "cms_revisions_editor_insert"
+  on pi.cms_revisions for insert
+  with check (pi.is_cms_admin());
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'cms-assets',
+  'cms-assets',
+  false,
+  10485760,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/avif']
+)
+on conflict (id) do nothing;
+
+drop policy if exists "cms_assets_editor_insert" on storage.objects;
+create policy "cms_assets_editor_insert"
+  on storage.objects for insert
+  with check (bucket_id = 'cms-assets' and pi.is_cms_admin());
+
+drop policy if exists "cms_assets_editor_select" on storage.objects;
+create policy "cms_assets_editor_select"
+  on storage.objects for select
+  using (bucket_id = 'cms-assets' and pi.is_cms_admin());
+
+drop policy if exists "cms_assets_editor_update" on storage.objects;
+create policy "cms_assets_editor_update"
+  on storage.objects for update
+  using (bucket_id = 'cms-assets' and pi.is_cms_admin())
+  with check (bucket_id = 'cms-assets' and pi.is_cms_admin());
+
+drop policy if exists "cms_assets_editor_delete" on storage.objects;
+create policy "cms_assets_editor_delete"
+  on storage.objects for delete
+  using (bucket_id = 'cms-assets' and pi.is_cms_admin());

--- a/ops/migrations/2026-05-10-pi-cms-public-read.sql
+++ b/ops/migrations/2026-05-10-pi-cms-public-read.sql
@@ -1,0 +1,32 @@
+-- Migration: PI CMS — public-read for published rows
+-- Date: 2026-05-10
+-- Purpose: allow the static site (anon key) to read CMS-managed text fields and
+--          image slots at build time, restricted to status = 'published'.
+-- Scope: additive policy only. Editor-write/read paths from the v1 migration are
+--        unchanged.
+
+drop policy if exists "cms_text_fields_public_read_published" on pi.cms_text_fields;
+create policy "cms_text_fields_public_read_published"
+  on pi.cms_text_fields for select
+  to anon, authenticated
+  using (status = 'published');
+
+drop policy if exists "cms_image_slots_public_read_published" on pi.cms_image_slots;
+create policy "cms_image_slots_public_read_published"
+  on pi.cms_image_slots for select
+  to anon, authenticated
+  using (status = 'published');
+
+drop policy if exists "cms_assets_public_select_published" on storage.objects;
+create policy "cms_assets_public_select_published"
+  on storage.objects for select
+  to anon, authenticated
+  using (
+    bucket_id = 'cms-assets'
+    and exists (
+      select 1
+      from pi.cms_image_slots s
+      where s.storage_path = storage.objects.name
+        and s.status = 'published'
+    )
+  );

--- a/ops/migrations/README.md
+++ b/ops/migrations/README.md
@@ -1,0 +1,192 @@
+# Peninsula Insider — Supabase migrations
+
+This directory holds the raw SQL migrations applied to the Peninsula Insider
+Supabase project. They are intentionally small, dated, and idempotent so any
+operator can re-run them safely against the same database.
+
+- **Project ref:** `tjjhpvslpysfklwpqmgz`
+- **Project URL:** `https://tjjhpvslpysfklwpqmgz.supabase.co`
+- **Dashboard:** <https://supabase.com/dashboard/project/tjjhpvslpysfklwpqmgz/sql/new>
+
+> All migrations create objects in the `pi` schema (sometimes touching
+> `auth.*` and `storage.*` for FK / policy reasons). The anon key is in
+> `next/.env` as `PUBLIC_SUPABASE_ANON_KEY`; the service-role key is
+> intentionally **not** stored in the repo. RLS is the security boundary on
+> the request path.
+
+## Apply order — CMS admin layer (May 2026)
+
+Two migrations make up the v1 CMS admin layer. Apply in this order against
+the `tjjhpvslpysfklwpqmgz` project:
+
+1. `2026-05-09-pi-cms-admin.sql`
+   - Creates `pi.admin_user_allowlist`, `pi.cms_text_fields`,
+     `pi.cms_image_slots`, `pi.cms_revisions`
+   - Adds the `pi.is_cms_admin()` and `pi.can_publish_cms()` helper functions
+   - Enables RLS and the editor-only policies
+   - Creates the `cms-assets` Storage bucket (private, 10 MiB cap, image
+     mime-types only) and its editor-only policies
+2. `2026-05-10-pi-cms-public-read.sql`
+   - Adds *additive* policies that let the anon key read **only**
+     `status = 'published'` rows from `cms_text_fields` / `cms_image_slots`
+   - Adds the matching `storage.objects` SELECT policy so published image
+     assets are publicly fetchable through Storage
+
+Order matters because the second migration references tables, columns, and
+the `cms-assets` bucket created by the first.
+
+### How to apply
+
+#### Option A — Supabase SQL editor (recommended for prod)
+
+1. Open <https://supabase.com/dashboard/project/tjjhpvslpysfklwpqmgz/sql/new>
+2. Paste the entire contents of `2026-05-09-pi-cms-admin.sql`
+3. Run it. Confirm no errors.
+4. Repeat for `2026-05-10-pi-cms-public-read.sql`.
+
+#### Option B — `psql`
+
+```bash
+# Get the connection string from
+# https://supabase.com/dashboard/project/tjjhpvslpysfklwpqmgz/settings/database
+export DATABASE_URL='postgres://postgres:<password>@db.tjjhpvslpysfklwpqmgz.supabase.co:5432/postgres'
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -f ops/migrations/2026-05-09-pi-cms-admin.sql
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -f ops/migrations/2026-05-10-pi-cms-public-read.sql
+```
+
+#### Option C — Supabase CLI
+
+```bash
+supabase link --project-ref tjjhpvslpysfklwpqmgz
+supabase db execute --file ops/migrations/2026-05-09-pi-cms-admin.sql
+supabase db execute --file ops/migrations/2026-05-10-pi-cms-public-read.sql
+```
+
+### Verify
+
+```sql
+-- Tables exist and have RLS enabled
+select schemaname, tablename, rowsecurity
+  from pg_tables
+ where schemaname = 'pi'
+   and tablename in (
+     'admin_user_allowlist',
+     'cms_text_fields',
+     'cms_image_slots',
+     'cms_revisions'
+   );
+
+-- Helper functions exist
+select proname from pg_proc
+ where pronamespace = 'pi'::regnamespace
+   and proname in ('is_cms_admin', 'can_publish_cms');
+
+-- Storage bucket present
+select id, public, file_size_limit from storage.buckets where id = 'cms-assets';
+
+-- Public-read policies present
+select polname from pg_policy
+ where polrelid in (
+   'pi.cms_text_fields'::regclass,
+   'pi.cms_image_slots'::regclass
+ );
+```
+
+## Adding an editor
+
+There are two layers:
+
+1. `pi.profiles.is_editor` must be `true`
+2. `pi.admin_user_allowlist` may carry an explicit role / `can_publish` flag
+
+The minimum required for admin access is `pi.profiles.is_editor = true`. The
+allowlist is optional metadata; if a row exists, its `role` must be one of
+`editor | publisher | admin`. Publish rights require either
+`can_publish = true` or `role in ('publisher', 'admin')`.
+
+```sql
+-- 1. Find the user id (must already exist in auth.users, e.g. they signed in
+--    once via /admin/login).
+select id, email from auth.users where email = 'editor@example.com';
+
+-- 2. Promote them to editor in the profile (creates row if missing).
+insert into pi.profiles (id, is_editor)
+values ('<user-uuid>', true)
+on conflict (id) do update set is_editor = excluded.is_editor;
+
+-- 3. (Optional) Add an allowlist row with publish rights.
+insert into pi.admin_user_allowlist (user_id, email, role, can_publish, notes)
+values ('<user-uuid>', 'editor@example.com', 'publisher', true, 'Founding editor')
+on conflict (user_id) do update
+  set role        = excluded.role,
+      can_publish = excluded.can_publish,
+      notes       = excluded.notes;
+```
+
+## Rollback
+
+The CMS admin layer is intentionally additive — no existing tables are
+modified — so rollback is just a matter of dropping what was created.
+
+> **Warning:** dropping `pi.cms_text_fields` / `pi.cms_image_slots` /
+> `pi.cms_revisions` deletes all editor content and the audit trail. Take a
+> snapshot first via the Supabase dashboard ("Database → Backups") or
+> `pg_dump --schema=pi` before rolling back in production.
+
+Reverse order — drop the public-read policies first, then the v1 layer:
+
+```sql
+-- 2026-05-10-pi-cms-public-read.sql
+drop policy if exists "cms_assets_public_select_published" on storage.objects;
+drop policy if exists "cms_image_slots_public_read_published" on pi.cms_image_slots;
+drop policy if exists "cms_text_fields_public_read_published" on pi.cms_text_fields;
+
+-- 2026-05-09-pi-cms-admin.sql
+drop policy if exists "cms_assets_editor_delete" on storage.objects;
+drop policy if exists "cms_assets_editor_update" on storage.objects;
+drop policy if exists "cms_assets_editor_select" on storage.objects;
+drop policy if exists "cms_assets_editor_insert" on storage.objects;
+
+-- Optional: keep the bucket if you want to retain uploaded assets.
+-- delete from storage.buckets where id = 'cms-assets';
+
+drop policy if exists "cms_revisions_editor_insert"      on pi.cms_revisions;
+drop policy if exists "cms_revisions_editor_select"      on pi.cms_revisions;
+drop policy if exists "cms_image_slots_editor_all"       on pi.cms_image_slots;
+drop policy if exists "cms_text_fields_editor_all"       on pi.cms_text_fields;
+drop policy if exists "cms_admin_allowlist_editor_all"   on pi.admin_user_allowlist;
+drop policy if exists "cms_admin_allowlist_self_or_editor_select"
+  on pi.admin_user_allowlist;
+
+drop function if exists pi.can_publish_cms();
+drop function if exists pi.is_cms_admin();
+
+drop trigger if exists cms_image_slots_set_updated_at on pi.cms_image_slots;
+drop trigger if exists cms_text_fields_set_updated_at on pi.cms_text_fields;
+drop function if exists pi.cms_set_updated_at();
+
+drop table if exists pi.cms_revisions;
+drop table if exists pi.cms_image_slots;
+drop table if exists pi.cms_text_fields;
+
+drop trigger if exists admin_user_allowlist_set_updated_at on pi.admin_user_allowlist;
+drop function if exists pi.admin_user_allowlist_set_updated_at();
+drop table if exists pi.admin_user_allowlist;
+```
+
+## Troubleshooting
+
+- **`permission denied for schema pi`** — RLS is doing its job. Confirm the
+  caller is signed in as an editor and that `pi.profiles.is_editor = true`
+  for their `user_id`. Service-role key bypasses RLS but should never be used
+  on the request path.
+- **Anon-key reads return empty** even after applying
+  `2026-05-10-pi-cms-public-read.sql` — check that the rows you expect have
+  `status = 'published'`. The public-read policy is intentionally restricted.
+- **`@astrojs/vercel is not installed`** during `astro build` — that error
+  comes from `next/astro.config.mjs` when `PI_ADMIN_HYBRID=1` is set without
+  the adapter. Run `npm install` in `next/`.


### PR DESCRIPTION
## Summary

Phase 1 of the Peninsula Insider CMS / admin layer. Lands the env-gated hybrid mode (\`PI_ADMIN_HYBRID=1\`), middleware, admin shell + login, editable wrappers, Supabase CMS data layer + server-side session helper, homepage content seam, and the SQL migrations for content / media / revisions / admin allowlist.

## Behaviour

- **\`PI_ADMIN_HYBRID\` unset** (default, including production): pure static build, no admin routes, byte-identical public output. Verified via \`npx astro sync\`.
- **\`PI_ADMIN_HYBRID=1\`** (intended for the Vercel preview only): server output via the Vercel adapter, middleware protects \`/admin\` and \`/admin/api/*\`, redirects to \`/admin/login\`, returns 401 JSON on protected API. Verified via \`PI_ADMIN_HYBRID=1 npx astro sync\`.

## Phase 1 (this PR) — interface QA scope

- Routing + auth-gate behaviour of \`/admin\`, \`/admin/login\`, \`/admin/api/content/[collection]/[slug]\`
- Editable wrappers (\`EditableText\`, \`EditableImage\`) on homepage and the three seeded pages (\`eat/best-restaurants\`, \`explore/best-walks\`, \`stay/best-accommodation\`)
- Mobile Safari + tablet pass on inline controls
- Public site unaffected when admin mode is off

## Phase 2 — gated on (separate work)

1. Wire \`src/lib/cms/server.ts\` (real Supabase JWT validation + RLS-backed \`is_editor\` check) into \`src/middleware.ts\`, replacing the transitional \`?admin=1\` / cookie seam in \`src/lib/admin.ts\`
2. Upgrade \`src/pages/admin/api/content/[collection]/[slug].ts\` from scaffold to real reads/writes via \`src/lib/cms/api.ts\`
3. Connect homepage fields from \`next/src/data/homepage.json\` seam to CMS tables
4. Run \`ops/migrations/2026-05-09-pi-cms-admin.sql\` and \`ops/migrations/2026-05-10-pi-cms-public-read.sql\` against the Supabase project

## How to enable for the preview

Set \`PI_ADMIN_HYBRID=1\` on the Preview environment in Vercel for this branch only. Production environment must remain unset until Phase 2 ships.

## Notes

- Cutover plan in \`next/docs/pi-cms-hybrid-cutover-2026-05-10.md\`
- Adapter (\`@astrojs/vercel\`) added as a dependency in the prior commit so Vercel installs cleanly.