### PR TITLE
fix(places + cards): indent quick-take bullets, centre save/share icons

### DIFF
--- a/next/src/components/PiSaveActions.astro
+++ b/next/src/components/PiSaveActions.astro
@@ -159,13 +159,22 @@ const { kind, slug, title, href, section, dek, imageUrl, floating = true } = Ast
   .pi-actions__btn:active { transform: scale(0.95); }
 
   /* Hover label — desktop only. Fades in after the button has started
-     expanding so text never appears clipped mid-animation. */
+     expanding so text never appears clipped mid-animation.
+     `max-width: 0` is critical: `opacity: 0` alone does not remove the
+     element from the flex layout, so the label would still claim its
+     natural text width and shove the icon off-centre inside the 2rem
+     collapsed circle. Zeroing max-width + overflow:hidden makes the
+     label contribute zero width when collapsed; the icon then sits
+     truly centred. */
   .pi-actions__label {
     opacity: 0;
+    max-width: 0;
     overflow: hidden;
     white-space: nowrap;
     pointer-events: none;
-    transition: opacity 0.14s ease 0.12s;
+    transition:
+      opacity   0.14s ease 0.12s,
+      max-width 0.24s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   @media (hover: hover) and (pointer: fine) {
@@ -177,6 +186,7 @@ const { kind, slug, title, href, section, dek, imageUrl, floating = true } = Ast
     }
     .pi-actions__btn:hover .pi-actions__label {
       opacity: 1;
+      max-width: 6rem;
     }
   }
 

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -2171,6 +2171,31 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   background-position: center;
 }
 
+/* Quick take TLDR list on /places/[slug] pages.
+   The global reset zeroes UL padding so without this rule the bullets
+   sit flush against the column edge. Padding-left + outside list-style
+   gives the classic hanging-indent so wrapped text aligns under the
+   first character of the item, not under the bullet. */
+.place-detail__tldr {
+  max-width: 62ch;
+  margin-bottom: 2.25rem;
+}
+.place-detail__tldr-list {
+  list-style: disc outside;
+  padding-left: 1.4rem;
+  margin-top: 0.6rem;
+}
+.place-detail__tldr-list li {
+  padding-left: 0.35rem;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--soft);
+}
+.place-detail__tldr-list li::marker {
+  color: var(--accent);
+}
+
 /* =========================================================
    WHY INSIDER (homepage closing pitch)
    ========================================================= */


### PR DESCRIPTION
## Summary
Per James on /places/point-nepean/ — two template-wide fixes.

**1. Quick-take bullets indented.** Template was rendering bullets flush against the column edge because the global reset zeroes UL padding and no rule existed for `.place-detail__tldr-list`. Added a scoped rule with hanging-indent (`list-style: disc outside`, padding-left 1.4rem) and accent-coloured `::marker`.

**2. Save/Share icon now sits dead centre in the 32x32 circle.** The collapsed label had `opacity: 0` but stayed in the flex layout, claiming its text width and shoving the icon off-centre. Adding `max-width: 0` + `overflow: hidden` to the collapsed label gives it zero flex contribution; `max-width: 6rem` on hover restores the smooth pill-expansion transition.

Rolls across every place page (Mornington, Sorrento, Flinders, …) and every card on the site that uses PiSaveActions (Article, Event, Venue, Place, Experience, Itinerary, Tour, Operator, Package).

## Test plan
- [ ] Build green (verified — 1360 pages, 36s)
- [ ] Live: confirm point-nepean Quick Take bullets have visible indent + accent-coloured markers
- [ ] Live: hover/inspect a Save circle on any card; the bookmark icon should sit centred in the circle when collapsed, and the pill expansion to 'Save' should still animate smoothly
