### PR TITLE
fix(masthead): Sign in as small text in top utility row

### DIFF
--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -35,6 +35,12 @@ const {
           <span class="masthead__edition-mark">{issueMark}</span>
           <span class="masthead__edition-label">{issueLabel}</span>
         </span>
+        <button
+          class="masthead__signin"
+          type="button"
+          data-open-auth
+          data-auth-anonymous
+        >Sign in</button>
       </div>
     </div>
   </div>
@@ -106,13 +112,6 @@ const {
               <line x1="21" y1="21" x2="16.5" y2="16.5" />
             </svg>
           </a>
-          <button class="v4-signin" type="button" aria-label="Sign in to Peninsula Insider" data-open-auth data-auth-anonymous>
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-              <circle cx="12" cy="7" r="4" />
-            </svg>
-            <span>Sign in</span>
-          </button>
           <a href={v4Utility.ask.href} class="v4-ask-pill" aria-label="Ask PI" data-pi-trigger="true">
             <span class="v4-ask-pill__dot">PI</span>
             Ask PI

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -233,6 +233,25 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .masthead__utility-links a:hover { color: var(--accent); }
 
+/* Small-text Sign in link in the utility row, top-right. */
+.masthead__signin {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--soft);
+  transition: color .2s var(--ease);
+  flex-shrink: 0;
+}
+.masthead__signin:hover { color: var(--accent); }
+.masthead__signin[hidden] { display: none; }
+
 /* ── Brand row (middle) ── */
 .masthead__brand-inner {
   display: flex;

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -178,35 +178,6 @@ body[data-v4="true"] .masthead {
   line-height: 1;
 }
 
-/* Sign-in pill — ghost variant of the subscribe CTA. Hidden when the
-   ProfileDropdown mounts an authenticated profile menu in its place. */
-.v4-signin {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 14px;
-  height: 36px;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  font-family: 'Outfit', sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  transition: background var(--v4-mega-open-delay) var(--v4-ease),
-              border-color var(--v4-mega-open-delay) var(--v4-ease),
-              color        var(--v4-mega-open-delay) var(--v4-ease);
-}
-.v4-signin:hover {
-  background: var(--bg-alt);
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.v4-signin:focus-visible { outline: none; box-shadow: var(--v4-focus-ring); }
-.v4-signin[hidden] { display: none; }
-
 .v4-subscribe-cta {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Small fix on top of PR #92: the Sign in is now small text in the top-right of the utility row (next to 'May 2026'), not a pill in the action cluster. Drop the unused .v4-signin styles.