### PR TITLE
docs(cms): integrity system — architecture, editorial guide, Claude rules

### DIFF
--- a/HANDOVER-CLAUDE.md
+++ b/HANDOVER-CLAUDE.md
@@ -222,6 +222,39 @@ Start with a **SERP snippet optimisation pass** on the highest-leverage pages:
 
 That is the fastest next SEO win.
 
+## 12. CMS Integrity — non-negotiable rules
+
+The inline CMS (right-click image replace, contenteditable text) is governed
+by a referential-integrity system established 2026-05-11 after a
+shared-image bug let one click overwrite many venues at once. The full
+spec is in [`docs/cms-architecture.md`](docs/cms-architecture.md). The
+non-negotiables for any Claude session touching cards, CMS, or content:
+
+1. **Never key overrides on filenames.** Every editable image must call
+   `editableImage({ entityType, entitySlug, fieldPath, ... })`. The
+   `entityType` must be one of: `article, page, event, place, venue,
+   experience, itinerary, tour, tour-operator, tour-package`. No
+   exceptions; new kinds require a coordinated DB migration.
+2. **Every new card component must pass the enforcer.** Before committing
+   a new `*Card.astro`, run `node scripts/check-editable-coverage.mjs`.
+   The CI also runs it; do not push expecting CI to be the first check.
+3. **Adding a new content collection** means three coordinated changes:
+   (a) the directory under `next/src/content/`, (b) an entry in
+   `COLLECTIONS` in `scripts/refresh-content-registry.mjs`, (c) the
+   matching kind in the database CHECK constraints if it's new.
+4. **The DB trigger is the floor, not the ceiling.** `pi.assert_content_
+   registry_match` refuses writes for unknown entities. If you see
+   `foreign_key_violation` on CMS save, the entity is genuinely not in
+   `pi.content_registry` — fix the slug or wait for a deploy refresh, do
+   not bypass the trigger.
+5. **Open followup as of 2026-05-11:** rotate the `SUPABASE_SERVICE_KEY`
+   repo secret to authenticate against project `tjjhpvslpysfklwpqmgz`
+   (the active CMS database). Then remove `continue-on-error: true` from
+   the registry-refresh step in `.github/workflows/deploy.yml`.
+
+For the editor-facing version of these rules, see
+[`docs/cms-editorial-guide.md`](docs/cms-editorial-guide.md).
+
 ## Social Publishing
 
 Skills and process docs for social media publishing live at `ops/skills/`:

--- a/docs/cms-architecture.md
+++ b/docs/cms-architecture.md
@@ -1,0 +1,231 @@
+# Peninsula Insider — CMS architecture
+
+**Last updated:** 2026-05-11
+**Status:** live in production
+**Owners:** James, Claude
+
+This document is the canonical reference for how the Peninsula Insider inline
+CMS works. It explains the architecture, the rules every contributor must
+follow, and the safeguards that exist to keep editor overrides referentially
+sound.
+
+If you are touching anything that calls `editableImage()`, `editableText()`,
+`cms_image_slots`, `cms_text_fields`, or `pi.content_registry`, **read this
+first.** The rules here are what stand between a single editor click and a
+2026-05-11-style "same image across many venues" bug.
+
+## The problem this solves
+
+Before 2026-05-11, image overrides were keyed by source filename. The flow
+was:
+
+1. Editor right-clicks a venue's hero photo and replaces it.
+2. The CMS records an override with key `img:<basename-of-old-photo.jpg>`.
+3. On every page load, the inline-edit client walks the DOM and, for any
+   `<img>` whose `src` basename matches a known key, swaps the src.
+
+The implicit assumption was that each photo file was used by exactly one
+venue. In practice many venues shared the same stock image, so editing one
+venue overwrote the photo for every other venue using the same file. Editors
+had no way to see the spread before clicking save.
+
+This document describes the architecture that replaced the filename-keyed
+approach. The new model is **entity-scoped**: every editable element declares
+its identity (entity type, entity slug, field path) and overrides key on
+that identity.
+
+## High-level architecture
+
+```
+                ┌────────────────────────────┐
+   Editor click │  next/src/lib/inline-edit/ │ ◀── DOM elements tagged via
+                │  client.ts (right-click,   │     editableImage({...}) /
+                │  contenteditable, save UI) │     editableText({...})
+                └─────────────┬──────────────┘
+                              │ writes
+                              ▼
+              ┌──────────────────────────────────┐
+   Supabase   │ pi.cms_image_slots               │
+              │ pi.cms_text_fields               │
+              │   key: (entity_type, entity_slug,│
+              │        field_path, locale?)      │
+              └──────────────┬───────────────────┘
+                             │ INSERT/UPDATE intercepted by:
+                             ▼
+              ┌──────────────────────────────────┐
+              │ pi.assert_content_registry_match │  ──── raises
+              │  (BEFORE trigger on both tables) │       foreign_key_violation
+              └──────────────┬───────────────────┘       for unknown entities
+                             │ reads
+                             ▼
+              ┌──────────────────────────────────┐
+   Refreshed  │ pi.content_registry              │
+   every      │   row per valid                  │
+   deploy by  │   (entity_type, entity_slug)     │
+   refresh-…  │   the live site renders          │
+   .mjs       └──────────────────────────────────┘
+```
+
+## The three rules
+
+### Rule 1 — Every editable image carries its entity identity
+
+Any element a user can edit must be tagged with the canonical helper. There
+is no "auto-detect" anymore.
+
+```astro
+---
+import { editableImage } from '../lib/inline-edit/attrs';
+---
+<a class="venue-card__hero" {...editableImage({
+  entityType: 'venue',
+  entitySlug: slug,
+  fieldPath: 'hero',
+  label: `${data.name} hero`,
+  purpose: 'hero',
+})}>
+  <img src={data.image} alt={data.name} />
+</a>
+```
+
+`entityType` must be one of:
+
+```
+article, page, event, place, venue, experience, itinerary,
+tour, tour-operator, tour-package
+```
+
+Adding a new entity type requires both a database migration to extend the
+`CHECK` constraints **and** an update to `VALID_KINDS` in
+[`scripts/check-editable-coverage.mjs`](../scripts/check-editable-coverage.mjs).
+
+`fieldPath` convention:
+
+- `'hero'` for the primary card image. The build-time enforcer warns on any
+  other path for the hero.
+- `'hero.alt'`, `'hero.credit'` for sibling fields on the same image.
+- `'image'` is tolerated for legacy compatibility.
+
+### Rule 2 — Every override targets an entity that exists
+
+`pi.content_registry` holds one row per `(entity_type, entity_slug)` the live
+site renders. A `BEFORE INSERT OR UPDATE` trigger on `pi.cms_image_slots` and
+`pi.cms_text_fields` calls `pi.assert_content_registry_match()` and raises:
+
+```
+CMS override for (venue, foo-bar) refused: no matching row in
+pi.content_registry. Run the deploy-time content registry refresh, or
+use a valid entity.
+```
+
+The registry is refreshed automatically on every deploy by
+[`scripts/refresh-content-registry.mjs`](../scripts/refresh-content-registry.mjs),
+which:
+
+1. Walks every collection directory under `next/src/content/` and converts
+   each file into a `(entity_type, entity_slug, title, href)` row.
+2. Appends a fixed set of static page rows (`home`, `_global`, section
+   landings).
+3. Upserts in chunks of 500 with `refreshed_at = now()`.
+4. Deletes any rows whose `refreshed_at` is older than the run watermark —
+   so deleted content pages are pruned automatically.
+
+The script requires a service-role key (`SUPABASE_SERVICE_ROLE_KEY` env var)
+and is invoked from `.github/workflows/deploy.yml` before the Astro build.
+
+### Rule 3 — CI fails the build if a card forgets to tag itself
+
+[`scripts/check-editable-coverage.mjs`](../scripts/check-editable-coverage.mjs)
+walks `next/src/components/**/*Card.astro` and fails the deploy if:
+
+- A card is missing `<PiSaveActions .../>`.
+- A card is missing an `editableImage({...})` call (unless explicitly listed
+  in `HERO_EXEMPT` — text-only editorial variants).
+- An `editableImage()` call is missing `entityType`, `entitySlug`, or
+  `fieldPath`.
+- The `entityType` is not in the canonical list.
+
+The enforcer warns (but does not fail) when `fieldPath` is not `'hero'` /
+`'hero.*'` / `'image'`. This is to nudge naming toward the convention while
+allowing intentional exceptions.
+
+The enforcer runs as the **"Enforce CMS editor conventions"** step in
+`.github/workflows/deploy.yml`, immediately before the Astro build. Fail
+fast — by the time the build hits this step it has only run preflight, so
+errors here are cheap.
+
+## File map
+
+| Layer | Path | What it does |
+|---|---|---|
+| DOM tagging | [`next/src/lib/inline-edit/attrs.ts`](../next/src/lib/inline-edit/attrs.ts) | `editableImage()` / `editableText()` helpers — produce the `data-pi-*` attrs the client reads |
+| Build-time hydration | [`next/src/lib/inline-edit/overrides.ts`](../next/src/lib/inline-edit/overrides.ts) | `loadOverrides(entity_type, entity_slug)` — read published overrides during Astro build so SSG'd HTML carries the editor's choices |
+| Browser-side hydration | [`next/src/lib/inline-edit/client.ts`](../next/src/lib/inline-edit/client.ts) | Right-click menu, image picker, text save flow, **and** the load-time override patcher (explicit-pass + implicit-pass) |
+| DB schema | [`ops/migrations/2026-05-09-pi-cms-admin.sql`](../ops/migrations/2026-05-09-pi-cms-admin.sql) | `cms_text_fields`, `cms_image_slots`, `cms_revisions`, `admin_user_allowlist`, RLS, Storage bucket |
+| DB integrity | [`ops/migrations/2026-05-11-pi-cms-content-registry-and-referential-integrity.sql`](../ops/migrations/2026-05-11-pi-cms-content-registry-and-referential-integrity.sql) | `pi.content_registry` + trigger + extended `entity_type` CHECK |
+| Build-time refresh | [`scripts/refresh-content-registry.mjs`](../scripts/refresh-content-registry.mjs) | Walk content collections, upsert registry, prune stale rows |
+| CI enforcement | [`scripts/check-editable-coverage.mjs`](../scripts/check-editable-coverage.mjs) | Block deploys that omit the editor attrs |
+| CI wiring | [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) | Runs enforcer + refresh before build |
+
+## Adding a new editable card
+
+1. Add the helper to the hero element of your card component:
+   ```astro
+   <a class="x-card__hero" {...editableImage({
+     entityType: '<one-of-the-canonical-kinds>',
+     entitySlug: slug,
+     fieldPath: 'hero',
+     label: `${data.name} hero`,
+     purpose: 'hero',
+   })}>
+   ```
+2. Include `<PiSaveActions .../>` somewhere in the card.
+3. Run `node scripts/check-editable-coverage.mjs` to confirm conformance.
+4. If your card represents a brand-new content collection, also add it to
+   the `COLLECTIONS` array in `scripts/refresh-content-registry.mjs` so the
+   registry refresh picks up the new slugs.
+
+## Adding a new entity type
+
+This is rare and requires two coordinated changes:
+
+1. **Database** — write a migration to extend the `CHECK (entity_type IN
+   (...))` constraint on both `pi.cms_image_slots` and `pi.cms_text_fields`,
+   and on the `pi.content_registry` table itself.
+2. **Build pipeline** — add the new kind to:
+   - `VALID_KINDS` in `scripts/check-editable-coverage.mjs`
+   - The `COLLECTIONS` array in `scripts/refresh-content-registry.mjs`
+   - The "canonical kinds" list in this document.
+
+Until both sides are landed, the CI enforcer will reject any card that uses
+the new kind. That is intentional — it forces the database migration to
+ship at the same time as the code.
+
+## Operational state today
+
+- **Database:** Project `tjjhpvslpysfklwpqmgz`, schema `pi`. Migration
+  `2026-05-11-pi-cms-content-registry-and-referential-integrity.sql` applied.
+- **Registry rows:** 516 entities seeded (154 venue, 173 article, 91 event,
+  42 experience, 20 tour, 20 place, 10 page, 6 itinerary).
+- **CI:** Enforcer + registry refresh wired. The registry refresh is
+  currently `continue-on-error: true` because the `SUPABASE_SERVICE_KEY`
+  repo secret authenticates against an older project — rotation is the
+  open followup. The protection is **not weakened** by this, because the
+  trigger runs in the database and is independent of CI.
+
+## What this does NOT cover (deferred phases)
+
+- **Phase 2 — Storage tombstones.** Today, replacing a hero image leaves the
+  old object in the `cms-assets` bucket forever. Future work: mark
+  superseded uploads as tombstoned and run a nightly cleanup edge function.
+- **Phase 4 — Draft mode + revert UI.** Editors currently save published
+  directly. A draft/review flow with one-click revert to the prior version
+  is the next safety net to add.
+
+## Pointers to related docs
+
+- [`docs/cms-editorial-guide.md`](cms-editorial-guide.md) — operator-facing
+  guide: how to edit a venue, how to add a new venue, what to do when an
+  edit fails.
+- [`ops/migrations/README.md`](../ops/migrations/README.md) — migration
+  apply order and rollback notes.

--- a/docs/cms-editorial-guide.md
+++ b/docs/cms-editorial-guide.md
@@ -1,0 +1,151 @@
+# Peninsula Insider — Editorial guide to the inline CMS
+
+**Last updated:** 2026-05-11
+**Audience:** James, Emma, future editors (not developers)
+
+This is the practical operator's guide to editing Peninsula Insider through
+the inline CMS. It explains what works today, the rules to follow, and what
+to do when something doesn't behave the way you expected.
+
+For the engineering side, see [`docs/cms-architecture.md`](cms-architecture.md).
+
+## How to sign in
+
+1. Visit `/admin/login` on either localhost or the live site.
+2. Sign in with the Google account that's on the editor allowlist
+   (`james@peninsulainsider.com.au`).
+3. Once you're signed in, a small "Editor" indicator appears in the top
+   utility bar. Right-click and contenteditable affordances activate on
+   any page you visit.
+
+If sign-in says success but you don't see editor controls, check
+`pi.admin_user_allowlist` in the Supabase dashboard — your row needs
+`role IN ('editor', 'publisher', 'admin')`.
+
+## How to replace an image
+
+1. Sign in.
+2. Navigate to the page that shows the image. Card grids, hero blocks, and
+   inline article photos all support replacement.
+3. Right-click the image.
+4. Pick "Replace image". Upload a file from your machine, or paste a URL.
+5. Click "Save and publish". The new image appears on the live site within
+   a few seconds.
+
+**One rule that matters:** the right-click acts on the **entity** the image
+belongs to, not on the image file. If two different venues happen to show
+the same stock photo, replacing the photo on one venue's card will leave
+the other venue's card untouched. This is by design — the entire 2026-05-11
+overhaul existed to make this true. If you ever see the old behaviour
+again (one click affecting many cards), flag it as a regression.
+
+## How to edit text
+
+1. Sign in.
+2. Click the text you want to change. If it's editable, the cursor will
+   land inside it and the border will highlight.
+3. Type your edits. Markdown is supported inline.
+4. Click outside, or press Esc. The "Save" button at the top of the screen
+   will glow.
+5. Click Save. The change goes live.
+
+If the cursor won't land in a text block, that block isn't tagged for
+editing yet. Tell Claude which block and on which page, and ask for it to
+be tagged.
+
+## How to save and share
+
+Every card has a Save (heart) and Share affordance. As a signed-in editor,
+your saves sync to the cloud and are visible across devices. As a
+signed-out visitor, saves live in the browser only.
+
+Sharing a plan generates a base64-encoded URL — no server lookups, no
+auth. Anyone with the link can see the same plan you saved.
+
+## What to do when an edit fails
+
+### "CMS override refused: no matching row in pi.content_registry"
+
+This means the page slug doesn't match any entity the registry knows about.
+The two common reasons:
+
+1. **You're editing a brand new venue** that was added to the site since
+   the last deploy. The registry refreshes at deploy time; until the next
+   deploy lands, the new slug isn't registered. Wait for the next deploy
+   (~5 min) or trigger one by pushing any change to `main`.
+2. **The slug on the page has drifted** from the content collection. Look
+   in `next/src/content/venues/<slug>.json` and confirm the filename
+   matches what's in the URL.
+
+### "Storage upload failed: 500 / stack depth limit"
+
+Already fixed in production on 2026-05-11. If you see this on a local dev
+environment, you're missing migration
+`2026-05-11-pi-cms-admin-fix-recursion.sql`. Apply it.
+
+### "Save button doesn't enable"
+
+The Save button enables when the page has at least one pending edit. If
+you've made changes and nothing's happening, refresh the page and try
+again — the inline edit client occasionally needs to re-hydrate after
+view transitions.
+
+### "Image preview shows the new image but the live site shows the old one"
+
+GitHub Pages caches aggressively. Force-refresh (Ctrl+Shift+R) or wait
+5–10 minutes for the edge cache to expire.
+
+## Adding a new venue (or any new content entity)
+
+The inline CMS is for **editing** content that already exists. Adding new
+entities is still done by adding JSON / MDX files to `next/src/content/`.
+
+1. Add `next/src/content/venues/your-new-venue.json` (or events, places,
+   etc.) following the existing schema.
+2. Commit and push. The deploy runs the registry refresh, which picks up
+   the new slug.
+3. Once the deploy lands, the new venue's page becomes inline-editable.
+
+If you skip step 2 and try to edit the venue inline, you'll get the
+"no matching row in pi.content_registry" error described above.
+
+## The canonical kinds
+
+These are the only `entity_type` values the system understands. The list
+is enforced both in the database and at build time:
+
+| Kind | What it covers |
+|---|---|
+| `venue` | Cellar doors, restaurants, accommodation, etc. |
+| `place` | Towns / suburbs / locales |
+| `event` | One-off or recurring events |
+| `experience` | Activities, walks, golf courses, beaches |
+| `itinerary` | Multi-stop curated itineraries |
+| `article` | Journal entries, guides, area pages |
+| `tour` | Bookable tours from third-party operators |
+| `tour-operator` | The companies that run tours |
+| `tour-package` | Bundled tour packages |
+| `page` | Static landing pages (`/`, `/wine/`, `/eat/`, etc.) |
+
+Adding a new kind is a developer task — it requires a coordinated
+database migration. Ask Claude to handle it.
+
+## Known limitations
+
+These are documented openly so editors don't waste time looking for them:
+
+- **No draft/preview mode yet.** Saves are immediate and published. The
+  rollout plan calls for adding a draft flow + revert UI as Phase 4.
+- **No image cleanup.** When you replace a hero, the old image file stays
+  in storage. Phase 2 will add nightly tombstone cleanup.
+- **No bulk edits.** You edit one element at a time. Bulk operations
+  (e.g. "swap this image on every venue using it") are deliberately not
+  exposed, because shared-image bugs were the entire point of the
+  2026-05-11 overhaul.
+
+## For more detail
+
+- Architecture, file map, and code references:
+  [`docs/cms-architecture.md`](cms-architecture.md)
+- Database schema and migration order:
+  [`ops/migrations/README.md`](../ops/migrations/README.md)


### PR DESCRIPTION
## Summary

Phase 5 of the CMS Integrity Plan — closes the documentation gap after the system shipped in [#109](https://github.com/richmondjw/peninsula-insider/pull/109).

Three new/updated documents:

| Doc | Audience | What it covers |
|---|---|---|
| `docs/cms-architecture.md` (new) | Engineers, future Claude | The 2026-05-11 bug we replaced, the three-rule architecture (tagged cards / referential trigger / CI enforcer), full file map, operational state, deferred phases |
| `docs/cms-editorial-guide.md` (new) | James, Emma | Sign in, replace image, edit text, error recovery, canonical kinds, known limitations |
| `HANDOVER-CLAUDE.md` §12 (added) | Future Claude sessions | Five non-negotiables: no filename keys, run the enforcer locally, add new collections in three places, never bypass the DB trigger, rotate the service key |

No code changes. Pure documentation.

## Test plan

- [ ] Read `docs/cms-architecture.md` end-to-end — confirm it matches the system as shipped in #109.
- [ ] Read `docs/cms-editorial-guide.md` as if it's your first time editing the site — confirm the steps work.
- [ ] Confirm `HANDOVER-CLAUDE.md` §12 lands in the right place between §11 and Social Publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)