### PR TITLE
feat(cms): Wave A — entity-scoped inline editing across detail templates + section landings

### DIFF
--- a/next/src/components/GuideHero.astro
+++ b/next/src/components/GuideHero.astro
@@ -15,6 +15,8 @@ export interface MetaItem {
   label: string;
 }
 
+import { editableText, editableImage, type CmsEntityType } from '../lib/inline-edit/attrs';
+
 export interface Props {
   /** Small caps eyebrow, e.g. "EAT & DRINK · 101 VENUES MAPPED · LAST VERIFIED 30 APR 2026". */
   eyebrow?: string;
@@ -30,6 +32,13 @@ export interface Props {
   imageAlt?: string;
   /** Optional photographer / source credit shown under the image. */
   imageCredit?: string;
+  /**
+   * Optional CMS identity for inline editing. When provided, the title,
+   * dek, and hero image become editable. Pattern mirrors SectionHero so
+   * call sites are uniform: <GuideHero ... entitySlug="eat" />.
+   */
+  entitySlug?: string;
+  entityType?: CmsEntityType;
 }
 
 const {
@@ -40,7 +49,20 @@ const {
   heroImage,
   imageAlt = '',
   imageCredit,
+  entitySlug,
+  entityType = 'page',
 } = Astro.props;
+
+const editable = !!entitySlug;
+const titleAttrs = editable
+  ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.title', label: `${entitySlug} hero title` })
+  : {};
+const dekAttrs = editable
+  ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.dek', label: `${entitySlug} hero dek` })
+  : {};
+const imageAttrs = editable
+  ? editableImage({ entityType, entitySlug: entitySlug!, fieldPath: 'hero', label: `${entitySlug} hero image`, purpose: 'hero' })
+  : {};
 ---
 
 <section class="guide-hero" aria-label={title}>
@@ -48,8 +70,8 @@ const {
     <div class="guide-hero__inner">
       <div class="guide-hero__content">
         {eyebrow && <p class="guide-hero__eyebrow">{eyebrow}</p>}
-        <h1 class="guide-hero__title" set:html={title} />
-        {dek && <p class="guide-hero__dek">{dek}</p>}
+        <h1 class="guide-hero__title" set:html={title} {...titleAttrs} />
+        {dek && <p class="guide-hero__dek" {...dekAttrs}>{dek}</p>}
         {meta && meta.length > 0 && (
           <div class="guide-hero__meta">
             {meta.map((item) => (
@@ -65,6 +87,7 @@ const {
             role="img"
             aria-label={imageAlt}
             style={`background-image: url(${heroImage})`}
+            {...imageAttrs}
           ></div>
           {imageCredit && <figcaption class="guide-hero__credit">Photo · {imageCredit}</figcaption>}
         </figure>

--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -8,6 +8,7 @@ import ArticleCard from './ArticleCard.astro';
 import NewsletterBlock from './NewsletterBlock.astro';
 import CorrectionNote from './CorrectionNote.astro';
 import { titleize, heroBackgroundStyle } from '../lib/editorial';
+import { editableText, editableImage } from '../lib/inline-edit/attrs';
 
 export interface Props {
   place: any;
@@ -49,6 +50,7 @@ const zoneGradient: Record<string, string> = {
   tip: 'hero-grad--stay',
 };
 const heroGradientClass = zoneGradient[place.data.zone] ?? 'hero-grad--vineyard';
+const placeSlug = place.id ?? place.slug ?? place.data?.slug ?? place.data?.id;
 
 // Anchors for the in-page nav.
 const anchors: { href: string; label: string; count: number }[] = [];
@@ -74,16 +76,29 @@ const totalVenues = eatVenues.length + wineVenues.length + stayVenues.length;
 <section class="place-detail">
   <div class="container">
     <p class="place-detail__eyebrow">{zoneLabel} · {place.data.kind}</p>
-    <h1 class="place-detail__title">{place.data.name}</h1>
+    <h1 class="place-detail__title" {...editableText({
+      entityType: 'place', entitySlug: placeSlug, fieldPath: 'name',
+      label: `${place.data.name} — name`,
+    })}>{place.data.name}</h1>
     {place.data.factualLede && (
-      <p class="place-detail__factual-lede">{place.data.factualLede}</p>
+      <p class="place-detail__factual-lede" {...editableText({
+        entityType: 'place', entitySlug: placeSlug, fieldPath: 'factualLede',
+        label: `${place.data.name} — factual lede`,
+      })}>{place.data.factualLede}</p>
     )}
-    <p class="place-detail__intro">{place.data.intro}</p>
+    <p class="place-detail__intro" {...editableText({
+      entityType: 'place', entitySlug: placeSlug, fieldPath: 'intro',
+      label: `${place.data.name} — intro`,
+    })}>{place.data.intro}</p>
 
     <div
       class={`place-detail__hero ${heroGradientClass}`}
       aria-hidden="true"
       style={heroBackgroundStyle(place.data)}
+      {...editableImage({
+        entityType: 'place', entitySlug: placeSlug, fieldPath: 'hero',
+        label: `${place.data.name} hero`, purpose: 'hero',
+      })}
     >
       <div class="section-hero__visual-fog"></div>
       <span class="section-hero__visual-label">{place.data.heroImage.alt}</span>

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -9,7 +9,7 @@ import ItineraryCard from './ItineraryCard.astro';
 import PiArticleActions from './PiArticleActions.astro';
 import CorrectionNote from './CorrectionNote.astro';
 import { loadOverrides } from '../lib/inline-edit/overrides';
-import { editableImage } from '../lib/inline-edit/attrs';
+import { editableImage, editableText } from '../lib/inline-edit/attrs';
 
 export interface Props {
   venue: any;
@@ -74,11 +74,17 @@ const isClosed = data.status === 'closed';
       <span class="venue-detail__price-band">{data.priceBand}</span>
     </div>
 
-    <h1 class="venue-detail__title">{data.name}</h1>
+    <h1 class="venue-detail__title" {...editableText({
+      entityType: 'venue', entitySlug: venueSlug, fieldPath: 'name',
+      label: `${data.name} — name`,
+    })}>{data.name}</h1>
     {isClosed && (
       <p class="venue-detail__closed-notice">This cellar door is permanently closed. The page is preserved for historical reference.</p>
     )}
-    <p class="venue-detail__signature">{data.signature}</p>
+    <p class="venue-detail__signature" {...editableText({
+      entityType: 'venue', entitySlug: venueSlug, fieldPath: 'signature',
+      label: `${data.name} — signature`,
+    })}>{data.signature}</p>
 
     {(data.bookingUrl || data.phone) && (
       <div class="venue-detail__booking-bar">

--- a/next/src/lib/inline-edit/attrs.ts
+++ b/next/src/lib/inline-edit/attrs.ts
@@ -16,7 +16,10 @@ export type CmsEntityType =
   | 'place'
   | 'venue'
   | 'experience'
-  | 'itinerary';
+  | 'itinerary'
+  | 'tour'
+  | 'tour-operator'
+  | 'tour-package';
 
 export type CmsTextKind = 'text' | 'markdown' | 'richtext';
 

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -206,6 +206,7 @@ const faqSchema = {
     heroImage="/images/sourced/venue-italian-dining-01.webp"
     imageAlt="An Italian-leaning Peninsula dining room, table laid, light low"
     imageCredit="Peninsula Insider"
+    entitySlug="eat"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/explore/[slug].astro
+++ b/next/src/pages/explore/[slug].astro
@@ -8,6 +8,7 @@ import ItineraryCard from '../../components/ItineraryCard.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { placeLabel, routeSlug, titleize, venueHrefPrefix, heroBackgroundStyle } from '../../lib/editorial';
+import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 
 const difficultyLabel: Record<string, string> = {
   easy: 'Easy',
@@ -168,9 +169,15 @@ if (experience.data.type === 'golf-course') {
         )}
       </div>
 
-      <h1 class="experience-detail__title">{experience.data.name}</h1>
+      <h1 class="experience-detail__title" {...editableText({
+        entityType: 'experience', entitySlug: slug, fieldPath: 'name',
+        label: `${experience.data.name} — name`,
+      })}>{experience.data.name}</h1>
 
-      <div class={`experience-detail__hero feature__image-block ${heroClass}`} aria-hidden="true" style={heroStyle}>
+      <div class={`experience-detail__hero feature__image-block ${heroClass}`} aria-hidden="true" style={heroStyle} {...editableImage({
+        entityType: 'experience', entitySlug: slug, fieldPath: 'hero',
+        label: `${experience.data.name} hero`, purpose: 'hero',
+      })}>
         <div class="experience-detail__hero-fog"></div>
         <span class="experience-detail__hero-label">{experience.data.heroImage.alt}</span>
       </div>

--- a/next/src/pages/explore/beaches.astro
+++ b/next/src/pages/explore/beaches.astro
@@ -128,6 +128,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/explore-gunnamatta-01.webp"
     imageAlt="Gunnamatta Ocean Beach — Bass Strait surf and dune ridges at the Peninsula's southern edge"
     imageCredit="Peninsula Insider"
+    entitySlug="explore-beaches"
   />
 
   <CompareBlock

--- a/next/src/pages/explore/golf.astro
+++ b/next/src/pages/explore/golf.astro
@@ -175,6 +175,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/golf-rye-sunrise-01.webp"
     imageAlt="Coastal golf landscape on the Mornington Peninsula at sunrise"
     imageCredit="Peninsula Insider"
+    entitySlug="explore-golf"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -144,6 +144,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     heroImage="/images/sourced/explore-cape-schanck-lighthouse-01.webp"
     imageAlt="Cape Schanck Lighthouse and the Bass Strait coast, the Peninsula at its most explorable"
     imageCredit="Peninsula Insider"
+    entitySlug="explore"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -14,6 +14,7 @@ import CorrectionNote from '../../components/CorrectionNote.astro';
 import { formatLabel, routeSlug, venueHrefPrefix, titleize, heroBackgroundStyle, formatHeroCredit } from '../../lib/editorial';
 import { pickRelatedArticles, resolveRefs } from '../../lib/related';
 import { isPeninsulaThisWeekend, ptwArchivePath } from '../../lib/peninsula-this-weekend';
+import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ data }) => data.status === 'published');
@@ -200,8 +201,14 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
                 </>
               )}
             </div>
-            <h1 class="article-hero__title">{article.data.title}</h1>
-            <p class="article-hero__dek">{article.data.dek}</p>
+            <h1 class="article-hero__title" {...editableText({
+              entityType: 'article', entitySlug: slug, fieldPath: 'title',
+              label: `${article.data.title} — title`,
+            })}>{article.data.title}</h1>
+            <p class="article-hero__dek" {...editableText({
+              entityType: 'article', entitySlug: slug, fieldPath: 'dek',
+              label: `${article.data.title} — dek`,
+            })}>{article.data.dek}</p>
             <PiArticleActions
               slug={article.id}
               section={article.data.section ?? 'journal'}
@@ -226,7 +233,10 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
             )}
           </div>
           <figure class="article-hero__figure">
-            <div class="article-hero__image" role="img" aria-label={article.data.heroImage.alt} style={articleHeroStyle}></div>
+            <div class="article-hero__image" role="img" aria-label={article.data.heroImage.alt} style={articleHeroStyle} {...editableImage({
+              entityType: 'article', entitySlug: slug, fieldPath: 'hero',
+              label: `${article.data.title} hero`, purpose: 'hero',
+            })}></div>
             {article.data.heroImage.credit && (
               <figcaption class="article-hero__credit">{formatHeroCredit(article.data.heroImage.credit)}</figcaption>
             )}

--- a/next/src/pages/places/index.astro
+++ b/next/src/pages/places/index.astro
@@ -124,6 +124,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     heroImage="/images/sourced/places-hub-hero-01.webp"
     imageAlt="The Mornington Peninsula coastline — bay on one side, Bass Strait on the other"
     imageCredit="Peninsula Insider"
+    entitySlug="places"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/plans/[slug].astro
+++ b/next/src/pages/plans/[slug].astro
@@ -38,6 +38,7 @@ import {
   seasonLabel,
   themeLabel,
 } from '../../lib/escape';
+import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 
 const timeOfDayLabel: Record<string, string> = {
   morning: 'Morning',
@@ -349,11 +350,20 @@ const ogImage = data
                 </>
               )}
             </div>
-            <h1 class="article-hero__title">{ad.title}</h1>
-            <p class="article-hero__dek">{ad.dek}</p>
+            <h1 class="article-hero__title" {...editableText({
+              entityType: 'article', entitySlug: articleSlug!, fieldPath: 'title',
+              label: `${ad.title} — title`,
+            })}>{ad.title}</h1>
+            <p class="article-hero__dek" {...editableText({
+              entityType: 'article', entitySlug: articleSlug!, fieldPath: 'dek',
+              label: `${ad.title} — dek`,
+            })}>{ad.dek}</p>
           </div>
           <figure class="article-hero__figure">
-            <div class="article-hero__image" role="img" aria-label={ad.heroImage.alt} style={heroBackgroundStyle(ad)}></div>
+            <div class="article-hero__image" role="img" aria-label={ad.heroImage.alt} style={heroBackgroundStyle(ad)} {...editableImage({
+              entityType: 'article', entitySlug: articleSlug!, fieldPath: 'hero',
+              label: `${ad.title} hero`, purpose: 'hero',
+            })}></div>
           </figure>
         </div>
       </div>
@@ -445,8 +455,14 @@ const ogImage = data
         )}
       </div>
 
-      <h1 class="itinerary-detail__title">{data!.title}</h1>
-      <p class="itinerary-detail__dek">{data!.dek}</p>
+      <h1 class="itinerary-detail__title" {...editableText({
+        entityType: 'itinerary', entitySlug: slug, fieldPath: 'title',
+        label: `${data!.title} — title`,
+      })}>{data!.title}</h1>
+      <p class="itinerary-detail__dek" {...editableText({
+        entityType: 'itinerary', entitySlug: slug, fieldPath: 'dek',
+        label: `${data!.title} — dek`,
+      })}>{data!.dek}</p>
 
       <div class="itinerary-detail__chips">
         <span>{audienceText}</span>

--- a/next/src/pages/plans/index.astro
+++ b/next/src/pages/plans/index.astro
@@ -120,6 +120,7 @@ const faqSchema = {
     heroImage="/images/sourced/article-sunset-01.webp"
     imageAlt="Golden hour on the Mornington Peninsula, the moment a weekend earns the drive"
     imageCredit="Peninsula Insider"
+    entitySlug="plans"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/stay/index.astro
+++ b/next/src/pages/stay/index.astro
@@ -125,6 +125,7 @@ const faqSchema = {
     heroImage="/images/sourced/venue-jackalope-hotel-01.webp"
     imageAlt="Jackalope Hotel, Merricks North vineyard at dusk"
     imageCredit="Peninsula Insider"
+    entitySlug="stay"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/tour-packages/[slug].astro
+++ b/next/src/pages/tour-packages/[slug].astro
@@ -7,6 +7,7 @@ import TourCard from '../../components/TourCard.astro';
 import TourPackageCard from '../../components/TourPackageCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { buildTourPackageSchema } from '../../lib/schema';
+import { editableText } from '../../lib/inline-edit/attrs';
 
 export async function getStaticPaths() {
   const packages = await getCollection('tourPackages');
@@ -82,7 +83,10 @@ const breadcrumbItems = [
     imageAlt={data.heroImage.alt}
   >
     <div class="prose">
-      <p>{data.intro}</p>
+      <p {...editableText({
+        entityType: 'tour-package', entitySlug: slug, fieldPath: 'intro',
+        label: `${data.name} — intro`,
+      })}>{data.intro}</p>
       <p class="venues__sub" style="font-size:0.8rem;color:var(--soft)">Last verified: {data.lastVerified?.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}</p>
     </div>
   </SubpageHero>

--- a/next/src/pages/tour/[slug].astro
+++ b/next/src/pages/tour/[slug].astro
@@ -5,6 +5,7 @@ import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import SubpageHero from '../../components/SubpageHero.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { buildTourSchema } from '../../lib/schema';
+import { editableText } from '../../lib/inline-edit/attrs';
 
 export async function getStaticPaths() {
   const tours = await getCollection('tours');
@@ -98,7 +99,10 @@ const breadcrumbItems = [
     imageCaption={data.departsFrom ?? undefined}
   >
     <div class="prose">
-      <p>{data.intro}</p>
+      <p {...editableText({
+        entityType: 'tour', entitySlug: slug, fieldPath: 'intro',
+        label: `${data.name} — intro`,
+      })}>{data.intro}</p>
       <p class="venues__sub" style="font-size:0.8rem;color:var(--soft)">Last verified: {data.lastVerified?.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}</p>
     </div>
   </SubpageHero>

--- a/next/src/pages/whats-on/[slug].astro
+++ b/next/src/pages/whats-on/[slug].astro
@@ -24,6 +24,7 @@ import {
   venueHrefPrefix,
   weatherCopy,
 } from '../../lib/editorial';
+import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 
 export async function getStaticPaths() {
   const events = await getCollection('events');
@@ -96,8 +97,14 @@ const breadcrumbItems = [
           <span class="event-detail__meta-item">{recurrenceLabel}</span>
         </div>
 
-        <h1 class="event-detail__title">{event.data.title}</h1>
-        <p class="event-detail__summary">{event.data.summary}</p>
+        <h1 class="event-detail__title" {...editableText({
+          entityType: 'event', entitySlug: slug, fieldPath: 'title',
+          label: `${event.data.title} — title`,
+        })}>{event.data.title}</h1>
+        <p class="event-detail__summary" {...editableText({
+          entityType: 'event', entitySlug: slug, fieldPath: 'summary',
+          label: `${event.data.title} — summary`,
+        })}>{event.data.summary}</p>
 
         <EventBadges
           worthTheDrive={event.data.worthTheDrive}

--- a/next/src/pages/whats-on/index.astro
+++ b/next/src/pages/whats-on/index.astro
@@ -179,6 +179,7 @@ const faqSchema = {
     heroImage="/images/sourced/category-market-02.webp"
     imageAlt="Saturday morning at a Peninsula farmers market, the recurring event spine of the calendar"
     imageCredit="Peninsula Insider"
+    entitySlug="whats-on"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -107,6 +107,7 @@ const faqSchema = {
     heroImage="/images/sourced/article-cellar-door-01.webp"
     imageAlt="A Peninsula cellar door, bottles open, glasses poured, the moment before the tasting"
     imageCredit="Peninsula Insider"
+    entitySlug="wine"
   />
 
   <!-- ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes the gap on inline editing site-wide. Every detail-page template and section landing now tags its hero / title / dek with **entity-scoped** attrs, so editors get clean named edits everywhere instead of the URL-path fallback.

### Templates tagged
| Template | Pages affected | What's now editable |
|---|---|---|
| `journal/[slug].astro` | ~170 articles | hero, title, dek |
| `VenueDetailTemplate.astro` | ~160 venues | name, signature (hero already tagged yesterday) |
| `PlaceDetailTemplate.astro` | ~20 places | name, factualLede, intro, hero |
| `whats-on/[slug].astro` | ~91 events | title, summary |
| `explore/[slug].astro` | ~42 experiences | name, hero |
| `plans/[slug].astro` | ~6 itineraries (both shapes) | title, dek, hero |
| `tour/[slug].astro` | ~20 tours | intro |
| `tour-packages/[slug].astro` | tour packages | intro |
| `GuideHero.astro` (component) | 9 hub pages | opt-in title/dek/hero via `entitySlug` prop |

### Section landings opted in via GuideHero
`eat`, `wine`, `stay`, `explore`, `places`, `plans`, `whats-on`, `explore/beaches`, `explore/golf` — pass `entitySlug` to GuideHero, mirroring James's SectionHero convention from c774db6ff3.

### Library
- `CmsEntityType` union extended to include `tour`, `tour-operator`, `tour-package` (matches DB schema).

### Verification
- `node scripts/check-editable-coverage.mjs` → all 12 cards conform.
- Naming convention matches `SectionHero`: `entitySlug` (string) + optional `entityType` (defaults to 'page').

### Followups (not in this PR)
- 30+ standalone .astro journal articles (each is bespoke — separate batch tag pass).
- Awards / quick-note templates (covered by page-slug fallback today).
- Body-paragraph editing on detail templates (defer until needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)