### PR TITLE
fix(masthead): profile menu actually hides when hidden is set

### DIFF
--- a/next/src/components/v2/ProfileDropdown.astro
+++ b/next/src/components/v2/ProfileDropdown.astro
@@ -179,6 +179,10 @@
     z-index: 50;
     display: grid; gap: 0.1rem;
   }
+  /* `display: grid` above wins over the browser default [hidden]{display:none}
+     so we must restate the hidden behaviour explicitly. Without this, setting
+     menu.hidden = true updates the attribute but the menu stays visible. */
+  .v2-profile__menu[hidden] { display: none; }
   .v2-profile__menu-item {
     display: block; width: 100%; text-align: left;
     padding: 0.5rem 0.7rem;


### PR DESCRIPTION
CSS specificity bug.  overrode the browser's , so  updated the attribute but never hid the menu visually.