### PR TITLE
fix(plans): tidy hero CTA row (drop helper copy, single row, ghost secondary)

### DIFF
--- a/next/src/components/PiForkPlanButton.astro
+++ b/next/src/components/PiForkPlanButton.astro
@@ -21,13 +21,20 @@ export interface Props {
   items: Array<Omit<SavedItem, 'savedAt'>>;
   /** Optional override for the button label. */
   label?: string;
+  /**
+   * Visual variant.
+   *  - 'solid' (default): filled dark pill, for standalone placements.
+   *  - 'ghost': outlined pill, for placements where this button sits next
+   *    to a primary CTA and should defer to it visually.
+   */
+  variant?: 'solid' | 'ghost';
 }
 
-const { items, label = 'Save this plan as mine' } = Astro.props;
+const { items, label = 'Save this plan as mine', variant = 'solid' } = Astro.props;
 const encoded = JSON.stringify(items);
 ---
 
-<div class="pi-fork-plan">
+<div class={`pi-fork-plan pi-fork-plan--${variant}`}>
   <button
     type="button"
     class="pi-fork-plan__btn"
@@ -39,41 +46,43 @@ const encoded = JSON.stringify(items);
     </svg>
     {label}
   </button>
-  <p class="pi-fork-plan__hint">
-    Forks the itinerary plus every stop into your plan. Edit, share, or print from <a href="/account/saved/">your saves</a>.
-  </p>
 </div>
 
 <style is:global>
   .pi-fork-plan {
     margin: 1.5rem 0 0;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
+    display: inline-flex;
   }
+
+  /* When nested inside a CTA row (e.g. on the plan-detail page), the
+     parent row owns the spacing — drop the standalone top margin. */
+  .itinerary-detail__cta-row .pi-fork-plan { margin: 0; }
 
   .pi-fork-plan__btn {
     display: inline-flex;
     align-items: center;
     gap: 0.6rem;
+    /* Match the .itinerary-detail__cta padding/typography so the two
+       buttons share the same vertical rhythm when they sit in one row. */
     padding: 0.85rem 1.4rem;
     background: var(--ink, #171413);
     color: var(--paper, #FAF7F0);
     border: 1px solid var(--ink, #171413);
-    border-radius: 100px;
+    border-radius: 999px;
     font-family: 'Outfit', system-ui, sans-serif;
-    font-size: 0.78rem;
+    font-size: 0.74rem;
     font-weight: 700;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     cursor: pointer;
-    transition: background 0.18s ease, border-color 0.18s ease, transform 0.08s ease;
+    transition: background 0.18s ease, border-color 0.18s ease,
+                color 0.18s ease, transform 0.08s ease;
   }
 
   .pi-fork-plan__btn:hover {
     background: var(--ochre, #A0541F);
     border-color: var(--ochre, #A0541F);
+    color: #FFFFFF;
   }
 
   .pi-fork-plan__btn:active { transform: scale(0.98); }
@@ -81,22 +90,27 @@ const encoded = JSON.stringify(items);
   .pi-fork-plan__btn[data-state="forked"] {
     background: var(--ochre, #A0541F);
     border-color: var(--ochre, #A0541F);
+    color: #FFFFFF;
   }
 
-  .pi-fork-plan__hint {
-    font-family: var(--serif, 'Newsreader', Georgia, serif);
-    font-size: 0.85rem;
-    line-height: 1.45;
-    color: var(--ink-soft, #3A3531);
-    margin: 0;
-    max-width: 36rem;
+  /* ── Ghost variant ────────────────────────────────────────────────
+     For placements where this button sits next to a filled primary CTA
+     (anchor-stay on /plans/[slug]). Outlined pill so the hierarchy
+     reads: primary action = filled, secondary = outlined. */
+  .pi-fork-plan--ghost .pi-fork-plan__btn {
+    background: transparent;
+    color: var(--ink, #171413);
+    border-color: var(--ink, #171413);
   }
-
-  .pi-fork-plan__hint a {
-    color: var(--ochre, #A0541F);
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
+  .pi-fork-plan--ghost .pi-fork-plan__btn:hover {
+    background: var(--ink, #171413);
+    color: var(--paper, #FAF7F0);
+    border-color: var(--ink, #171413);
+  }
+  .pi-fork-plan--ghost .pi-fork-plan__btn[data-state="forked"] {
+    background: var(--ochre, #A0541F);
+    border-color: var(--ochre, #A0541F);
+    color: #FFFFFF;
   }
 </style>
 

--- a/next/src/pages/plans/[slug].astro
+++ b/next/src/pages/plans/[slug].astro
@@ -473,9 +473,13 @@ const ogImage = data
         {data!.totalDriveMinutes && <span>{data!.totalDriveMinutes} min driving</span>}
       </div>
 
-      {/* Anchor-stay 3-placement rule, slot 1: hero CTA */}
-      {effectiveStay && effectiveStayHref && (
-        <div class="itinerary-detail__cta-row">
+      {/* Hero CTA row — anchor-stay (filled, primary) + fork-to-saves (ghost,
+          secondary). One row so the two reader actions read as a pair, not
+          a stacked pile. The utility caption that used to sit beside the
+          anchor CTA and the hint paragraph that used to sit under the fork
+          button were removed 2026-05-14 — both buttons are self-evident. */}
+      <div class="itinerary-detail__cta-row">
+        {effectiveStay && effectiveStayHref && (
           <a
             href={`${effectiveStayHref}?utm_source=peninsula-insider&utm_medium=escape&utm_campaign=${slug}&utm_content=hero`}
             class="itinerary-detail__cta"
@@ -484,13 +488,9 @@ const ogImage = data
           >
             Stay at {(effectiveStay as any).data.name} →
           </a>
-          <span class="itinerary-detail__cta-note">Anchor stay for this plan</span>
-        </div>
-      )}
-
-      {/* Fork this editorial plan into the reader's saves. Wave 5 of the
-          Save & Share rebuild — editorial content as a template. */}
-      <PiForkPlanButton items={forkItems} />
+        )}
+        <PiForkPlanButton items={forkItems} variant="ghost" />
+      </div>
 
       <div
         class="itinerary-detail__hero feature__image-block feature__image-block--sand"


### PR DESCRIPTION
## Summary
Per James on /plans/ridge-to-sea-two-night-escape/ — clean up the messy stack of two CTA buttons at the top of every plan page.

- Drop 'Anchor stay for this plan' caption.
- Drop 'Forks the itinerary plus every stop into your plan. Edit, share, or print from your saves.' hint paragraph.
- Both buttons now share one flex row instead of stacking with helper copy between them.
- 'Stay at {anchor}' stays as the filled-dark primary CTA (the conversion).
- 'Save this plan as mine' becomes a ghost/outlined pill (PiForkPlanButton has a new \`variant='ghost'\` prop) so the hierarchy reads filled-primary + outlined-secondary. Same pattern as the homepage cover.

Solid variant is still the default for any other placement.

## Scope
- \`next/src/pages/plans/[slug].astro\` — drop the caption span, merge fork button into the cta-row
- \`next/src/components/PiForkPlanButton.astro\` — drop the hint paragraph, add variant prop, restyle button to match \`.itinerary-detail__cta\` typography + add \`--ghost\` variant

## Test plan
- [ ] Build green (verified — 1360 pages, 28s; both removed strings absent from built page)
- [ ] Live: confirm /plans/ridge-to-sea-two-night-escape/ shows the two buttons side-by-side, no helper copy, ghost-styled fork button to the right of the dark anchor-stay CTA
- [ ] Spot-check at mobile width — flex-wrap keeps them stacked when there isn't room