### PR TITLE
feat(saves): Wave 5 — editorial fork + printable plan

### DIFF
--- a/next/src/components/PiForkPlanButton.astro
+++ b/next/src/components/PiForkPlanButton.astro
@@ -1,0 +1,145 @@
+---
+/**
+ * PiForkPlanButton — "Save this plan as mine" for editorial itineraries.
+ *
+ * Wave 5 of the Save & Share rebuild. Editorial itineraries (Sorrento
+ * Off-Season Weekend, Ridge-to-Sea, etc.) are the closest thing
+ * Peninsula Insider has to a template. This button takes one, plus
+ * every venue / experience referenced in its stops, and forks the whole
+ * lot into the reader's pi:saves:v2 store. The reader can then edit,
+ * remove, share, or print as their own plan.
+ *
+ * The page passes a JSON-encoded array of `SavedItem`-shaped objects;
+ * the script reads them out of a data attribute and calls
+ * `Saves.merge(...)`. Duplicates are de-duped naturally by the unified
+ * store (kind + slug uniqueness).
+ */
+import type { SavedItem } from '../lib/saves/store';
+
+export interface Props {
+  /** Each fork target — typically the itinerary itself first, then every stop. */
+  items: Array<Omit<SavedItem, 'savedAt'>>;
+  /** Optional override for the button label. */
+  label?: string;
+}
+
+const { items, label = 'Save this plan as mine' } = Astro.props;
+const encoded = JSON.stringify(items);
+---
+
+<div class="pi-fork-plan">
+  <button
+    type="button"
+    class="pi-fork-plan__btn"
+    data-pi-fork-plan
+    data-pi-items={encoded}
+  >
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+    {label}
+  </button>
+  <p class="pi-fork-plan__hint">
+    Forks the itinerary plus every stop into your plan. Edit, share, or print from <a href="/account/saved/">your saves</a>.
+  </p>
+</div>
+
+<style is:global>
+  .pi-fork-plan {
+    margin: 1.5rem 0 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .pi-fork-plan__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.85rem 1.4rem;
+    background: var(--ink, #171413);
+    color: var(--paper, #FAF7F0);
+    border: 1px solid var(--ink, #171413);
+    border-radius: 100px;
+    font-family: 'Outfit', system-ui, sans-serif;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 0.18s ease, border-color 0.18s ease, transform 0.08s ease;
+  }
+
+  .pi-fork-plan__btn:hover {
+    background: var(--ochre, #A0541F);
+    border-color: var(--ochre, #A0541F);
+  }
+
+  .pi-fork-plan__btn:active { transform: scale(0.98); }
+
+  .pi-fork-plan__btn[data-state="forked"] {
+    background: var(--ochre, #A0541F);
+    border-color: var(--ochre, #A0541F);
+  }
+
+  .pi-fork-plan__hint {
+    font-family: var(--serif, 'Newsreader', Georgia, serif);
+    font-size: 0.85rem;
+    line-height: 1.45;
+    color: var(--ink-soft, #3A3531);
+    margin: 0;
+    max-width: 36rem;
+  }
+
+  .pi-fork-plan__hint a {
+    color: var(--ochre, #A0541F);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+</style>
+
+<script>
+  import * as Saves from '../lib/saves/store';
+
+  function bind() {
+    document.querySelectorAll<HTMLButtonElement>('[data-pi-fork-plan]').forEach((btn) => {
+      if ((btn as any)._piInit) return;
+      (btn as any)._piInit = true;
+      btn.addEventListener('click', () => {
+        let parsed: Array<Omit<Saves.SavedItem, 'savedAt'>> = [];
+        try {
+          parsed = JSON.parse(btn.dataset.piItems ?? '[]');
+        } catch { return; }
+        const now = Date.now();
+        const items: Saves.SavedItem[] = parsed.map((it) => ({ ...it, savedAt: now }));
+        const added = Saves.merge(items);
+        btn.setAttribute('data-state', 'forked');
+        showToast(
+          added > 0
+            ? `Saved ${added} ${added === 1 ? 'item' : 'items'} to your plan.`
+            : 'These are already in your plan.',
+        );
+      });
+    });
+  }
+
+  function showToast(message: string) {
+    let toast = document.querySelector<HTMLElement>('[data-pi-fork-toast]');
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.className = 'saved-toast';
+      toast.setAttribute('data-pi-fork-toast', '');
+      toast.setAttribute('role', 'status');
+      document.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.classList.add('saved-toast--visible');
+    setTimeout(() => toast?.classList.remove('saved-toast--visible'), 2400);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', bind);
+  else bind();
+  document.addEventListener('astro:page-load', bind);
+</script>

--- a/next/src/pages/account/saved.astro
+++ b/next/src/pages/account/saved.astro
@@ -33,9 +33,21 @@ import '../../styles/account.css';
           </svg>
           Share this plan
         </button>
+        <button type="button" class="saved-toolbar__btn saved-toolbar__btn--ghost" data-action="print-plan">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="6 9 6 2 18 2 18 9" />
+            <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+            <rect x="6" y="14" width="12" height="8" />
+          </svg>
+          Print
+        </button>
         <button type="button" class="saved-toolbar__btn saved-toolbar__btn--ghost" data-action="clear-plan">
           Clear all
         </button>
+      </div>
+      <div class="saved-print-mast" aria-hidden="true">
+        <span class="saved-print-mast__brand">Peninsula <em>Insider</em></span>
+        <span class="saved-print-mast__tag">My Peninsula plan · the independent editorial guide</span>
       </div>
 
       <div data-saved-groups class="saved-groups"></div>
@@ -172,6 +184,12 @@ import '../../styles/account.css';
       if (action === 'clear-plan') {
         if (!confirm('Clear every saved item? This can\'t be undone.')) return;
         Saves.clear();
+      }
+
+      if (action === 'print-plan') {
+        // Browser-native print pipeline. The @media print rules below strip
+        // chrome and render a one-pager that prints cleanly or saves as PDF.
+        window.print();
       }
     });
 
@@ -415,5 +433,107 @@ import '../../styles/account.css';
   .saved-toast--visible {
     opacity: 1;
     transform: translateX(-50%) translateY(0);
+  }
+
+  /* Print masthead is shown only on paper. The screen layout has its own
+     masthead higher up in the page. */
+  .saved-print-mast { display: none; }
+
+  @media print {
+    /* Hide everything that isn't the plan content. */
+    .masthead,
+    footer,
+    nav,
+    .v4-mobile-actions,
+    .pi-edit-toggle,
+    [data-pi-actions],
+    [data-pi-article-actions],
+    [data-pi-article-sticky],
+    .saved-toolbar,
+    .saved-toast,
+    .v2-account-page__nav,
+    .saved-card__remove,
+    .v2-account-page__lead {
+      display: none !important;
+    }
+
+    body, html { background: #fff !important; color: #000 !important; }
+    .v2-account-page { padding: 0 !important; min-height: 0 !important; background: #fff !important; }
+    .v2-account-page__container { max-width: 100% !important; padding: 0 1.5rem !important; }
+
+    .v2-account-page__eyebrow { font-size: 0.6rem !important; color: #6e655c !important; margin: 0 0 0.3rem !important; }
+    .v2-account-page__title { font-size: 1.6rem !important; margin: 0 0 1rem !important; }
+    .v2-account-page__title em { color: #a0541f !important; }
+
+    .saved-print-mast {
+      display: flex !important;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.6rem 0 1rem;
+      border-bottom: 1px solid #d9d1be;
+      margin-bottom: 1.5rem;
+    }
+
+    .saved-print-mast__brand {
+      font-family: var(--serif, 'Newsreader', Georgia, serif);
+      font-size: 1.05rem;
+      font-weight: 500;
+    }
+    .saved-print-mast__brand em {
+      font-style: italic;
+      color: #a0541f;
+      font-weight: 300;
+    }
+    .saved-print-mast__tag {
+      font-family: 'Outfit', system-ui, sans-serif;
+      font-size: 0.55rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: #6e655c;
+    }
+
+    .saved-groups { gap: 1.2rem !important; }
+    .saved-group__head { margin: 0 0 0.5rem !important; }
+    .saved-group__title { font-size: 0.95rem !important; }
+    .saved-group__eyebrow { color: #a0541f !important; }
+    .saved-group__count { color: #6e655c !important; }
+
+    .saved-group__grid {
+      grid-template-columns: 1fr 1fr !important;
+      gap: 0.5rem !important;
+    }
+
+    .saved-card {
+      grid-template-columns: 3.5rem 1fr !important;
+      gap: 0.65rem !important;
+      padding: 0.5rem !important;
+      border: 1px solid #d9d1be !important;
+      box-shadow: none !important;
+      transform: none !important;
+      page-break-inside: avoid;
+      break-inside: avoid;
+    }
+    .saved-card:hover {
+      border-color: #d9d1be !important;
+      transform: none !important;
+      box-shadow: none !important;
+    }
+    .saved-card__img {
+      aspect-ratio: 1 !important;
+      border-radius: 2px !important;
+    }
+    .saved-card__title { font-size: 0.78rem !important; margin: 0 0 0.2rem !important; }
+    .saved-card__dek { font-size: 0.65rem !important; -webkit-line-clamp: 2 !important; line-clamp: 2 !important; }
+    .saved-card__eyebrow { font-size: 0.5rem !important; }
+
+    /* Print URL after the title so a reader can re-find the page later. */
+    .saved-card::after {
+      content: "peninsulainsider.com.au" attr(href);
+      display: none; /* attr() in pseudo-content varies; we leave the href visible only when needed via a future enhancement. */
+    }
+
+    /* Newsletter / related blocks shouldn't appear on the print sheet. */
+    .v2-newsletter, .related-cards, .article-related, .editor-letter { display: none !important; }
   }
 </style>

--- a/next/src/pages/plans/[slug].astro
+++ b/next/src/pages/plans/[slug].astro
@@ -19,6 +19,7 @@ import ExperienceCard from '../../components/ExperienceCard.astro';
 import ItineraryCard from '../../components/ItineraryCard.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import PiForkPlanButton from '../../components/PiForkPlanButton.astro';
 import {
   routeSlug,
   stayTypes,
@@ -200,6 +201,53 @@ const relatedArticles = articles
 const relatedItineraries = allItineraries
   .filter((entry: any) => routeSlug(entry) !== slug)
   .slice(0, 4);
+
+// ─── Fork-plan items (Wave 5) ─────────────────────────────────────────────
+// Editorial itineraries become templates: a single tap merges the itinerary
+// itself plus every referenced venue and experience into the reader's
+// pi:saves:v2 store. They can then edit, share, or print as their own plan.
+type ForkItem = {
+  kind: 'article' | 'venue' | 'place' | 'event' | 'experience' | 'itinerary' | 'tour' | 'tour-operator' | 'tour-package';
+  slug: string;
+  section?: string;
+  title: string;
+  dek?: string;
+  image_url?: string;
+  href: string;
+};
+const forkItems: ForkItem[] = [];
+if (data) {
+  forkItems.push({
+    kind: 'itinerary',
+    slug,
+    title: data.title,
+    dek: data.dek,
+    image_url: data.heroImage?.src,
+    href: `/plans/${slug}/`,
+  });
+  for (const v of highlightedVenues) {
+    const vSlug = routeSlug(v as any);
+    forkItems.push({
+      kind: 'venue',
+      slug: vSlug,
+      title: (v as any).data.name,
+      dek: (v as any).data.signature || (v as any).data.editorNote,
+      image_url: (v as any).data.heroImage?.src,
+      href: `${venueHrefPrefix((v as any).data.type)}/${vSlug}/`,
+    });
+  }
+  for (const e of highlightedExperiences) {
+    const eSlug = routeSlug(e as any);
+    forkItems.push({
+      kind: 'experience',
+      slug: eSlug,
+      title: (e as any).data.name,
+      dek: (e as any).data.editorNote,
+      image_url: (e as any).data.heroImage?.src,
+      href: `/explore/${eSlug}/`,
+    });
+  }
+}
 
 // ─── Display labels ───────────────────────────────────────────────────────
 const duration = data ? deriveDuration(data) : null;
@@ -423,6 +471,10 @@ const ogImage = data
           <span class="itinerary-detail__cta-note">Anchor stay for this plan</span>
         </div>
       )}
+
+      {/* Fork this editorial plan into the reader's saves. Wave 5 of the
+          Save & Share rebuild — editorial content as a template. */}
+      <PiForkPlanButton items={forkItems} />
 
       <div
         class="itinerary-detail__hero feature__image-block feature__image-block--sand"


### PR DESCRIPTION
Fifth and final wave of the Save & Share rebuild. PiForkPlanButton turns editorial itineraries into templates; print stylesheet on /account/saved/ lets the reader save-as-PDF or print a one-pager via the browser's native print dialog.