### PR TITLE
Wine sub-regions: build out 5 pages with rich PI template + fix empty grid bug

### DIFF
--- a/next/src/components/WineSubregionTemplate.astro
+++ b/next/src/components/WineSubregionTemplate.astro
@@ -1,0 +1,302 @@
+---
+/**
+ * WineSubregionTemplate
+ * ---------------------
+ * Rich landing template for the five wine sub-regions linked from the
+ * top-nav "By the place" column under Wine: Red Hill, Main Ridge, Merricks,
+ * Balnarring, Flinders.
+ *
+ * Modelled on the depth of /places/<slug>/ but kept wine-first: terroir,
+ * anchor producers, the full grid, signature varietals, pair-with-the-village,
+ * logistics, a scoped map, journal cross-links, related sub-regions, FAQ.
+ *
+ * Reuses existing layout classes (.venues, .zone-intro, .zone-card,
+ * .split-intro, .place-detail__*) so it inherits site CSS without new rules.
+ */
+import Breadcrumbs from './Breadcrumbs.astro';
+import VenueCard from './VenueCard.astro';
+import NewsletterBlock from './NewsletterBlock.astro';
+import PlaceMap from './PlaceMap.astro';
+import { routeSlug } from '../lib/editorial';
+
+export interface AnchorPick {
+  venueSlug: string;
+  verdict: string;
+}
+
+export interface PairWithVillage {
+  placeSlug: string;
+  placeName: string;
+  body: string;
+}
+
+export interface NearbySubregion {
+  slug: string;
+  label: string;
+  hint?: string;
+}
+
+export interface Props {
+  h1: string;
+  badgeLabel: string;
+  subregionSlug: string;
+  introText: string;
+  terroirText: string;
+  venues: any[];
+  anchorPicks?: AnchorPick[];
+  signatureChardonnay?: string;
+  signaturePinot?: string;
+  pairWith?: PairWithVillage;
+  logisticsText?: string;
+  nearbySubregions?: NearbySubregion[];
+  journalLinks?: Array<{ href: string; title: string; body: string }>;
+  place?: any | null; // optional matching `places` collection entry for the map
+  breadcrumbs: Array<{ label: string; href?: string }>;
+  faqItems?: Array<{ q: string; a: string }>;
+}
+
+const {
+  h1,
+  badgeLabel,
+  subregionSlug,
+  introText,
+  terroirText,
+  venues,
+  anchorPicks = [],
+  signatureChardonnay,
+  signaturePinot,
+  pairWith,
+  logisticsText,
+  nearbySubregions = [],
+  journalLinks = [],
+  place = null,
+  breadcrumbs,
+  faqItems = [],
+} = Astro.props;
+
+const venueBySlug: Record<string, any> = {};
+for (const v of venues) {
+  venueBySlug[routeSlug(v)] = v;
+}
+const anchors = anchorPicks
+  .map((p) => ({ venue: venueBySlug[p.venueSlug], verdict: p.verdict }))
+  .filter((a) => a.venue);
+
+const totalProducers = venues.length;
+const hattedCount = venues.filter((v) => Number(v.data.authority?.hats ?? 0) > 0).length;
+const topAuthority = venues
+  .map((v) => Number(v.data.authority?.hallidayScore ?? 0))
+  .filter((n) => n > 0)
+  .sort((a, b) => b - a)[0];
+---
+
+<Breadcrumbs items={breadcrumbs} />
+
+<section class="place-detail">
+  <div class="container">
+    <p class="place-detail__eyebrow">{badgeLabel}</p>
+    <h1 class="place-detail__title">{h1}</h1>
+
+    <div class="prose">
+      {introText.split('\n\n').map((p) => <p>{p}</p>)}
+    </div>
+
+    <dl class="place-detail__stats">
+      <div><dt>Producers mapped</dt><dd>{totalProducers}</dd></div>
+      {hattedCount > 0 && <div><dt>Hatted restaurants</dt><dd>{hattedCount}</dd></div>}
+      {topAuthority && <div><dt>Top Halliday score</dt><dd>{topAuthority}</dd></div>}
+      <div><dt>Sub-region</dt><dd>{h1.replace(' Wineries', '')}</dd></div>
+    </dl>
+  </div>
+</section>
+
+<section class="zone-intro">
+  <div class="container">
+    <div class="split-intro">
+      <div>
+        <p class="label label--accent">Why this sub-region</p>
+        <h2 class="split-intro__title">The land does most of the work</h2>
+      </div>
+      <p class="split-intro__body">Cool-climate Mornington Peninsula wine is hyper-local. The five sub-regions sit within twenty minutes of each other but the bottle in your glass changes as you move between them. Here's what this one does.</p>
+    </div>
+    <div class="prose">
+      {terroirText.split('\n\n').map((p) => <p>{p}</p>)}
+    </div>
+  </div>
+</section>
+
+{anchors.length > 0 && (
+  <section class="venues" id="anchors">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Editor's anchors</p>
+          <h2 class="venues__title">Start with these</h2>
+          <p class="venues__sub">The names we send people to first when they have one afternoon in {h1.replace(' Wineries', '')}.</p>
+        </div>
+      </div>
+      <div class="zone-intro__grid zone-intro__grid--three">
+        {anchors.map(({ venue, verdict }) => (
+          <a href={`/wine/${routeSlug(venue)}/`} class="zone-card zone-card--link">
+            <p class="zone-card__label">{venue.data.authority?.hallidayScore ? `Halliday ${venue.data.authority.hallidayScore}` : (venue.data.type === 'producer' ? 'Producer' : 'Cellar door')}</p>
+            <h3 class="zone-card__title">{venue.data.name}</h3>
+            <p class="zone-card__body">{verdict}</p>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+<section class="venues venues--plain" id="producers">
+  <div class="container">
+    <div class="venues__header">
+      <div>
+        <p class="label label--accent">Every producer · {new Date().getFullYear()}</p>
+        <h2 class="venues__title">{totalProducers} cellar door{totalProducers !== 1 ? 's and producers' : ' / producer'} in {h1.replace(' Wineries', '')}</h2>
+        <p class="venues__sub">Ordered by editorial authority and Halliday score. Each card opens the full editor's note.</p>
+      </div>
+      <a href="/wine/" class="venues__link">All producers →</a>
+    </div>
+    <div class="venues__grid">
+      {venues.map((venue) => <VenueCard venue={venue} hrefPrefix="/wine" />)}
+    </div>
+    <p class="venues__rankings-link"><a href="/wine/best-cellar-doors/">See the editorial rankings → Best Cellar Doors on the Peninsula</a></p>
+  </div>
+</section>
+
+{(signatureChardonnay || signaturePinot) && (
+  <section class="zone-intro">
+    <div class="container">
+      <div class="split-intro">
+        <div>
+          <p class="label label--accent">What to drink here</p>
+          <h2 class="split-intro__title">The bottles this sub-region does best</h2>
+        </div>
+        <p class="split-intro__body">Mornington Peninsula is, in the bottle, mostly two grapes done seriously. Here's what each does in this corner.</p>
+      </div>
+      <div class="zone-intro__grid zone-intro__grid--two">
+        {signatureChardonnay && (
+          <a href="/wine/chardonnay/" class="zone-card zone-card--link">
+            <p class="zone-card__label">Chardonnay</p>
+            <h3 class="zone-card__title">The Chardonnay case</h3>
+            <p class="zone-card__body">{signatureChardonnay}</p>
+          </a>
+        )}
+        {signaturePinot && (
+          <a href="/wine/pinot-noir/" class="zone-card zone-card--link">
+            <p class="zone-card__label">Pinot Noir</p>
+            <h3 class="zone-card__title">The Pinot benchmark</h3>
+            <p class="zone-card__body">{signaturePinot}</p>
+          </a>
+        )}
+      </div>
+    </div>
+  </section>
+)}
+
+{pairWith && (
+  <section class="venues venues--plain">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Pair with the village</p>
+          <h2 class="venues__title">Eat and sleep in {pairWith.placeName}</h2>
+          <p class="venues__sub">{pairWith.body}</p>
+        </div>
+        <a href={`/places/${pairWith.placeSlug}/`} class="venues__link">Open the {pairWith.placeName} hub →</a>
+      </div>
+    </div>
+  </section>
+)}
+
+{logisticsText && (
+  <section class="zone-intro">
+    <div class="container">
+      <div class="split-intro">
+        <div>
+          <p class="label label--accent">Cellar door logistics</p>
+          <h2 class="split-intro__title">Before you drive</h2>
+        </div>
+        <p class="split-intro__body">A small amount of planning is the difference between a working visit and a queue.</p>
+      </div>
+      <div class="prose">
+        {logisticsText.split('\n\n').map((p) => <p>{p}</p>)}
+      </div>
+    </div>
+  </section>
+)}
+
+{place && (
+  <PlaceMap
+    place={place}
+    venues={venues}
+    experiences={[]}
+    events={[]}
+  />
+)}
+
+{journalLinks.length > 0 && (
+  <section class="venues venues--plain" id="journal">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">In voice</p>
+          <h2 class="venues__title">Journal pieces that touch this sub-region</h2>
+          <p class="venues__sub">Long-form writing connected to the producers above.</p>
+        </div>
+        <a href="/journal/" class="venues__link">All journal →</a>
+      </div>
+      <div class="zone-intro__grid zone-intro__grid--three">
+        {journalLinks.map((j) => (
+          <a href={j.href} class="zone-card zone-card--link">
+            <p class="zone-card__label">Journal</p>
+            <h3 class="zone-card__title">{j.title}</h3>
+            <p class="zone-card__body">{j.body}</p>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+{nearbySubregions.length > 0 && (
+  <section class="venues venues--plain" id="nearby">
+    <div class="container">
+      <div class="venues__header">
+        <div>
+          <p class="label label--accent">Keep going</p>
+          <h2 class="venues__title">Nearby wine sub-regions</h2>
+          <p class="venues__sub">The Peninsula's plateau is small. You can cover two sub-regions in one afternoon if you keep tastings short.</p>
+        </div>
+      </div>
+      <div class="zone-intro__grid zone-intro__grid--three">
+        {nearbySubregions.map((n) => (
+          <a href={`/wine/${n.slug}/`} class="zone-card zone-card--link">
+            <p class="zone-card__label">Sub-region</p>
+            <h3 class="zone-card__title">{n.label}</h3>
+            {n.hint && <p class="zone-card__body">{n.hint}</p>}
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+{faqItems.length > 0 && (
+  <section class="faq-section">
+    <div class="container">
+      <div class="prose">
+        <h2>Frequently asked questions</h2>
+        {faqItems.map((item) => (
+          <>
+            <h3>{item.q}</h3>
+            <p>{item.a}</p>
+          </>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+<NewsletterBlock />

--- a/next/src/pages/wine/balnarring.astro
+++ b/next/src/pages/wine/balnarring.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import WineHubTemplate from '../../components/WineHubTemplate.astro';
+import WineSubregionTemplate from '../../components/WineSubregionTemplate.astro';
 import { buildItemListSchema, buildBreadcrumbSchema } from '../../lib/schema';
 import { routeSlug } from '../../lib/editorial';
 
@@ -11,16 +11,20 @@ const canonical = `${SITE}/wine/balnarring/`;
 const wineTypes = ['winery', 'producer'];
 const allVenues = await getCollection('venues');
 const venues = allVenues
-  .filter(
-    (v) =>
-      wineTypes.includes(v.data.type) &&
-      (v.data.place === 'balnarring' || (v.data as any).subregion === 'balnarring')
-  )
+  .filter((v) => {
+    if (!wineTypes.includes(v.data.type)) return false;
+    const placeId = String((v.data as any).place?.id ?? (v.data as any).place ?? '');
+    const sub = String((v.data as any).subregion ?? '');
+    return placeId === 'balnarring' || sub === 'balnarring';
+  })
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
+
+const places = await getCollection('places');
+const place = places.find((p) => routeSlug(p) === 'balnarring') ?? null;
 
 const itemListSchema = buildItemListSchema({
   name: 'Balnarring wineries — Mornington Peninsula',
-  description: 'The cellar doors of the Balnarring subregion on the southern Mornington Peninsula.',
+  description: 'The cellar doors of the Balnarring sub-region — the Peninsula\'s quieter Western Port edge.',
   listPath: '/wine/balnarring',
   items: venues.map((v) => ({ name: v.data.name, path: `/wine/${routeSlug(v)}`, itemType: 'Winery' })),
 });
@@ -34,24 +38,83 @@ const breadcrumbSchema = buildBreadcrumbSchema([
 
 <BaseLayout
   title="Balnarring Wineries · Mornington Peninsula · Peninsula Insider"
-  description="Balnarring is a quieter corner of the Mornington Peninsula wine region. Find the cellar doors in this south-facing coastal subregion."
+  description="The complete editorial guide to the Balnarring wine sub-region — Quealy, Hurley, Elan Vineyard and the Peninsula's quieter Western Port edge."
   section="wine"
   canonical={canonical}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 
-  <WineHubTemplate
+  <WineSubregionTemplate
     h1="Balnarring Wineries"
-    badgeLabel="Subregion · Balnarring"
-    introText={`Balnarring sits on the south-facing slopes above Western Port Bay, south of Merricks. The subregion is cooler and more wind-exposed than the interior plateau, with a character that rewards explorers willing to look beyond the well-signposted cellar doors further north.
+    badgeLabel="Sub-region · Balnarring"
+    subregionSlug="balnarring"
+    introText={`Balnarring is the Peninsula's quieter wine edge. Sitting on the Western Port side, the sub-region trades the polished cellar-door theatre of Red Hill for a smaller, more grower-focused scene — paddocks, gravel driveways, smaller producers working with conviction.
 
-The producers here are typically smaller operations — often appointment-only or open on limited days — but they represent some of the most focused winemaking on the Peninsula. The village itself has a good bakery and pub, making a half-day of it straightforward.`}
+Quealy Winemakers (Halliday 95) and Hurley Vineyard are the names that matter. Both are small, careful operations turning out wines that punch well above the visitor numbers they get. Elan Vineyard adds a gallery to the cellar door — wine and art under one roof in a way that feels organic rather than themed.
+
+The compensation for a smaller producer list is the surrounding village: the monthly Balnarring Farmers' Market is one of the Peninsula's best, the beach is family-scaled and quiet, and the drive between cellar doors feels properly rural.`}
+    terroirText={`Balnarring sits east of the Peninsula ridge at 30–100m elevation, with the land falling gently toward Western Port Bay. The maritime influence is direct — Bittern Inlet is minutes away — but the bay itself is calmer, shallower and warmer than Port Phillip, moderating temperatures rather than aggressively cooling them the way Bass Strait does on the western side.
+
+Soils run to deeper sandy loams over clay, with less of the bright red volcanic basalt that defines the ridge. Drainage is generous. Vine vigour can be higher, which the best Balnarring producers manage with low-yielding plantings and careful canopy work.
+
+The result is wines with a softer, more open texture than the ridge sub-regions. Pinot Gris does particularly well here — Quealy made the case for the variety on the Peninsula long before it was fashionable. Pinot Noir from Balnarring tends to drink earlier than Main Ridge equivalents, with more red-fruit charm and less savoury structure.`}
     venues={venues}
+    anchorPicks={[
+      {
+        venueSlug: 'quealy-winemakers',
+        verdict: 'Kathleen Quealy made the Peninsula case for Pinot Gris (and Friulano, and Moscato Giallo) before the rest of the country caught up. A quiet, working cellar door run by a family that genuinely cares about the answer to your question.',
+      },
+      {
+        venueSlug: 'hurley-vineyard',
+        verdict: "Kevin Bell's tiny single-vineyard estate makes Pinot Noir from three blocks on the same property, bottled separately. Appointment only, deliberately small — one of the most rewarding tastings on the Peninsula if you're in for the detail.",
+      },
+      {
+        venueSlug: 'elan-vineyard',
+        verdict: 'Wine and gallery in the same low-slung shed. Selma Lowther farms biodynamically; the art and the bottles share a quiet, unhurried sensibility. Bring time, not a schedule.',
+      },
+    ]}
+    signatureChardonnay="Balnarring Chardonnay is less common than further west, but where it's made — Hurley's whole-bunch-pressed Chardonnay is the reference — it tends to be textural and gently nutty rather than steely. The warmer, lower sites suit it."
+    signaturePinot="Pinot Noir from Balnarring is open-fruited, perfumed and ready earlier than the ridge sub-regions. The wines drink beautifully young; Hurley's three-block estate range is the most serious local example of how the sub-region's softer soils can still produce structured wines."
+    pairWith={{
+      placeSlug: 'balnarring',
+      placeName: 'Balnarring',
+      body: 'Balnarring village has a strong general store, a good bakery and a hotel pub that does an honest counter lunch. The third-Saturday-of-the-month Balnarring Farmers\' Market is a destination in its own right. Balnarring Beach is calm, shallow Western Port — best for families.',
+    }}
+    logisticsText={`Cellar doors in Balnarring are smaller and more variable in hours than on the ridge. Quealy opens Thursday to Monday; Hurley is appointment-only; Elan opens Friday to Sunday. Always confirm before you drive.
+
+This is a "two stops plus the market" sub-region rather than a cellar-door crawl. If you are visiting on a market Saturday (third Saturday of the month), build the morning around the market and pick one producer for the afternoon.
+
+The roads here are quieter and less direct than the ridge — allow extra time. Mornington Peninsula tour operators cover Balnarring less often than Red Hill; a designated driver is the simplest plan.`}
+    nearbySubregions={[
+      { slug: 'merricks', label: 'Merricks', hint: 'The next sub-region west. Pt. Leo Estate, Stonier, Scorpo and the General Wine Store.' },
+      { slug: 'red-hill', label: 'Red Hill', hint: 'Up the ridge. Paringa, Montalto, Polperro and the monthly market.' },
+      { slug: 'main-ridge', label: 'Main Ridge', hint: 'The highest plateau. Kooyong, Ten Minutes by Tractor, Main Ridge Estate.' },
+    ]}
+    journalLinks={[
+      { href: '/journal/the-cellar-door-short-list/', title: 'The cellar-door short list', body: 'The seven cellar doors I send people to first.' },
+      { href: '/wine/chardonnay/', title: 'The Chardonnay case', body: 'Where Balnarring fits in the Peninsula Chardonnay story.' },
+      { href: '/wine/pinot-noir/', title: 'The Pinot benchmark', body: 'How to read Peninsula Pinot Noir, sub-region by sub-region.' },
+    ]}
+    place={place}
     breadcrumbs={[
       { label: 'Home', href: '/' },
       { label: 'Wine Country', href: '/wine' },
       { label: 'Balnarring' },
+    ]}
+    faqItems={[
+      {
+        q: 'What is Balnarring known for in wine?',
+        a: 'Balnarring is the Peninsula\'s quieter Western Port edge. Quealy Winemakers and Hurley Vineyard are the two producers that have made the sub-region\'s reputation — both small, family-run, and consistently among Halliday\'s top-rated Peninsula estates. Pinot Gris and Pinot Noir are the strengths.',
+      },
+      {
+        q: 'Are there many wineries in Balnarring?',
+        a: 'Fewer than on the ridge. Three is the practical visitor list (Quealy, Hurley, Elan). Several smaller growers in the area sell fruit to estates elsewhere rather than running cellar doors. Pair a Balnarring visit with the monthly farmers\' market or with cellar doors in Merricks for a fuller day.',
+      },
+      {
+        q: 'When is the Balnarring Farmers\' Market?',
+        a: 'Third Saturday of every month, year-round. It is one of the Peninsula\'s best produce markets — smaller and more local than Red Hill Market, with a stronger focus on growers from the Western Port side of the Peninsula. Build a wine day around it.',
+      },
     ]}
   />
 </BaseLayout>

--- a/next/src/pages/wine/flinders.astro
+++ b/next/src/pages/wine/flinders.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import WineHubTemplate from '../../components/WineHubTemplate.astro';
+import WineSubregionTemplate from '../../components/WineSubregionTemplate.astro';
 import { buildItemListSchema, buildBreadcrumbSchema } from '../../lib/schema';
 import { routeSlug } from '../../lib/editorial';
 
@@ -10,17 +10,28 @@ const canonical = `${SITE}/wine/flinders/`;
 
 const wineTypes = ['winery', 'producer'];
 const allVenues = await getCollection('venues');
+
+// Flinders proper has very few wine producers, so we extend the surface
+// to include the southern Peninsula coast — Shoreham, Boneo, Cape Schanck —
+// which sit within ten minutes' drive and share Flinders's cooler, ocean-
+// facing character.
+const FLINDERS_ZONE = new Set(['flinders', 'shoreham', 'boneo', 'cape-schanck', 'main-ridge']);
 const venues = allVenues
-  .filter(
-    (v) =>
-      wineTypes.includes(v.data.type) &&
-      (v.data.place === 'flinders' || (v.data as any).subregion === 'flinders')
-  )
+  .filter((v) => {
+    if (!wineTypes.includes(v.data.type)) return false;
+    const placeId = String((v.data as any).place?.id ?? (v.data as any).place ?? '');
+    const sub = String((v.data as any).subregion ?? '');
+    if (placeId === 'main-ridge') return false;
+    return FLINDERS_ZONE.has(placeId) || sub === 'flinders' || sub === 'shoreham';
+  })
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
 
+const places = await getCollection('places');
+const place = places.find((p) => routeSlug(p) === 'flinders') ?? null;
+
 const itemListSchema = buildItemListSchema({
-  name: 'Flinders wineries — Mornington Peninsula',
-  description: 'The cellar doors of the Flinders subregion on the southern tip of the Mornington Peninsula.',
+  name: 'Flinders & southern Peninsula wineries — Mornington Peninsula',
+  description: 'The cellar doors of the Flinders and southern Peninsula coast — small, cool-climate producers on the ocean side.',
   listPath: '/wine/flinders',
   items: venues.map((v) => ({ name: v.data.name, path: `/wine/${routeSlug(v)}`, itemType: 'Winery' })),
 });
@@ -34,24 +45,75 @@ const breadcrumbSchema = buildBreadcrumbSchema([
 
 <BaseLayout
   title="Flinders Wineries · Mornington Peninsula · Peninsula Insider"
-  description="Flinders is the southernmost wine subregion of the Mornington Peninsula — exposed, cool, and home to some of the most individual producers on the peninsula."
+  description="The complete editorial guide to the Flinders wine area — Nazaaray Estate, the southern coast producers, and how the Peninsula's ocean edge shapes the bottle."
   section="wine"
   canonical={canonical}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 
-  <WineHubTemplate
+  <WineSubregionTemplate
     h1="Flinders Wineries"
-    badgeLabel="Subregion · Flinders"
-    introText={`Flinders sits at the southern tip of the peninsula, exposed to Bass Strait winds and producing some of the coolest, most austere wines in the GI. The growing season is short, yields are minimal, and the wines that result are often the most distinctive on the Peninsula — built for the patient drinker.
+    badgeLabel="Sub-region · Flinders & the southern coast"
+    subregionSlug="flinders"
+    introText={`Flinders sits at the Peninsula's southern ocean edge — Bass Strait directly off the coast, the wind sharper, the wine country smaller. This is the thinnest sub-region by producer count but one of the most distinctive in character: cool, exposed, working close to the climatic limit of where Pinot Noir and Chardonnay can ripen.
 
-Most producers here operate at small scale, often appointment-only. Visiting Flinders combines well with the Flinders General Store, the pier, and the coastal walking tracks — wine country tourism at its quietest and most considered.`}
+Nazaaray Estate is the cellar door name on the ground here. The broader southern Peninsula — Shoreham just to the east, Boneo and Cape Schanck along the coast — folds into the same conversation, with small growers and a handful of restaurants that take Flinders fruit seriously.
+
+Most people who visit Flinders for wine come for one cellar door plus the village: the Flinders Hotel for lunch, the bakery for the drive home, the coastal walk to clear the head. That's the model — wine as one move in a slower, ocean-edge weekend rather than a cellar-door crawl.`}
+    terroirText={`The Flinders wine landscape is shaped by one fact: Bass Strait is right there. The southern coast of the Peninsula faces the Southern Ocean across one of the windiest, coolest stretches of southern Australian coastline. Vineyards here are working at the cool end of cool-climate viticulture.
+
+Elevation drops as you move south from the Main Ridge plateau toward Flinders village, but exposure compensates. Sea breezes are stronger and more constant. The ripening curve is longer than on the ridge plateau. Frost risk is real in spring. Yields are lower. Producers who farm successfully here tend to be small, careful, and patient.
+
+The soils run to lighter loams over clay, with patches of the same red volcanic material that defines the ridge but generally thinner. Wines from the Flinders side tend to show more savoury character on release — more salt-air, more herb, less obvious primary fruit — which is exactly the character that makes them interesting to drink.`}
     venues={venues}
+    anchorPicks={[
+      {
+        venueSlug: 'nazaaray-estate',
+        verdict: 'A small, family-run estate making cool-climate Chardonnay, Pinot Noir and Cabernet Sauvignon from a single property near the coast. The cellar door is unhurried and the wines reflect their southern exposure — leaner, more savoury, longer on the finish.',
+      },
+    ]}
+    signatureChardonnay="Flinders-area Chardonnay sits at the leaner, more austere end of the Peninsula spectrum. Higher natural acidity, less primary stone fruit, more flint and citrus oils. The wines reward food and a few years in the bottle."
+    signaturePinot="Pinot Noir from the southern coast carries the cool-climate signature most clearly — more red fruit than black, more savoury herb and forest floor, a tighter mid-palate than equivalent wines from Red Hill or Merricks. Small-production bottles to seek out rather than household names."
+    pairWith={{
+      placeSlug: 'flinders',
+      placeName: 'Flinders',
+      body: 'Flinders is the slow-pace village: the Flinders Hotel for lunch (the pub kitchen is genuinely good), the general store, the bakery, and a foreshore walk that runs along the cliff edge. Cape Schanck and the Bushrangers Bay walk are ten minutes south. The full weekend reads as one cellar door, two coast walks, and a Sunday roast at the pub.',
+    }}
+    logisticsText={`Cellar doors in the Flinders area open fewer days than further north on the ridge. Nazaaray opens Saturdays and Sundays year-round, with weekday visits by arrangement. Phone ahead — the operations here are family-scaled and small changes in opening hours are common.
+
+Build the day around one cellar door plus the village. Trying to compress three southern-coast tastings into an afternoon won't work — the drive distances and the size of the operations don't support it.
+
+Flinders Road is the main spine, sealed all the way, but it's a slower drive than the ridge — single lane, narrow shoulders, frequent farm traffic. Allow more time than the map suggests. Petrol fills up best in Mornington or Hastings on the way down.`}
+    nearbySubregions={[
+      { slug: 'main-ridge', label: 'Main Ridge', hint: 'Just north up the ridge. Kooyong, Ten Minutes by Tractor and Main Ridge Estate.' },
+      { slug: 'red-hill', label: 'Red Hill', hint: 'A short drive north-east. The Peninsula\'s densest cellar-door cluster.' },
+      { slug: 'merricks', label: 'Merricks', hint: 'East along Western Port. Pt. Leo Estate, Stonier, Scorpo.' },
+    ]}
+    journalLinks={[
+      { href: '/journal/the-cellar-door-short-list/', title: 'The cellar-door short list', body: 'The seven cellar doors I send people to first across the Peninsula.' },
+      { href: '/wine/chardonnay/', title: 'The Chardonnay case', body: 'Where Peninsula Chardonnay sits in the Australian conversation.' },
+      { href: '/wine/pinot-noir/', title: 'The Pinot benchmark', body: 'A sub-region-by-sub-region read on Peninsula Pinot Noir.' },
+    ]}
+    place={place}
     breadcrumbs={[
       { label: 'Home', href: '/' },
       { label: 'Wine Country', href: '/wine' },
       { label: 'Flinders' },
+    ]}
+    faqItems={[
+      {
+        q: 'Are there many wineries in Flinders?',
+        a: 'No — Flinders proper has only a small number of cellar doors. Nazaaray Estate is the main on-the-ground name. The broader southern coast (Shoreham, Boneo, Cape Schanck) adds a handful more. For a fuller wine day, pair a Flinders cellar door with Red Hill or Main Ridge, fifteen minutes north up the ridge.',
+      },
+      {
+        q: 'Why is Flinders worth visiting for wine?',
+        a: 'Character, not volume. The southern coast is the coolest, most exposed part of the Peninsula wine landscape — wines here carry a leaner, more savoury cool-climate signature that the ridge plateau doesn\'t quite match. Combined with the village (Flinders Hotel, the bakery, the coast walk), it makes for a different kind of wine weekend.',
+      },
+      {
+        q: 'Do I need to book at Flinders cellar doors?',
+        a: 'For weekend visits, yes, especially in summer. The cellar doors are small and a single tour bus can fill the room. Call ahead for groups of four or more, and confirm opening hours mid-week — they vary seasonally.',
+      },
     ]}
   />
 </BaseLayout>

--- a/next/src/pages/wine/main-ridge.astro
+++ b/next/src/pages/wine/main-ridge.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import WineHubTemplate from '../../components/WineHubTemplate.astro';
+import WineSubregionTemplate from '../../components/WineSubregionTemplate.astro';
 import { buildItemListSchema, buildBreadcrumbSchema } from '../../lib/schema';
 import { routeSlug } from '../../lib/editorial';
 
@@ -11,16 +11,20 @@ const canonical = `${SITE}/wine/main-ridge/`;
 const wineTypes = ['winery', 'producer'];
 const allVenues = await getCollection('venues');
 const venues = allVenues
-  .filter(
-    (v) =>
-      wineTypes.includes(v.data.type) &&
-      (v.data.place === 'main-ridge' || (v.data as any).subregion === 'main-ridge')
-  )
+  .filter((v) => {
+    if (!wineTypes.includes(v.data.type)) return false;
+    const placeId = String((v.data as any).place?.id ?? (v.data as any).place ?? '');
+    const sub = String((v.data as any).subregion ?? '');
+    return placeId === 'main-ridge' || sub === 'main-ridge';
+  })
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
+
+const places = await getCollection('places');
+const place = places.find((p) => routeSlug(p) === 'main-ridge') ?? null;
 
 const itemListSchema = buildItemListSchema({
   name: 'Main Ridge wineries — Mornington Peninsula',
-  description: 'The cellar doors of the Main Ridge subregion — the highest and coolest part of the Mornington Peninsula wine region.',
+  description: 'The cellar doors of the Main Ridge sub-region — the highest and coolest part of the Mornington Peninsula wine region.',
   listPath: '/wine/main-ridge',
   items: venues.map((v) => ({ name: v.data.name, path: `/wine/${routeSlug(v)}`, itemType: 'Winery' })),
 });
@@ -34,22 +38,65 @@ const breadcrumbSchema = buildBreadcrumbSchema([
 
 <BaseLayout
   title="Main Ridge Wineries · Mornington Peninsula · Peninsula Insider"
-  description="Main Ridge is the highest and coolest subregion of the Mornington Peninsula. Find the best cellar doors in Australia's most elevation-intensive wine district."
+  description="The complete editorial guide to the Main Ridge wine sub-region — Kooyong, Main Ridge Estate, Ten Minutes by Tractor, Dexter and the rest of the Peninsula's highest, coolest plateau."
   section="wine"
   canonical={canonical}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 
-  <WineHubTemplate
+  <WineSubregionTemplate
     h1="Main Ridge Wineries"
-    badgeLabel="Subregion · Main Ridge"
-    introText={`Main Ridge sits at the highest point of the Mornington Peninsula — up to 400m elevation — making it the coolest, most challenging subregion to farm. The short growing season demands discipline: yields are low, ripening requires patience, and the wines that emerge carry a distinctive intensity that marks them immediately.
+    badgeLabel="Sub-region · Main Ridge"
+    subregionSlug="main-ridge"
+    introText={`Main Ridge sits at the highest point of the Mornington Peninsula — up to 400m elevation — making it the coolest and most challenging sub-region to farm. The short growing season demands discipline: yields are low, ripening requires patience, and the wines that emerge carry a distinctive intensity that marks them immediately.
 
-Main Ridge Estate, planted in 1975 by Nat and Rosalie White, is the oldest winery on the Peninsula. Kooyong follows with single-vineyard bottlings that rank among Victoria's finest. Dexter Wines occupies the newer generation: lower intervention, direct fruit, the same serious acidity.
+Main Ridge Estate, planted in 1975 by Nat and Rosalie White, is the oldest winery on the Peninsula. Kooyong follows with single-vineyard bottlings that rank among Victoria's finest. Dexter Wines occupies the newer generation: lower intervention, direct fruit, the same serious acidity. Ten Minutes by Tractor — three vineyards and a hatted restaurant — is the sub-region's most ambitious estate.
 
 The roads here are narrow and the properties smaller than the Red Hill plateau. Visiting requires more effort but rewards accordingly — this is where the Peninsula shows its most demanding, wine-first face.`}
+    terroirText={`Main Ridge is the geographic spine of the Peninsula wine region. The vineyards run along the apex of the volcanic ridge between Arthur's Seat and Cape Schanck, mostly at 250–400m elevation — meaningfully higher than Red Hill next door. That elevation does three things: it extends the growing season by 7–14 days, drops night-time temperatures further, and exposes the vines to more wind from both bays.
+
+The soils are similar to Red Hill — red basalt over clay — but thinner and stonier on the ridge crests. Drainage is sharper. Vine roots struggle harder. Yields are smaller. The wines, on release, are less generous and slower to open than their Red Hill neighbours.
+
+Three to five years in the bottle is the rule rather than the exception for serious Main Ridge Pinot Noir and Chardonnay. The reward for patience is a wine that holds its line longer, with more savoury complexity and less primary fruit. Burgundy comparisons get over-used in Australian wine writing; here they are at their most defensible.`}
     venues={venues}
+    anchorPicks={[
+      {
+        venueSlug: 'ten-minutes-by-tractor',
+        verdict: "Three single-vineyard sites, three restaurants on one estate, and a Wallis Pinot Noir that is the Peninsula's most quietly serious wine. Book lunch at the cellar door bistro for the best entry point; book the main restaurant for the full statement.",
+      },
+      {
+        venueSlug: 'kooyong',
+        verdict: "The Halliday top-rated estate on the plateau. Sandro Mosele's single-vineyard Pinot Noirs — Ferrous, Haven and Meres — are textbook expressions of how Main Ridge changes when you move 200m along the ridge.",
+      },
+      {
+        venueSlug: 'main-ridge-estate',
+        verdict: 'The original. Nat and Rosalie White planted in 1975 and the estate still farms the same blocks. Tiny production, small cellar door, almost no theatre — the wine is the whole point.',
+      },
+    ]}
+    signatureChardonnay="Main Ridge Chardonnay is the Peninsula's most flint-driven and structured. Less stone fruit, more lemon zest and oyster shell. Higher natural acidity than Red Hill means the best examples take five years to fully open. Kooyong's Faultline and Ten Minutes by Tractor's 10X are the reference points."
+    signaturePinot="Pinot Noir from Main Ridge runs darker, more savoury, and tighter than Red Hill. Black cherry rather than red. More forest floor, more spice. The wines are not generous on release — give them two or three years. Kooyong, Ten Minutes by Tractor, Dexter and Main Ridge Estate are the names to start with."
+    pairWith={{
+      placeSlug: 'main-ridge',
+      placeName: 'Main Ridge',
+      body: 'Main Ridge village is small — a general store, a few houses, vineyards in every direction. For lunch beyond the cellar doors, drop down to Red Hill or sideways to Merricks. For a bed among the vines, the boutique stays on the ridge book months ahead in summer.',
+    }}
+    logisticsText={`Most Main Ridge cellar doors operate Thursday to Sunday only, and several smaller producers are appointment-only mid-week. Phone ahead outside peak weekends. The ridge fog can roll in unexpectedly between May and August — pleasant for atmosphere, but it slows the drive between properties.
+
+Two producers per afternoon is realistic. The roads are narrow and almost all turns are blind crests; the speed limit is 80 but anyone driving it that fast hasn't been here before. If you are tasting at Kooyong or Ten Minutes by Tractor, give yourself 90 minutes — the experiences are designed for it.
+
+Designated driver, an organised tour, or staying overnight at one of the on-ridge cottages are the practical options. The plateau has limited mobile coverage in pockets; download maps offline before you leave Mornington.`}
+    nearbySubregions={[
+      { slug: 'red-hill', label: 'Red Hill', hint: 'Just below, slightly warmer, more dining-led. Paringa, Montalto, Polperro and the monthly market.' },
+      { slug: 'merricks', label: 'Merricks', hint: 'The gentler eastern slope. Pt. Leo Estate, Stonier, Scorpo and Merricks General Wine Store.' },
+      { slug: 'balnarring', label: 'Balnarring', hint: 'Below the ridge to the east. Quealy and Hurley are the names worth the detour.' },
+    ]}
+    journalLinks={[
+      { href: '/journal/the-cellar-door-short-list/', title: 'The cellar-door short list', body: 'The seven cellar doors I send people to first. Ten Minutes by Tractor and Kooyong both feature.' },
+      { href: '/wine/chardonnay/', title: 'The Chardonnay case', body: 'Why Main Ridge sits at the top end of the Australian Chardonnay conversation.' },
+      { href: '/wine/pinot-noir/', title: 'The Pinot benchmark', body: 'A sub-region-by-sub-region read on Peninsula Pinot Noir.' },
+    ]}
+    place={place}
     breadcrumbs={[
       { label: 'Home', href: '/' },
       { label: 'Wine Country', href: '/wine' },
@@ -58,7 +105,15 @@ The roads here are narrow and the properties smaller than the Red Hill plateau. 
     faqItems={[
       {
         q: 'What makes Main Ridge different from Red Hill?',
-        a: 'Elevation. Main Ridge tops out at around 400m — 100m higher than most Red Hill vineyards — making it significantly cooler and extending the growing season further. The wines have more austerity and intensity on release and typically require more time to open up. Main Ridge Estate and Kooyong are the primary reference points.',
+        a: 'Elevation. Main Ridge tops out at around 400m — 100m higher than most Red Hill vineyards — making it significantly cooler and extending the growing season further. The wines have more austerity and intensity on release and typically require more time to open up. Main Ridge Estate, Kooyong and Ten Minutes by Tractor are the primary reference points.',
+      },
+      {
+        q: 'Which Main Ridge wineries should I visit first?',
+        a: 'Ten Minutes by Tractor for the full estate experience with a hatted restaurant, Kooyong for benchmark single-vineyard tastings, and Main Ridge Estate for the historical reference point. Two of those three is enough for a full afternoon.',
+      },
+      {
+        q: 'Are Main Ridge wineries open mid-week?',
+        a: 'Some, but fewer than Red Hill. The bigger estates with restaurants — Ten Minutes by Tractor, Kooyong — open Thursday to Sunday. Smaller producers like Main Ridge Estate and Dexter are best visited Friday to Sunday or by appointment outside those days.',
       },
     ]}
   />

--- a/next/src/pages/wine/merricks.astro
+++ b/next/src/pages/wine/merricks.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import WineHubTemplate from '../../components/WineHubTemplate.astro';
+import WineSubregionTemplate from '../../components/WineSubregionTemplate.astro';
 import { buildItemListSchema, buildBreadcrumbSchema } from '../../lib/schema';
 import { routeSlug } from '../../lib/editorial';
 
@@ -11,18 +11,20 @@ const canonical = `${SITE}/wine/merricks/`;
 const wineTypes = ['winery', 'producer'];
 const allVenues = await getCollection('venues');
 const venues = allVenues
-  .filter(
-    (v) =>
-      wineTypes.includes(v.data.type) &&
-      (v.data.place === 'merricks' ||
-        v.data.place === 'merricks-north' ||
-        (v.data as any).subregion === 'merricks')
-  )
+  .filter((v) => {
+    if (!wineTypes.includes(v.data.type)) return false;
+    const placeId = String((v.data as any).place?.id ?? (v.data as any).place ?? '');
+    const sub = String((v.data as any).subregion ?? '');
+    return placeId === 'merricks' || placeId === 'merricks-north' || sub === 'merricks' || sub === 'merricks-north';
+  })
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
+
+const places = await getCollection('places');
+const place = places.find((p) => routeSlug(p) === 'merricks') ?? null;
 
 const itemListSchema = buildItemListSchema({
   name: 'Merricks wineries — Mornington Peninsula',
-  description: 'The cellar doors of Merricks and Merricks North on the Mornington Peninsula.',
+  description: 'The cellar doors of the Merricks sub-region — the Peninsula\'s gentler eastern slope toward Western Port Bay.',
   listPath: '/wine/merricks',
   items: venues.map((v) => ({ name: v.data.name, path: `/wine/${routeSlug(v)}`, itemType: 'Winery' })),
 });
@@ -36,22 +38,65 @@ const breadcrumbSchema = buildBreadcrumbSchema([
 
 <BaseLayout
   title="Merricks Wineries · Mornington Peninsula · Peninsula Insider"
-  description="Merricks and Merricks North produce some of the Mornington Peninsula's most approachable Pinot Noir. Find the best cellar doors in this lower-altitude coastal subregion."
+  description="The complete editorial guide to the Merricks wine sub-region — Pt. Leo Estate, Stonier, Scorpo, Paradigm Hill, the General Wine Store and the eastern slope of the Peninsula."
   section="wine"
   canonical={canonical}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 
-  <WineHubTemplate
+  <WineSubregionTemplate
     h1="Merricks Wineries"
-    badgeLabel="Subregion · Merricks"
-    introText={`Merricks sits lower and closer to Western Port Bay than the Red Hill plateau. The maritime influence is direct — the vineyards are wind-exposed, the soils are heavier clay — producing Pinot Noir that leans riper and more generously textured than the precision wines of Main Ridge above.
+    badgeLabel="Sub-region · Merricks"
+    subregionSlug="merricks"
+    introText={`Merricks runs down the gentler eastern slope of the Peninsula ridge toward Western Port Bay. The land is rolling rather than plateau, the soils slightly warmer than Main Ridge, and the vibe — village store turned wine bar, sculpture in the paddocks — is more relaxed than its high-altitude neighbours.
 
-Stonier Wines is the anchor: one of the Peninsula's longest-established estates and the producer that first drew serious attention to the subregion. Scorpo follows with single-vineyard bottlings that showcase the complexity available at this latitude when yields are controlled.
+Pt. Leo Estate is the most ambitious project on the Peninsula: a sculpture park, three restaurants, and a producer in its own right. Stonier is the oldest established estate. Scorpo, Paradigm Hill and Kerri Greens are the newer generation working with conviction.
 
-Elgee Park, one of the Peninsula's pioneer estates, sits in the broader Merricks North area. The cellar doors here are more intimate than the tourist-scaled operations further north — quieter, more personal, and often selling wines that don't make it to distributors.`}
+Merricks General Wine Store anchors the village — a casual lunch destination that doubles as the unofficial cellar door for several smaller producers without their own visitor space.`}
+    terroirText={`Merricks sits 50–200m above sea level on the eastern flank of the Peninsula ridge, falling away toward Western Port. The slope direction matters: vineyards here see more morning sun and slightly less of the afternoon sea breeze that cools Red Hill and Main Ridge from the Bass Strait side.
+
+The soils are a mix of red volcanic loam in the upper paddocks and grey-brown clay-loams lower down. Yields can be a touch higher than the ridge, ripening a few days earlier. The result is wines with a softer, more open mid-palate — generous on release, less austere than Main Ridge, less polished than Red Hill at its best.
+
+Western Port Bay, calmer and warmer than Port Phillip, has its own moderating effect. Frost is rarer here. Vineyards on the gentle slopes above Balcombe Creek catch enough air movement to avoid disease pressure without losing flavour. Pt. Leo Estate and Merricks Estate sit close enough to the bay to feel its influence directly.`}
     venues={venues}
+    anchorPicks={[
+      {
+        venueSlug: 'pt-leo-estate',
+        verdict: "The Peninsula's most ambitious estate experience. Sculpture park, three restaurants (including hatted Laura), and a wine list that earns its prices. Book Laura for the statement; the casual bistro for the value.",
+      },
+      {
+        venueSlug: 'stonier-wines',
+        verdict: 'A pioneer Peninsula producer making consistently serious Chardonnay and Pinot Noir from estate fruit. Less theatre, more wine. The Reserve range repays cellaring.',
+      },
+      {
+        venueSlug: 'scorpo-wines',
+        verdict: 'Paul and Caroline Scorpo work with restraint and conviction — single-vineyard Pinot Gris, Pinot Noir and Chardonnay with a textural confidence that has quietly made them a critic favourite.',
+      },
+    ]}
+    signatureChardonnay="Merricks Chardonnay tends to be the most approachable of the four serious sub-regions — rounder on the mid-palate, lower acid than Main Ridge, with stone fruit and toasted nut more than mineral flint. Stonier and Pt. Leo Estate set the standard."
+    signaturePinot="Pinot Noir from Merricks runs riper and more red-fruited than Main Ridge, with a generous mid-palate that drinks well young. Scorpo, Paradigm Hill and Kerri Greens make distinctly elegant examples; Pt. Leo Estate's single-vineyard bottlings show the upper end of what the slope can do."
+    pairWith={{
+      placeSlug: 'merricks',
+      placeName: 'Merricks',
+      body: 'Merricks General Wine Store is the lunch anchor — a converted village store now serving one of the Peninsula\'s most popular casual restaurants. Beach access at Merricks is quieter than Pt. Leo, and the surrounding farm lanes make for an unhurried drive between cellar doors.',
+    }}
+    logisticsText={`Most Merricks cellar doors operate Friday to Sunday, with some opening Wednesday and Thursday in peak season. The bigger estates — Pt. Leo, Stonier, Willow Creek — open daily for most of the year; smaller producers are appointment-only mid-week.
+
+The sub-region is more spread out than Red Hill. Allow more drive-time between stops. Three cellar doors plus lunch at the General Wine Store is a full Saturday — don't try to pack four.
+
+Merricks Beach Road and Stanleys Road are the spine. Both are sealed but narrow. The roads east of Merricks Beach Road can be unsealed in places — fine for a careful drive, less fine after summer storms.`}
+    nearbySubregions={[
+      { slug: 'red-hill', label: 'Red Hill', hint: 'Up the ridge to the west. Paringa, Montalto, Polperro and the monthly market.' },
+      { slug: 'main-ridge', label: 'Main Ridge', hint: 'The highest plateau. Kooyong, Ten Minutes by Tractor, Main Ridge Estate.' },
+      { slug: 'balnarring', label: 'Balnarring', hint: 'Further east toward Western Port. Quealy and Hurley.' },
+    ]}
+    journalLinks={[
+      { href: '/journal/the-cellar-door-short-list/', title: 'The cellar-door short list', body: 'The seven cellar doors I send people to first.' },
+      { href: '/wine/chardonnay/', title: 'The Chardonnay case', body: 'Why Mornington Peninsula Chardonnay belongs in the Australian conversation.' },
+      { href: '/wine/pinot-noir/', title: 'The Pinot benchmark', body: 'How to read Peninsula Pinot Noir, sub-region by sub-region.' },
+    ]}
+    place={place}
     breadcrumbs={[
       { label: 'Home', href: '/' },
       { label: 'Wine Country', href: '/wine' },
@@ -59,8 +104,16 @@ Elgee Park, one of the Peninsula's pioneer estates, sits in the broader Merricks
     ]}
     faqItems={[
       {
-        q: 'Is Merricks worth visiting for wine?',
-        a: 'Yes — particularly if you want a quieter experience than the busier Red Hill cellar doors. Stonier Wines and Scorpo are two of the Peninsula\'s most consistent producers. The subregion sits close to Western Port Bay, so the coastal scenery is part of the day.',
+        q: 'What is Merricks known for in wine?',
+        a: 'Merricks is the Peninsula\'s gentler eastern slope, falling from the ridge toward Western Port Bay. Wines here tend to be more approachable and rounder than Main Ridge, with Pt. Leo Estate, Stonier, Scorpo and Paradigm Hill as the lead names. Merricks General Wine Store is the casual lunch anchor.',
+      },
+      {
+        q: 'Is Merricks the same as Merricks North?',
+        a: 'Adjacent but distinct. Merricks is the coastal village with the General Wine Store and beach access. Merricks North is slightly inland and higher, home to several vineyards on the slopes toward Red Hill. Both are quiet and share the same character. For wine purposes they are treated as a single sub-region.',
+      },
+      {
+        q: 'Can I do Merricks and Red Hill in one day?',
+        a: 'Yes, comfortably. The two sub-regions are 15 minutes apart by car. A common move is morning at one and afternoon at the other, with lunch at Pt. Leo Estate or Montalto bridging the two. Pick one anchor with food and two smaller producers either side.',
       },
     ]}
   />

--- a/next/src/pages/wine/red-hill.astro
+++ b/next/src/pages/wine/red-hill.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import WineHubTemplate from '../../components/WineHubTemplate.astro';
+import WineSubregionTemplate from '../../components/WineSubregionTemplate.astro';
 import { buildItemListSchema, buildBreadcrumbSchema } from '../../lib/schema';
 import { routeSlug } from '../../lib/editorial';
 
@@ -11,18 +11,20 @@ const canonical = `${SITE}/wine/red-hill/`;
 const wineTypes = ['winery', 'producer'];
 const allVenues = await getCollection('venues');
 const venues = allVenues
-  .filter(
-    (v) =>
-      wineTypes.includes(v.data.type) &&
-      (v.data.place === 'red-hill' ||
-        v.data.place === 'red-hill-south' ||
-        (v.data as any).subregion === 'red-hill')
-  )
+  .filter((v) => {
+    if (!wineTypes.includes(v.data.type)) return false;
+    const placeId = String((v.data as any).place?.id ?? (v.data as any).place ?? '');
+    const sub = String((v.data as any).subregion ?? '');
+    return placeId === 'red-hill' || placeId === 'red-hill-south' || sub === 'red-hill' || sub === 'red-hill-south';
+  })
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
+
+const places = await getCollection('places');
+const place = places.find((p) => routeSlug(p) === 'red-hill') ?? null;
 
 const itemListSchema = buildItemListSchema({
   name: 'Red Hill wineries — Mornington Peninsula',
-  description: 'The cellar doors of the Red Hill subregion on the Mornington Peninsula.',
+  description: 'The cellar doors of the Red Hill sub-region on the Mornington Peninsula.',
   listPath: '/wine/red-hill',
   items: venues.map((v) => ({ name: v.data.name, path: `/wine/${routeSlug(v)}`, itemType: 'Winery' })),
 });
@@ -36,22 +38,65 @@ const breadcrumbSchema = buildBreadcrumbSchema([
 
 <BaseLayout
   title="Red Hill Wineries · Mornington Peninsula · Peninsula Insider"
-  description="The Red Hill subregion is the heart of the Mornington Peninsula wine region. Find the best cellar doors, tasting rooms, and producers in Red Hill and Red Hill South."
+  description="The complete editorial guide to the Red Hill wine sub-region — Montalto, Paringa Estate, Polperro, Port Phillip Estate and the rest, with terroir, anchors and logistics."
   section="wine"
   canonical={canonical}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 
-  <WineHubTemplate
+  <WineSubregionTemplate
     h1="Red Hill Wineries"
-    badgeLabel="Subregion · Red Hill"
+    badgeLabel="Sub-region · Red Hill"
+    subregionSlug="red-hill"
     introText={`Red Hill is the plateau that defines Mornington Peninsula wine country. Sitting at 100–300m elevation inland from the coast, it catches cool afternoon breezes from both Port Phillip Bay and Western Port — a mesoclimate that lengthens the growing season and builds complexity slowly. The basalt and clay soils retain moisture without waterlogging.
 
-Montalto, Ten Minutes by Tractor, and Paringa Estate are the anchors. The cluster of producers around Shoreham Road and Red Hill South Road contains some of the most consistent Pinot Noir and Chardonnay in Victoria. The restaurant cellars doors here — Montalto's hatted dining room, Ten Minutes by Tractor's three-restaurant estate — set a standard for wine country hospitality that the rest of Australia is still catching up to.
+Montalto, Ten Minutes by Tractor, and Paringa Estate are the anchors. The cluster of producers around Shoreham Road and Red Hill South Road contains some of the most consistent Pinot Noir and Chardonnay in Victoria. The restaurant cellar doors here — Montalto's hatted dining room, Ten Minutes by Tractor's three-restaurant estate — set a standard for wine country hospitality that the rest of Australia is still catching up to.
 
 Most cellar doors are open weekends. Several require bookings, particularly in winter. Driving the ridge roads between producers is itself part of the experience.`}
+    terroirText={`The Red Hill plateau is what happens when ancient basalt meets cool maritime air. Vineyards sit 150–250m above sea level on deep red volcanic soils that drain freely but hold moisture in the subsoil — the kind of profile that lets vines work hard without stress, slowing ripening just enough to build flavour without losing acidity.
+
+Two bodies of water do most of the work: Port Phillip Bay to the north-west and Western Port to the south-east. The afternoon sea breeze that lifts off Bass Strait reaches Red Hill by mid-afternoon in summer, dropping temperatures and preserving the natural acidity that defines the sub-region's best Pinot Noir and Chardonnay.
+
+The result is wines with line and length rather than weight. Reds with red-fruited transparency rather than black-fruited density. Whites that taste like fruit before they taste like oak. Compared to Main Ridge — the higher, cooler plateau next door — Red Hill leans a touch warmer and rounder. Compared to Merricks — the gentler eastern slope — it leans more savoury and structured.`}
     venues={venues}
+    anchorPicks={[
+      {
+        venueSlug: 'paringa-estate',
+        verdict: "Lindsay McCall's benchmark Pinot Noir and Shiraz, served from a hatted restaurant terrace that understands what Saturday lunch is supposed to be. Less theatre than Montalto, more focus on what's in the bottle.",
+      },
+      {
+        venueSlug: 'montalto',
+        verdict: "The full Red Hill experience — hatted restaurant, sculpture trail, olive grove and a cellar door that knows it's the day's centrepiece. Book the dining room early; the kitchen does the work that justifies the room.",
+      },
+      {
+        venueSlug: 'polperro',
+        verdict: 'A more intimate cellar-door alternative to the estate-scale neighbours. Sam Coverdale makes some of the sub-region\'s most precise small-batch Pinot Noir; the casual bistro is built for a long lunch without a tie.',
+      },
+    ]}
+    signatureChardonnay="Red Hill Chardonnay is restrained, mineral, and Burgundy-influenced — flint, citrus oils, and a finish that ends clean rather than buttery. Producers here have largely moved past heavy oak; the best examples taste like fruit grown on volcanic ground."
+    signaturePinot="The sub-region's Pinot Noir runs lighter and more red-fruited than Main Ridge, with a slightly riper, rounder mid-palate. Paringa, Polperro, Montalto and Port Phillip Estate all bottle distinct expressions; tasting two or three side-by-side teaches you more about the plateau than any tour would."
+    pairWith={{
+      placeSlug: 'red-hill',
+      placeName: 'Red Hill',
+      body: 'The Red Hill village itself is small but the surrounding hamlets — Red Hill South, Shoreham, Main Ridge — give you Red Hill Cheese, the monthly market, Quail Run for a casual meal, and a handful of stays among the vines.',
+    }}
+    logisticsText={`Most Red Hill cellar doors open from 11am to 5pm Friday to Sunday, with Monday and Tuesday by appointment. Winter weekdays can be quiet — call ahead. Summer weekends require a booking at any cellar door attached to a restaurant.
+
+Plan to visit no more than three producers in an afternoon. The roads connecting them are narrow ridge roads, drink-driving limits are taken seriously, and most cellar doors are now a tasting experience rather than a tasting bar — expect 45 minutes per stop.
+
+Designated drivers, organised peninsula tour operators, and Uber from Mornington all work. The car parks fill at hatted restaurants by midday on Saturdays.`}
+    nearbySubregions={[
+      { slug: 'main-ridge', label: 'Main Ridge', hint: 'Higher, cooler, more producer-focused. Kooyong, Ten Minutes by Tractor and Main Ridge Estate.' },
+      { slug: 'merricks', label: 'Merricks', hint: 'The eastern slope. Pt. Leo Estate, Stonier, Scorpo and the General Wine Store.' },
+      { slug: 'balnarring', label: 'Balnarring', hint: 'The Western Port edge. Quealy, Hurley and a quieter scene.' },
+    ]}
+    journalLinks={[
+      { href: '/journal/the-cellar-door-short-list/', title: 'The cellar-door short list', body: 'The seven cellar doors I send people to first, with Red Hill anchoring the list.' },
+      { href: '/wine/chardonnay/', title: 'The Chardonnay case', body: 'Why Mornington Peninsula Chardonnay belongs in the Australian conversation, with Red Hill at the front of it.' },
+      { href: '/wine/pinot-noir/', title: 'The Pinot benchmark', body: 'How to read Peninsula Pinot Noir, sub-region by sub-region.' },
+    ]}
+    place={place}
     breadcrumbs={[
       { label: 'Home', href: '/' },
       { label: 'Wine Country', href: '/wine' },
@@ -60,11 +105,19 @@ Most cellar doors are open weekends. Several require bookings, particularly in w
     faqItems={[
       {
         q: 'What is Red Hill known for in wine?',
-        a: 'Red Hill and its southern extension Red Hill South sit on elevated plateau country with basalt soils and cool maritime air. The subregion produces Pinot Noir and Chardonnay with unusual precision — the cooling influence of nearby Bass Strait extends the growing season, allowing slow, complex ripening. Montalto, Ten Minutes by Tractor, and Paringa Estate are the benchmark names.',
+        a: 'Red Hill and its southern extension Red Hill South sit on elevated plateau country with basalt soils and cool maritime air. The sub-region produces Pinot Noir and Chardonnay with unusual precision — the cooling influence of nearby Bass Strait extends the growing season, allowing slow, complex ripening. Montalto, Ten Minutes by Tractor, and Paringa Estate are the benchmark names.',
       },
       {
         q: 'How far is Red Hill from Melbourne?',
         a: 'Around 70–75km from central Melbourne, or approximately 75 minutes by car via the Nepean Highway or Mornington Peninsula Freeway. The drive through the peninsula backroads from Mornington to Red Hill takes 30–40 minutes and passes several cellar doors en route.',
+      },
+      {
+        q: 'How many wineries can I visit in Red Hill in an afternoon?',
+        a: 'Two or three is the practical maximum if you want to taste properly and have lunch. Cellar doors here are now full experiences, not tasting bars — most take 45–60 minutes. Pick one anchor with food (Montalto, Paringa, Ten Minutes by Tractor) and one or two smaller producers for tastings either side.',
+      },
+      {
+        q: 'Do I need to book Red Hill cellar doors?',
+        a: 'For the hatted restaurants and any cellar door attached to a restaurant, yes — book at least a week ahead in summer, longer in November and December. Casual cellar doors like Polperro and Foxeys Hangout walk-ins are usually fine outside peak periods. Call any cellar door if you are travelling with a group of six or more.',
       },
     ]}
   />

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -4141,6 +4141,27 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   gap: 1.25rem;
 }
 
+/* Three-up + two-up variants used by WineSubregionTemplate.
+   Mobile collapses to a single column via the existing
+   .zone-intro__grid @media rules below 720px. */
+.zone-intro__grid--three {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+.zone-intro__grid--two {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+@media (max-width: 900px) {
+  .zone-intro__grid--three { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .zone-intro__grid--three,
+  .zone-intro__grid--two { grid-template-columns: 1fr; }
+}
+
 /* =========================================================
    PLACE DETAIL  -  extras: stats bar + in-page jump nav.
    ========================================================= */


### PR DESCRIPTION
## Summary

- Builds out `/wine/{red-hill, main-ridge, merricks, balnarring, flinders}/` with a new `WineSubregionTemplate` that matches the depth of `/places/<slug>/`: terroir, editor's anchors with custom verdicts, full producer grid, signature varietal cards, pair-with-the-village, cellar-door logistics, scoped Leaflet map, journal cross-links, nearby sub-regions, FAQ.
- Fixes a silent pre-existing bug: the venue filters compared `v.data.place === '<slug>'` against a Zod reference object, so the producer grids were rendering empty. Now compares against the resolved reference id — all 37 mapped winery / producer entries surface in the right sub-region.

| Page | Producers | Anchors |
|---|---|---|
| Red Hill | 12 | Paringa, Montalto, Polperro |
| Main Ridge | 10 | Ten Minutes by Tractor, Kooyong, Main Ridge Estate |
| Merricks | 9 | Pt. Leo Estate, Stonier, Scorpo |
| Balnarring | 3 | Quealy, Hurley, Elan |
| Flinders | 3 | Nazaaray (extended to the southern coast) |

## Test plan

- [x] `astro build` green locally (1360 pages, 30s)
- [x] All 5 pages now serve full producer grids (previously 0 cards)
- [x] Anchor cards, map, FAQ, nearby-subregions all render
- [x] `WineHubTemplate` left untouched — cellar-doors / chardonnay / pinot-noir / appointment-producers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)