### PR TITLE
feat(breadcrumbs): sticky under the masthead, site-wide

### DIFF
--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -192,6 +192,31 @@ const isAskPage = rawPathname.startsWith('/ask');
 
   <V4Masthead section={section} />
 
+  {/* Measure the masthead height and publish it as --masthead-h on
+      <html> so .breadcrumbs (and any other element that wants to pin
+      itself just under the masthead) can sticky-position itself
+      precisely on every viewport. ResizeObserver handles the mobile
+      utility-row collapse and the responsive nav height changes. */}
+  <script is:inline>
+    (function () {
+      function setMastheadH() {
+        var m = document.querySelector('.masthead');
+        if (!m) return;
+        var h = Math.round(m.getBoundingClientRect().height);
+        document.documentElement.style.setProperty('--masthead-h', h + 'px');
+      }
+      setMastheadH();
+      if ('ResizeObserver' in window) {
+        var m = document.querySelector('.masthead');
+        if (m) new ResizeObserver(setMastheadH).observe(m);
+      } else {
+        window.addEventListener('resize', setMastheadH);
+      }
+      // Re-measure after page transitions (Astro view-transitions).
+      document.addEventListener('astro:page-load', setMastheadH);
+    })();
+  </script>
+
   {/* data-pagefind-body scopes the index to <main>, so the masthead, footer,
       concierge drawer, and search overlay aren't indexed.
       data-pagefind-filter populates the "kind" facet on /search.

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -2944,7 +2944,15 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   background: var(--bg);
   /* Generous top padding so the breadcrumb never reads as "tucked under"
      the sticky masthead — visible breathing room is the whole point. */
-  padding: 1.4rem 0 0.85rem;
+  padding: 1.0rem 0 0.85rem;
+  /* Sticky under the masthead so the reader can always see where they
+     are in the hierarchy on long pages. `--masthead-h` is set in JS by
+     BaseLayout (ResizeObserver on .masthead); the fallback covers SSR
+     and the brief window before the script runs. z-index sits just
+     under the masthead (9999) so dropdowns/modals still layer above. */
+  position: sticky;
+  top: var(--masthead-h, 6rem);
+  z-index: 50;
   /* When linking to a breadcrumb anchor (rare but possible), make sure
      the masthead doesn't occlude it on scroll. */
   scroll-margin-top: 140px;


### PR DESCRIPTION
## Summary
`.breadcrumbs` is now position: sticky with `top: var(--masthead-h)`. Readers can always see where they are in the hierarchy on long pages without scrolling back to the top.

- `global.css` — adds `position: sticky; top: var(--masthead-h, 6rem); z-index: 50` to `.breadcrumbs`. Padding-top trimmed from 1.4rem to 1rem so the pinned bar reads as a thin orientation strip rather than a tall band.
- `BaseLayout.astro` — small inline script measures the masthead with ResizeObserver and publishes the height as `--masthead-h` on `<html>`. Handles mobile utility-row collapse, desktop nav, and re-measures on Astro view-transitions.

## Test plan
- [ ] Build green (verified — 1360 pages, 26s)
- [ ] Live: scroll any journal article / place page / venue page; breadcrumb should pin under the masthead instead of scrolling away
- [ ] Verify dropdowns and modals (search overlay, profile dropdown, auth modal) still layer above the breadcrumb
- [ ] Re-test at mobile width where the utility row collapses — masthead height changes, sticky offset should follow

## Follow-up: audit findings (separate PR)
76 of 225 live pages currently don't import `Breadcrumbs`. Top categories that probably should:
- 32 hand-built journal pages
- 10 wine pages
- 5 guides
- 5 partners
- 3 each: eat, escape
- ~12 scattered across stay/explore/boating/plan/places/fishing

Correctly omitted: index, 404, ask, newsletter, account/* (utility/logged-in surfaces).
