### PR TITLE
Place template v2 — preview (Mornington top-half redesign)

### DIFF
--- a/next/src/components/PlaceDetailTemplateV2.astro
+++ b/next/src/components/PlaceDetailTemplateV2.astro
@@ -1,0 +1,584 @@
+---
+/**
+ * PlaceDetailTemplateV2 — preview/staging template for the place-page top half.
+ *
+ * Scope of changes vs PlaceDetailTemplate:
+ *  - Full-bleed magazine hero with eyebrow + title set over the image
+ *  - Two-column editorial lede (running prose + sidebar "editor's card")
+ *  - Signature pull-quote band (off-white)
+ *  - Numbered chapter index in place of the count-pill nav
+ *  - "How this hub works" snapshot block dropped
+ *
+ * Downstream sections (eat / wine / stay / explore / escapes / journal /
+ * service guides / related places / submit CTA) are unchanged from
+ * PlaceDetailTemplate so this preview can be compared like-for-like.
+ *
+ * Not linked from anywhere. Used by /preview-place-mornington for review.
+ */
+import Breadcrumbs from './Breadcrumbs.astro';
+import VenueCard from './VenueCard.astro';
+import ExperienceCard from './ExperienceCard.astro';
+import ItineraryCard from './ItineraryCard.astro';
+import ArticleCard from './ArticleCard.astro';
+import PlaceCard from './PlaceCard.astro';
+import NewsletterBlock from './NewsletterBlock.astro';
+import { titleize, resolveHeroSrc, formatHeroCredit } from '../lib/editorial';
+
+export interface Props {
+  place: any;
+  eatVenues?: any[];
+  wineVenues?: any[];
+  stayVenues?: any[];
+  experiences?: any[];
+  itineraries?: any[];
+  articles?: any[];
+  relatedPlaces?: any[];
+}
+
+const {
+  place,
+  eatVenues = [],
+  wineVenues = [],
+  stayVenues = [],
+  experiences = [],
+  itineraries = [],
+  articles = [],
+  relatedPlaces = [],
+} = Astro.props;
+
+const zoneLabel = titleize(place.data.zone);
+const kindLabel = titleize(place.data.kind);
+const heroSrc = resolveHeroSrc(place.data);
+const heroCredit = formatHeroCredit(place.data.heroImage?.credit);
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Places', href: '/places' },
+  { label: place.data.name },
+];
+
+const chapters: { href: string; label: string }[] = [];
+if (eatVenues.length > 0) chapters.push({ href: '#eat-drink', label: 'Eat & drink' });
+if (wineVenues.length > 0) chapters.push({ href: '#wine', label: 'Wine & producers' });
+if (stayVenues.length > 0) chapters.push({ href: '#stay', label: 'Stay' });
+if (experiences.length > 0) chapters.push({ href: '#explore', label: 'Explore' });
+if (itineraries.length > 0) chapters.push({ href: '#escapes', label: 'Escape plans' });
+if (articles.length > 0) chapters.push({ href: '#journal', label: 'From the journal' });
+
+// First-letter drop-cap for the factual lede.
+const factual = place.data.factualLede ?? place.data.intro ?? '';
+const factualHead = factual.charAt(0);
+const factualRest = factual.slice(1);
+---
+
+<Breadcrumbs items={breadcrumbItems} />
+
+<!-- ===========================================================
+     1. FULL-BLEED HERO
+     =========================================================== -->
+<section class="pdv2-hero" style={`background-image: url(${heroSrc});`}>
+  <div class="pdv2-hero__scrim"></div>
+  <div class="pdv2-hero__inner container">
+    <p class="pdv2-hero__eyebrow">{zoneLabel} · {kindLabel}</p>
+    <h1 class="pdv2-hero__title">{place.data.name}</h1>
+    {place.data.heroImage?.alt && (
+      <p class="pdv2-hero__alt">{place.data.heroImage.alt}</p>
+    )}
+  </div>
+  {heroCredit && (
+    <p class="pdv2-hero__credit">{heroCredit}</p>
+  )}
+</section>
+
+<!-- ===========================================================
+     2. EDITORIAL LEDE — 7 / 4 grid, drop-cap, editor's card
+     =========================================================== -->
+<section class="pdv2-lede">
+  <div class="container pdv2-lede__grid">
+    <div class="pdv2-lede__main">
+      {factual && (
+        <p class="pdv2-lede__factual">
+          <span class="pdv2-lede__dropcap">{factualHead}</span>{factualRest}
+        </p>
+      )}
+      {place.data.intro && place.data.intro !== factual && (
+        <p class="pdv2-lede__intro">{place.data.intro}</p>
+      )}
+    </div>
+
+    <aside class="pdv2-card" aria-label={`${place.data.name} at a glance`}>
+      <p class="pdv2-card__label">At a glance</p>
+      <dl class="pdv2-card__list">
+        {place.data.driveTime && (
+          <div><dt>From Melbourne</dt><dd>{place.data.driveTime}</dd></div>
+        )}
+        {place.data.bestSeason && (
+          <div><dt>Best season</dt><dd>{titleize(place.data.bestSeason)}</dd></div>
+        )}
+        {place.data.stayDuration && (
+          <div><dt>Stay</dt><dd>{place.data.stayDuration}</dd></div>
+        )}
+        {Array.isArray(place.data.bestFor) && place.data.bestFor.length > 0 && (
+          <div><dt>Best for</dt><dd>{place.data.bestFor.slice(0, 2).join(', ')}</dd></div>
+        )}
+      </dl>
+      {place.data.insiderNote && (
+        <p class="pdv2-card__note"><span>Insider</span> {place.data.insiderNote}</p>
+      )}
+    </aside>
+  </div>
+</section>
+
+<!-- ===========================================================
+     3. PULL-QUOTE — uses place.data.signature when present
+     =========================================================== -->
+{place.data.signature && (
+  <section class="pdv2-quote">
+    <div class="container">
+      <blockquote class="pdv2-quote__text">
+        <span class="pdv2-quote__mark" aria-hidden="true">&ldquo;</span>
+        {place.data.signature}
+      </blockquote>
+      <p class="pdv2-quote__byline">Peninsula Insider — editor's note</p>
+    </div>
+  </section>
+)}
+
+<!-- ===========================================================
+     4. CHAPTER INDEX — numbered, no count brackets
+     =========================================================== -->
+{chapters.length > 0 && (
+  <nav class="pdv2-chapters" aria-label={`${place.data.name} chapters`}>
+    <div class="container">
+      <p class="pdv2-chapters__label">In this guide</p>
+      <ol class="pdv2-chapters__list">
+        {chapters.map((chapter, i) => (
+          <li>
+            <a href={chapter.href}>
+              <span class="pdv2-chapters__num">{String(i + 1).padStart(2, '0')}</span>
+              <span class="pdv2-chapters__name">{chapter.label}</span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </div>
+  </nav>
+)}
+
+<!-- ===========================================================
+     DOWNSTREAM SECTIONS — unchanged from v1 for like-for-like comparison
+     =========================================================== -->
+
+{eatVenues.length > 0 && (
+  <section class="venues" id="eat-drink">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Eat & drink</p>
+          <h2 class="venues__title">Where to eat and drink in {place.data.name}</h2>
+          <p class="venues__sub">Restaurants, cafés, bakeries, and pubs — each with an editor note, not a star rating.</p>
+        </div>
+        <a href="/eat/" class="venues__link">All venues →</a>
+      </div>
+      <div class="venues__grid">
+        {eatVenues.map((venue) => <VenueCard venue={venue} hrefPrefix="/eat" />)}
+      </div>
+    </div>
+  </section>
+)}
+
+{wineVenues.length > 0 && (
+  <section class="venues venues--plain" id="wine">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Wine & producers</p>
+          <h2 class="venues__title">Cellar doors and makers around {place.data.name}</h2>
+          <p class="venues__sub">The producers worth the appointment — and the ones already shaping the region's vintage conversation.</p>
+        </div>
+        <a href="/wine/" class="venues__link">All wine →</a>
+      </div>
+      <div class="venues__grid">
+        {wineVenues.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+      </div>
+    </div>
+  </section>
+)}
+
+{stayVenues.length > 0 && (
+  <section class="venues" id="stay">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Stay</p>
+          <h2 class="venues__title">Sleep in {place.data.name}</h2>
+        </div>
+        <a href="/stay/" class="venues__link">All stays →</a>
+      </div>
+      <div class="venues__grid">
+        {stayVenues.map((venue) => <VenueCard venue={venue} hrefPrefix="/stay" />)}
+      </div>
+    </div>
+  </section>
+)}
+
+{experiences.length > 0 && (
+  <section class="experience-index" id="explore">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Get outside</p>
+          <h2 class="venues__title">Explore moves anchored to {place.data.name}</h2>
+        </div>
+        <a href="/explore/" class="venues__link">Explore all →</a>
+      </div>
+      <div class="experience-grid">
+        {experiences.map((experience) => <ExperienceCard experience={experience} />)}
+      </div>
+    </div>
+  </section>
+)}
+
+{itineraries.length > 0 && (
+  <section class="escape-callout" id="escapes">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Use it in sequence</p>
+          <h2 class="venues__title">Escapes that already route through {place.data.name}</h2>
+        </div>
+        <a href="/plans/" class="venues__link">Plans →</a>
+      </div>
+      <div class="itinerary-grid">
+        {itineraries.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+      </div>
+    </div>
+  </section>
+)}
+
+{articles.length > 0 && (
+  <section class="venues venues--plain" id="journal">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Read this place properly</p>
+          <h2 class="venues__title">Journal pieces connected to {place.data.name}</h2>
+        </div>
+        <a href="/journal/" class="venues__link">Journal →</a>
+      </div>
+      <div class="venues__grid">
+        {articles.map((article) => <ArticleCard article={article} />)}
+      </div>
+    </div>
+  </section>
+)}
+
+{relatedPlaces.length > 0 && (
+  <section class="places">
+    <div class="container">
+      <div class="places__header">
+        <p class="label label--accent places__label">Keep going</p>
+        <h2 class="places__title">Nearby places worth knowing next</h2>
+      </div>
+      <div class="places__grid">
+        {relatedPlaces.map((item, index) => (
+          <PlaceCard place={item} variant={index % 2 === 0 ? 'bay' : 'sand'} />
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+<NewsletterBlock />
+
+<style>
+  /* ===========================================================
+     PlaceDetailTemplateV2 — scoped styles
+     All v2-only class names are prefixed `pdv2-` to avoid colliding
+     with v1 styles in global.css.
+     =========================================================== */
+
+  /* --- 1. Full-bleed hero ----------------------------------- */
+  .pdv2-hero {
+    position: relative;
+    min-height: 62vh;
+    background-size: cover;
+    background-position: center;
+    color: var(--white);
+    display: flex;
+    align-items: flex-end;
+    overflow: hidden;
+  }
+  .pdv2-hero__scrim {
+    position: absolute;
+    inset: 0;
+    background:
+      linear-gradient(180deg, rgba(0,0,0,0) 35%, rgba(0,0,0,0.55) 100%),
+      linear-gradient(180deg, rgba(0,0,0,0.25) 0%, rgba(0,0,0,0) 30%);
+    pointer-events: none;
+  }
+  .pdv2-hero__inner {
+    position: relative;
+    z-index: 1;
+    padding-top: clamp(4rem, 10vh, 8rem);
+    padding-bottom: clamp(2.5rem, 6vh, 4.5rem);
+    width: 100%;
+  }
+  .pdv2-hero__eyebrow {
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--gold);
+    margin-bottom: 1.1rem;
+    text-shadow: 0 1px 12px rgba(0,0,0,0.4);
+  }
+  .pdv2-hero__title {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-size: clamp(3.4rem, 8.5vw, 7rem);
+    font-weight: 500;
+    line-height: 0.95;
+    letter-spacing: -0.02em;
+    color: var(--white);
+    margin: 0;
+    text-shadow: 0 2px 24px rgba(0,0,0,0.35);
+    max-width: 14ch;
+  }
+  .pdv2-hero__alt {
+    margin-top: 1.25rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: rgba(255,255,255,0.82);
+    max-width: 48ch;
+    font-style: italic;
+    font-family: 'Cormorant Garamond', Georgia, serif;
+  }
+  .pdv2-hero__credit {
+    position: absolute;
+    right: 1.5rem;
+    bottom: 0.85rem;
+    z-index: 2;
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.7);
+  }
+
+  /* --- 2. Editorial lede ------------------------------------ */
+  .pdv2-lede {
+    padding: clamp(3.5rem, 7vw, 6rem) 0 clamp(2.5rem, 5vw, 4rem);
+    background: var(--bg);
+  }
+  .pdv2-lede__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 7fr) minmax(0, 4fr);
+    gap: clamp(2rem, 5vw, 5rem);
+    align-items: start;
+  }
+  .pdv2-lede__main {
+    max-width: 62ch;
+  }
+  .pdv2-lede__factual {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-size: clamp(1.4rem, 2vw, 1.65rem);
+    line-height: 1.45;
+    color: var(--dark);
+    margin-bottom: 1.75rem;
+    font-weight: 400;
+  }
+  .pdv2-lede__dropcap {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    float: left;
+    font-size: 4.5em;
+    line-height: 0.85;
+    padding: 0.05em 0.12em 0 0;
+    margin-top: 0.04em;
+    color: var(--accent);
+    font-weight: 500;
+  }
+  .pdv2-lede__intro {
+    font-size: 1.05rem;
+    line-height: 1.75;
+    color: var(--soft);
+    font-weight: 300;
+  }
+  .pdv2-card {
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1.6rem 1.6rem 1.4rem;
+    font-size: 0.92rem;
+    position: sticky;
+    top: 6rem;
+  }
+  .pdv2-card__label {
+    font-size: 0.65rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 600;
+    margin-bottom: 1rem;
+  }
+  .pdv2-card__list {
+    display: grid;
+    gap: 0.9rem;
+    margin: 0 0 1.2rem;
+  }
+  .pdv2-card__list > div {
+    display: grid;
+    grid-template-columns: 9rem 1fr;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  }
+  .pdv2-card__list > div:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .pdv2-card__list dt {
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--soft);
+    font-weight: 600;
+  }
+  .pdv2-card__list dd {
+    color: var(--dark);
+    line-height: 1.45;
+    font-weight: 400;
+  }
+  .pdv2-card__note {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-size: 1.05rem;
+    line-height: 1.55;
+    color: var(--dark);
+    font-style: italic;
+    border-top: 1px solid var(--border);
+    padding-top: 1.1rem;
+  }
+  .pdv2-card__note span {
+    display: block;
+    font-family: inherit;
+    font-style: normal;
+    font-size: 0.65rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+  }
+
+  /* --- 3. Pull-quote --------------------------------------- */
+  .pdv2-quote {
+    background: var(--bg-alt);
+    padding: clamp(4rem, 8vw, 7rem) 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+  .pdv2-quote__text {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-size: clamp(1.9rem, 3.6vw, 2.9rem);
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+    color: var(--dark);
+    font-weight: 400;
+    font-style: italic;
+    max-width: 32ch;
+    margin: 0 auto;
+    text-align: center;
+    position: relative;
+  }
+  .pdv2-quote__mark {
+    font-family: inherit;
+    color: var(--accent);
+    font-size: 1.4em;
+    line-height: 0;
+    position: relative;
+    top: 0.25em;
+    margin-right: 0.05em;
+  }
+  .pdv2-quote__byline {
+    margin-top: 1.6rem;
+    text-align: center;
+    font-size: 0.7rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--soft);
+    font-weight: 600;
+  }
+
+  /* --- 4. Chapter index ------------------------------------ */
+  .pdv2-chapters {
+    background: var(--bg);
+    padding: clamp(2.5rem, 5vw, 4rem) 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .pdv2-chapters__label {
+    font-size: 0.65rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 600;
+    margin-bottom: 1.4rem;
+  }
+  .pdv2-chapters__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0;
+    border-top: 1px solid var(--border);
+  }
+  .pdv2-chapters__list li {
+    border-bottom: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+  }
+  .pdv2-chapters__list li:nth-child(-n+1) { border-right: 1px solid var(--border); }
+  .pdv2-chapters__list li a {
+    display: flex;
+    align-items: baseline;
+    gap: 0.9rem;
+    padding: 1.1rem 1rem;
+    color: var(--dark);
+    text-decoration: none;
+    transition: background-color 160ms var(--ease), color 160ms var(--ease);
+  }
+  .pdv2-chapters__list li a:hover {
+    background: var(--bg-alt);
+    color: var(--accent);
+  }
+  .pdv2-chapters__num {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-size: 1.4rem;
+    color: var(--accent);
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    min-width: 2ch;
+  }
+  .pdv2-chapters__name {
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    line-height: 1.3;
+  }
+
+  /* --- Responsive ------------------------------------------ */
+  @media (max-width: 900px) {
+    .pdv2-lede__grid {
+      grid-template-columns: 1fr;
+      gap: 2.5rem;
+    }
+    .pdv2-card { position: static; }
+    .pdv2-card__list > div { grid-template-columns: 8rem 1fr; }
+  }
+  @media (max-width: 600px) {
+    .pdv2-hero { min-height: 70vh; }
+    .pdv2-hero__title { font-size: clamp(3rem, 14vw, 5rem); }
+    .pdv2-lede__dropcap { font-size: 3.6em; }
+    .pdv2-card__list > div {
+      grid-template-columns: 1fr;
+      gap: 0.25rem;
+    }
+  }
+</style>

--- a/next/src/pages/preview-place-mornington.astro
+++ b/next/src/pages/preview-place-mornington.astro
@@ -1,0 +1,97 @@
+---
+/**
+ * DRAFT PREVIEW — Place template v2 (Mornington)
+ * View at: /preview-place-mornington
+ *
+ * Compares like-for-like with /places/mornington/. Not linked from anywhere.
+ * Top half redesigned per Wave 1 brief 2026-05-13:
+ *   - Full-bleed magazine hero
+ *   - Two-column editorial lede with editor's-card sidebar
+ *   - Signature pull-quote
+ *   - Numbered chapter index (drops the count-pill nav and the
+ *     "How this hub works" snapshot block)
+ *
+ * Downstream sections (eat / wine / stay / explore / escapes / journal /
+ * related places) are inherited unchanged so the visual diff is isolated
+ * to the top half.
+ */
+import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import PlaceDetailTemplateV2 from '../components/PlaceDetailTemplateV2.astro';
+import { routeSlug, stayTypes, wineTypes } from '../lib/editorial';
+
+const placeSlug = 'mornington';
+const places = await getCollection('places');
+const place = places.find((entry) => routeSlug(entry) === placeSlug);
+if (!place) {
+  throw new Error(`Preview route: place "${placeSlug}" not found in content collection.`);
+}
+
+const allVenues = await getCollection('venues');
+const allExperiences = await getCollection('experiences');
+const allItineraries = await getCollection('itineraries');
+const allArticles = await getCollection('articles', ({ data }) => data.status === 'published');
+
+const placeNameLower = place.data.name.toLowerCase();
+
+const venuesForPlace = allVenues
+  .filter((venue) => String(venue.data.place?.id ?? venue.data.place) === placeSlug);
+
+const venueSlugs = venuesForPlace.map((venue) => routeSlug(venue));
+const experiences = allExperiences
+  .filter((experience) => String(experience.data.place?.id ?? experience.data.place) === placeSlug);
+const experienceSlugs = experiences.map((experience) => routeSlug(experience));
+
+const eatVenues = venuesForPlace
+  .filter((venue) => !stayTypes.includes(venue.data.type) && !wineTypes.includes(venue.data.type))
+  .slice(0, 6);
+const wineVenues = venuesForPlace
+  .filter((venue) => wineTypes.includes(venue.data.type))
+  .slice(0, 6);
+const stayVenues = venuesForPlace
+  .filter((venue) => stayTypes.includes(venue.data.type))
+  .slice(0, 4);
+
+const relatedSlugs = (place.data.relatedPlaces ?? []).map((entry: any) => String(entry.id ?? entry));
+const relatedPlaces = places.filter((entry) => relatedSlugs.includes(routeSlug(entry)));
+
+const itineraries = allItineraries
+  .filter((itinerary) =>
+    itinerary.data.stops.some(
+      (stop) =>
+        venueSlugs.includes(String(stop.venue?.id ?? stop.venue ?? '')) ||
+        experienceSlugs.includes(String(stop.experience?.id ?? stop.experience ?? '')),
+    ),
+  )
+  .slice(0, 3);
+
+const articles = allArticles
+  .filter(
+    (article) =>
+      article.data.tags.includes(placeSlug) ||
+      article.data.tags.some((tag) => tag === placeNameLower) ||
+      article.data.relatedVenues.some((entry) => venueSlugs.includes(String(entry.id ?? entry))) ||
+      article.data.relatedExperiences.some((entry) => experienceSlugs.includes(String(entry.id ?? entry))) ||
+      article.data.title.toLowerCase().includes(placeNameLower),
+  )
+  .slice(0, 4);
+---
+
+<BaseLayout
+  title={`PREVIEW — ${place.data.name} | Place template v2`}
+  description="Internal preview of the redesigned place template. Not for public indexing."
+  section="places"
+  canonical={`https://peninsulainsider.com.au/preview-place-mornington/`}
+  noindex={true}
+>
+  <PlaceDetailTemplateV2
+    place={place}
+    eatVenues={eatVenues}
+    wineVenues={wineVenues}
+    stayVenues={stayVenues}
+    experiences={experiences}
+    itineraries={itineraries}
+    articles={articles}
+    relatedPlaces={relatedPlaces}
+  />
+</BaseLayout>


### PR DESCRIPTION
## Summary
Unlinked, noindex'd preview of the redesigned place-page top half. Live at `/preview-place-mornington/` after merge for side-by-side comparison with `/places/mornington/`.

Top-half changes only (Wave 1):
- Full-bleed magazine hero with eyebrow + serif title over the image
- Two-column editorial lede with drop-cap and sticky editor's-card sidebar (drive time, season, stay duration, best for, insider note)
- Signature pull-quote band sourced from `place.data.signature`
- Numbered chapter index replaces the count-pill nav
- "How this hub works" snapshot block dropped

Downstream sections (eat / wine / stay / explore / escapes / journal / related places) carried over unchanged so the visual diff is isolated to the top.

## Scope
- `next/src/components/PlaceDetailTemplateV2.astro` — new component, scoped `pdv2-` styles
- `next/src/pages/preview-place-mornington.astro` — preview route, noindex, not in nav
- Live `next/src/components/PlaceDetailTemplate.astro` and `places/[slug].astro` untouched

## Test plan
- [ ] Pull branch, `cd next && npm install && npm run dev`, open http://localhost:4321/preview-place-mornington
- [ ] Compare side-by-side with `/places/mornington/` in another tab
- [ ] Check responsive behaviour at 1280 / 900 / 600 viewport widths
- [ ] Confirm `/places/mornington/` and other place pages are visually unchanged
- [ ] After merge, confirm `https://peninsulainsider.com.au/preview-place-mornington/` renders and is noindex'd

If Emma signs off, Wave 2 rolls the v2 template across all town pages (one-line swap in `places/[slug].astro`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)