### PR TITLE
fix(search): resolve merge conflict in pagefind-entry.json

### DIFF
--- a/pagefind/pagefind-entry.json
+++ b/pagefind/pagefind-entry.json
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-{"version":"1.5.2","languages":{"en-au":{"hash":"en-au_28d208f2b9a6b","wasm":"en-au","page_count":707}},"include_characters":["_","‿","⁀","⁔","︳","︴","﹍","﹎","﹏","＿"]}
-=======
 {"version":"1.5.2","languages":{"en-au":{"hash":"en-au_e86a50b443a53","wasm":"en-au","page_count":707}},"include_characters":["_","‿","⁀","⁔","︳","︴","﹍","﹎","﹏","＿"]}
->>>>>>> fcdfde2ccf (publish: autofix deploy 2026-05-12 — weekend planner May 16-17, pricing disclaimer, event status normalisation)


### PR DESCRIPTION
## Summary

The site search has been broken on production since commit `dca19c20` ("publish: autofix deploy 2026-05-12"), which committed **unresolved git merge conflict markers** into `pagefind/pagefind-entry.json`:

```
<<<<<<< HEAD
{"version":"1.5.2","languages":{"en-au":{"hash":"en-au_28d208f2b9a6b",...}}}
=======
{"version":"1.5.2","languages":{"en-au":{"hash":"en-au_e86a50b443a53",...}}}
>>>>>>> fcdfde2ccf (...)
```

Pagefind loads `pagefind-entry.json` at runtime to discover the index hash. With the file containing literal conflict markers it is invalid JSON, the load throws, and `runSearch()` in `next/src/pages/search.astro:320` silently fails — which is why the page stays on "Start typing to search." even after the user types a query.

**Fix:** resolved the conflict to the incoming hash `en-au_e86a50b443a53`. Both `pf_meta` variants from the conflict are present on disk (`pagefind.en-au_28d208f2b9a6b.pf_meta` and `pagefind.en-au_e86a50b443a53.pf_meta`) and both are tracked in git, so either side would load — I kept the incoming side because that is what the publish merge was intended to ship.

### Heads up — related conflicts not fixed here

The same bad merge (`dca19c20`) left identical unresolved conflict markers in two other files; these are unrelated to search so I scoped this PR to the search fix only:

- `quick-note/index.html` (lines 57–61)
- `reports/concierge-corpus/2026-05-12.json` (lines 1–90)

Worth fixing those in a follow-up — the quick-note page is probably rendering broken HTML on the live site.

## Test plan

- [ ] Deploy to production
- [ ] Visit `/search` on the live site
- [ ] Type a query (e.g. "Wine") and confirm results render instead of "Start typing to search."
- [ ] Confirm category filter chips (Eat & Drink, Stay, Wine, etc.) narrow the results
- [ ] Spot-check `quick-note/index.html` and the concierge-corpus report for similar damage and queue a follow-up

---
_Generated by [Claude Code](https://claude.ai/code/session_01591JLaaWYtdkpspYdJaZU1)_