### PR TITLE
fix(scroll): strip Lenis + parallax for native scroll baseline

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -11,7 +11,6 @@
         "@astrojs/mdx": "5.0.3",
         "@astrojs/vercel": "^10.0.6",
         "@supabase/supabase-js": "^2.105.1",
-        "lenis": "^1.3.23",
         "potrace": "^2.1.8"
       },
       "devDependencies": {
@@ -5170,37 +5169,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/lenis": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.23.tgz",
-      "integrity": "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==",
-      "license": "MIT",
-      "workspaces": [
-        "packages/*",
-        "playground",
-        "playground/*"
-      ],
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/darkroomengineering"
-      },
-      "peerDependencies": {
-        "@nuxt/kit": ">=3.0.0",
-        "react": ">=17.0.0",
-        "vue": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nuxt/kit": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
       }
     },
     "node_modules/lines-and-columns": {

--- a/next/package.json
+++ b/next/package.json
@@ -28,7 +28,6 @@
     "@astrojs/mdx": "5.0.3",
     "@astrojs/vercel": "^10.0.6",
     "@supabase/supabase-js": "^2.105.1",
-    "lenis": "^1.3.23",
     "potrace": "^2.1.8"
   },
   "optionalDependencies": {

--- a/next/public/assets/scroll-animations.css
+++ b/next/public/assets/scroll-animations.css
@@ -139,19 +139,6 @@ html {
 
 
 /* ------------------------------------------------------------------
-   7. PARALLAX
-   Hero visuals get a subtle scale-up so there's room to translate
-   without revealing edges. The actual transform is set by JS.
-   ------------------------------------------------------------------ */
-
-.parallax-hero {
-  will-change: transform;
-  transform: scale(1.08) translateY(0);
-  transition: none;  /* JS drives this — no CSS transition */
-}
-
-
-/* ------------------------------------------------------------------
    8. FEATURE IMAGE REVEAL
    The feature story image block fades and scales in gently.
    ------------------------------------------------------------------ */
@@ -186,11 +173,6 @@ html {
     opacity: 1 !important;
     transform: none !important;
     transition: none !important;
-    will-change: auto !important;
-  }
-
-  .parallax-hero {
-    transform: none !important;
     will-change: auto !important;
   }
 

--- a/next/public/assets/scroll-animations.js
+++ b/next/public/assets/scroll-animations.js
@@ -24,7 +24,6 @@
   function init() {
     tagElements();
     applyReveals();
-    initParallax();
   }
 
 
@@ -190,43 +189,6 @@
         observer.observe(el);
       }
     }
-  }
-
-
-  /* ----------------------------------------------------------------
-     PARALLAX
-     ---------------------------------------------------------------- */
-
-  function initParallax() {
-    var heroes = document.querySelectorAll('.parallax-hero');
-    if (!heroes.length) return;
-
-    var SPEED = 0.12;
-    var ticking = false;
-
-    function updateParallax() {
-      for (var i = 0; i < heroes.length; i++) {
-        var el = heroes[i];
-        var rect = el.getBoundingClientRect();
-        var elCenter = rect.top + rect.height / 2;
-        var viewCenter = window.innerHeight / 2;
-        var offset = (elCenter - viewCenter) * SPEED;
-
-        if (rect.bottom > -200 && rect.top < window.innerHeight + 200) {
-          el.style.transform = 'scale(1.08) translateY(' + offset.toFixed(1) + 'px)';
-        }
-      }
-      ticking = false;
-    }
-
-    window.addEventListener('scroll', function () {
-      if (!ticking) {
-        requestAnimationFrame(updateParallax);
-        ticking = true;
-      }
-    }, { passive: true });
-
-    updateParallax();
   }
 
 

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -508,43 +508,5 @@ const isAskPage = rawPathname.startsWith('/ask');
   <script is:inline src="/assets/subscribe-form.js"></script>
   <script is:inline src="/assets/scroll-animations.js"></script>
 
-  <!-- Lenis smooth scroll, buttery weighted physics on every page -->
-  <script>
-    import Lenis from 'lenis';
-
-    let lenis: InstanceType<typeof Lenis> | null = null;
-    let rafId: number | null = null;
-
-    function startLenis() {
-      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-
-      lenis = new Lenis({
-        duration: 1.4,
-        easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
-        wheelMultiplier: 0.9,
-        touchMultiplier: 1.0,
-        smoothTouch: false,
-      });
-
-      function raf(time: number) {
-        lenis!.raf(time);
-        rafId = requestAnimationFrame(raf);
-      }
-      rafId = requestAnimationFrame(raf);
-    }
-
-    function stopLenis() {
-      if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
-      if (lenis) { lenis.destroy(); lenis = null; }
-    }
-
-    // Boot on first load
-    startLenis();
-
-    // Restart cleanly after each view-transition page swap
-    document.addEventListener('astro:before-swap', stopLenis);
-    document.addEventListener('astro:page-load', startLenis);
-  </script>
-
 </body>
 </html>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -50,15 +50,7 @@
    RESET
    ========================================================= */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: auto; font-size: 16px; } /* Lenis overrides scroll physics */
-
-/* =========================================================
-   LENIS SMOOTH SCROLL — required base CSS
-   ========================================================= */
-html.lenis, html.lenis body { height: auto; }
-.lenis.lenis-smooth { scroll-behavior: auto !important; }
-.lenis.lenis-smooth [data-lenis-prevent] { overscroll-behavior: contain; }
-.lenis.lenis-stopped { overflow: hidden; }
+html { scroll-behavior: auto; font-size: 16px; }
 
 /* =========================================================
    VIEW TRANSITIONS — page fade between routes


### PR DESCRIPTION
## Summary
- Removes the **Lenis** smooth-scroll library (`BaseLayout.astro` script block + `.lenis*` CSS in `global.css` + `lenis` npm dep).
- Removes the **parallax loop** in `scroll-animations.js` and the static `transform: scale(1.08)` CSS for `.parallax-hero`.
- Keeps the IntersectionObserver fade-in reveals, all `scroll-snap` rails, and component-local scroll behaviours intact.

Why: the combination of Lenis intercepting wheel events and the parallax loop reading `getBoundingClientRect()` every scroll frame was producing visible jitter / stutter on page scroll. Returning to native browser scroll as the baseline so we can layer effects back deliberately.

Local Astro build passes (1334 pages, no errors).

## Test plan
- [ ] Verify scroll feel on `/` (cover hero), `/journal/`, and a long article page after deploy — should now feel like native browser scroll.
- [ ] Confirm card grids still fade in on scroll-into-view (IntersectionObserver reveals retained).
- [ ] Confirm horizontal scroll-snap rails (pillar nav, dining showcase, `/insider-plans/`) still snap correctly — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)