### PR TITLE
feat(cms): Waves 1+2 — inline editing on listicle + section-landing pages

### DIFF
--- a/next/src/components/SectionHero.astro
+++ b/next/src/components/SectionHero.astro
@@ -2,9 +2,15 @@
 /**
  * SectionHero  -  the two-column editorial hero used on
  * section index pages (/eat, /stay, /wine, /journal, /places).
+ *
+ * When `entitySlug` is provided, the title, dek, and hero image become
+ * CMS-editable via right-click + inline contenteditable. Published
+ * overrides are consulted at build time so the static HTML ships pre-
+ * patched (no flash).
  */
 
-import { editableImage } from '../lib/inline-edit/attrs';
+import { editableImage, editableText, type CmsEntityType } from '../lib/inline-edit/attrs';
+import { loadOverrides } from '../lib/inline-edit/overrides';
 
 export interface Props {
   eyebrow?: string;
@@ -14,9 +20,9 @@ export interface Props {
   gradient?: 'vineyard' | 'bay' | 'sand' | 'hinterland' | 'stay' | 'journal';
   visualLabel?: string;
   heroImage?: string;
-  /** When provided, the visual panel becomes CMS-editable via right-click. */
+  /** When provided, the title, dek, and visual panel become CMS-editable. */
   entitySlug?: string;
-  entityType?: string;
+  entityType?: CmsEntityType;
 }
 
 const {
@@ -31,11 +37,30 @@ const {
   entityType = 'page',
 } = Astro.props;
 
-const gradClass = `section-hero__visual hero-grad--${gradient}`;
-const heroStyle = heroImage ? `background-image: url(${heroImage})` : undefined;
+const editable = !!entitySlug;
 
-const editAttrs = entitySlug
-  ? editableImage({ entityType, entitySlug, fieldPath: 'hero', label: `${entitySlug} hero`, purpose: 'hero' })
+// Build-time override consult — eliminate flash where the default
+// title / dek / hero paints before the client-side patcher swaps.
+const overrides = editable ? await loadOverrides(entityType, entitySlug!) : null;
+const titleOverride = overrides?.text['hero.title'];
+const dekOverride = overrides?.text['hero.dek'];
+const imageOverride = overrides?.image['hero'];
+
+const resolvedTitle = titleOverride ?? title;
+const resolvedDek = dekOverride ?? dek;
+const resolvedHeroImage = imageOverride?.src ?? heroImage;
+
+const gradClass = `section-hero__visual hero-grad--${gradient}`;
+const heroStyle = resolvedHeroImage ? `background-image: url(${resolvedHeroImage})` : undefined;
+
+const titleAttrs = editable
+  ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.title', label: `${entitySlug} hero title` })
+  : {};
+const dekAttrs = editable
+  ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.dek', label: `${entitySlug} hero dek` })
+  : {};
+const imageAttrs = editable
+  ? editableImage({ entityType, entitySlug: entitySlug!, fieldPath: 'hero', label: `${entitySlug} hero`, purpose: 'hero' })
   : {};
 ---
 
@@ -48,10 +73,10 @@ const editAttrs = entitySlug
           <span class="section-hero__rule" aria-hidden="true"></span>
           {subEyebrow && <span class="label">{subEyebrow}</span>}
         </div>
-        <h1 class="section-hero__title" set:html={title} />
-        <p class="section-hero__dek">{dek}</p>
+        <h1 class="section-hero__title" set:html={resolvedTitle} {...titleAttrs} />
+        <p class="section-hero__dek" {...dekAttrs}>{resolvedDek}</p>
       </div>
-      <div class={gradClass} aria-hidden="true" style={heroStyle} {...editAttrs}>
+      <div class={gradClass} aria-hidden="true" style={heroStyle} {...imageAttrs}>
         <div class="section-hero__visual-fog"></div>
         {visualLabel && <span class="section-hero__visual-label">{visualLabel}</span>}
       </div>

--- a/next/src/components/SubpageHero.astro
+++ b/next/src/components/SubpageHero.astro
@@ -5,7 +5,13 @@
  *
  * Left column: eyebrow → H1 → prose slot
  * Right column: hero photo, fills full column height
+ *
+ * When `entitySlug` is provided, the title and hero image become CMS-
+ * editable via right-click. Convention mirrors GuideHero / SectionHero
+ * so call sites read uniformly across the codebase.
  */
+import { editableText, editableImage, type CmsEntityType } from '../lib/inline-edit/attrs';
+import { loadOverrides } from '../lib/inline-edit/overrides';
 
 export interface Props {
   /** Section label shown in accent colour before the rule — e.g. "Eat & Drink" */
@@ -20,6 +26,15 @@ export interface Props {
   imageAlt: string;
   /** Optional photo caption. Temporarily retained for data compatibility, but not displayed until image locations are verified. */
   imageCaption?: string;
+  /**
+   * Optional CMS identity for inline editing. When provided, the title
+   * and hero image become editable, and any published overrides are
+   * applied at build time so the static HTML ships pre-patched.
+   * Defaults to `entityType='page'` to match the URL-path fallback
+   * convention used elsewhere.
+   */
+  entitySlug?: string;
+  entityType?: CmsEntityType;
 }
 
 const {
@@ -29,7 +44,29 @@ const {
   heroImage,
   imageAlt,
   imageCaption: _imageCaption,
+  entitySlug,
+  entityType = 'page',
 } = Astro.props;
+
+const editable = !!entitySlug;
+
+// Build-time override consult — apply published title / hero overrides
+// to the initial markup so there's no flash where the default paints
+// before the client-side patcher runs.
+const overrides = editable ? await loadOverrides(entityType, entitySlug!) : null;
+const titleOverride = overrides?.text['hero.title'];
+const imageOverride = overrides?.image['hero'];
+
+const resolvedTitle = titleOverride ?? title;
+const resolvedImageSrc = imageOverride?.src ?? heroImage;
+const resolvedImageAlt = imageOverride?.alt ?? imageAlt;
+
+const titleAttrs = editable
+  ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.title', label: `${entitySlug} hero title` })
+  : {};
+const imageAttrs = editable
+  ? editableImage({ entityType, entitySlug: entitySlug!, fieldPath: 'hero', label: `${entitySlug} hero image`, purpose: 'hero' })
+  : {};
 ---
 
 <section class="subpage-hero">
@@ -42,14 +79,14 @@ const {
           <span class="subpage-hero__rule" aria-hidden="true"></span>
           {category && <span class="label">{category}</span>}
         </div>
-        <h1 class="subpage-hero__title" set:html={title} />
+        <h1 class="subpage-hero__title" set:html={resolvedTitle} {...titleAttrs} />
         <div class="subpage-hero__prose">
           <slot />
         </div>
       </div>
 
       <div class="subpage-hero__visual" aria-hidden="true">
-        <img src={heroImage} alt={imageAlt} loading="lazy" decoding="async" />
+        <img src={resolvedImageSrc} alt={resolvedImageAlt} loading="lazy" decoding="async" {...imageAttrs} />
         <div class="subpage-hero__fog"></div>
       </div>
 

--- a/next/src/pages/awards/index.astro
+++ b/next/src/pages/awards/index.astro
@@ -54,6 +54,7 @@ const DEFAULT_CATEGORIES = [
     dek="Nine categories. Editor selections and reader voting. Nominations open August, voting through September, results announced the first weekend of October. Independent, editorially gated, never paid."
     gradient="journal"
     visualLabel="Peninsula Insider · Awards"
+  entitySlug="awards"
   />
 
   <section class="awards-page">

--- a/next/src/pages/boating/hire/index.astro
+++ b/next/src/pages/boating/hire/index.astro
@@ -63,6 +63,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="Self-drive boat hire on the <em>Peninsula</em>"
     dek="Tinnies and polycraft from Mornington, Sorrento, Rye, and Safety Beach. No-licence options for visitors. Half-day and full-day rates with the gear sometimes included — confirm with the operator."
     gradient="vineyard"
+  entitySlug="boating-hire"
   />
 
   <section class="experience-index">

--- a/next/src/pages/boating/index.astro
+++ b/next/src/pages/boating/index.astro
@@ -75,6 +75,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     dek="Two clean choices: own a vessel and need a ramp, or do not own one and need a hire operator or skippered charter. The infrastructure is here. So are the avoidable mistakes."
     gradient="vineyard"
     heroImage="/images/sourced/explore-portsea-front-beach-01.webp"
+  entitySlug="boating"
   />
 
   <section class="experience-index" data-bf-article>

--- a/next/src/pages/boating/ramps/index.astro
+++ b/next/src/pages/boating/ramps/index.astro
@@ -67,6 +67,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="Peninsula boat ramps, <em>by use case</em>"
     dek="Every metadata-only ramp directory tells you the lane count and the postcode. This one tells you whether you can launch at low tide and whether you'll get a park on Saturday morning."
     gradient="vineyard"
+  entitySlug="boating-ramps"
   />
 
   <p class="affiliate-disclosure container">

--- a/next/src/pages/boating/tides-safety/index.astro
+++ b/next/src/pages/boating/tides-safety/index.astro
@@ -64,6 +64,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="Tides, weather, and safety on the <em>Peninsula</em>"
     dek="Pre-trip planning for Port Phillip Bay and Western Port. The reference stations to use, the conditions to read, the alternatives to know about. The kind of session that does not feature in the news is the one that started with the right pre-trip check."
     gradient="vineyard"
+  entitySlug="boating-tides-safety"
   />
 
   <article class="venue-detail" data-bf-article>

--- a/next/src/pages/corporate-events/index.astro
+++ b/next/src/pages/corporate-events/index.astro
@@ -4,6 +4,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
+import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 import { routeSlug } from '../../lib/editorial';
 
 const allArticles = await getCollection('articles', ({ data }) => data.status === 'published');
@@ -94,10 +95,10 @@ const collectionSchema = {
       <div class="section-hero__inner">
         <div class="section-hero__content">
           <p class="label label--accent">Corporate Events &amp; Retreats</p>
-          <h1 class="section-hero__title">Mornington Peninsula Corporate Events</h1>
-          <p class="section-hero__dek">Teams and planners are not only choosing a venue. They are choosing what kind of Peninsula offsite or retreat will actually work — executive retreat, leadership offsite, strategy day, or conference. This section helps you make that decision with the right information.</p>
+          <h1 class="section-hero__title" {...editableText({ entityType: 'page', entitySlug: 'corporate-events', fieldPath: 'hero.title', label: 'Corporate Events — title' })}>Mornington Peninsula Corporate Events</h1>
+          <p class="section-hero__dek" {...editableText({ entityType: 'page', entitySlug: 'corporate-events', fieldPath: 'hero.dek', label: 'Corporate Events — dek' })}>Teams and planners are not only choosing a venue. They are choosing what kind of Peninsula offsite or retreat will actually work — executive retreat, leadership offsite, strategy day, or conference. This section helps you make that decision with the right information.</p>
         </div>
-        <div class="section-hero__visual" aria-hidden="true" style="background-image: url(/images/sourced/venue-jackalope-hotel-01.webp); background-size: cover; background-position: center;">
+        <div class="section-hero__visual" aria-hidden="true" style="background-image: url(/images/sourced/venue-jackalope-hotel-01.webp); background-size: cover; background-position: center;" {...editableImage({ entityType: 'page', entitySlug: 'corporate-events', fieldPath: 'hero', label: 'Corporate Events — hero image' })}>
           <div class="section-hero__visual-fog"></div>
           <span class="section-hero__visual-label">Corporate Retreats · Executive Offsites · Peninsula</span>
         </div>

--- a/next/src/pages/dog-friendly/index.astro
+++ b/next/src/pages/dog-friendly/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
@@ -69,10 +70,10 @@ const utilityCards = [
       <div class="section-hero__inner">
         <div class="section-hero__content">
           <p class="label label--accent">Dog-Friendly Peninsula</p>
-          <h1 class="section-hero__title">The practical guide to doing the Peninsula properly with the dog</h1>
-          <p class="section-hero__dek">Beaches, wineries, cafés, stays, walks, and backup options that actually work with a dog in the plan. No fluffy pet-travel clichés, just useful local trip logic.</p>
+          <h1 class="section-hero__title" {...editableText({ entityType: 'page', entitySlug: 'dog-friendly', fieldPath: 'hero.title', label: 'Dog-Friendly — title' })}>The practical guide to doing the Peninsula properly with the dog</h1>
+          <p class="section-hero__dek" {...editableText({ entityType: 'page', entitySlug: 'dog-friendly', fieldPath: 'hero.dek', label: 'Dog-Friendly — dek' })}>Beaches, wineries, cafés, stays, walks, and backup options that actually work with a dog in the plan. No fluffy pet-travel clichés, just useful local trip logic.</p>
         </div>
-        <div class="section-hero__visual" aria-hidden="true" style="background-image: url(/images/sourced/dog-beach-emma-01.webp); background-size: cover; background-position: center;">
+        <div class="section-hero__visual" aria-hidden="true" style="background-image: url(/images/sourced/dog-beach-emma-01.webp); background-size: cover; background-position: center;" {...editableImage({ entityType: 'page', entitySlug: 'dog-friendly', fieldPath: 'hero', label: 'Dog-Friendly — hero image' })}>
           <div class="section-hero__visual-fog"></div>
           <span class="section-hero__visual-label">Dog-Friendly Peninsula</span>
         </div>

--- a/next/src/pages/eat/bakeries.astro
+++ b/next/src/pages/eat/bakeries.astro
@@ -84,6 +84,7 @@ const faqSchema = {
   heroImage="/images/sourced/explore-dromana-beach-01.webp"
   imageAlt="Dromana beach morning light, Mornington Peninsula"
   imageCaption="Mornington Peninsula"
+  entitySlug="eat-bakeries"
 >
   <div class="prose">
     <p>The Peninsula bakery scene is smaller than the cafe scene and better for it. There are six bakeries worth knowing about, scattered across the Peninsula from Mornington to Flinders. Each has a reason: a particular loaf, a particular morning, a particular detour that makes it worth the drive from wherever you are staying.</p>

--- a/next/src/pages/eat/best-restaurants.astro
+++ b/next/src/pages/eat/best-restaurants.astro
@@ -86,6 +86,7 @@ const breadcrumbItems = [
   heroImage="/images/sourced/article-hatted-restaurants-01.webp"
   imageAlt="Open kitchen at a Peninsula fine dining restaurant — hatted dining on the Mornington Peninsula"
   imageCaption="Peninsula fine dining"
+  entitySlug="eat-best-restaurants"
 >
   <div class="prose">
     <p>The Mornington Peninsula runs on the Sunday long lunch. From the ridge-top dining rooms of Red Hill to the fisherman's-wharf-adjacent tables of Mornington, the dining options are deep, opinionated, and worth the drive. This list is built on editorial judgement — every entry has been visited and earned its sentence. No advertising, no paid placement, no sponsored rankings. If a restaurant appears here, it's because the meal was worth the drive and the editor was willing to say so.</p>

--- a/next/src/pages/eat/brunch.astro
+++ b/next/src/pages/eat/brunch.astro
@@ -90,6 +90,7 @@ const faqSchema = {
   heroImage="/images/sourced/explore-mount-martha-beach-01.webp"
   imageAlt="Mount Martha beach, Mornington Peninsula — morning light and bay views"
   imageCaption="Mount Martha · Mornington Peninsula"
+  entitySlug="eat-brunch"
 >
   <div class="prose">
     <p>Brunch on the Mornington Peninsula means either a specialty coffee destination in Mornington or a village cafe you would drive forty minutes for if you were not already nearby. The Peninsula's brunch scene is not a destination category in itself — it is the first half of a Peninsula day, the thing you do before the cellar door or the beach walk.</p>

--- a/next/src/pages/eat/cafes.astro
+++ b/next/src/pages/eat/cafes.astro
@@ -89,6 +89,7 @@ const faqSchema = {
   heroImage="/images/sourced/explore-mprg-01.webp"
   imageAlt="Mornington Peninsula Regional Gallery and foreshore, Mornington"
   imageCaption="Mornington"
+  entitySlug="eat-cafes"
 >
   <div class="prose">
     <p>The Peninsula's cafe scene concentrates in Mornington and the hinterland villages. Commonfolk Coffee in Mornington is the benchmark for specialty coffee — a house roaster, an excellent kitchen, and the kind of back courtyard that makes a weekday morning feel like a weekend decision. Below it, a scattered set of village cafes and general stores doing honest work without trying to be anything they are not.</p>

--- a/next/src/pages/eat/cellar-door-lunch.astro
+++ b/next/src/pages/eat/cellar-door-lunch.astro
@@ -96,6 +96,7 @@ const faqSchema = {
   heroImage="/images/sourced/article-cellar-door-01.webp"
   imageAlt="Peninsula cellar door wine tasting — estate dining on the Mornington Peninsula"
   imageCaption="Red Hill plateau"
+  entitySlug="eat-cellar-door-lunch"
 >
   <div class="prose">
     <p>The cellar door lunch is the Peninsula's most distinctive food experience. A winery with a kitchen — estate wine poured from the vineyard outside, produce grown or sourced within a few kilometres, and a dining room that exists because the place earned it rather than because a marketing brief suggested it would convert tastings.</p>

--- a/next/src/pages/eat/date-night.astro
+++ b/next/src/pages/eat/date-night.astro
@@ -25,6 +25,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/article-couples-weekend-01.webp"
   imageAlt="Couples weekend at a Mornington Peninsula vineyard estate — Peninsula date night"
   imageCaption="Mornington Peninsula"
+  entitySlug="eat-date-night"
 >
   <div class="prose">
     <p>A Peninsula date night works best when you resist the temptation to over-programme it. Pick one destination: dinner at a hatted room, or a long late-afternoon at a vineyard restaurant, then somewhere comfortable to stay. Trying to fit a cellar door tasting, a sunset walk, and a dinner at a restaurant forty minutes away never improves the evening.</p><p>The Peninsula's strongest date-night rooms are intimate: Tedesca Osteria (30 seats), Polperro (small, seasonal, vineyard), and Bistro Elba in Sorrento (French-inflected, dinner-focused, village-based). For the most impressive setting, Laura at Pt. Leo Estate has no peer in Victoria. For the most dramatic interior, Doot Doot Doot at Jackalope Hotel is the answer.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/dog-friendly.astro
+++ b/next/src/pages/eat/dog-friendly.astro
@@ -90,6 +90,7 @@ const faqSchema = {
   heroImage="/images/sourced/article-dog-friendly-01.webp"
   imageAlt="Dog-friendly Peninsula — outdoor dining and café culture on the Mornington Peninsula"
   imageCaption="Mornington Peninsula"
+  entitySlug="eat-dog-friendly"
 >
   <div class="prose">
     <p style="background:rgba(180,100,40,0.08);border-left:3px solid var(--accent);padding:1rem 1.25rem;border-radius:0 4px 4px 0"><strong>Dog policies change.</strong> This list is based on outdoor-seating policies as of April 2026. Verify directly with the venue before you visit with a dog.</p>

--- a/next/src/pages/eat/family-friendly.astro
+++ b/next/src/pages/eat/family-friendly.astro
@@ -25,6 +25,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/article-kids-peninsula-01.webp"
   imageAlt="Family day out on the Mornington Peninsula — dining with kids"
   imageCaption="Mornington Peninsula"
+  entitySlug="eat-family-friendly"
 >
   <div class="prose">
     <p>Family-friendly dining on the Peninsula means outdoor seating, formats that do not require children to sit completely still for two hours, and venues where the staff have seen a high chair before. The list is shorter than the general dining list, but it is honest: these are the places that work with kids rather than merely tolerating them.</p><p>Red Gum BBQ in Red Hill is the clearest call — BBQ format, outdoor tables, and food that children actually want to eat. Montalto Piazza is the best family-friendly winery option: walk-in daily, sculpture trail on the property, outdoor seating, and a kitchen that does not require advance planning. Village cafes and pub beer gardens fill in the practical gaps.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/fine-dining.astro
+++ b/next/src/pages/eat/fine-dining.astro
@@ -96,6 +96,7 @@ const faqSchema = {
   heroImage="/images/sourced/venue-lindenderry-01.webp"
   imageAlt="Lindenderry at Red Hill — boutique hotel and fine dining on the Mornington Peninsula"
   imageCaption="Red Hill · Mornington Peninsula"
+  entitySlug="eat-fine-dining"
 >
   <div class="prose">
     <p>Fine dining on the Mornington Peninsula is not city fine dining. The format here is embedded in vineyard estates, working farms, and converted heritage buildings. You eat in a 40-seat room in a converted 1940s farmhouse where the kitchen garden is outside the window. Or in a glass-walled dining room above a sculpture park overlooking Western Port Bay. Or under a 10,000-globe chandelier in a boutique winery hotel.</p>

--- a/next/src/pages/eat/hatted-restaurants.astro
+++ b/next/src/pages/eat/hatted-restaurants.astro
@@ -99,6 +99,7 @@ const faqSchema = {
   heroImage="/images/sourced/venue-pt-leo-sculpture-01.webp"
   imageAlt="Pt. Leo Estate sculpture park and fine dining, Merricks — two-hat Peninsula restaurant"
   imageCaption="Pt. Leo Estate · Merricks"
+  entitySlug="eat-hatted-restaurants"
 >
   <div class="prose">
     <p>The Good Food Guide awarded 15 hats across 11 Peninsula venues. Four venues carry two hats — the highest recognition in the region. What distinguishes the Peninsula's hatted scene is its context: these are not city strip restaurants. You eat in a converted 1940s farmhouse on a biodynamic property, a 40-seat room inside a sculpture park estate, or a cave-like dining room beneath a boutique winery hotel. The long lunch is the defining format.</p>

--- a/next/src/pages/eat/long-lunch.astro
+++ b/next/src/pages/eat/long-lunch.astro
@@ -97,6 +97,7 @@ const faqSchema = {
   heroImage="/images/sourced/article-long-lunch-01.webp"
   imageAlt="Long lunch at a Peninsula vineyard restaurant — wine country dining on the Mornington Peninsula"
   imageCaption="Peninsula wine country"
+  entitySlug="eat-long-lunch"
 >
   <div class="prose">
     <p>The long lunch is the Peninsula's defining dining format. A two-to-three-hour table, estate wine from the vineyard outside, produce grown within five kilometres, and an unhurried service rhythm that makes a Melbourne city restaurant feel rushed by comparison. The Peninsula does this better than almost anywhere else in Victoria.</p>

--- a/next/src/pages/eat/markets.astro
+++ b/next/src/pages/eat/markets.astro
@@ -24,6 +24,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/article-red-hill-saturday-01.webp"
   imageAlt="Red Hill Saturday morning, Mornington Peninsula — market day"
   imageCaption="Red Hill · Saturday morning"
+  entitySlug="eat-markets"
 >
   <div class="prose">
     <p>The Peninsula has three established food markets, each with a different character. Red Hill Market is the one worth planning a morning around — a large monthly market on the first Saturday of the month at Red Hill Showgrounds, with Peninsula produce, artisan food, and a coffee and brunch scene that makes the visit feel like an event rather than a shopping errand.</p><p>Mornington Farmers' Market runs every Wednesday at Craig's Reserve and is the best option for fresh local produce during the week — smaller, more focused, and less tourist-facing than Red Hill. Balnarring Farmers' Market is the most genuinely local of the three — a village-scale market with strong produce and a relaxed pace.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/no-booking.astro
+++ b/next/src/pages/eat/no-booking.astro
@@ -25,6 +25,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/explore-mornington-foreshore-01.webp"
   imageAlt="Mornington foreshore and harbour — casual dining and walk-in venues on the Peninsula"
   imageCaption="Mornington"
+  entitySlug="eat-no-booking"
 >
   <div class="prose">
     <p>Most serious Peninsula restaurants require bookings — often weeks or months in advance for hatted venues. But there are genuine walk-in options, and two of them are hatted: Rare Hare at Willow Creek takes no reservations at all and is walk-in only from 2pm on weekends; Foxeys Hangout accepts no bookings and has a maximum group size of 6.</p><p>Below the hatted tier, Montalto Piazza (daily, 11am–5pm), most of the Peninsula's village cafes and bakeries, and most pub bistros operate on a walk-in basis. If you have arrived on the Peninsula without a booking for the destination you wanted, this list is where to start.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/paddock-to-plate.astro
+++ b/next/src/pages/eat/paddock-to-plate.astro
@@ -25,6 +25,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/article-producer-trail-01.webp"
   imageAlt="Peninsula producer trail — farm-to-table dining on the Mornington Peninsula"
   imageCaption="Red Hill hinterland"
+  entitySlug="eat-paddock-to-plate"
 >
   <div class="prose">
     <p>The Peninsula has more genuine farm-to-table dining than almost any other regional destination in Victoria. The landscape produces it: the cool plateau grows some of Australia's best cool-climate produce, the Bass Strait coast supplies exceptional seafood, and the farm density in the Red Hill hinterland means short supply chains are the rule rather than the exception.</p><p>The strongest example is Tedesca Osteria — a biodynamic property in Red Hill where Brigitte Hafner keeps chickens, beehives, and Wiltshire Horn sheep that supply the kitchen alongside an on-site garden. It is the most fully realised farm restaurant on the Peninsula and one of the most serious in Victoria. Below it, Barragunda (estate-grown organic vegetables, hibachi-charred proteins), Green Olive (olive grove, orchard, kitchen garden), and a set of cellar door restaurants where the wine and food share the same landscape.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/pubs.astro
+++ b/next/src/pages/eat/pubs.astro
@@ -24,6 +24,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/place-portsea-01.webp"
   imageAlt="Portsea coastline, Mornington Peninsula — gateway to the Peninsula's best pubs"
   imageCaption="Portsea · Mornington Peninsula"
+  entitySlug="eat-pubs"
 >
   <div class="prose">
     <p>The Peninsula's pub scene is spread across its towns and coastal villages rather than concentrated in one area. Portsea Hotel leads for setting — the clifftop position above Portsea beach, bay views, and a dog-friendly beer garden make it the strongest pub experience on the Peninsula. Balnarring Pub is the most local and genuinely village-feeling. The Bay Hotel Mornington works as a practical stop for anyone based in or passing through town.</p><p>Peninsula pub kitchens range from honest bistro meals to better-than-expected seasonal menus. The general rule: pub food here is not the reason to drive; the setting is. Pair any pub stop with a coastal walk or afternoon activity nearby to get the most from it.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/seafood.astro
+++ b/next/src/pages/eat/seafood.astro
@@ -25,6 +25,7 @@ const faqSchema={'@context':'https://schema.org','@type':'FAQPage',mainEntity:[{
   heroImage="/images/sourced/article-seafood-01.webp"
   imageAlt="Fresh seafood on the Mornington Peninsula — waterfront dining and fish kitchens"
   imageCaption="Mornington Peninsula coast"
+  entitySlug="eat-seafood"
 >
   <div class="prose">
     <p>The Peninsula's seafood scene is concentrated around its waterfront towns and fishing piers. Pier Street Kitchen in Flinders is the strongest all-round seafood dining room — one GFG hat, a proper kitchen, and a setting that justifies the southern drive. The Baths at Sorrento is the waterfront experience, and Flinders Pier Takeaway is the benchmark for a genuinely good casual stop that does not pretend to be anything else.</p><p>The Peninsula's fish is primarily sourced locally or from the southern Victorian coast — king george whiting, calamari, abalone in season, and Mornington Peninsula oysters when available. The category rewards finding the right venue for the right kind of afternoon.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/waterfront.astro
+++ b/next/src/pages/eat/waterfront.astro
@@ -93,6 +93,7 @@ const faqSchema = {
   heroImage="/images/sourced/explore-sorrento-ferry-01.webp"
   imageAlt="Sorrento waterfront and Queenscliff ferry, Port Phillip Bay — Peninsula waterfront dining"
   imageCaption="Sorrento · Port Phillip Bay"
+  entitySlug="eat-waterfront"
 >
   <div class="prose">
     <p>The Peninsula's waterfront dining concentrates on Port Phillip Bay — the calmer, bay-facing side rather than the ocean. Three venues define the category. The Baths at Sorrento for special-occasion seafood with panoramic views. The Rocks at Mornington for casual waterfront dining at the marina. The Portsea Hotel for a pub setting with the most dramatic bay outlook of any pub on the Peninsula.</p>

--- a/next/src/pages/events/index.astro
+++ b/next/src/pages/events/index.astro
@@ -60,6 +60,7 @@ const breadcrumbItems = [
     title={`Signature Events &mdash; the Peninsula calendar's <em>anchor moments</em>`}
     heroImage="/images/sourced/wine-hub-hero-01.webp"
     imageAlt="Mornington Peninsula vineyard in winter — the cool-climate wine country where many of the Peninsula's biggest annual events run."
+    entitySlug="events"
   >
     <p class="subpage-hero__dek">
       Editorial guides to the Mornington Peninsula's most recognisable annual events — the dates locals plan their year around and the ones that define a season.

--- a/next/src/pages/fishing/charters/first-charter-guide/index.astro
+++ b/next/src/pages/fishing/charters/first-charter-guide/index.astro
@@ -70,6 +70,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="Your first <em>Peninsula fishing charter</em>"
     dek="Choosing a charter, knowing what is covered, packing the right kit, and not embarrassing yourself on the deck. The complete first-time guide."
     gradient="vineyard"
+  entitySlug="fishing-charters-first-charter-guide"
   />
 
   <article class="venue-detail" data-bf-article>

--- a/next/src/pages/fishing/charters/index.astro
+++ b/next/src/pages/fishing/charters/index.astro
@@ -70,6 +70,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="Peninsula fishing charters, <em>compared</em>"
     dek="The buyer's guide. Each operator profile names the species they actually target, the departure points they use, the vessel, the price band, and whether the licence is covered for the day."
     gradient="vineyard"
+  entitySlug="fishing-charters"
   />
 
   <section class="experience-index">

--- a/next/src/pages/fishing/index.astro
+++ b/next/src/pages/fishing/index.astro
@@ -85,6 +85,7 @@ const seasonalityRows = [
     dek="Three overlapping fisheries, Port Phillip Bay, Western Port, the Bass Strait fringe, twelve species, and a calendar that runs year-round. The editorial layer above the VFA data and below the operator brochures."
     gradient="vineyard"
     heroImage="/images/sourced/explore-portsea-front-beach-01.webp"
+  entitySlug="fishing"
   />
 
   <p class="affiliate-disclosure container">

--- a/next/src/pages/fishing/locations/index.astro
+++ b/next/src/pages/fishing/locations/index.astro
@@ -69,6 +69,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="Where to <em>actually</em> fish on the Peninsula"
     dek="Twelve locations grouped by water body. Access, parking pressure, primary species, tide windows, and what each spot is and isn't suited to."
     gradient="vineyard"
+  entitySlug="fishing-locations"
   />
 
   {Object.entries(grouped).every(([, items]) => items.length === 0) ? (

--- a/next/src/pages/fishing/seasons/snapper-run-oct-dec/index.astro
+++ b/next/src/pages/fishing/seasons/snapper-run-oct-dec/index.astro
@@ -72,6 +72,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="The Peninsula <em>snapper season</em>, week by week"
     dek="The October to December snapper run is the most significant event in the Victorian recreational fishing calendar. Nothing else on the Peninsula concentrates as many anglers, charters, and local knowledge into a single 12-week window. This is how it actually unfolds."
     gradient="vineyard"
+  entitySlug="fishing-seasons-snapper-run-oct-dec"
   />
 
   <article class="venue-detail" data-bf-article>

--- a/next/src/pages/fishing/species/index.astro
+++ b/next/src/pages/fishing/species/index.astro
@@ -69,6 +69,7 @@ const breadcrumbSchema = buildBreadcrumbSchema([
     title="The 12 species that <em>actually</em> fish on the Peninsula"
     dek="Bag and size limits cite the Victorian Fisheries Authority verbatim. The editorial layer covers Peninsula-specific tide windows, where the species reliably runs, and which charters target it."
     gradient="vineyard"
+  entitySlug="fishing-species"
   />
 
   <p class="affiliate-disclosure container">

--- a/next/src/pages/guides/index.astro
+++ b/next/src/pages/guides/index.astro
@@ -112,6 +112,7 @@ const breadcrumbItems = [
     dek="Eight-page editorial guides — venues, walks, and a sample weekend, shaped for the time of year. Print one for the glove box, keep one in the kitchen drawer, forward one to the friend who is asking what to do."
     gradient="journal"
     visualLabel="Peninsula Insider · seasonal guides"
+  entitySlug="guides"
   />
 
   <section class="guides-page">

--- a/next/src/pages/insiders-30/index.astro
+++ b/next/src/pages/insiders-30/index.astro
@@ -116,6 +116,7 @@ const yearsForArchive = lists.map((l) => l.data.year);
     gradient="journal"
     heroImage={currentList.data.heroImage?.src}
     visualLabel={currentList.data.heroImage?.alt ?? `Peninsula Insider · The Insider's 30, ${currentList.data.year}`}
+  entitySlug="insiders-30"
   />
 
   <section class="insiders-30">

--- a/next/src/pages/journal/cellar-door/index.astro
+++ b/next/src/pages/journal/cellar-door/index.astro
@@ -10,6 +10,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import ArticleCard from '../../../components/ArticleCard.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+import { editableText } from '../../../lib/inline-edit/attrs';
 
 const dispatches = (await getCollection('articles', ({ data }) =>
   data.format === 'cellar-door-dispatch' && data.status === 'published'
@@ -34,8 +35,8 @@ const breadcrumbItems = [
     <div class="container">
       <div class="cellar-door-hub__header">
         <p class="label label--accent">Wine</p>
-        <h1 class="cellar-door-hub__title">Cellar Door Dispatches</h1>
-        <p class="cellar-door-hub__dek">The producers worth the appointment, the wines worth the cellar, and the arguments happening in the vines.</p>
+        <h1 class="cellar-door-hub__title" {...editableText({ entityType: 'page', entitySlug: 'journal-cellar-door', fieldPath: 'hero.title', label: 'Cellar Door — title' })}>Cellar Door Dispatches</h1>
+        <p class="cellar-door-hub__dek" {...editableText({ entityType: 'page', entitySlug: 'journal-cellar-door', fieldPath: 'hero.dek', label: 'Cellar Door — dek' })}>The producers worth the appointment, the wines worth the cellar, and the arguments happening in the vines.</p>
       </div>
 
       {dispatches.length > 0 ? (

--- a/next/src/pages/journal/index.astro
+++ b/next/src/pages/journal/index.astro
@@ -106,6 +106,7 @@ const breadcrumbItems = [
     gradient="journal"
     visualLabel="Guides · features · weekend notes"
     heroImage="/images/sourced/journal-hub-hero-01.webp"
+  entitySlug="journal"
   />
 
   <!-- Editor’s desk note  -  a short seasonal framing block that tells

--- a/next/src/pages/journal/local-secrets/index.astro
+++ b/next/src/pages/journal/local-secrets/index.astro
@@ -38,6 +38,7 @@ const breadcrumbItems = [
     dek="Spots, stories, and recommendations that came in from readers — vetted by the editor, published with named credit, never paid for."
     gradient="journal"
     visualLabel="Peninsula Insider · local secrets"
+  entitySlug="journal-local-secrets"
   />
 
   <section class="local-secrets-page">

--- a/next/src/pages/partners/index.astro
+++ b/next/src/pages/partners/index.astro
@@ -12,6 +12,7 @@
  */
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { editableText } from '../../lib/inline-edit/attrs';
 ---
 
 <BaseLayout
@@ -24,8 +25,8 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
     <section class="partners-hero">
       <div class="partners-hero__inner">
         <p class="partners-hero__eyebrow">Peninsula Insider</p>
-        <h1 class="partners-hero__heading">Partner with Peninsula Insider</h1>
-        <p class="partners-hero__sub">
+        <h1 class="partners-hero__heading" {...editableText({ entityType: 'page', entitySlug: 'partners', fieldPath: 'hero.title', label: 'Partners — title' })}>Partner with Peninsula Insider</h1>
+        <p class="partners-hero__sub" {...editableText({ entityType: 'page', entitySlug: 'partners', fieldPath: 'hero.dek', label: 'Partners — dek' })}>
           Reach people already planning where to eat, stay, explore and spend
           time on the Mornington Peninsula.
         </p>

--- a/next/src/pages/tour/for-couples.astro
+++ b/next/src/pages/tour/for-couples.astro
@@ -42,6 +42,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/article-picnic-01.webp"
     imageAlt="Picnic among the vineyards on the Mornington Peninsula — tours for couples"
     imageCaption="Red Hill Plateau"
+  entitySlug="tour-for-couples"
   >
     <div class="prose">
       <p>The Peninsula's guided tour options for couples concentrate around wine and private charters. A small-group wine tour is the practical starting point — you cover multiple cellar doors in a single day, no one has to drive, and the format is comfortable for two people joining a shared group.</p>

--- a/next/src/pages/tour/for-families.astro
+++ b/next/src/pages/tour/for-families.astro
@@ -35,6 +35,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/explore-two-bays-walk-01.webp"
     imageAlt="Two Bays Walking Track on the Mornington Peninsula — family-friendly tours"
     imageCaption="Mornington Peninsula"
+  entitySlug="tour-for-families"
   >
     <div class="prose">
       <p>The Peninsula's family-suited guided tours concentrate around wildlife experiences, coastal activities, and walking tours that work for a range of ages. Most wine-focused tours are adult-oriented — the family-friendly options tend to sit in the wildlife, nature, and activity categories.</p>

--- a/next/src/pages/tour/full-day-tours.astro
+++ b/next/src/pages/tour/full-day-tours.astro
@@ -35,6 +35,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/explore-arthurs-seat-lookout-01.webp"
     imageAlt="Arthurs Seat lookout over Port Phillip Bay — full-day Peninsula tours"
     imageCaption="Mornington Peninsula"
+  entitySlug="tour-full-day-tours"
   >
     <div class="prose">
       <p>Full-day tours on the Mornington Peninsula typically run eight to ten hours, departing Melbourne in the morning and returning by early evening. They cover multiple stops — cellar doors, produce destinations, the hot springs, or coastal walks — depending on the operator's product.</p>

--- a/next/src/pages/tour/hot-springs-tours.astro
+++ b/next/src/pages/tour/hot-springs-tours.astro
@@ -39,6 +39,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/spa-peninsula-hot-springs-hilltop-01.webp"
     imageAlt="Peninsula Hot Springs hilltop pools — guided hot springs tours from Melbourne"
     imageCaption="Mornington Peninsula"
+  entitySlug="tour-hot-springs-tours"
   >
     <div class="prose">
       <p>Peninsula Hot Springs at Fingal is the region's main thermal bathing destination. Most guided tours that include hot springs combine them with a wine component or a beach stop. Pure hot springs tours are less common from Melbourne — the most practical option for visitors who want to focus the day on bathing is to stay on the Peninsula and book directly with the springs.</p>

--- a/next/src/pages/tour/operators/index.astro
+++ b/next/src/pages/tour/operators/index.astro
@@ -37,6 +37,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/place-mornington-01.webp"
     imageAlt="Mornington township — Peninsula tour operators guide"
     imageCaption="Sorrento"
+  entitySlug="tour-operators"
   >
     <div class="prose">
       <p>Peninsula Insider vets every operator listed here against a consistent set of criteria: product accuracy, guest experience track record, and affiliate transparency. We note which operator type each one is, what they are genuinely good at, and where they fall short.</p>

--- a/next/src/pages/tour/private-tours.astro
+++ b/next/src/pages/tour/private-tours.astro
@@ -39,6 +39,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/spa-treatment-room-rose-01.webp"
     imageAlt="Private spa experience on the Mornington Peninsula — bespoke private tours"
     imageCaption="Mornington Peninsula"
+  entitySlug="tour-private-tours"
   >
     <div class="prose">
       <p>Private tours give you a dedicated vehicle, a guide working only for your group, and an itinerary that you shape. The cost is higher than a small-group day, but if you fill the vehicle — typically four to eight guests — the per-person difference is often modest.</p>

--- a/next/src/pages/tour/small-group-tours.astro
+++ b/next/src/pages/tour/small-group-tours.astro
@@ -35,6 +35,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/category-winery-06.webp"
     imageAlt="Small-group cellar door tasting on the Mornington Peninsula"
     imageCaption="Mornington Peninsula"
+  entitySlug="tour-small-group-tours"
   >
     <div class="prose">
       <p>Small-group tours — typically 8 to 24 guests sharing a vehicle — are the practical middle ground between a private charter and a large coach. You get the logistics removed, a guide, and a structured itinerary, without the premium of a private booking.</p>

--- a/next/src/pages/tour/wine-tours.astro
+++ b/next/src/pages/tour/wine-tours.astro
@@ -35,6 +35,7 @@ const breadcrumbItems = [
     heroImage="/images/sourced/venue-montalto-banner-01.webp"
     imageAlt="Montalto Estate on the Mornington Peninsula — guided wine tours"
     imageCaption="Red Hill Plateau"
+  entitySlug="tour-wine-tours"
   >
     <div class="prose">
       <p>A guided wine tour removes the logistics of driving between cellar doors. You cover more ground, everyone in the group can drink, and a good guide adds the regional context that makes the difference between a pleasant day and a properly illuminating one.</p>

--- a/scripts/check-editable-coverage.mjs
+++ b/scripts/check-editable-coverage.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * CMS / card integrity smoke-check.
+ *
+ * Kept intentionally lightweight: this runs in deploy.yml before the site
+ * build, so it should catch obvious convention drift without becoming a
+ * brittle parser for Astro templates.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const root = process.cwd();
+const srcRoot = join(root, 'next', 'src');
+const errors = [];
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) out.push(...walk(path));
+    else if (/\.(astro|tsx?|jsx?)$/.test(entry)) out.push(path);
+  }
+  return out;
+}
+
+function rel(path) {
+  return relative(root, path);
+}
+
+function lineFor(text, index) {
+  return text.slice(0, index).split('\n').length;
+}
+
+for (const file of walk(srcRoot)) {
+  const text = readFileSync(file, 'utf8');
+
+  // Literal inline-editor elements should be entity-scoped. Most production
+  // uses flow through editableText()/editableImage(), which generate these
+  // attrs dynamically; this only catches hand-written static attrs.
+  for (const match of text.matchAll(/<[^>]+\bdata-pi-edit\b[\s=>][^>]*>/g)) {
+    const block = match[0];
+    for (const required of ['data-pi-entity-type', 'data-pi-entity-slug', 'data-pi-field-path']) {
+      if (!block.includes(required)) {
+        errors.push(`${rel(file)}:${lineFor(text, match.index ?? 0)} data-pi-edit missing ${required}`);
+      }
+    }
+  }
+
+  // Card-level Save/Share affordances need stable identity fields. This is
+  // deliberately structural rather than semantic: Astro expressions are often
+  // dynamic, but the props themselves must be present.
+  if (file.endsWith('Card.astro') && text.includes('<PiSaveActions')) {
+    const blocks = [...text.matchAll(/<PiSaveActions[\s\S]*?(?:\/>|>)/g)];
+    blocks.forEach((match, i) => {
+      const block = match[0];
+      for (const prop of ['kind', 'slug', 'title', 'href']) {
+        if (!new RegExp(`\\b${prop}=`).test(block)) {
+          errors.push(`${rel(file)}:${lineFor(text, match.index ?? 0)} PiSaveActions #${i + 1} missing ${prop}`);
+        }
+      }
+    });
+  }
+
+  // Guard against malformed saved/share links such as //journal/foo.
+  let hrefIdx = 0;
+  while ((hrefIdx = text.indexOf('data-pi-href="//', hrefIdx)) !== -1) {
+    errors.push(`${rel(file)}:${lineFor(text, hrefIdx)} malformed data-pi-href starts with //`);
+    hrefIdx += 'data-pi-href'.length;
+  }
+}
+
+if (errors.length) {
+  console.error('Editable/card coverage check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log('Editable/card coverage check passed.');


### PR DESCRIPTION
## Summary

Extends entity-scoped inline editing to **~55 additional URLs** that were previously only covered by the URL-path fallback. Two component changes plus 46 call sites.

### `SubpageHero` (1 component, 26 call sites)
- New `entitySlug` / `entityType` props mirror the `GuideHero` / `SectionHero` convention.
- Build-time override consult — static HTML ships pre-patched, no flash.
- Wired into:
  - all 17 `eat/*` category pages (`bakeries`, `best-restaurants`, `brunch`, `cafes`, `cellar-door-lunch`, `date-night`, `dog-friendly`, `family-friendly`, `fine-dining`, `hatted-restaurants`, `long-lunch`, `markets`, `no-booking`, `paddock-to-plate`, `pubs`, `seafood`, `waterfront`)
  - all 8 `tour/*` category pages (`for-couples`, `for-families`, `full-day-tours`, `hot-springs-tours`, `operators/index`, `private-tours`, `small-group-tours`, `wine-tours`)
  - `events/index`
- The 9 dynamic-route `[slug].astro` consumers of SubpageHero are intentionally **not** wired — those pages already have their own per-entity tagging in earlier waves.

### `SectionHero` (1 component, 15 call sites)
- Extends earlier image-only tagging ([c774db6ff3](https://github.com/richmondjw/peninsula-insider/commit/c774db6ff3)) with **editableText on title + dek**, plus a build-time overrides consult.
- Wired into: `awards`, `boating + hire + ramps + tides-safety`, `fishing + charters (+ first-charter-guide) + locations + seasons/snapper-run + species`, `guides`, `insiders-30`, `journal + cellar-door + local-secrets`.

### Bespoke landings (4 pages)
- `corporate-events`, `dog-friendly`, `partners`, `journal/cellar-door` — H1 + dek + hero tagged inline.

### Excluded from this PR
| Page | Why |
|---|---|
| `account/` + `admin/` | No editing semantics |
| `escape/index` | Redirect-only |
| `partners/advertising-kit` + `partners/founders-prospectus` | PrintLayout (PDF render path — no inline editor mount) |
| All `[slug].astro` SubpageHero consumers | Already tagged per-entity in earlier waves |

### Also in this PR
- Restores `scripts/check-editable-coverage.mjs` from [84718aa189](https://github.com/richmondjw/peninsula-insider/commit/84718aa189). The deploy.yml already gracefully handles a missing file (warning, not failure), but the presence is the strong default.
- All 45 new entity slugs are already in `pi.content_registry` — verified via MCP before commit.

### Followups
- **Wave 3** — tag the ~50 bespoke standalone `.astro` pages that don't use any shared hero (about, contact, methodology, the 30+ hardcoded journal articles like `mornington-peninsula-itinerary.astro`, etc.).
- **Body-prose editing in MDX articles** — currently only title/dek are editable on collection articles. The body content lives in MDX and needs a different inline-editor approach. Deferred until editor demand confirms.
- **`SUPABASE_SERVICE_KEY` rotation** — still outstanding. While that secret is wrong, the deploy registry-refresh step continues to no-op (continue-on-error). Doesn't block editing today since URLs are seeded directly via MCP, but unblocking auto-refresh is the natural close on the integrity loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)