### PR TITLE
feat(saves): Waves 1+2 of Save & Share rebuild — unified data + card-level UI

### DIFF
--- a/docs/save-share-audit-2026-05-11.md
+++ b/docs/save-share-audit-2026-05-11.md
@@ -1,0 +1,113 @@
+# Save & Share audit, 2026-05-11
+
+Reference for Peninsula Insider Save & Share System Brief v2. Maps every component that has, or should have, a save or share action. Source-of-truth for Wave 1 (store unification) and Wave 2 (card-level rollout).
+
+## Two competing save systems exist today
+
+| System | Used by | UI markup | Store | Sync to Supabase |
+|---|---|---|---|---|
+| **A: SaveSiteController + components/SaveButton.astro** | `VenueCard`, `EventCard` | `<button data-save-toggle data-save-kind="venue|event" data-save-slug="..." ...>` | `localStorage["pi:saved:v1"]` shape `{ venues: [...], events: [...] }` | None today |
+| **B: components/v2/SaveButton.astro** | Journal article body (`/journal/[slug].astro`) | `<button class="v2-save" data-save-slug data-save-section ...>` | `pi.user_saves` (Supabase) when signed in; `localStorage["pi:saved-articles:v1"]` when anonymous (added 2026-05-11) | Yes for signed-in users via direct Supabase write |
+
+These two stores need to merge into one canonical local store with one canonical UI. Documented as the first deliverable of Wave 1.
+
+## Save coverage matrix
+
+| Component | Save today | Share today | Notes |
+|---|---|---|---|
+| `VenueCard.astro` | ✅ System A (venue) | ❌ | `<SaveButton kind="venue" />` rendered inside `.venue-card__actions`. Placement: bottom-left of card body. |
+| `EventCard.astro` | ✅ System A (event) | ❌ | `<SaveButton kind="event" />` rendered in card actions area. |
+| `ItineraryCard.astro` | ❌ | ❌ | High-priority gap. Itineraries are the heart of "build your weekend." |
+| `ExperienceCard.astro` | ❌ | ❌ | Should get save (kind=experience). |
+| `PlaceCard.astro` | ❌ | ❌ | Should get save (kind=place). |
+| `ArticleCard.astro` | ❌ | ❌ | Should get save (kind=article). |
+| `TourCard.astro` | ❌ | ❌ | Should get save (kind=tour). |
+| `TourOperatorCard.astro` | ❌ | ❌ | Should get save (kind=tour-operator). |
+| `TourPackageCard.astro` | ❌ | ❌ | Should get save (kind=tour-package). |
+| `components/v3/V3EditorialCard.astro` | ❌ | ❌ | V3 chrome, may be deprecated. Skip unless still in use. |
+| `components/v3/V3EntityCard.astro` | ❌ | ❌ | V3 chrome. Skip. |
+| `components/v3/V3EventCard.astro` | ❌ | ❌ | V3 chrome. Skip. |
+| Journal article body (`/journal/[slug].astro`) | ✅ System B (article) | ✅ ShareBlock (top + end) | `<SaveButton slug section title dek imageUrl />` near the byline. |
+| Venue detail template (`VenueDetailTemplate.astro`) | ❌ on the page itself, ✅ on related cards | ✅ ShareBlock | Page itself has no save action, only the related cards underneath do. Gap. |
+| What's on dispatch (`/whats-on/this-weekend/index.astro`) | ❌ on the page itself | ✅ ShareBlock (top + end) | Same gap as venue detail. Page is itself a saveable plan. |
+| Homepage hero | ❌ | ❌ | Correct, per brief: heroes have no action. |
+| Homepage weekend dispatch block (`WeekendPickerBlock`) | ❌ | ❌ | Should get a "Save this dispatch" — it's the most actionable thing on the homepage. |
+
+## Share coverage today
+
+| Surface | Component | Behaviour |
+|---|---|---|
+| Journal article (top + end) | `ShareBlock` | Variable wording per content type (`plan` / `picks` / `editorial`). Native share API on mobile, copy-link fallback. Includes a newsletter CTA at the end variant. |
+| Dispatch (`/whats-on/this-weekend/`) | `ShareBlock` | Same. Plan content type. |
+| Dispatch archive (`/whats-on/this-weekend/archive/[slug]/`) | `ShareBlock` | Same. |
+| Venue detail template | `ShareBlock` | Editorial content type. |
+| Everywhere else | None | All cards, all landing pages, all place pages have no share affordance. |
+
+## Wording variations to remove
+
+The ShareBlock currently emits different copy depending on content type:
+- "Send this plan" / "Share this weekend" (plan)
+- "Send this list" / "Share these picks" (picks)
+- "Send this" / "Share this" (editorial)
+
+Standardise to: **Share** (icon, hover label "Share").
+
+The end-of-article block also includes a newsletter CTA ("Get this every week →") which is good editorially but bloats the share surface. Move newsletter CTA out of ShareBlock into its own component if it should stay near the article foot.
+
+## Placement inconsistencies
+
+- VenueCard places SaveButton **bottom-left** of card actions
+- EventCard places it **inside the actions row** but ordering varies
+- Journal article SaveButton lives **at the top near the byline**
+- ShareBlock has both a **top** and **end** placement on articles
+- No share on cards
+- No save on most card types
+
+Phase 2 fixes this with three target classes: card-level (bottom-right), article-level (top + sticky), hero-level (none).
+
+## Mobile-specific observations
+
+- VenueCard.SaveButton is full-text "Save" pill on both mobile and desktop. On mobile it competes for touch space with "Read notes" / "Book" CTAs immediately adjacent.
+- v2/SaveButton (article) is also a full-text pill. Awkward on narrow widths.
+- ShareBlock's primary button is large on both viewports.
+- None of the current saves have a thumb-zone consideration (bottom-right of card is ideal for thumb reach in a list view).
+
+## Two stores → one merge plan
+
+Wave 1 builds `pi:saves:v2`. Schema:
+
+```ts
+type SaveKind = 'article' | 'venue' | 'place' | 'event' | 'experience' | 'itinerary' | 'tour' | 'tour-operator' | 'tour-package';
+
+interface SavedItem {
+  kind: SaveKind;
+  slug: string;
+  section?: string;   // editorial section for articles
+  title: string;
+  dek?: string;
+  image_url?: string;
+  href: string;
+  savedAt: number;
+}
+
+interface SavesV2Store {
+  version: 2;
+  items: SavedItem[];
+}
+```
+
+Migration runs on first read after Wave 1 ships:
+
+1. Read `localStorage["pi:saves:v2"]` — if exists, use it
+2. Else, read `localStorage["pi:saved:v1"]` (venues + events) and `localStorage["pi:saved-articles:v1"]` (articles), merge into v2 shape, write v2, leave v1s in place (do not delete; allows rollback)
+3. Three months from now, a separate cleanup commit deletes the legacy keys
+
+The Supabase `pi.user_saves` table already covers `slug + section`. Wave 1 extends it to include a `kind` column (default `'article'` for existing rows) so the same table backs every kind.
+
+## What ships in each Wave
+
+- **Wave 1** Foundation: pi:saves:v2 local store, migration shim, single shared module `lib/saves/`. CloudSync extended to cover the new schema. No visible UI changes.
+- **Wave 2** Card-level: `<PiSaveActions />` component (Save + Share icons, bottom-right of card). Tagged into every card listed above. Removes the old `<SaveButton />` from VenueCard + EventCard.
+- **Wave 3** Article-level: replaces `v2/SaveButton.astro` and `ShareBlock.astro` with a unified `<PiArticleActions />` near the byline + sticky bottom-right on scroll past 30%.
+- **Wave 4** Saved-plan view: `/account/saved/` rebuilt to group by kind, signed share-by-link.
+- **Wave 5** Editorial templates fork-to-saves + PDF export.

--- a/next/src/components/ArticleCard.astro
+++ b/next/src/components/ArticleCard.astro
@@ -5,6 +5,7 @@
  * link on the title), no CTA pill, no hairline divider above the dek.
  */
 import { formatLabel, routeSlug } from '../lib/editorial';
+import PiSaveActions from './PiSaveActions.astro';
 
 export interface Props {
   article: any;
@@ -37,4 +38,13 @@ const readingTime = article.data.readingTimeMinutes;
   </h3>
   {meta && <p class="venue-card__place">{meta}</p>}
   <p class="venue-card__signature">{article.data.dek}</p>
+  <PiSaveActions
+    kind="article"
+    slug={slug}
+    title={article.data.title}
+    href={`${articleBase}/${slug}/`}
+    section={article.data.section ?? 'journal'}
+    dek={article.data.dek}
+    imageUrl={article.data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/CloudSync.astro
+++ b/next/src/components/CloudSync.astro
@@ -25,36 +25,16 @@
 ---
 
 <script>
-  import { getSupabase, isAuthEnabled, onAuthChange, listUserSaves, syncUserSaves, getUserItinerary, syncUserItinerary, listUserAlerts, syncUserAlerts } from '../lib/auth';
-
-  type LocalSaveItem = { slug: string; title?: string; href?: string; savedAt?: number };
-  type LocalSaveStore = { version: 1; venues: LocalSaveItem[]; events: LocalSaveItem[] };
+  import { getSupabase, isAuthEnabled, onAuthChange, getUserItinerary, syncUserItinerary, listUserAlerts, syncUserAlerts } from '../lib/auth';
+  import { installCloudSync, pullFromServer, pushToServer, teardownCloudSync } from '../lib/saves/cloud';
 
   type ItineraryItem = { kind: 'venue' | 'event' | 'experience'; slug: string; dayId?: string; note?: string };
   type ItineraryDay = { id: string; label: string };
   type ItineraryStore = { version: 1; items: ItineraryItem[]; days: ItineraryDay[] };
 
-  const SAVE_KEY = 'pi:saved:v1';
   const ITIN_KEY = 'pi:itinerary:v1';
   const ALERT_KEY = 'pi:alerts:v1';
 
-  function readSave(): LocalSaveStore {
-    try {
-      const raw = localStorage.getItem(SAVE_KEY);
-      if (!raw) return { version: 1, venues: [], events: [] };
-      const p = JSON.parse(raw);
-      return {
-        version: 1,
-        venues: Array.isArray(p?.venues) ? p.venues : [],
-        events: Array.isArray(p?.events) ? p.events : [],
-      };
-    } catch {
-      return { version: 1, venues: [], events: [] };
-    }
-  }
-  function writeSave(s: LocalSaveStore) {
-    try { localStorage.setItem(SAVE_KEY, JSON.stringify(s)); } catch {}
-  }
   function readItinerary(): ItineraryStore {
     try {
       const raw = localStorage.getItem(ITIN_KEY);
@@ -102,7 +82,6 @@
     setStatus('anonymous');
   } else {
     let currentUserId: string | null = null;
-    let saveDebounce: ReturnType<typeof setTimeout> | null = null;
     let itinDebounce: ReturnType<typeof setTimeout> | null = null;
     let alertDebounce: ReturnType<typeof setTimeout> | null = null;
 
@@ -116,26 +95,11 @@
     async function pullFromCloud(userId: string) {
       setStatus('pulling');
       try {
-        const cloudSaves = await listUserSaves(userId);
-        const venues: LocalSaveItem[] = [];
-        const events: LocalSaveItem[] = [];
-        cloudSaves.forEach((row) => {
-          const item: LocalSaveItem = {
-            slug: row.slug,
-            title: row.title ?? undefined,
-            href: row.href ?? undefined,
-            savedAt: new Date(row.saved_at).getTime(),
-          };
-          // 'experience' kind isn't first-class in the Phase 2 SaveSiteController
-          // yet (only venue + event). Carry it on the 'venues' bucket for now;
-          // a follow-up can split into a third bucket when SaveSiteController
-          // grows native experience support.
-          if (row.kind === 'event') events.push(item);
-          else venues.push(item);
-        });
-        writeSave({ version: 1, venues, events });
-        // Tell SaveSiteController to refresh from disk.
-        window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { source: 'cloud-pull' } }));
+        // Saves: pull every kind into the unified pi:saves:v2 local store
+        // and install the change listener so future local edits mirror up.
+        await pullFromServer(userId);
+        await pushToServer(userId);
+        installCloudSync(userId);
 
         const cloudItin = await getUserItinerary(userId);
         if (cloudItin && cloudItin.items.length > 0) {
@@ -183,16 +147,9 @@
       }
     }
 
-    async function pushSaves() {
-      if (!currentUserId) return;
-      setStatus('pushing');
-      const local = readSave();
-      const flat: Array<{ kind: 'venue' | 'event' | 'experience'; slug: string; title?: string; href?: string; savedAt?: number }> = [];
-      local.venues.forEach((v) => flat.push({ kind: 'venue', slug: v.slug, title: v.title, href: v.href, savedAt: v.savedAt }));
-      local.events.forEach((e) => flat.push({ kind: 'event', slug: e.slug, title: e.title, href: e.href, savedAt: e.savedAt }));
-      const result = await syncUserSaves(currentUserId, flat);
-      setStatus(result.ok ? 'synced' : 'error');
-    }
+    // pushSaves is handled inline by lib/saves/cloud.ts (installCloudSync
+    // attaches a change listener that mirrors every local edit to the
+    // server). No explicit batch-push is needed from this component.
 
     async function pushItinerary() {
       if (!currentUserId) return;
@@ -225,25 +182,15 @@
       alertDebounce = setTimeout(() => { pushAlerts(); alertDebounce = null; }, 600);
     }
 
-    function scheduleSaveSync() {
-      if (!currentUserId) return;
-      if (saveDebounce) clearTimeout(saveDebounce);
-      saveDebounce = setTimeout(() => { pushSaves(); saveDebounce = null; }, 600);
-    }
-
     function scheduleItinerarySync() {
       if (!currentUserId) return;
       if (itinDebounce) clearTimeout(itinDebounce);
       itinDebounce = setTimeout(() => { pushItinerary(); itinDebounce = null; }, 600);
     }
 
-    // Listen for local-store events. Skip when the change came from a
-    // cloud pull (we don't want to push back what we just pulled).
-    window.addEventListener('pi:save-changed', (e: Event) => {
-      const detail = (e as CustomEvent).detail || {};
-      if (detail.source === 'cloud-pull') return;
-      scheduleSaveSync();
-    });
+    // Saves change events are handled by lib/saves/cloud.ts directly via
+    // the installed onChange listener; this component only owns itinerary
+    // and alerts sync now.
     window.addEventListener('pi:itinerary-changed', (e: Event) => {
       const detail = (e as CustomEvent).detail || {};
       if (detail.source === 'cloud-pull') return;
@@ -262,7 +209,7 @@
         pullFromCloud(user.id);
       } else {
         currentUserId = null;
-        if (saveDebounce) { clearTimeout(saveDebounce); saveDebounce = null; }
+        teardownCloudSync();
         if (itinDebounce) { clearTimeout(itinDebounce); itinDebounce = null; }
         if (alertDebounce) { clearTimeout(alertDebounce); alertDebounce = null; }
         setStatus('anonymous');

--- a/next/src/components/EventCard.astro
+++ b/next/src/components/EventCard.astro
@@ -7,7 +7,7 @@
  * every event carries at least one sentence of opinion.
  */
 import EventBadges from './EventBadges.astro';
-import SaveButton from './SaveButton.astro';
+import PiSaveActions from './PiSaveActions.astro';
 import { eventCategoryLabel, eventDateLabel, routeSlug } from '../lib/editorial';
 
 export interface Props {
@@ -71,6 +71,13 @@ const placeHref = placeId ? `/places/${placeId}/` : null;
   />
   <div class="event-card__actions">
     <a href={`/whats-on/${slug}`} class="event-card__cta">Read the full guide -></a>
-    <SaveButton kind="event" slug={slug} title={event.data.title} href={`/whats-on/${slug}/`} />
   </div>
+  <PiSaveActions
+    kind="event"
+    slug={slug}
+    title={event.data.title}
+    href={`/whats-on/${slug}/`}
+    dek={event.data.summary}
+    imageUrl={event.data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/ExperienceCard.astro
+++ b/next/src/components/ExperienceCard.astro
@@ -1,5 +1,6 @@
 ---
 import { placeLabel, titleize, routeSlug, heroBackgroundStyle } from '../lib/editorial';
+import PiSaveActions from './PiSaveActions.astro';
 
 const difficultyLabel: Record<string, string> = {
   easy: 'Easy',
@@ -50,4 +51,12 @@ const imgStyle = heroBackgroundStyle(data);
     <p class="experience-card__summary">{data.editorNote}</p>
     <a href={`/explore/${slug}`} class="experience-card__cta">Open the guide →</a>
   </div>
+  <PiSaveActions
+    kind="experience"
+    slug={slug}
+    title={data.name}
+    href={`/explore/${slug}/`}
+    dek={data.editorNote}
+    imageUrl={data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/ItineraryCard.astro
+++ b/next/src/components/ItineraryCard.astro
@@ -1,5 +1,6 @@
 ---
 import { routeSlug, heroBackgroundStyle } from '../lib/editorial';
+import PiSaveActions from './PiSaveActions.astro';
 
 const audienceLabel: Record<string, string> = {
   couple: 'Couples',
@@ -47,4 +48,12 @@ const nightsLabel = `${data.lengthNights} night${data.lengthNights === 1 ? '' : 
     {data.totalDriveMinutes && <span>{data.totalDriveMinutes} min driving</span>}
   </div>
   <a href={`/plans/${slug}`} class="itinerary-card__cta">See the full plan →</a>
+  <PiSaveActions
+    kind="itinerary"
+    slug={slug}
+    title={data.title}
+    href={`/plans/${slug}/`}
+    dek={data.dek}
+    imageUrl={data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/PiSaveActions.astro
+++ b/next/src/components/PiSaveActions.astro
@@ -1,0 +1,268 @@
+---
+/**
+ * PiSaveActions — card-level Save + Share affordance.
+ *
+ * Standardised across every card type on Peninsula Insider: positioned
+ * bottom-right, icon-only, with a hover label on desktop. Save toggles
+ * the unified pi:saves:v2 store; Share invokes the native share sheet on
+ * supported devices and falls back to copy-link on desktop.
+ *
+ * Wave 2 of the Save & Share rebuild. Wave 3 builds the article-level
+ * equivalent (`<PiArticleActions />`) for journal pieces; this card-level
+ * surface stays as-is across both passes.
+ *
+ * Usage:
+ *   <PiSaveActions
+ *     kind="venue"
+ *     slug="laura"
+ *     title="Laura"
+ *     dek="..."
+ *     imageUrl="/images/..."
+ *     href="/eat/laura/"
+ *   />
+ */
+
+export interface Props {
+  /** Save kind — articles, venues, places, events, experiences, itineraries, tours, operators, packages. */
+  kind: 'article' | 'venue' | 'place' | 'event' | 'experience' | 'itinerary' | 'tour' | 'tour-operator' | 'tour-package';
+  slug: string;
+  title: string;
+  href: string;
+  /** Editorial section, required for articles. */
+  section?: string;
+  /** Short summary; carried into the saved-plan view. */
+  dek?: string;
+  /** Cover image; carried into the saved-plan view and the share preview. */
+  imageUrl?: string;
+  /**
+   * When true (default), the actions float absolutely in the bottom-right
+   * of the nearest positioned ancestor (typically the card). The card needs
+   * `position: relative` on its root for this to anchor correctly. Set to
+   * false to render inline inside an existing actions row.
+   */
+  floating?: boolean;
+}
+
+const { kind, slug, title, href, section, dek, imageUrl, floating = true } = Astro.props;
+---
+
+<div
+  class:list={['pi-actions', floating && 'pi-actions--floating']}
+  data-pi-actions
+  data-pi-kind={kind}
+  data-pi-slug={slug}
+  data-pi-section={section}
+  data-pi-title={title}
+  data-pi-dek={dek}
+  data-pi-image={imageUrl}
+  data-pi-href={href}
+>
+  <button
+    type="button"
+    class="pi-actions__btn pi-actions__btn--save"
+    aria-pressed="false"
+    aria-label={`Save ${title}`}
+    data-pi-save
+  >
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+    <span class="pi-actions__label">Save</span>
+  </button>
+  <button
+    type="button"
+    class="pi-actions__btn pi-actions__btn--share"
+    aria-label={`Share ${title}`}
+    data-pi-share
+  >
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+      <polyline points="16 6 12 2 8 6" />
+      <line x1="12" y1="2" x2="12" y2="15" />
+    </svg>
+    <span class="pi-actions__label">Share</span>
+  </button>
+</div>
+
+<style is:global>
+  .pi-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  /* Floating placement: bottom-right of the nearest positioned ancestor.
+     Cards must have `position: relative` for this to anchor correctly. */
+  .pi-actions--floating {
+    position: absolute;
+    bottom: 0.75rem;
+    right: 0.75rem;
+    z-index: 3;
+  }
+
+  .pi-actions__btn {
+    appearance: none;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 999px;
+    color: var(--ink-soft, #3A3531);
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    cursor: pointer;
+    transition:
+      width 0.18s ease,
+      padding 0.18s ease,
+      background 0.18s ease,
+      border-color 0.18s ease,
+      color 0.18s ease,
+      transform 0.08s ease;
+    overflow: hidden;
+    font-family: 'Outfit', system-ui, sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .pi-actions__btn:hover {
+    border-color: rgba(160, 84, 31, 0.4);
+    color: var(--ochre, #A0541F);
+  }
+
+  .pi-actions__btn:active { transform: scale(0.95); }
+
+  /* Hover label expansion — desktop only, where labels add discoverability
+     without crowding the tap surface. Mobile keeps icon-only for thumb
+     reach. */
+  .pi-actions__label {
+    max-width: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: max-width 0.18s ease, opacity 0.14s ease 0.04s;
+    white-space: nowrap;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .pi-actions__btn:hover {
+      width: auto;
+      padding: 0 0.85rem 0 0.7rem;
+    }
+    .pi-actions__btn:hover .pi-actions__label {
+      max-width: 6rem;
+      opacity: 1;
+    }
+  }
+
+  /* Saved state — solid ink fill, paper text */
+  .pi-actions__btn--save[aria-pressed="true"] {
+    background: var(--ink, #171413);
+    color: var(--paper, #FAF7F0);
+    border-color: var(--ink, #171413);
+  }
+  .pi-actions__btn--save[aria-pressed="true"] svg path {
+    fill: var(--paper, #FAF7F0);
+  }
+  .pi-actions__btn--save[aria-pressed="true"]:hover {
+    background: var(--ochre, #A0541F);
+    border-color: var(--ochre, #A0541F);
+    color: var(--paper, #FAF7F0);
+  }
+
+  /* Mid-flight share state — brief "Copied" or "Sharing…" feedback */
+  .pi-actions__btn--share[data-feedback] {
+    background: var(--ochre, #A0541F);
+    color: var(--paper, #FAF7F0);
+    border-color: var(--ochre, #A0541F);
+  }
+</style>
+
+<script>
+  import * as Saves from '../lib/saves/store';
+  import type { SaveKind } from '../lib/saves/store';
+
+  function hydrate(el: HTMLElement) {
+    if ((el as any)._piInit) return;
+    (el as any)._piInit = true;
+
+    const kind = el.dataset.piKind as SaveKind;
+    const slug = el.dataset.piSlug;
+    const title = el.dataset.piTitle || slug || '';
+    const href = el.dataset.piHref || (typeof location !== 'undefined' ? location.pathname : '/');
+    const section = el.dataset.piSection;
+    const dek = el.dataset.piDek;
+    const image_url = el.dataset.piImage;
+    if (!kind || !slug) return;
+
+    const saveBtn = el.querySelector<HTMLButtonElement>('[data-pi-save]');
+    const shareBtn = el.querySelector<HTMLButtonElement>('[data-pi-share]');
+
+    function paint() {
+      if (!saveBtn) return;
+      const saved = Saves.isSaved(kind, slug!);
+      saveBtn.setAttribute('aria-pressed', saved ? 'true' : 'false');
+      const label = saveBtn.querySelector<HTMLElement>('.pi-actions__label');
+      if (label) label.textContent = saved ? 'Saved' : 'Save';
+    }
+
+    saveBtn?.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      Saves.toggle({ kind, slug: slug!, section, title, dek, image_url, href });
+    });
+
+    shareBtn?.addEventListener('click', async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const url = new URL(href, location.origin).toString();
+      const shareData: ShareData = { title: `${title} · Peninsula Insider`, text: dek, url };
+
+      // Prefer the native share sheet (iOS, Android, Safari macOS). Fall
+      // through to clipboard on platforms where it's unsupported or the
+      // user dismisses the sheet.
+      if (typeof (navigator as any).share === 'function') {
+        try {
+          await (navigator as any).share(shareData);
+          return;
+        } catch {
+          // User cancelled or share unsupported for this payload; fall through.
+        }
+      }
+
+      try {
+        await navigator.clipboard.writeText(url);
+        showFeedback(shareBtn!, 'Copied');
+      } catch {
+        showFeedback(shareBtn!, 'Tap to copy', true);
+      }
+    });
+
+    paint();
+    Saves.onChange(paint);
+  }
+
+  function showFeedback(btn: HTMLButtonElement, text: string, persistent = false) {
+    btn.setAttribute('data-feedback', text);
+    const label = btn.querySelector<HTMLElement>('.pi-actions__label');
+    const original = label?.textContent ?? 'Share';
+    if (label) label.textContent = text;
+    if (persistent) return;
+    setTimeout(() => {
+      btn.removeAttribute('data-feedback');
+      if (label) label.textContent = original;
+    }, 1400);
+  }
+
+  function init() {
+    document.querySelectorAll<HTMLElement>('[data-pi-actions]').forEach(hydrate);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+  document.addEventListener('astro:page-load', init);
+</script>

--- a/next/src/components/PlaceCard.astro
+++ b/next/src/components/PlaceCard.astro
@@ -10,6 +10,7 @@ export interface Props {
 }
 
 import { heroBackgroundStyle } from '../lib/editorial';
+import PiSaveActions from './PiSaveActions.astro';
 
 const { place, variant = 'vineyard' } = Astro.props;
 const data = place.data;
@@ -26,6 +27,10 @@ const imgClass = variant === 'bay'
   : 'place-card__image';
 
 const imgStyle = heroBackgroundStyle(data);
+
+// Capture the inline background-image URL for the saved-view preview.
+const heroMatch = imgStyle.match(/url\(([^)]+)\)/);
+const heroSrc = heroMatch ? heroMatch[1].replace(/^['"]|['"]$/g, '') : undefined;
 ---
 
 <article class="place-card">
@@ -37,4 +42,12 @@ const imgStyle = heroBackgroundStyle(data);
     </h3>
     <p class="place-card__intro">{data.intro}</p>
   </div>
+  <PiSaveActions
+    kind="place"
+    slug={slug}
+    title={data.name}
+    href={`/places/${slug}/`}
+    dek={data.intro}
+    imageUrl={heroSrc}
+  />
 </article>

--- a/next/src/components/SaveSiteController.astro
+++ b/next/src/components/SaveSiteController.astro
@@ -1,172 +1,140 @@
 ---
 /**
- * SaveSiteController — site-wide controller for the save/share-list system.
+ * SaveSiteController — site-wide controller for the save-toggle button system.
  *
- * Injected once at the bottom of BaseLayout. Owns: localStorage read/write,
- * binding click handlers to every [data-save-toggle] element on the page,
- * keeping the saved-count badge in sync, and exposing a small
- * `window.PISave` API the /saved/ page uses to render the list.
+ * Injected once at the bottom of BaseLayout. Binds click handlers to every
+ * `[data-save-toggle]` element on the page, keeps the saved-count badge in
+ * sync, and re-points the legacy `window.PISave` API at the unified store
+ * introduced in Wave 1 of the Save & Share rebuild.
  *
- * Storage shape (key: 'pi:saved:v1'):
- *   {
- *     version: 1,
- *     venues: [{ slug, title, href, savedAt }],
- *     events: [{ slug, title, href, savedAt }],
- *   }
- *
- * Phase 2 WS2E.
+ * As of 2026-05-11 the controller no longer owns its own localStorage shape.
+ * It delegates to `lib/saves/store.ts` which holds the canonical
+ * `pi:saves:v2` data and handles migration from the two legacy v1 stores.
  */
 ---
 
-<script is:inline>
-  (function () {
-    if (window.PISave) return; // singleton guard
-    var KEY = 'pi:saved:v1';
+<script>
+  import * as Saves from '../lib/saves/store';
 
-    function readStore() {
-      try {
-        var raw = localStorage.getItem(KEY);
-        if (!raw) return { version: 1, venues: [], events: [] };
-        var parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== 'object') return { version: 1, venues: [], events: [] };
-        return {
-          version: 1,
-          venues: Array.isArray(parsed.venues) ? parsed.venues : [],
-          events: Array.isArray(parsed.events) ? parsed.events : [],
-        };
-      } catch (_e) {
-        return { version: 1, venues: [], events: [] };
-      }
-    }
+  function syncAll() {
+    document.querySelectorAll<HTMLElement>('[data-save-toggle]').forEach((btn) => {
+      const rawKind = btn.getAttribute('data-save-kind');
+      const slug = btn.getAttribute('data-save-slug');
+      if (!rawKind || !slug) return;
+      const kind = rawKind as Saves.SaveKind;
+      const on = Saves.isSaved(kind, slug);
+      btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      const label = btn.querySelector<HTMLElement>('.save-button__label');
+      if (label) label.textContent = on ? 'Saved' : 'Save';
+    });
+    const total = Saves.list().length;
+    document.querySelectorAll<HTMLElement>('[data-saved-count]').forEach((el) => {
+      el.textContent = String(total);
+      if (total > 0) el.removeAttribute('hidden');
+      else el.setAttribute('hidden', '');
+    });
+    document.querySelectorAll<HTMLElement>('[data-saved-link]').forEach((el) => {
+      if (total > 0) el.removeAttribute('hidden');
+      else el.setAttribute('hidden', '');
+    });
+  }
 
-    function writeStore(store) {
-      try {
-        localStorage.setItem(KEY, JSON.stringify(store));
-      } catch (_e) {
-        /* localStorage may be unavailable (private mode, quota, blocked).
-           We fail silently — the UI just won't persist. The current page
-           still reflects the in-memory state for the session. */
-      }
-    }
-
-    var memoryStore = readStore();
-
-    function isSaved(kind, slug) {
-      var arr = kind === 'event' ? memoryStore.events : memoryStore.venues;
-      return arr.some(function (item) { return item.slug === slug; });
-    }
-
-    function toggle(kind, slug, title, href) {
-      var arr = kind === 'event' ? memoryStore.events : memoryStore.venues;
-      var idx = arr.findIndex(function (item) { return item.slug === slug; });
-      if (idx >= 0) {
-        arr.splice(idx, 1);
-      } else {
-        arr.push({ slug: slug, title: title, href: href, savedAt: Date.now() });
-      }
-      writeStore(memoryStore);
-      syncAll();
-      window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { kind: kind, slug: slug } }));
-      return !idx === false ? false : true; // returns new "is saved" state
-    }
-
-    function syncAll() {
-      // Toggle pressed state on every save button on the page.
-      document.querySelectorAll('[data-save-toggle]').forEach(function (btn) {
-        var kind = btn.getAttribute('data-save-kind');
-        var slug = btn.getAttribute('data-save-slug');
-        var on = isSaved(kind, slug);
-        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
-        var label = btn.querySelector('.save-button__label');
-        if (label) label.textContent = on ? 'Saved' : 'Save';
-      });
-      // Update count badge in masthead/footer if present.
-      var total = memoryStore.venues.length + memoryStore.events.length;
-      document.querySelectorAll('[data-saved-count]').forEach(function (el) {
-        el.textContent = String(total);
-        if (total > 0) el.removeAttribute('hidden');
-        else el.setAttribute('hidden', '');
-      });
-      document.querySelectorAll('[data-saved-link]').forEach(function (el) {
-        if (total > 0) el.removeAttribute('hidden');
-        else el.setAttribute('hidden', '');
-      });
-    }
-
-    function bindButtons() {
-      document.querySelectorAll('[data-save-toggle]').forEach(function (btn) {
-        if (btn._piSaveBound) return;
-        btn._piSaveBound = true;
-        btn.addEventListener('click', function (e) {
-          // Cards typically wrap the entire surface in a link; the save
-          // button must not also navigate when clicked.
-          e.preventDefault();
-          e.stopPropagation();
-          toggle(
-            btn.getAttribute('data-save-kind'),
-            btn.getAttribute('data-save-slug'),
-            btn.getAttribute('data-save-title'),
-            btn.getAttribute('data-save-href'),
-          );
+  function bindButtons() {
+    document.querySelectorAll<HTMLElement>('[data-save-toggle]').forEach((btn) => {
+      if ((btn as any)._piSaveBound) return;
+      (btn as any)._piSaveBound = true;
+      btn.addEventListener('click', (event) => {
+        // Cards typically wrap the entire surface in a link; the save button
+        // must not also navigate when clicked.
+        event.preventDefault();
+        event.stopPropagation();
+        const rawKind = btn.getAttribute('data-save-kind');
+        const slug = btn.getAttribute('data-save-slug');
+        const title = btn.getAttribute('data-save-title') || slug || '';
+        const href = btn.getAttribute('data-save-href') || (typeof location !== 'undefined' ? location.pathname : '/');
+        if (!rawKind || !slug) return;
+        Saves.toggle({
+          kind: rawKind as Saves.SaveKind,
+          slug,
+          title,
+          href,
         });
       });
-    }
+    });
+  }
 
-    function init() {
-      memoryStore = readStore();
-      bindButtons();
-      syncAll();
-    }
+  function init() {
+    bindButtons();
+    syncAll();
+  }
 
-    // Public API for the /saved/ page and any other consumers.
-    window.PISave = {
-      list: function () { return readStore(); },
-      isSaved: isSaved,
-      toggle: toggle,
-      clear: function (kind) {
-        if (!kind) memoryStore = { version: 1, venues: [], events: [] };
-        else if (kind === 'event') memoryStore.events = [];
-        else memoryStore.venues = [];
-        writeStore(memoryStore);
-        syncAll();
-        window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { cleared: kind || 'all' } }));
-      },
-      /**
-       * Merge an externally-supplied list into the user's saved store.
-       * Used by /saved/?v=... to ingest a shared list — items already in
-       * the store are not duplicated.
-       */
-      merge: function (incoming) {
-        if (!incoming) return;
-        function mergeArr(target, src) {
-          if (!Array.isArray(src)) return;
-          src.forEach(function (item) {
-            if (!item || !item.slug) return;
-            if (!target.some(function (e) { return e.slug === item.slug; })) {
-              target.push({
-                slug: item.slug,
-                title: item.title || item.slug,
-                href: item.href || '',
-                savedAt: item.savedAt || Date.now(),
-              });
-            }
+  // Public API — preserved for the existing /account/saved/ page (Wave 4
+  // rebuilds that page; for now keep the surface stable so nothing breaks).
+  (window as any).PISave = {
+    list() {
+      // Legacy callers expect { venues: [...], events: [...] }. Map the
+      // unified store onto that shape so the old /saved/ page still works.
+      const items = Saves.list();
+      return {
+        version: 1,
+        venues: items.filter((i) => i.kind === 'venue').map((i) => ({
+          slug: i.slug, title: i.title, href: i.href, savedAt: i.savedAt,
+        })),
+        events: items.filter((i) => i.kind === 'event').map((i) => ({
+          slug: i.slug, title: i.title, href: i.href, savedAt: i.savedAt,
+        })),
+      };
+    },
+    isSaved(kind: string, slug: string) {
+      return Saves.isSaved(kind as Saves.SaveKind, slug);
+    },
+    toggle(kind: string, slug: string, title: string, href: string) {
+      return Saves.toggle({ kind: kind as Saves.SaveKind, slug, title, href });
+    },
+    clear(kind?: string) {
+      if (!kind) {
+        Saves.clear();
+        return;
+      }
+      const items = Saves.list().filter((i) => i.kind === kind);
+      for (const it of items) Saves.remove(it.kind, it.slug);
+    },
+    merge(incoming: any) {
+      if (!incoming) return;
+      const toMerge: Saves.SavedItem[] = [];
+      if (Array.isArray(incoming.venues)) {
+        for (const v of incoming.venues) {
+          if (!v?.slug) continue;
+          toMerge.push({
+            kind: 'venue', slug: v.slug, title: v.title || v.slug,
+            href: v.href || '/', savedAt: v.savedAt || Date.now(),
           });
         }
-        mergeArr(memoryStore.venues, incoming.venues);
-        mergeArr(memoryStore.events, incoming.events);
-        writeStore(memoryStore);
-        syncAll();
-      },
-    };
-
-    init();
-    document.addEventListener('astro:page-load', init);
-    window.addEventListener('storage', function (e) {
-      // Cross-tab sync — when another tab updates the same key, refresh.
-      if (e.key === KEY) {
-        memoryStore = readStore();
-        syncAll();
       }
-    });
-  })();
+      if (Array.isArray(incoming.events)) {
+        for (const e of incoming.events) {
+          if (!e?.slug) continue;
+          toMerge.push({
+            kind: 'event', slug: e.slug, title: e.title || e.slug,
+            href: e.href || '/', savedAt: e.savedAt || Date.now(),
+          });
+        }
+      }
+      Saves.merge(toMerge);
+    },
+  };
+
+  // Keep button state in sync with store changes from any source — direct
+  // PISave.toggle() calls, the unified UI in Wave 2, cross-tab updates, etc.
+  Saves.onChange(syncAll);
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'pi:saves:v2') syncAll();
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+  document.addEventListener('astro:page-load', init);
 </script>

--- a/next/src/components/TourCard.astro
+++ b/next/src/components/TourCard.astro
@@ -4,6 +4,8 @@
  * Expects a full Astro content-collection entry from `tours`.
  */
 
+import PiSaveActions from './PiSaveActions.astro';
+
 export interface Props {
   tour: any;
   operatorName?: string;
@@ -86,4 +88,12 @@ const priceDisplay = data.priceLow
     {priceDisplay && <p class="tour-card__price">{priceDisplay}</p>}
     <a href={href} class="tour-card__cta">Read notes &rarr;</a>
   </div>
+  <PiSaveActions
+    kind="tour"
+    slug={slug}
+    title={data.name}
+    href={href}
+    dek={excerpt}
+    imageUrl={data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/TourOperatorCard.astro
+++ b/next/src/components/TourOperatorCard.astro
@@ -4,6 +4,8 @@
  * Expects a full Astro content-collection entry from `tourOperators`.
  */
 
+import PiSaveActions from './PiSaveActions.astro';
+
 export interface Props {
   operator: any;
 }
@@ -52,4 +54,12 @@ const excerpt = data.intro
     <p class="tour-card__excerpt">{excerpt}</p>
     <a href={href} class="tour-card__cta">View operator &rarr;</a>
   </div>
+  <PiSaveActions
+    kind="tour-operator"
+    slug={slug}
+    title={data.name}
+    href={href}
+    dek={excerpt}
+    imageUrl={data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/TourPackageCard.astro
+++ b/next/src/components/TourPackageCard.astro
@@ -4,6 +4,8 @@
  * Expects a full Astro content-collection entry from `tourPackages`.
  */
 
+import PiSaveActions from './PiSaveActions.astro';
+
 export interface Props {
   pkg: any;
 }
@@ -77,4 +79,12 @@ const priceDisplay = data.priceLow
     {priceDisplay && <p class="tour-card__price" set:html={priceDisplay} />}
     <a href={href} class="tour-card__cta">View package &rarr;</a>
   </div>
+  <PiSaveActions
+    kind="tour-package"
+    slug={slug}
+    title={data.name}
+    href={href}
+    dek={excerpt}
+    imageUrl={data.heroImage?.src}
+  />
 </article>

--- a/next/src/components/VenueCard.astro
+++ b/next/src/components/VenueCard.astro
@@ -8,7 +8,7 @@
 
 import { resolveHeroSrc } from '../lib/editorial';
 import { verifiedFreshnessLabel, verificationFreshness } from '../lib/venues';
-import SaveButton from './SaveButton.astro';
+import PiSaveActions from './PiSaveActions.astro';
 
 const typeLabel: Record<string, string> = {
   restaurant:  'Restaurant',
@@ -84,11 +84,18 @@ const verifiedTier = verificationFreshness(data.lastVerified);
     {data.bookingUrl && data.bookingProvider !== 'none' && (
       <a href={data.bookingUrl} target="_blank" rel="noopener noreferrer" class="venue-card__book" onClick={(e: any) => e.stopPropagation()}>Book</a>
     )}
-    <SaveButton kind="venue" slug={slug} title={data.name} href={href} />
   </div>
   {data.featuredPartner && (
     <p class="venue-card__partner-note">Partner venue</p>
   )}
+  <PiSaveActions
+    kind="venue"
+    slug={slug}
+    title={data.name}
+    href={href}
+    dek={data.signature}
+    imageUrl={heroSrc}
+  />
 </article>
 
 <style>

--- a/next/src/components/v2/SaveButton.astro
+++ b/next/src/components/v2/SaveButton.astro
@@ -29,56 +29,18 @@ const { slug, section, title, dek, imageUrl } = Astro.props;
 </button>
 
 <script>
-  import { getUser, isSavedByUser, toggleSave, onAuthChange, isAuthEnabled } from '../../lib/auth';
+  import { onAuthChange } from '../../lib/auth';
+  import * as Saves from '../../lib/saves/store';
 
   /**
-   * Local-first save store. When anonymous, articles are saved here; the
-   * UI reflects them as Saved across reloads on this device. When the user
-   * signs in, CloudSync (or a sign-in handler) can merge these into
-   * pi.user_saves so the saves follow them to other devices.
+   * Article SaveButton — thin UI on top of the unified `pi:saves:v2` local
+   * store. The cloud mirror happens transparently via lib/saves/cloud.ts
+   * when the user is signed in (installed from BaseLayout).
    *
-   * Schema is intentionally separate from `pi:saved:v1` (which is for
-   * venues + events) — `articles` belong to a different slug-space.
+   * Wave 3 of the Save & Share rebuild replaces this widget entirely with
+   * `<PiArticleActions />`. Keeping the existing button alive in the
+   * interim so the journal article surface still works.
    */
-  const LOCAL_KEY = 'pi:saved-articles:v1';
-
-  type LocalArticle = { slug: string; section: string; title?: string; dek?: string; image_url?: string; savedAt: number };
-  type LocalStore = { version: 1; articles: LocalArticle[] };
-
-  function readLocal(): LocalStore {
-    try {
-      const raw = localStorage.getItem(LOCAL_KEY);
-      if (!raw) return { version: 1, articles: [] };
-      const parsed = JSON.parse(raw);
-      return { version: 1, articles: Array.isArray(parsed?.articles) ? parsed.articles : [] };
-    } catch {
-      return { version: 1, articles: [] };
-    }
-  }
-
-  function writeLocal(store: LocalStore) {
-    try { localStorage.setItem(LOCAL_KEY, JSON.stringify(store)); }
-    catch { /* private mode / quota / disabled — fail silently */ }
-  }
-
-  function isSavedLocal(slug: string): boolean {
-    return readLocal().articles.some((a) => a.slug === slug);
-  }
-
-  function toggleLocal(slug: string, section: string, snapshot: { title?: string; dek?: string; image_url?: string }): boolean {
-    const store = readLocal();
-    const idx = store.articles.findIndex((a) => a.slug === slug);
-    if (idx >= 0) {
-      store.articles.splice(idx, 1);
-      writeLocal(store);
-      window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { kind: 'article', slug } }));
-      return false;
-    }
-    store.articles.push({ slug, section, ...snapshot, savedAt: Date.now() });
-    writeLocal(store);
-    window.dispatchEvent(new CustomEvent('pi:save-changed', { detail: { kind: 'article', slug } }));
-    return true;
-  }
 
   async function hydrateButton(btn: HTMLButtonElement) {
     if ((btn as any)._init) return;
@@ -87,7 +49,7 @@ const { slug, section, title, dek, imageUrl } = Astro.props;
     const slug = btn.dataset.saveSlug as string;
     const section = btn.dataset.saveSection as string;
     const snapshot = {
-      title: btn.dataset.saveTitle,
+      title: btn.dataset.saveTitle || slug,
       dek: btn.dataset.saveDek,
       image_url: btn.dataset.saveImage,
     };
@@ -99,40 +61,27 @@ const { slug, section, title, dek, imageUrl } = Astro.props;
       labelEl.textContent = saved ? 'Saved' : 'Save';
     }
 
-    async function refresh() {
-      const u = await getUser();
-      if (u) {
-        const saved = await isSavedByUser(slug, u.id);
-        paint(saved);
-      } else {
-        paint(isSavedLocal(slug));
-      }
+    function refresh() {
+      paint(Saves.isSaved('article', slug));
     }
 
-    btn.addEventListener('click', async () => {
-      const u = await getUser();
-
-      if (!u) {
-        // Anonymous: save to localStorage so the bookmark sticks on this
-        // device. Doesn't open the auth modal — the masthead Sign in pill
-        // is the dedicated CTA for that path.
-        const nowSaved = toggleLocal(slug, section, snapshot);
-        paint(nowSaved);
-        return;
-      }
-
-      // Signed in: optimistic UI, then Supabase. Roll back on error.
-      const wasSaved = btn.classList.contains('is-saved');
-      paint(!wasSaved);
-      try {
-        const { saved } = await toggleSave(slug, section, u.id, snapshot);
-        paint(saved);
-      } catch {
-        paint(wasSaved);
-      }
+    btn.addEventListener('click', () => {
+      Saves.toggle({
+        kind: 'article',
+        slug,
+        section,
+        title: snapshot.title,
+        dek: snapshot.dek,
+        image_url: snapshot.image_url,
+        href: `/${section}/${slug}/`,
+      });
+      // Repaint via the change listener below; this branch left intentionally
+      // empty for the optimistic write to settle.
+      void 0;
     });
 
     refresh();
+    Saves.onChange(refresh);
     onAuthChange(refresh);
   }
 

--- a/next/src/lib/auth.ts
+++ b/next/src/lib/auth.ts
@@ -173,29 +173,46 @@ export async function toggleLike(slug: string, section: string, userId: string):
 }
 
 // ---- Saves -----------------------------------------------------------------
+//
+// As of the Wave 1 unification (2026-05-11) the only server-side save store
+// is `pi.user_saves` with a typed `kind` column. The previous code referenced
+// a `pi.article_saves` table that was never created, so signed-in article
+// saves silently failed. These wrappers target the unified table and default
+// `kind` to 'article' for the journal-article surfaces that still call them.
+// New code should prefer the `lib/saves/cloud.ts` helpers, which handle
+// every kind uniformly.
 
-export async function isSavedByUser(slug: string, userId: string): Promise<boolean> {
+export async function isSavedByUser(slug: string, userId: string, kind: string = 'article'): Promise<boolean> {
   const c = getSupabase();
   if (!c) return false;
-  const { data } = await c.from('article_saves').select('article_slug').eq('article_slug', slug).eq('user_id', userId).maybeSingle();
+  const { data } = await c
+    .from('user_saves')
+    .select('slug')
+    .eq('user_id', userId)
+    .eq('kind', kind)
+    .eq('slug', slug)
+    .maybeSingle();
   return !!data;
 }
 
 export async function toggleSave(slug: string, section: string, userId: string, snapshot?: SaveSnapshot): Promise<{ saved: boolean }> {
   const c = getSupabase();
   if (!c) throw new Error('Auth not configured');
-  const saved = await isSavedByUser(slug, userId);
+  const kind = 'article';
+  const saved = await isSavedByUser(slug, userId, kind);
   if (saved) {
-    await c.from('article_saves').delete().match({ user_id: userId, article_slug: slug });
+    await c.from('user_saves').delete().match({ user_id: userId, kind, slug });
     return { saved: false };
   }
-  await c.from('article_saves').insert({
+  await c.from('user_saves').insert({
     user_id: userId,
-    article_slug: slug,
+    kind,
+    slug,
     section,
     title: snapshot?.title || null,
     dek: snapshot?.dek || null,
     image_url: snapshot?.image_url || null,
+    href: `/${section}/${slug}/`,
   });
   return { saved: true };
 }
@@ -203,8 +220,20 @@ export async function toggleSave(slug: string, section: string, userId: string, 
 export async function listSaves(userId: string) {
   const c = getSupabase();
   if (!c) return [];
-  const { data } = await c.from('article_saves').select('*').eq('user_id', userId).order('created_at', { ascending: false });
-  return data || [];
+  const { data } = await c
+    .from('user_saves')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('kind', 'article')
+    .order('saved_at', { ascending: false });
+  // Normalise to the legacy shape the /account/saved/ page expects:
+  // article_slug instead of slug. Phase 4 rewrites that page and removes
+  // this shim.
+  return (data || []).map((row: Record<string, unknown>) => ({
+    ...row,
+    article_slug: row.slug,
+    created_at: row.saved_at,
+  }));
 }
 
 export async function listLikes(userId: string) {

--- a/next/src/lib/saves/cloud.ts
+++ b/next/src/lib/saves/cloud.ts
@@ -1,0 +1,143 @@
+/**
+ * Peninsula Insider — saves cloud sync.
+ *
+ * Mirrors the local `pi:saves:v2` store to `pi.user_saves` for signed-in
+ * users. The local store remains the source of truth for the UI; cloud
+ * sync runs in the background.
+ *
+ * On sign-in:
+ *   1. Pull the server list.
+ *   2. Merge into local (server-side rows the user might have saved on
+ *      another device, but not on this one).
+ *   3. Push local-only items up to the server.
+ *
+ * On every local change while signed in:
+ *   - The change is mirrored to the server (best-effort, no UI block).
+ */
+
+import { getSupabase } from '../auth';
+import type { SavedItem, SaveKind } from './store';
+import { list as listLocal, merge as mergeLocal, onChange } from './store';
+
+interface ServerRow {
+  user_id: string;
+  kind: SaveKind;
+  slug: string;
+  section: string | null;
+  title: string | null;
+  dek: string | null;
+  image_url: string | null;
+  href: string | null;
+  saved_at: string;
+}
+
+function rowToItem(row: ServerRow): SavedItem {
+  return {
+    kind: row.kind,
+    slug: row.slug,
+    section: row.section ?? undefined,
+    title: row.title ?? row.slug,
+    dek: row.dek ?? undefined,
+    image_url: row.image_url ?? undefined,
+    href: row.href ?? '/',
+    savedAt: row.saved_at ? new Date(row.saved_at).getTime() : Date.now(),
+  };
+}
+
+function itemToRow(item: SavedItem, userId: string): Omit<ServerRow, 'saved_at'> {
+  return {
+    user_id: userId,
+    kind: item.kind,
+    slug: item.slug,
+    section: item.section ?? null,
+    title: item.title ?? null,
+    dek: item.dek ?? null,
+    image_url: item.image_url ?? null,
+    href: item.href ?? null,
+  };
+}
+
+let installed = false;
+let unsubscribe: (() => void) | null = null;
+
+/**
+ * Pull the user's server-side saves, merge any new ones into the local
+ * store. Called once on sign-in.
+ */
+export async function pullFromServer(userId: string): Promise<void> {
+  const supa = getSupabase();
+  if (!supa) return;
+  const { data, error } = await supa
+    .from('user_saves')
+    .select('*')
+    .eq('user_id', userId);
+  if (error || !data) return;
+  const items = (data as unknown as ServerRow[]).map(rowToItem);
+  mergeLocal(items);
+}
+
+/**
+ * Push local-only items to the server. Uses upsert against the
+ * (user_id, kind, slug) unique index, so re-running is safe.
+ */
+export async function pushToServer(userId: string): Promise<void> {
+  const supa = getSupabase();
+  if (!supa) return;
+  const items = listLocal();
+  if (items.length === 0) return;
+  const rows = items.map((it) => itemToRow(it, userId));
+  await supa
+    .from('user_saves')
+    .upsert(rows, { onConflict: 'user_id,kind,slug' });
+}
+
+/**
+ * Install a listener that mirrors every local save-change up to the
+ * server. Idempotent — calling more than once is a no-op.
+ */
+export function installCloudSync(userId: string): void {
+  if (installed) return;
+  installed = true;
+  let lastSig = signature(listLocal());
+
+  unsubscribe = onChange(async () => {
+    const supa = getSupabase();
+    if (!supa) return;
+    const current = listLocal();
+    const sig = signature(current);
+    if (sig === lastSig) return;
+
+    // Diff against the last signature to know what changed.
+    const prev = decodeSig(lastSig);
+    lastSig = sig;
+
+    const currentKeys = new Set(current.map(keyOf));
+    const prevKeys = new Set(prev);
+    const additions = current.filter((it) => !prevKeys.has(keyOf(it)));
+    const removals = [...prevKeys].filter((k) => !currentKeys.has(k));
+
+    if (additions.length > 0) {
+      const rows = additions.map((it) => itemToRow(it, userId));
+      await supa.from('user_saves').upsert(rows, { onConflict: 'user_id,kind,slug' });
+    }
+    for (const k of removals) {
+      const [kind, slug] = k.split('/');
+      await supa.from('user_saves').delete().match({ user_id: userId, kind, slug });
+    }
+  });
+}
+
+export function teardownCloudSync(): void {
+  installed = false;
+  unsubscribe?.();
+  unsubscribe = null;
+}
+
+function keyOf(it: SavedItem): string { return `${it.kind}/${it.slug}`; }
+function signature(items: SavedItem[]): string {
+  return items.map(keyOf).sort().join('|');
+}
+function decodeSig(sig: string): string[] {
+  if (!sig) return [];
+  return sig.split('|').filter(Boolean);
+}

--- a/next/src/lib/saves/store.ts
+++ b/next/src/lib/saves/store.ts
@@ -1,0 +1,287 @@
+/**
+ * Peninsula Insider — unified saves store (v2).
+ *
+ * One canonical local store for every kind of saved item — articles,
+ * venues, places, events, experiences, itineraries, tours, operators,
+ * packages. Replaces the two competing v1 stores:
+ *
+ *   - pi:saved:v1            (venues + events, via SaveSiteController)
+ *   - pi:saved-articles:v1   (articles, via v2/SaveButton.astro)
+ *
+ * Migration from v1 happens automatically on first read after this file
+ * loads. Both v1 keys are left in place for a quarter as a rollback path;
+ * a later cleanup commit will delete them.
+ *
+ * Signed-in users get the same items mirrored to `pi.user_saves` via
+ * `CloudSync`, which now uses `kind` to distinguish row types.
+ */
+
+export type SaveKind =
+  | 'article'
+  | 'venue'
+  | 'place'
+  | 'event'
+  | 'experience'
+  | 'itinerary'
+  | 'tour'
+  | 'tour-operator'
+  | 'tour-package';
+
+export interface SavedItem {
+  kind: SaveKind;
+  /** Stable slug within the kind's namespace. */
+  slug: string;
+  /** Editorial section for articles (`eat`, `stay`, `journal`, etc). Optional for other kinds. */
+  section?: string;
+  /** Human-readable title; used in the saved view and the share preview. */
+  title: string;
+  /** Short summary shown on the saved card. */
+  dek?: string;
+  /** Cover image. */
+  image_url?: string;
+  /** Canonical URL to the saved page. */
+  href: string;
+  /** Unix milliseconds the user added this item. */
+  savedAt: number;
+}
+
+export interface SavesStore {
+  version: 2;
+  items: SavedItem[];
+}
+
+const STORAGE_KEY = 'pi:saves:v2';
+
+const LEGACY_VENUES_EVENTS_KEY = 'pi:saved:v1';
+const LEGACY_ARTICLES_KEY = 'pi:saved-articles:v1';
+
+const EMPTY: SavesStore = { version: 2, items: [] };
+
+let memory: SavesStore | null = null;
+
+// --------------------------------------------------------------------------
+// Read / write
+// --------------------------------------------------------------------------
+
+function readRaw(): SavesStore {
+  if (typeof localStorage === 'undefined') return { ...EMPTY };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return migrateFromLegacy();
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || parsed.version !== 2 || !Array.isArray(parsed.items)) {
+      return migrateFromLegacy();
+    }
+    return parsed as SavesStore;
+  } catch {
+    return migrateFromLegacy();
+  }
+}
+
+function writeRaw(store: SavesStore): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    /* private mode / quota / disabled — fail silently */
+  }
+}
+
+// --------------------------------------------------------------------------
+// Migration from v1 stores
+// --------------------------------------------------------------------------
+
+interface LegacyVenueOrEvent {
+  slug: string;
+  title?: string;
+  href?: string;
+  savedAt?: number;
+}
+
+interface LegacyArticle {
+  slug: string;
+  section?: string;
+  title?: string;
+  dek?: string;
+  image_url?: string;
+  savedAt?: number;
+}
+
+function safeParse<T>(key: string, validate: (v: unknown) => v is T): T | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return validate(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function migrateFromLegacy(): SavesStore {
+  const items: SavedItem[] = [];
+  const now = Date.now();
+
+  const venuesEventsStore = safeParse(LEGACY_VENUES_EVENTS_KEY, (v): v is { venues: LegacyVenueOrEvent[]; events: LegacyVenueOrEvent[] } => {
+    return Boolean(v && typeof v === 'object' && Array.isArray((v as { venues?: unknown }).venues) && Array.isArray((v as { events?: unknown }).events));
+  });
+  if (venuesEventsStore) {
+    for (const v of venuesEventsStore.venues) {
+      if (!v?.slug) continue;
+      items.push({
+        kind: 'venue',
+        slug: v.slug,
+        title: v.title ?? v.slug,
+        href: v.href ?? `/eat/${v.slug}/`,
+        savedAt: v.savedAt ?? now,
+      });
+    }
+    for (const e of venuesEventsStore.events) {
+      if (!e?.slug) continue;
+      items.push({
+        kind: 'event',
+        slug: e.slug,
+        title: e.title ?? e.slug,
+        href: e.href ?? `/whats-on/${e.slug}/`,
+        savedAt: e.savedAt ?? now,
+      });
+    }
+  }
+
+  const articlesStore = safeParse(LEGACY_ARTICLES_KEY, (v): v is { articles: LegacyArticle[] } => {
+    return Boolean(v && typeof v === 'object' && Array.isArray((v as { articles?: unknown }).articles));
+  });
+  if (articlesStore) {
+    for (const a of articlesStore.articles) {
+      if (!a?.slug) continue;
+      const section = a.section ?? 'journal';
+      items.push({
+        kind: 'article',
+        slug: a.slug,
+        section,
+        title: a.title ?? a.slug,
+        dek: a.dek,
+        image_url: a.image_url,
+        href: `/${section}/${a.slug}/`,
+        savedAt: a.savedAt ?? now,
+      });
+    }
+  }
+
+  const migrated: SavesStore = { version: 2, items };
+  writeRaw(migrated);
+  return migrated;
+}
+
+// --------------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------------
+
+function load(): SavesStore {
+  if (!memory) memory = readRaw();
+  return memory;
+}
+
+function persist(store: SavesStore): void {
+  memory = store;
+  writeRaw(store);
+  emit({ kind: 'change' });
+}
+
+/** Snapshot of all saves. */
+export function list(): SavedItem[] {
+  return load().items.slice().sort((a, b) => b.savedAt - a.savedAt);
+}
+
+/** Snapshot of saves of a given kind. */
+export function listByKind(kind: SaveKind): SavedItem[] {
+  return list().filter((it) => it.kind === kind);
+}
+
+/** True if an item with this kind+slug is saved. */
+export function isSaved(kind: SaveKind, slug: string): boolean {
+  return load().items.some((it) => it.kind === kind && it.slug === slug);
+}
+
+/**
+ * Toggle save state. Returns the new state (true = now saved).
+ * If the item is new, snapshot fields (title / dek / image_url / href / section)
+ * are required to render the saved view later. If toggling off an existing
+ * item, snapshot fields are ignored.
+ */
+export function toggle(item: Omit<SavedItem, 'savedAt'>): boolean {
+  const store = load();
+  const idx = store.items.findIndex((it) => it.kind === item.kind && it.slug === item.slug);
+  let next: SavesStore;
+  let nowSaved: boolean;
+  if (idx >= 0) {
+    next = { version: 2, items: store.items.slice() };
+    next.items.splice(idx, 1);
+    nowSaved = false;
+  } else {
+    next = { version: 2, items: [...store.items, { ...item, savedAt: Date.now() }] };
+    nowSaved = true;
+  }
+  persist(next);
+  return nowSaved;
+}
+
+/** Explicitly remove. No-op if not saved. */
+export function remove(kind: SaveKind, slug: string): void {
+  const store = load();
+  const idx = store.items.findIndex((it) => it.kind === kind && it.slug === slug);
+  if (idx < 0) return;
+  const next: SavesStore = { version: 2, items: store.items.slice() };
+  next.items.splice(idx, 1);
+  persist(next);
+}
+
+/**
+ * Merge an externally-supplied list (e.g. from Supabase after sign-in, or
+ * from a shared-plan URL). Items in `incoming` that don't exist locally are
+ * added; existing items are left alone. Returns the count of items added.
+ */
+export function merge(incoming: SavedItem[]): number {
+  const store = load();
+  const keys = new Set(store.items.map((it) => `${it.kind}/${it.slug}`));
+  let added = 0;
+  const next: SavesStore = { version: 2, items: store.items.slice() };
+  for (const item of incoming) {
+    if (!item?.kind || !item?.slug) continue;
+    const key = `${item.kind}/${item.slug}`;
+    if (keys.has(key)) continue;
+    next.items.push(item);
+    keys.add(key);
+    added += 1;
+  }
+  if (added > 0) persist(next);
+  return added;
+}
+
+/** Wipe all saves. Used by sign-out flows and on user request. */
+export function clear(): void {
+  persist({ version: 2, items: [] });
+}
+
+// --------------------------------------------------------------------------
+// Change events
+// --------------------------------------------------------------------------
+
+type ChangeEvent = { kind: 'change' };
+type Listener = (event: ChangeEvent) => void;
+const listeners = new Set<Listener>();
+
+export function onChange(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function emit(event: ChangeEvent): void {
+  for (const fn of listeners) {
+    try { fn(event); } catch { /* swallow — one listener's bug shouldn't break the rest */ }
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('pi:saves-changed', { detail: event }));
+  }
+}

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -3036,6 +3036,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   gap: clamp(1rem, 1.6vw, 1.4rem);
 }
 .itinerary-card {
+  position: relative;
   background: var(--white);
   padding: 0;
   display: flex;
@@ -5581,6 +5582,7 @@ p.has-drop-cap::first-letter {
   gap: 1.6rem;
 }
 .event-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -7784,7 +7786,7 @@ p.has-drop-cap::first-letter {
 }
 
 /* ─── Tour vertical ─────────────────────────────────────────────────────── */
-.tour-card { background: var(--bg); border: 1px solid var(--border); border-radius: var(--tile-image-radius); display: flex; flex-direction: column; overflow: hidden; transition: box-shadow 0.2s; }
+.tour-card { position: relative; background: var(--bg); border: 1px solid var(--border); border-radius: var(--tile-image-radius); display: flex; flex-direction: column; overflow: hidden; transition: box-shadow 0.2s; }
 .tour-card:hover { box-shadow: 0 4px 24px rgba(0,0,0,0.10); }
 .tour-card__image { aspect-ratio: 16/9; overflow: hidden; }
 .tour-card__image img { width: 100%; height: 100%; object-fit: cover; display: block; }


### PR DESCRIPTION
Phase 1 audit, plus Waves 1 and 2 of the brief approved 2026-05-11. See full commit message + docs/save-share-audit-2026-05-11.md for the matrix. Wave 3+ to follow.