### PR TITLE
fix(home): white background on cover band

### DIFF
--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -500,7 +500,7 @@ const coverDate = new Date('2026-05-13').toLocaleDateString('en-AU', {
      narrow screens the columns stack vertically with the type on top.
      ===================================================================== */
   .cover {
-    background: #F6F1E8;
+    background: #FFFFFF;
     color: #171413;
     /* Asymmetric vertical rhythm: real breathing room above the eyebrow
        so it lifts off the masthead hairline, but a tight gap below so
@@ -658,7 +658,7 @@ const coverDate = new Date('2026-05-13').toLocaleDateString('en-AU', {
      rotation-bench scenes in the page frontmatter.
      ────────────────────────────────────────────────────────────────────── */
   .cover-also {
-    background: #F6F1E8;
+    background: #FFFFFF;
     /* Tightened top (was 1–1.5rem) so the strip reads as part of the
        same spread as the cover, not a fresh band. */
     padding: clamp(0.5rem, 1vw, 1rem) 0 clamp(2.5rem, 4.5vw, 4.5rem);


### PR DESCRIPTION
Per James — cover header background moved from #F6F1E8 cream to #FFFFFF. Matching change on .cover-also so the strip below stays visually continuous.