### PR TITLE
fix(pi): align Plans card CTA row and de-duplicate meta line

### DIFF
--- a/next/src/components/ItineraryCard.astro
+++ b/next/src/components/ItineraryCard.astro
@@ -22,7 +22,7 @@ const regionLabel = (() => {
 const tripType = data.lengthNights <= 1 ? 'One-night escape' : data.lengthNights === 2 ? 'Two-night escape' : `${data.lengthNights}-night escape`;
 const audienceLabel = String(data.audience ?? 'weekend').replace(/-/g, ' ');
 const driveLabel = data.totalDriveMinutes ? `${data.totalDriveMinutes} min drive` : null;
-const metaLine = [tripType, `Best for ${audienceLabel}`, regionLabel, driveLabel, `${data.lengthNights} night${data.lengthNights === 1 ? '' : 's'}`].filter(Boolean).join(' · ');
+const metaLine = [tripType, `Best for ${audienceLabel}`, regionLabel, driveLabel].filter(Boolean).join(' · ');
 ---
 
 <article class="itinerary-card">
@@ -53,13 +53,16 @@ const metaLine = [tripType, `Best for ${audienceLabel}`, regionLabel, driveLabel
   </h3>
   <p class="itinerary-card__dek">{data.dek}</p>
   <p class="itinerary-card__meta">{metaLine}</p>
-  <a href={`/plans/${slug}`} class="itinerary-card__cta">View Plan →</a>
-  <PiSaveActions
-    kind="itinerary"
-    slug={slug}
-    title={data.title}
-    href={`/plans/${slug}/`}
-    dek={data.dek}
-    imageUrl={data.heroImage?.src}
-  />
+  <div class="itinerary-card__actions">
+    <a href={`/plans/${slug}`} class="itinerary-card__cta">View Plan →</a>
+    <PiSaveActions
+      kind="itinerary"
+      slug={slug}
+      title={data.title}
+      href={`/plans/${slug}/`}
+      dek={data.dek}
+      imageUrl={data.heroImage?.src}
+      floating={false}
+    />
+  </div>
 </article>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -3131,7 +3131,9 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .itinerary-card__title,
 .itinerary-card__dek,
 .itinerary-card__chips,
-.itinerary-card__cta {
+.itinerary-card__meta,
+.itinerary-card__cta,
+.itinerary-card__actions {
   padding-left: 1.75rem;
   padding-right: 1.75rem;
 }
@@ -3175,6 +3177,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   font-size: 0.72rem;
   font-weight: 500;
   color: var(--soft);
+  letter-spacing: 0.02em;
+  margin-bottom: 1rem;
 }
 .itinerary-card__title {
   font-family: 'Cormorant Garamond', Georgia, serif;
@@ -3209,6 +3213,14 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   padding: 0.25rem 0.6rem;
   border: 1px solid var(--border);
 }
+.itinerary-card__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: auto;
+  padding-bottom: 1.5rem;
+}
 .itinerary-card__cta {
   display: inline-flex;
   align-items: center;
@@ -3218,8 +3230,6 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-top: auto;
-  padding-bottom: 1.75rem;
   transition: gap .18s var(--ease), color .18s var(--ease);
 }
 .itinerary-card__cta:hover { gap: 0.65rem; color: var(--acc-h); }
@@ -7448,12 +7458,14 @@ p.has-drop-cap::first-letter {
   .itinerary-card__title,
   .itinerary-card__dek,
   .itinerary-card__chips,
-  .itinerary-card__cta {
+  .itinerary-card__meta,
+  .itinerary-card__cta,
+  .itinerary-card__actions {
     padding-left: 1.2rem;
     padding-right: 1.2rem;
   }
   .itinerary-card__top { padding-top: 1.2rem; }
-  .itinerary-card__cta { padding-bottom: 1.2rem; }
+  .itinerary-card__actions { padding-bottom: 1.2rem; }
 
   /* Split intro: tighter */
   .split-intro__title {


### PR DESCRIPTION
## Summary
- Drop the trailing `N nights` from the meta line on `ItineraryCard` — it duplicated the leading `Two-night escape` and caused the line to wrap unevenly across cards.
- Convert the bottom-of-card region to a flex `.itinerary-card__actions` row so `View Plan →` and Save/Share share a baseline. `PiSaveActions` is rendered inline (`floating={false}`) inside that row instead of absolute-positioned.
- Add the meta and new actions row to the shared horizontal-inset ruleset (desktop and mobile breakpoint) so they line up with the title/dek.

These are template-level changes — they propagate everywhere `ItineraryCard` is used (homepage Plans block, /plans index, related-plan rails).

## Test plan
- [ ] Homepage Plans grid: meta on one line at desktop width, View Plan + icons on the same baseline
- [ ] /plans index: same layout holds at the smaller grid widths
- [ ] Mobile (375px): meta and actions row stay within card padding