### PR TITLE
fix(masthead): ProfileDropdown into top utility row

### DIFF
--- a/next/src/components/v2/ProfileDropdown.astro
+++ b/next/src/components/v2/ProfileDropdown.astro
@@ -27,9 +27,11 @@
     if (!el || (el as any)._init) return;
     (el as any)._init = true;
 
-    // Mount into the masthead action cluster — prefer V4 actions (current
-    // chrome), fall back to the legacy V2 utility bar links.
+    // Mount into the top utility row so the signed-in profile sits in the
+    // same slot as the anonymous "Sign in" text. Falls back to V4 actions
+    // (legacy slot) then the V2 utility bar links for older mastheads.
     const mountTarget =
+      document.querySelector('.masthead__utility-inner') ||
       document.querySelector('.v4-actions') ||
       document.querySelector('.v2-util__links');
     if (mountTarget && el.parentElement !== mountTarget) {
@@ -152,4 +154,45 @@
   }
   .v2-profile__menu-item:hover { background: var(--paper-warm, #F3EDDE); color: var(--ochre, #A0541F); }
   .v2-profile__signout { color: var(--ink-muted, #6E655C); border-top: 1px solid var(--line-soft, #E8E2D1); margin-top: 0.2rem; padding-top: 0.55rem; }
+
+  /* Utility-row variant — matches the .masthead__signin treatment so the
+     signed-in profile sits in the same slot as the anonymous Sign in
+     link. Drops the pill chrome, shrinks the avatar, uppercases the name. */
+  .masthead__utility-inner .v2-profile {
+    flex-shrink: 0;
+  }
+  .masthead__utility-inner .v2-profile__trigger {
+    padding: 0;
+    background: transparent;
+    border: 0;
+    gap: 0.45rem;
+    font-family: 'Outfit', system-ui, sans-serif;
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--soft, #6B5A48);
+    line-height: 1;
+    transition: color 0.2s var(--ease, ease);
+  }
+  .masthead__utility-inner .v2-profile__trigger:hover {
+    background: transparent;
+    border: 0;
+    color: var(--accent, #A0541F);
+  }
+  .masthead__utility-inner .v2-profile__avatar {
+    width: 1rem;
+    height: 1rem;
+    font-size: 0.55rem;
+    font-weight: 600;
+  }
+  .masthead__utility-inner .v2-profile__name {
+    max-width: 10rem;
+  }
+  .masthead__utility-inner .v2-profile__menu {
+    /* Anchor to right edge of utility row, not the trigger, so the menu
+       drops nicely under the masthead area. */
+    top: calc(100% + 0.5rem);
+    min-width: 12rem;
+  }
 </style>


### PR DESCRIPTION
Move the signed-in profile chip into the top utility row (same slot as the anonymous Sign in link). Reskin to match the utility-row text style — no pill, small uppercase, accent hover.