### PR TITLE
feat(saves): Wave 3 — article-level Save + Share

### DIFF
--- a/next/src/components/PiArticleActions.astro
+++ b/next/src/components/PiArticleActions.astro
@@ -1,0 +1,191 @@
+---
+/**
+ * PiArticleActions — article-level Save + Share.
+ *
+ * Renders both placements the brief calls for:
+ *   - An inline Save + Share pair near the byline (always visible).
+ *   - A sticky bottom-right pair that fades in after the reader scrolls
+ *     past ~30% of the article and fades back out when they're past 90%
+ *     (no point urging Save on someone already at the conclusion).
+ *
+ * Both placements share the same Save + Share behaviour because they're
+ * both `<PiSaveActions />` instances under the hood, anchored to the
+ * same `(kind=article, slug)` row. Tapping save in either spot reflects
+ * in the other (and in the saved-plan view) via the unified store.
+ *
+ * Replaces the journal article's two ShareBlock placements plus the
+ * v2/SaveButton. Wave 3 of the Save & Share rebuild.
+ */
+import PiSaveActions from './PiSaveActions.astro';
+
+export interface Props {
+  /** Save kind — defaults to 'article' for journal pieces. */
+  kind?: 'article' | 'venue' | 'place' | 'event' | 'experience' | 'itinerary' | 'tour' | 'tour-operator' | 'tour-package';
+  slug: string;
+  section: string;
+  title: string;
+  href?: string;
+  dek?: string;
+  imageUrl?: string;
+}
+
+const { kind = 'article', slug, section, title, href, dek, imageUrl } = Astro.props;
+const resolvedHref = href ?? `/${section}/${slug}/`;
+---
+
+<div class="pi-article-actions" data-pi-article-actions>
+  <span class="pi-article-actions__hint">Keep this for later</span>
+  <PiSaveActions
+    kind={kind}
+    slug={slug}
+    section={section}
+    title={title}
+    href={resolvedHref}
+    dek={dek}
+    imageUrl={imageUrl}
+    floating={false}
+  />
+</div>
+
+<aside
+  class="pi-article-sticky"
+  data-pi-article-sticky
+  aria-hidden="true"
+  hidden
+>
+  <PiSaveActions
+    kind={kind}
+    slug={slug}
+    section={section}
+    title={title}
+    href={resolvedHref}
+    dek={dek}
+    imageUrl={imageUrl}
+    floating={false}
+  />
+</aside>
+
+<style is:global>
+  .pi-article-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 0.45rem 0;
+  }
+
+  .pi-article-actions__hint {
+    font-family: 'Outfit', system-ui, sans-serif;
+    font-size: 0.65rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-muted, #6E655C);
+  }
+
+  /* Sticky pair — bottom-right, fades in after scroll. */
+  .pi-article-sticky {
+    position: fixed;
+    bottom: clamp(1rem, 3vw, 1.5rem);
+    right: clamp(1rem, 3vw, 1.5rem);
+    z-index: 30;
+    padding: 0;
+    background: transparent;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
+  }
+
+  .pi-article-sticky[data-visible="1"] {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  /* Compact the buttons inside the sticky pair — slightly chunkier so
+     it reads as a deliberate floating control, not a card decoration. */
+  .pi-article-sticky .pi-actions__btn {
+    width: 2.4rem;
+    height: 2.4rem;
+    background: var(--ink, #171413);
+    color: var(--paper, #FAF7F0);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 8px 24px -8px rgba(0, 0, 0, 0.4);
+  }
+
+  .pi-article-sticky .pi-actions__btn:hover {
+    background: var(--ochre, #A0541F);
+    color: var(--paper, #FAF7F0);
+    border-color: var(--ochre, #A0541F);
+  }
+
+  .pi-article-sticky .pi-actions__btn--save[aria-pressed="true"] {
+    background: var(--ochre, #A0541F);
+    border-color: var(--ochre, #A0541F);
+  }
+
+  @media (max-width: 640px) {
+    /* Mobile: keep both pieces but tuck the sticky a little tighter and
+       avoid clashing with thumb-reach for the navbar. */
+    .pi-article-sticky {
+      bottom: 0.85rem;
+      right: 0.85rem;
+    }
+  }
+
+  /* Don't show the sticky pair when print or reduced-motion users want
+     a calm experience. */
+  @media print {
+    .pi-article-sticky { display: none; }
+  }
+</style>
+
+<script>
+  /**
+   * Sticky pair visibility — show between 30% and 90% scroll. We use the
+   * `<article>` element's bounding rect when available, falling back to
+   * window scroll for non-article pages that opt into this widget.
+   */
+  function bindSticky() {
+    const sticky = document.querySelector<HTMLElement>('[data-pi-article-sticky]');
+    if (!sticky || (sticky as any)._piInit) return;
+    (sticky as any)._piInit = true;
+
+    const article = document.querySelector('article') || document.body;
+
+    function update() {
+      const rect = article.getBoundingClientRect();
+      const articleHeight = rect.height;
+      const viewport = window.innerHeight;
+      const scrolled = -rect.top;
+      const progress = articleHeight > viewport
+        ? scrolled / (articleHeight - viewport)
+        : 0;
+
+      const visible = progress > 0.3 && progress < 0.9;
+      if (visible) {
+        sticky.hidden = false;
+        sticky.setAttribute('data-visible', '1');
+        sticky.setAttribute('aria-hidden', 'false');
+      } else {
+        sticky.removeAttribute('data-visible');
+        sticky.setAttribute('aria-hidden', 'true');
+        // Defer hidden=true until the fade has finished so the transition runs.
+        setTimeout(() => {
+          if (!sticky.hasAttribute('data-visible')) sticky.hidden = true;
+        }, 220);
+      }
+    }
+
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update, { passive: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bindSticky);
+  } else {
+    bindSticky();
+  }
+  document.addEventListener('astro:page-load', bindSticky);
+</script>

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -6,7 +6,7 @@ import NewsletterBlock from './NewsletterBlock.astro';
 import VenueCard from './VenueCard.astro';
 import ArticleCard from './ArticleCard.astro';
 import ItineraryCard from './ItineraryCard.astro';
-import ShareBlock from './ShareBlock.astro';
+import PiArticleActions from './PiArticleActions.astro';
 import CorrectionNote from './CorrectionNote.astro';
 
 export interface Props {
@@ -461,7 +461,15 @@ const isClosed = data.status === 'closed';
   </div>
 </section>
 
-<ShareBlock placement="end" title={data.name} summary={data.editorNote ? data.editorNote.slice(0, 120) + '…' : `${data.name} on the Mornington Peninsula`} />
+<PiArticleActions
+  kind="venue"
+  slug={venue.id ?? data.slug}
+  section={section}
+  title={data.name}
+  href={`/${venueHrefPrefix(data, section)}/${venue.id ?? data.slug}/`}
+  dek={data.editorNote}
+  imageUrl={data.heroImage?.src}
+/>
 <NewsletterBlock />
 
 <style>

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -7,8 +7,7 @@ import VenueCard from '../../components/VenueCard.astro';
 import ExperienceCard from '../../components/ExperienceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import LikeButton from '../../components/v2/LikeButton.astro';
-import ShareBlock from '../../components/ShareBlock.astro';
-import SaveButton from '../../components/v2/SaveButton.astro';
+import PiArticleActions from '../../components/PiArticleActions.astro';
 import ClusterLinks from '../../components/ClusterLinks.astro';
 import ItineraryCard from '../../components/ItineraryCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
@@ -204,7 +203,13 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
             </div>
             <h1 class="article-hero__title">{article.data.title}</h1>
             <p class="article-hero__dek">{article.data.dek}</p>
-            <ShareBlock placement="top" title={article.data.title} summary={article.data.dek} format={String(article.data.format ?? '')} />
+            <PiArticleActions
+              slug={article.id}
+              section={article.data.section ?? 'journal'}
+              title={article.data.title}
+              dek={article.data.dek}
+              imageUrl={article.data.heroImage?.src}
+            />
             <div class="article-hero__byline">
               <span class="article-hero__byline-name">— By <strong>{authorLabel}</strong></span>
               {article.data.lastVerified && (
@@ -273,16 +278,7 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
 
       <div class="v2-article-actions">
         <LikeButton slug={article.id} section="journal" />
-        <SaveButton
-          slug={article.id}
-          section="journal"
-          title={article.data.title}
-          dek={article.data.dek}
-          imageUrl={article.data.heroImage?.src}
-        />
       </div>
-
-      <ShareBlock placement="end" title={article.data.title} summary={article.data.dek} format={String(article.data.format ?? '')} />
     </div>
   </article>
 

--- a/next/src/pages/whats-on/this-weekend/archive/[slug].astro
+++ b/next/src/pages/whats-on/this-weekend/archive/[slug].astro
@@ -14,7 +14,7 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../../../components/NewsletterBlock.astro';
-import ShareBlock from '../../../../components/ShareBlock.astro';
+import PiArticleActions from '../../../../components/PiArticleActions.astro';
 import ClusterLinks from '../../../../components/ClusterLinks.astro';
 import {
   isPeninsulaThisWeekend,
@@ -106,7 +106,13 @@ const older = idx >= 0 && idx < allPtw.length - 1 ? allPtw[idx + 1] : null;
               This is an archived weekend dispatch. The current weekend lives at
               <a href="/whats-on/this-weekend/">/whats-on/this-weekend/</a>.
             </p>
-            <ShareBlock placement="top" title={article.data.title} summary={article.data.dek} format="weekend-picker" />
+            <PiArticleActions
+              slug={article.id}
+              section="whats-on"
+              title={article.data.title}
+              dek={article.data.dek}
+              imageUrl={article.data.heroImage?.src}
+            />
           </div>
           <figure class="article-hero__figure">
             <div class="article-hero__image" role="img" aria-label={article.data.heroImage.alt} style={heroStyle}></div>
@@ -161,7 +167,6 @@ const older = idx >= 0 && idx < allPtw.length - 1 ? allPtw[idx + 1] : null;
         )}
       </nav>
 
-      <ShareBlock placement="end" title={article.data.title} summary={article.data.dek} format="weekend-picker" />
     </div>
   </article>
 

--- a/next/src/pages/whats-on/this-weekend/index.astro
+++ b/next/src/pages/whats-on/this-weekend/index.astro
@@ -16,7 +16,7 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
-import ShareBlock from '../../../components/ShareBlock.astro';
+import PiArticleActions from '../../../components/PiArticleActions.astro';
 import ClusterLinks from '../../../components/ClusterLinks.astro';
 import {
   selectLatestPtw,
@@ -109,7 +109,14 @@ const archiveItems = ptwArticles
             </div>
             <h1 class="article-hero__title">{latest.data.title}</h1>
             <p class="article-hero__dek">{latest.data.dek}</p>
-            <ShareBlock placement="top" title={latest.data.title} summary={latest.data.dek} format="weekend-picker" />
+            <PiArticleActions
+              slug={latest.id}
+              section="whats-on"
+              title={latest.data.title}
+              dek={latest.data.dek}
+              imageUrl={latest.data.heroImage?.src}
+              href="/whats-on/this-weekend/"
+            />
             <p class="ptw__cadence">
               The weekend dispatch refreshes every Wednesday for the weekend ahead.
               <a href="#archive" class="ptw__archive-link">Past weekends ↓</a>
@@ -172,7 +179,6 @@ const archiveItems = ptwArticles
         </section>
       )}
 
-      <ShareBlock placement="end" title={latest.data.title} summary={latest.data.dek} format="weekend-picker" />
     </div>
   </article>
 


### PR DESCRIPTION
Replaces ShareBlock + v2/SaveButton across journal / dispatch / venue detail with the unified PiArticleActions. Inline near byline + sticky bottom-right after 30% scroll. Both share the pi:saves:v2 store, so taps in one reflect in the other.