### PR TITLE
feat(cms): rock-solid integrity system — entity-scoped editing + referential integrity + CI enforcement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,24 @@ jobs:
         run: |
           node ops/scripts/deploy-preflight.mjs --skip-env
 
+      - name: Enforce CMS editor conventions (CMS Integrity Plan, Phase 3)
+        # Fails the build if any *Card.astro or PiSaveActions consumer is
+        # missing the entity-scoped editor attrs. Stops the filename-keyed
+        # auto-detect bug from reappearing under a new card type.
+        run: |
+          node scripts/check-editable-coverage.mjs
+
+      - name: Refresh CMS content registry (CMS Integrity Plan, Phase 1)
+        # Populates pi.content_registry with the current set of valid
+        # (entity_type, entity_slug) pairs. The CMS write triggers refuse
+        # writes that don't match a row here, so this must run before any
+        # editor uses the inline editor.
+        env:
+          SUPABASE_URL: ${{ vars.PUBLIC_SUPABASE_URL || secrets.PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          node scripts/refresh-content-registry.mjs
+
       - name: Build Astro site
         working-directory: next
         env:

--- a/next/src/components/EventCard.astro
+++ b/next/src/components/EventCard.astro
@@ -9,6 +9,7 @@
 import EventBadges from './EventBadges.astro';
 import PiSaveActions from './PiSaveActions.astro';
 import { eventCategoryLabel, eventDateLabel, routeSlug } from '../lib/editorial';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 export interface Props {
   event: any;
@@ -41,7 +42,18 @@ const placeHref = placeId ? `/places/${placeId}/` : null;
 
 <article class={`event-card ${featured ? 'event-card--featured' : ''}`}>
   {event.data.heroImage?.src && (
-    <div class="event-card__hero" style={`background-image: url(${event.data.heroImage.src}); background-size: cover; background-position: center;`} aria-hidden="true"></div>
+    <div
+      class="event-card__hero"
+      style={`background-image: url(${event.data.heroImage.src}); background-size: cover; background-position: center;`}
+      aria-hidden="true"
+      {...editableImage({
+        entityType: 'event',
+        entitySlug: slug,
+        fieldPath: 'hero',
+        label: `${event.data.title} hero`,
+        purpose: 'hero',
+      })}
+    ></div>
   )}
   <div class="event-card__top">
     <span class="event-card__date">{dateLabel}</span>

--- a/next/src/components/ExperienceCard.astro
+++ b/next/src/components/ExperienceCard.astro
@@ -1,6 +1,7 @@
 ---
 import { placeLabel, titleize, routeSlug, heroBackgroundStyle } from '../lib/editorial';
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 const difficultyLabel: Record<string, string> = {
   easy: 'Easy',
@@ -34,7 +35,18 @@ const imgStyle = heroBackgroundStyle(data);
 ---
 
 <article class="experience-card">
-  <div class={`experience-card__visual experience-card__visual--${data.type}`} aria-hidden="true" style={imgStyle}>
+  <div
+    class={`experience-card__visual experience-card__visual--${data.type}`}
+    aria-hidden="true"
+    style={imgStyle}
+    {...editableImage({
+      entityType: 'experience',
+      entitySlug: slug,
+      fieldPath: 'hero',
+      label: `${data.name} hero`,
+      purpose: 'hero',
+    })}
+  >
     <div class="experience-card__fog"></div>
     <span class="experience-card__tag">{typeLabel[data.type] ?? titleize(data.type)}</span>
   </div>

--- a/next/src/components/ItineraryCard.astro
+++ b/next/src/components/ItineraryCard.astro
@@ -1,6 +1,7 @@
 ---
 import { routeSlug, heroBackgroundStyle } from '../lib/editorial';
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 const audienceLabel: Record<string, string> = {
   couple: 'Couples',
@@ -32,7 +33,18 @@ const nightsLabel = `${data.lengthNights} night${data.lengthNights === 1 ? '' : 
 
 <article class="itinerary-card">
   {data.heroImage && (
-    <div class="itinerary-card__hero" style={heroBackgroundStyle(data)} aria-hidden="true"></div>
+    <div
+      class="itinerary-card__hero"
+      style={heroBackgroundStyle(data)}
+      aria-hidden="true"
+      {...editableImage({
+        entityType: 'itinerary',
+        entitySlug: slug,
+        fieldPath: 'hero',
+        label: `${data.title} hero`,
+        purpose: 'hero',
+      })}
+    ></div>
   )}
   <div class="itinerary-card__top">
     <span class="itinerary-card__label">Escape plan</span>

--- a/next/src/components/PlaceCard.astro
+++ b/next/src/components/PlaceCard.astro
@@ -11,6 +11,7 @@ export interface Props {
 
 import { heroBackgroundStyle } from '../lib/editorial';
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 const { place, variant = 'vineyard' } = Astro.props;
 const data = place.data;
@@ -34,7 +35,18 @@ const heroSrc = heroMatch ? heroMatch[1].replace(/^['"]|['"]$/g, '') : undefined
 ---
 
 <article class="place-card">
-  <div class={imgClass} aria-hidden="true" style={imgStyle}></div>
+  <div
+    class={imgClass}
+    aria-hidden="true"
+    style={imgStyle}
+    {...editableImage({
+      entityType: 'place',
+      entitySlug: slug,
+      fieldPath: 'hero',
+      label: `${data.name} hero`,
+      purpose: 'hero',
+    })}
+  ></div>
   <div class="place-card__body">
     <p class="place-card__zone">{zoneLabel} · {data.kind}</p>
     <h3 class="place-card__name">

--- a/next/src/components/TourCard.astro
+++ b/next/src/components/TourCard.astro
@@ -5,6 +5,7 @@
  */
 
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 export interface Props {
   tour: any;
@@ -60,7 +61,19 @@ const priceDisplay = data.priceLow
   {data.heroImage?.src && (
     <div class="tour-card__image">
       <a href={href} tabindex="-1" aria-hidden="true">
-        <img src={data.heroImage.src} alt={data.heroImage.alt ?? data.name} loading="lazy" decoding="async" />
+        <img
+          src={data.heroImage.src}
+          alt={data.heroImage.alt ?? data.name}
+          loading="lazy"
+          decoding="async"
+          {...editableImage({
+            entityType: 'tour',
+            entitySlug: slug,
+            fieldPath: 'hero',
+            label: `${data.name} hero`,
+            purpose: 'hero',
+          })}
+        />
       </a>
     </div>
   )}

--- a/next/src/components/TourOperatorCard.astro
+++ b/next/src/components/TourOperatorCard.astro
@@ -5,6 +5,7 @@
  */
 
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 export interface Props {
   operator: any;
@@ -33,7 +34,19 @@ const excerpt = data.intro
   {data.heroImage?.src && (
     <div class="tour-card__image">
       <a href={href} tabindex="-1" aria-hidden="true">
-        <img src={data.heroImage.src} alt={data.heroImage.alt ?? data.name} loading="lazy" decoding="async" />
+        <img
+          src={data.heroImage.src}
+          alt={data.heroImage.alt ?? data.name}
+          loading="lazy"
+          decoding="async"
+          {...editableImage({
+            entityType: 'tour-operator',
+            entitySlug: slug,
+            fieldPath: 'hero',
+            label: `${data.name} hero`,
+            purpose: 'hero',
+          })}
+        />
       </a>
     </div>
   )}

--- a/next/src/components/TourPackageCard.astro
+++ b/next/src/components/TourPackageCard.astro
@@ -5,6 +5,7 @@
  */
 
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 export interface Props {
   pkg: any;
@@ -54,7 +55,19 @@ const priceDisplay = data.priceLow
   {data.heroImage?.src && (
     <div class="tour-card__image">
       <a href={href} tabindex="-1" aria-hidden="true">
-        <img src={data.heroImage.src} alt={data.heroImage.alt ?? data.name} loading="lazy" decoding="async" />
+        <img
+          src={data.heroImage.src}
+          alt={data.heroImage.alt ?? data.name}
+          loading="lazy"
+          decoding="async"
+          {...editableImage({
+            entityType: 'tour-package',
+            entitySlug: slug,
+            fieldPath: 'hero',
+            label: `${data.name} hero`,
+            purpose: 'hero',
+          })}
+        />
       </a>
     </div>
   )}

--- a/next/src/components/VenueCard.astro
+++ b/next/src/components/VenueCard.astro
@@ -9,6 +9,7 @@
 import { resolveHeroSrc } from '../lib/editorial';
 import { verifiedFreshnessLabel, verificationFreshness } from '../lib/venues';
 import PiSaveActions from './PiSaveActions.astro';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 const typeLabel: Record<string, string> = {
   restaurant:  'Restaurant',
@@ -55,7 +56,20 @@ const verifiedTier = verificationFreshness(data.lastVerified);
 
 <article class="venue-card">
   <div class="venue-card__wash"></div>
-  <a href={href} class="venue-card__hero" aria-hidden="true" tabindex="-1" style={`background-image: url(${heroSrc})`}></a>
+  <a
+    href={href}
+    class="venue-card__hero"
+    aria-hidden="true"
+    tabindex="-1"
+    style={`background-image: url(${heroSrc})`}
+    {...editableImage({
+      entityType: 'venue',
+      entitySlug: slug,
+      fieldPath: 'hero',
+      label: `${data.name} hero`,
+      purpose: 'hero',
+    })}
+  ></a>
   <div class="venue-card__top">
     <span class="venue-card__type">
       {typeLabel[data.type] ?? data.type}

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -8,6 +8,8 @@ import ArticleCard from './ArticleCard.astro';
 import ItineraryCard from './ItineraryCard.astro';
 import PiArticleActions from './PiArticleActions.astro';
 import CorrectionNote from './CorrectionNote.astro';
+import { loadOverrides } from '../lib/inline-edit/overrides';
+import { editableImage } from '../lib/inline-edit/attrs';
 
 export interface Props {
   venue: any;
@@ -27,7 +29,16 @@ const hats = data.authority?.hats ?? 0;
 const awards = data.authority?.awards ?? [];
 const pressMentions = data.authority?.pressMentions ?? [];
 const heroLabel = `${data.name} · ${placeLabel(data.place)}`;
-const heroStyle = heroBackgroundStyle(data);
+
+// Per-venue CMS override consult. If an editor has uploaded a venue-specific
+// hero via the inline editor, it wins over the content-JSON default.
+const venueSlug = venue.id ?? data.slug;
+const venueOverrides = await loadOverrides('venue', venueSlug);
+const overrideHero = venueOverrides.image['hero'];
+const heroStyle = overrideHero?.src
+  ? `background-image: url('${overrideHero.src.replace(/["\\]/g, (m: string) => `\\${m}`)}'); background-size: cover; background-position: center;`
+  : heroBackgroundStyle(data);
+const heroAlt = overrideHero?.alt ?? data.heroImage?.alt ?? heroLabel;
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
@@ -90,7 +101,19 @@ const isClosed = data.status === 'closed';
       </div>
     )}
 
-    <div class="venue-detail__hero" aria-hidden="true" style={heroStyle}>
+    <div
+      class="venue-detail__hero"
+      aria-hidden="true"
+      style={heroStyle}
+      aria-label={heroAlt}
+      {...editableImage({
+        entityType: 'venue',
+        entitySlug: venueSlug,
+        fieldPath: 'hero',
+        label: `${data.name} hero`,
+        purpose: 'hero',
+      })}
+    >
       <div class="venue-detail__hero-fog"></div>
       <span class="venue-detail__hero-label">{heroLabel}</span>
     </div>

--- a/next/src/lib/inline-edit/client.ts
+++ b/next/src/lib/inline-edit/client.ts
@@ -759,18 +759,60 @@ async function replaceImage(el: HTMLElement, desc: ImageDescriptor, file: File) 
 // --------------------------------------------------------------------------
 
 /**
- * After every page load, fetch any published image overrides for the current
- * page slug and patch matching `<img>` srcs in place. Lets auto-detected
- * image replacements appear without a site rebuild.
+ * After every page load, fetch any published image overrides relevant to the
+ * elements actually on this page and patch their srcs in place. Two passes:
  *
- * The match is by src basename — the same stable key the editor uses when
- * saving an override. Only `entity_type='page', entity_slug=currentPageSlug()`
- * rows are considered.
+ *   1. Explicit pass — every `[data-pi-edit="image"]` element declares its
+ *      identity via `data-pi-entity-type` / `data-pi-entity-slug` /
+ *      `data-pi-field-path`. Group those by `(entity_type, entity_slug)`,
+ *      run one query per group, apply matches by exact field_path.
+ *
+ *   2. Implicit pass — for untagged `<img>` and bg-image elements, fall back
+ *      to the legacy `(page, currentPageSlug(), img:<basename>)` lookup so
+ *      inline article photos and other one-offs still benefit from auto-
+ *      detect replacements.
  */
 async function applyOverridesOnLoad() {
   const supa = getSupabase();
   if (!supa) return;
 
+  // ── Explicit pass ────────────────────────────────────────────────────────
+  const taggedEls = document.querySelectorAll<HTMLElement>('[data-pi-edit="image"][data-pi-entity-slug][data-pi-field-path]');
+  const groups = new Map<string, { entityType: string; entitySlug: string; els: HTMLElement[] }>();
+  taggedEls.forEach((el) => {
+    const entityType = el.dataset.piEntityType;
+    const entitySlug = el.dataset.piEntitySlug;
+    if (!entityType || !entitySlug) return;
+    const key = `${entityType}/${entitySlug}`;
+    const group = groups.get(key) ?? { entityType, entitySlug, els: [] };
+    group.els.push(el);
+    groups.set(key, group);
+  });
+
+  await Promise.all(Array.from(groups.values()).map(async (group) => {
+    const { data } = await supa
+      .from('cms_image_slots')
+      .select('field_path, public_url, alt_text')
+      .eq('entity_type', group.entityType)
+      .eq('entity_slug', group.entitySlug)
+      .eq('status', 'published');
+    const rows = (data as Array<{ field_path: string; public_url: string | null; alt_text: string | null }> | null) ?? [];
+    const byPath = new Map(rows.map((r) => [r.field_path, r]));
+    for (const el of group.els) {
+      const fieldPath = el.dataset.piFieldPath;
+      if (!fieldPath) continue;
+      const row = byPath.get(fieldPath);
+      if (!row?.public_url) continue;
+      if (currentImageSrc(el) === row.public_url) continue;
+      setImageSrc(el, row.public_url);
+      if (row.alt_text) {
+        if (el instanceof HTMLImageElement) el.alt = row.alt_text;
+        else el.setAttribute('aria-label', row.alt_text);
+      }
+    }
+  }));
+
+  // ── Implicit pass ────────────────────────────────────────────────────────
   const entitySlug = currentPageSlug();
   const { data } = await supa
     .from('cms_image_slots')

--- a/ops/migrations/2026-05-11-pi-cms-content-registry-and-referential-integrity.sql
+++ b/ops/migrations/2026-05-11-pi-cms-content-registry-and-referential-integrity.sql
@@ -1,0 +1,104 @@
+-- Phase 1 of the CMS Integrity Plan, 2026-05-11.
+--
+-- Establishes pi.content_registry as the canonical list of every
+-- (entity_type, entity_slug) the live site renders, with a referential-
+-- integrity trigger that refuses CMS writes for unknown entities.
+--
+-- Applied to Supabase project tjjhpvslpysfklwpqmgz via MCP migration
+-- 20260511115516_pi_cms_content_registry_and_referential_integrity.
+-- This file is the source-of-truth checked into the repo.
+--
+-- Companion build-time script: scripts/refresh-content-registry.mjs
+-- (walks the Astro content collections at deploy time and upserts here).
+
+create table if not exists pi.content_registry (
+  entity_type text not null check (entity_type in (
+    'article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary',
+    'tour', 'tour-operator', 'tour-package'
+  )),
+  entity_slug text not null,
+  title       text,
+  href        text,
+  refreshed_at timestamptz not null default now(),
+  primary key (entity_type, entity_slug)
+);
+
+comment on table pi.content_registry is 'Canonical list of every (entity_type, entity_slug) the site renders. Refreshed at deploy time from Astro content collections. cms_image_slots and cms_text_fields reject writes that do not match a row here.';
+
+create index if not exists content_registry_refreshed_at_idx
+  on pi.content_registry (refreshed_at desc);
+
+-- Extend entity_type CHECK to cover tour kinds — the original cms_image_slots
+-- schema only knew about article/page/event/place/venue/experience/itinerary.
+alter table pi.cms_image_slots drop constraint if exists cms_image_slots_entity_type_check;
+alter table pi.cms_image_slots
+  add constraint cms_image_slots_entity_type_check
+  check (entity_type in (
+    'article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary',
+    'tour', 'tour-operator', 'tour-package'
+  ));
+
+alter table pi.cms_text_fields drop constraint if exists cms_text_fields_entity_type_check;
+alter table pi.cms_text_fields
+  add constraint cms_text_fields_entity_type_check
+  check (entity_type in (
+    'article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary',
+    'tour', 'tour-operator', 'tour-package'
+  ));
+
+create or replace function pi.assert_content_registry_match()
+returns trigger
+language plpgsql
+security definer
+set search_path = pi, public, pg_catalog
+as $$
+begin
+  if not exists (
+    select 1 from pi.content_registry r
+     where r.entity_type = new.entity_type
+       and r.entity_slug = new.entity_slug
+  ) then
+    raise exception
+      'CMS override for (%, %) refused: no matching row in pi.content_registry. Run the deploy-time content registry refresh, or use a valid entity.',
+      new.entity_type, new.entity_slug
+      using errcode = 'foreign_key_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists cms_image_slots_registry_check on pi.cms_image_slots;
+create trigger cms_image_slots_registry_check
+  before insert or update on pi.cms_image_slots
+  for each row execute function pi.assert_content_registry_match();
+
+drop trigger if exists cms_text_fields_registry_check on pi.cms_text_fields;
+create trigger cms_text_fields_registry_check
+  before insert or update on pi.cms_text_fields
+  for each row execute function pi.assert_content_registry_match();
+
+-- Public read of the registry — useful for the inline editor to enumerate
+-- valid entities. No write policies; only the service role writes here.
+alter table pi.content_registry enable row level security;
+
+drop policy if exists "content_registry_public_select" on pi.content_registry;
+create policy "content_registry_public_select"
+  on pi.content_registry for select
+  to anon, authenticated
+  using (true);
+
+-- Seed the static page rows. Collection-backed rows (venue/place/event/etc.)
+-- are populated by scripts/refresh-content-registry.mjs at deploy time.
+insert into pi.content_registry (entity_type, entity_slug, title, href)
+values
+  ('page', 'home',                'Homepage',              '/'),
+  ('page', '_global',             'Site-wide editorial',   null),
+  ('page', 'wine',                'Wine landing',          '/wine/'),
+  ('page', 'eat',                 'Eat landing',           '/eat/'),
+  ('page', 'stay',                'Stay landing',          '/stay/'),
+  ('page', 'explore',             'Explore landing',       '/explore/'),
+  ('page', 'plans',               'Plans landing',         '/plans/'),
+  ('page', 'whats-on',            'What''s On landing',    '/whats-on/'),
+  ('page', 'journal',             'Journal landing',       '/journal/'),
+  ('page', 'wine-cellar-doors',   'Wine cellar doors',     '/wine/cellar-doors/')
+on conflict (entity_type, entity_slug) do nothing;

--- a/ops/migrations/README.md
+++ b/ops/migrations/README.md
@@ -56,6 +56,20 @@ the `tjjhpvslpysfklwpqmgz` project:
      The CloudSync layer uses `upsert(..., { onConflict })` which can
      trigger an UPDATE; the previous policy set only allowed
      INSERT/SELECT/DELETE.
+6. `2026-05-11-pi-cms-content-registry-and-referential-integrity.sql`
+   - **Phase 1 of the CMS Integrity Plan.** Eliminates the shared-image-
+     across-venues bug class by making entity overrides referential.
+   - Creates `pi.content_registry` — the canonical list of every
+     `(entity_type, entity_slug)` the live site renders.
+   - Adds a `before insert or update` trigger on
+     `pi.cms_image_slots` / `pi.cms_text_fields` that raises
+     `foreign_key_violation` when the override targets an unknown entity.
+   - Extends both tables' `entity_type` CHECK to include `tour`,
+     `tour-operator`, `tour-package` (previously rejected at write time).
+   - Seeds the static `page` rows. Collection-backed rows
+     (venue/place/event/experience/itinerary/article/tour/tour-operator/
+     tour-package) are populated by
+     `scripts/refresh-content-registry.mjs` at every deploy.
 
 > **Note (2026-05-11):** the original `2026-05-09-pi-cms-admin.sql` declared
 > `unique (entity_type, entity_slug, field_path, coalesce(locale, ''))` as an

--- a/scripts/check-editable-coverage.mjs
+++ b/scripts/check-editable-coverage.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-editable-coverage.mjs
+ *
+ * Build-time enforcement of CMS editor conventions. Fails the build if a
+ * card component is missing the inline-editor tagging the architecture
+ * requires. The goal is that future developers (and future-me, and future
+ * Claude) cannot regress the system back to the auto-detect anti-pattern
+ * that caused the 2026-05-11 "same image across many venues" bug.
+ *
+ * Rules enforced:
+ *
+ *   1. Every `*Card.astro` component under next/src/components/ must call
+ *      `editableImage(...)` somewhere in its template. The hero element
+ *      must be tagged with entity-scoped attrs so inline-editor uploads
+ *      key on the entity, not on the image filename.
+ *
+ *   2. The `entityType` argument to `editableImage(...)` must use one of
+ *      the canonical kinds: article, venue, place, event, experience,
+ *      itinerary, tour, tour-operator, tour-package.
+ *
+ *   3. The hero `fieldPath` should be `'hero'` (convention). Other paths
+ *      are allowed but a warning is printed.
+ *
+ * Exit code 0 = pass. Exit code 1 = blocking error. Warnings print and
+ * pass.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const COMPONENTS_DIR = path.resolve(__dirname, '../next/src/components');
+
+const VALID_KINDS = new Set([
+  'article', 'venue', 'place', 'event', 'experience', 'itinerary',
+  'tour', 'tour-operator', 'tour-package',
+]);
+
+// Card components that legitimately have no hero image (e.g. text-only
+// editorial cards). They're exempt from the editableImage requirement
+// but still must use PiSaveActions for the save+share affordance.
+const HERO_EXEMPT = new Set([
+  'ArticleCard.astro',  // text-only editorial variant
+]);
+
+// Card components that aren't actually CMS-editable surfaces — typically
+// older v3 chrome no longer rendered. They're exempt from both checks.
+const SKIP_ENTIRELY = new Set([
+  // v3 cards we deliberately don't bother re-tagging; the V3 chrome is
+  // a parallel design system we may deprecate. If you uncomment and
+  // re-introduce them, remove them from this list.
+  'v3/V3EditorialCard.astro',
+  'v3/V3EntityCard.astro',
+  'v3/V3EventCard.astro',
+]);
+
+const errors = [];
+const warnings = [];
+
+async function walk(dir, rel = '') {
+  const found = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    const r = path.posix.join(rel, e.name);
+    if (e.isDirectory()) {
+      const nested = await walk(full, r);
+      found.push(...nested);
+    } else if (e.isFile() && /Card\.astro$/.test(e.name)) {
+      found.push({ rel: r, full });
+    }
+  }
+  return found;
+}
+
+function reportPath(rel) {
+  return path.posix.join('next/src/components', rel);
+}
+
+async function checkCard(card) {
+  if (SKIP_ENTIRELY.has(card.rel)) return;
+  const src = await fs.readFile(card.full, 'utf-8');
+
+  // Rule 1: PiSaveActions usage. Every card surfaces save + share.
+  if (!/<PiSaveActions\b/.test(src)) {
+    errors.push(`${reportPath(card.rel)}: missing <PiSaveActions .../> mount. Every card must have the save+share affordance.`);
+  }
+
+  // Rule 2: editableImage tagging on the hero. Hero-exempt cards are
+  // skipped here (text-only editorial layouts).
+  if (HERO_EXEMPT.has(card.rel)) return;
+
+  const editableImageCalls = [...src.matchAll(/editableImage\s*\(\s*{([\s\S]*?)}\s*\)/g)];
+  if (editableImageCalls.length === 0) {
+    errors.push(`${reportPath(card.rel)}: hero element is not tagged with editableImage({...}). Filename-keyed auto-detect is the bug we're preventing — every card hero must carry entity-scoped attrs.`);
+    return;
+  }
+
+  for (const [, args] of editableImageCalls) {
+    const kindMatch = args.match(/entityType\s*:\s*['"]([^'"]+)['"]/);
+    if (!kindMatch) {
+      errors.push(`${reportPath(card.rel)}: editableImage() call missing 'entityType'.`);
+      continue;
+    }
+    const kind = kindMatch[1];
+    if (!VALID_KINDS.has(kind)) {
+      errors.push(`${reportPath(card.rel)}: editableImage() entityType="${kind}" is not in the canonical list (${[...VALID_KINDS].join(', ')}).`);
+    }
+
+    const slugMatch = args.match(/entitySlug\s*:\s*([^,]+),/);
+    if (!slugMatch) {
+      errors.push(`${reportPath(card.rel)}: editableImage() call missing 'entitySlug'.`);
+    }
+
+    const fieldMatch = args.match(/fieldPath\s*:\s*['"]([^'"]+)['"]/);
+    if (!fieldMatch) {
+      errors.push(`${reportPath(card.rel)}: editableImage() call missing 'fieldPath'.`);
+    } else if (fieldMatch[1] !== 'hero' && !/^hero\.|^image$/.test(fieldMatch[1])) {
+      warnings.push(`${reportPath(card.rel)}: editableImage() fieldPath="${fieldMatch[1]}" — convention is 'hero' for the primary card image.`);
+    }
+  }
+}
+
+async function main() {
+  const cards = await walk(COMPONENTS_DIR);
+  for (const card of cards) await checkCard(card);
+
+  console.log(`[editable-coverage] checked ${cards.length} *Card.astro components`);
+
+  if (warnings.length > 0) {
+    console.log('');
+    console.log(`[editable-coverage] ${warnings.length} warning(s):`);
+    for (const w of warnings) console.log(`  warn: ${w}`);
+  }
+
+  if (errors.length > 0) {
+    console.log('');
+    console.error(`[editable-coverage] ${errors.length} error(s):`);
+    for (const e of errors) console.error(`  fail: ${e}`);
+    console.error('');
+    console.error('CMS conventions failed. See docs/cms-architecture.md for the rules.');
+    process.exit(1);
+  }
+
+  console.log('[editable-coverage] all cards conform.');
+}
+
+main().catch((err) => {
+  console.error('[editable-coverage] fatal:', err);
+  process.exit(1);
+});

--- a/scripts/refresh-content-registry.mjs
+++ b/scripts/refresh-content-registry.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * scripts/refresh-content-registry.mjs
+ *
+ * Walks the Astro content collections under next/src/content/ and writes
+ * one row to pi.content_registry per content entity. Run in CI on every
+ * deploy, before the Astro build step, so the database always knows the
+ * exact set of valid (entity_type, entity_slug) pairs the site will
+ * render.
+ *
+ * Without this, the CMS referential-integrity trigger on cms_image_slots
+ * / cms_text_fields will refuse writes for any entity it can't see — so
+ * if this script doesn't run, editors can't save new overrides.
+ *
+ * Requires:
+ *   SUPABASE_URL              — project URL
+ *   SUPABASE_SERVICE_ROLE_KEY — service-role key (writes bypass RLS)
+ *
+ * Both are configured in the GitHub Actions workflow as repo secrets.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONTENT_ROOT = path.resolve(__dirname, '../next/src/content');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('[content-registry] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in env. Skipping refresh.');
+  process.exit(0); // soft-exit so a missing key doesn't break local dev builds
+}
+
+/**
+ * Mapping from on-disk collection directory to the entity_type the CMS
+ * schema uses, plus the href prefix for the registry row. Add new
+ * collections here when you add them to next/src/content.config.ts.
+ */
+const COLLECTIONS = [
+  { dir: 'venues',       entityType: 'venue',         hrefPrefix: null    /* venue href varies by section; we don't store it */ },
+  { dir: 'places',       entityType: 'place',         hrefPrefix: '/places/' },
+  { dir: 'events',       entityType: 'event',         hrefPrefix: '/whats-on/' },
+  { dir: 'experiences',  entityType: 'experience',    hrefPrefix: '/explore/' },
+  { dir: 'itineraries',  entityType: 'itinerary',     hrefPrefix: '/plans/' },
+  { dir: 'articles',     entityType: 'article',       hrefPrefix: null    /* article href derives from section */ },
+  { dir: 'tours',        entityType: 'tour',          hrefPrefix: '/tour/' },
+  { dir: 'tourOperators', entityType: 'tour-operator', hrefPrefix: '/tour/operators/' },
+  { dir: 'tourPackages', entityType: 'tour-package',  hrefPrefix: '/tour-packages/' },
+];
+
+/**
+ * Static page entries — landing pages and editorial chrome that live
+ * outside the content collections. Keep this list in sync with the
+ * pages an editor can actually open in the inline editor.
+ */
+const STATIC_PAGES = [
+  { entitySlug: 'home',                title: 'Homepage',              href: '/' },
+  { entitySlug: '_global',             title: 'Site-wide editorial',   href: null },
+  { entitySlug: 'wine',                title: 'Wine landing',          href: '/wine/' },
+  { entitySlug: 'eat',                 title: 'Eat landing',           href: '/eat/' },
+  { entitySlug: 'stay',                title: 'Stay landing',          href: '/stay/' },
+  { entitySlug: 'explore',             title: 'Explore landing',       href: '/explore/' },
+  { entitySlug: 'plans',               title: 'Plans landing',         href: '/plans/' },
+  { entitySlug: 'whats-on',            title: "What's On landing",     href: '/whats-on/' },
+  { entitySlug: 'journal',             title: 'Journal landing',       href: '/journal/' },
+  { entitySlug: 'wine-cellar-doors',   title: 'Wine cellar doors',     href: '/wine/cellar-doors/' },
+];
+
+async function collectFromDir(collection) {
+  const dir = path.join(CONTENT_ROOT, collection.dir);
+  let entries;
+  try {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.warn(`[content-registry] skipped ${collection.dir} (missing dir)`);
+      return [];
+    }
+    throw err;
+  }
+
+  const rows = [];
+  for (const file of entries) {
+    if (!file.endsWith('.json') && !file.endsWith('.md') && !file.endsWith('.mdx')) continue;
+    const slug = file.replace(/\.(json|md|mdx)$/, '');
+    const full = path.join(dir, file);
+    let title = null;
+    try {
+      const raw = await fs.readFile(full, 'utf-8');
+      if (file.endsWith('.json')) {
+        const parsed = JSON.parse(raw);
+        title = parsed.name ?? parsed.title ?? null;
+      } else {
+        const m = raw.match(/^---[\s\S]*?\btitle:\s*['"]?([^'"\n]+)/);
+        if (m) title = m[1].trim();
+      }
+    } catch { /* leave title null */ }
+    rows.push({
+      entity_type: collection.entityType,
+      entity_slug: slug,
+      title,
+      href: collection.hrefPrefix ? `${collection.hrefPrefix}${slug}/` : null,
+    });
+  }
+  return rows;
+}
+
+async function main() {
+  const rows = [];
+  for (const collection of COLLECTIONS) {
+    const collected = await collectFromDir(collection);
+    rows.push(...collected);
+    console.log(`[content-registry] ${collection.entityType}: ${collected.length} entries`);
+  }
+  for (const page of STATIC_PAGES) {
+    rows.push({ entity_type: 'page', ...page });
+  }
+
+  console.log(`[content-registry] total rows to upsert: ${rows.length}`);
+
+  // Upsert in chunks of 500 so we stay well under PostgREST's request-size cap.
+  const CHUNK = 500;
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    const slice = rows.slice(i, i + CHUNK);
+    const resp = await fetch(`${SUPABASE_URL}/rest/v1/content_registry?on_conflict=entity_type,entity_slug`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${SERVICE_KEY}`,
+        'apikey': SERVICE_KEY,
+        'Prefer': 'resolution=merge-duplicates,return=minimal',
+        'Content-Profile': 'pi',
+      },
+      body: JSON.stringify(slice.map((r) => ({ ...r, refreshed_at: new Date().toISOString() }))),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      console.error(`[content-registry] upsert chunk ${i / CHUNK} failed (${resp.status}):`, body);
+      process.exit(1);
+    }
+  }
+
+  // Prune rows whose entity_type/entity_slug pair was not in this run —
+  // i.e., content entities deleted from the collections. We do this by
+  // pulling the current refreshed_at watermark and deleting anything
+  // older than 10 seconds. Safer than a full delete-then-insert.
+  const watermark = new Date(Date.now() - 10_000).toISOString();
+  const delResp = await fetch(`${SUPABASE_URL}/rest/v1/content_registry?refreshed_at=lt.${watermark}`, {
+    method: 'DELETE',
+    headers: {
+      'Authorization': `Bearer ${SERVICE_KEY}`,
+      'apikey': SERVICE_KEY,
+      'Content-Profile': 'pi',
+      'Prefer': 'return=representation',
+    },
+  });
+  if (!delResp.ok) {
+    const body = await delResp.text();
+    console.error(`[content-registry] prune failed (${delResp.status}):`, body);
+    process.exit(1);
+  }
+  const deleted = await delResp.json();
+  console.log(`[content-registry] pruned ${deleted.length} stale rows`);
+  console.log('[content-registry] refresh complete.');
+}
+
+main().catch((err) => {
+  console.error('[content-registry] fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes the **shared-image-across-venues** bug class permanently. Builds the rock-solid CMS integrity system James approved. Three phases (0+1+3) ship together; phases 2 (storage tombstones) and 5 (docs) follow in separate PRs.

### Phase 0 — Entity-scoped tagging
- All 8 card components (`VenueCard`, `PlaceCard`, `EventCard`, `ExperienceCard`, `ItineraryCard`, `TourCard`, `TourOperatorCard`, `TourPackageCard`) tag their hero with `editableImage({ entityType, entitySlug, fieldPath: 'hero', ... })`. Overrides now key on entity, not on src basename.
- `VenueDetailTemplate.astro` consults `loadOverrides('venue', slug)` at build time and applies the per-venue override before the content-JSON default.
- `inline-edit/client.ts` `applyOverridesOnLoad` now: explicit pass first (group tagged elements by `entity_type/entity_slug`, one query per group, exact `field_path` match) → fallback implicit pass for untagged `<img>` and bg-image elements (preserves legacy behaviour for inline article photos).

### Phase 1 — Referential integrity
- `pi.content_registry` (migrated separately to Supabase) is the authoritative list of `(entity_type, entity_slug)` pairs the site renders. Trigger on `cms_image_slots` / `cms_text_fields` refuses writes for unknown entities, so future stale-slug bugs cannot land.
- `scripts/refresh-content-registry.mjs` — deploy-time script, walks the Astro content collections + static pages, upserts all rows with `refreshed_at = now()`, then prunes rows older than 10s. Service-role key required.
- Entity-type CHECK extended to include `tour`, `tour-operator`, `tour-package`.

### Phase 3 — CI convention enforcement
- `scripts/check-editable-coverage.mjs` walks `next/src/components/**/*Card.astro` and fails the build if any card is missing `<PiSaveActions />` or `editableImage(...)`, or if a call has an unknown `entityType`. **Future devs cannot regress to filename-keyed auto-detect.**
- Wired into `.github/workflows/deploy.yml` as two new steps:
  - **Enforce CMS editor conventions** (before build)
  - **Refresh CMS content registry** (before site upload, with Supabase service-role secret)

### State of database (already applied via MCP)
- `pi.content_registry` table created with trigger + extended CHECK.
- 516 entities seeded: 154 venue · 173 article · 91 event · 42 experience · 20 tour · 20 place · 10 page · 6 itinerary.
- 45 mis-keyed rows in `cms_image_slots` wiped to clear the existing pollution.

## Test plan

- [x] Local enforcer run — `node scripts/check-editable-coverage.mjs` → `checked 12 *Card.astro components, all cards conform`.
- [ ] CI deploy: convention enforcer passes, registry refresh runs and upserts 516+ rows.
- [ ] Live: right-click any venue card hero, replace the image, only that venue's hero changes.
- [ ] Live: editing a stock-image-sharing venue (e.g. one of the three from James's screenshot) leaves the other two untouched.
- [ ] Database: `select * from pi.content_registry where entity_type='venue' limit 3` returns rows.
- [ ] Database: insert into `cms_image_slots` with bogus slug → trigger raises `unknown_entity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)