### PR TITLE
Rebalance homepage cover image (Bushrangers Bay) + fix gradient bleed

### DIFF
--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -148,9 +148,9 @@ const scenes: Scene[] = [
     id: 'flinders-weekend',
     label: 'THE SLOW SIDE',
     hours: '7 MIN READ',
-    image: '/images/sourced/home-cover-south-coast-rainbow-01.webp',
-    imageAlt: 'Flinders boat harbour and coastline from above, Bass Strait, south coast Mornington Peninsula',
-    caption: 'Flinders, south coast',
+    image: '/images/sourced/explore-bushrangers-bay-walk-01.webp',
+    imageAlt: 'Bushrangers Bay headland and Bass Strait below Cape Schanck, on the slow southern coast of the Mornington Peninsula',
+    caption: 'Bushrangers Bay, south coast',
     headline: 'The <em>other</em> Peninsula weekend.',
     dispatch: 'When Red Hill is booked out and Sorrento feels like a queue, there is another version of the Peninsula weekend, south of everything, closer to the ocean, and slower on purpose.',
     primaryHref: '/journal/a-flinders-weekend/',
@@ -614,10 +614,19 @@ const coverDate = new Date('2026-05-13').toLocaleDateString('en-AU', {
   .cover__visual {
     margin: 0;
     min-width: 0;
+    /* Page-scoped override: aspect-ratio is set here (and on the inner
+       frame) so the parent and frame match exactly. The 4/3 ratio set in
+       global.css for .cover__visual was leaving a sage-gradient strip
+       below the inner 3/2 frame on desktop. 4/5 portrait gives the image
+       enough vertical weight to balance the bold serif headline column
+       to its left. */
+    aspect-ratio: 4 / 5;
   }
   .cover__visual-frame {
     overflow: hidden;
-    aspect-ratio: 3 / 2;
+    width: 100%;
+    height: 100%;
+    aspect-ratio: 4 / 5;
   }
   .cover__visual img {
     width: 100%;
@@ -763,8 +772,12 @@ const coverDate = new Date('2026-05-13').toLocaleDateString('en-AU', {
     .cover__dispatch {
       margin-bottom: 1.5rem;
     }
+    /* Mobile: image leads the stack, so go landscape so it doesn't
+       dominate the viewport. Parent .cover__visual already overridden
+       to 16/9 by global.css at this breakpoint; match the frame. */
+    .cover__visual { aspect-ratio: 16 / 9; }
     .cover__visual-frame {
-      aspect-ratio: 3 / 2;
+      aspect-ratio: 16 / 9;
     }
     .cover__caption {
       text-align: left;


### PR DESCRIPTION
## Summary
Three coupled fixes on the homepage cover essay:

1. **Swap the cover image** to \`/images/sourced/explore-bushrangers-bay-walk-01.webp\`. Natively portrait, dramatically composed (basalt headland over open Bass Strait), and Bushrangers Bay is the lead FAQ in the linked Flinders Weekend article. The previous \`home-cover-south-coast-rainbow\` shot was muted and letterboxed inside the cover frame.

2. **Fix the sage-gradient bleed** at the bottom of the cover image. Parent \`.cover__visual\` was \`aspect-ratio: 4/3\` while inner \`.cover__visual-frame\` was \`3/2\`, leaving a strip of the parent's gradient visible below. Both now match.

3. **Take the cover taller** (\`4/5\` portrait on desktop) so the image has the vertical weight to balance the bold serif headline column to its left. Mobile stays \`16/9\` so the image doesn't dominate the stacked viewport.

## Scope
- \`next/src/pages/index.astro\` — scene[0] image/alt/caption, and the page-scoped \`.cover__visual\` / \`.cover__visual-frame\` styles

## Test plan
- [ ] Local build green (verified — 1353 pages, 22s)
- [ ] After deploy: confirm peninsulainsider.com.au shows the Bushrangers Bay shot with no green strip below
- [ ] Spot-check responsive at 1280 / 900 / 600 widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)