### PR TITLE
feat(breadcrumbs): roll out to remaining content pages

### DIFF
--- a/next/src/pages/journal/best-brunch-mornington-peninsula.astro
+++ b/next/src/pages/journal/best-brunch-mornington-peninsula.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Best Brunch', item: 'https://peninsulainsider.com.au/journal/best-brunch-mornington-peninsula' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Best Brunch on the Mornington Peninsula" },
+];
 ---
 
 <BaseLayout
@@ -69,6 +76,8 @@ const breadcrumbSchema = {
   ogType="article"
   modifiedTime="2026-04-14"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/best-towns-to-base-yourself-with-a-dog-mornington-peninsula.astro
+++ b/next/src/pages/journal/best-towns-to-base-yourself-with-a-dog-mornington-peninsula.astro
@@ -1,8 +1,17 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "The Best Peninsula Towns to Base Yourself With a Dog" },
+];
 ---
 
 <BaseLayout title="The Best Peninsula Towns to Base Yourself With a Dog | Peninsula Insider" description="A practical guide to the best Mornington Peninsula towns to base yourself with a dog." section="places">
+  <Breadcrumbs items={breadcrumbItems} />
+
   <main class="article-shell container prose" style="padding: 3rem 0 4rem; max-width: 820px;">
     <p class="label label--accent">Dog-Friendly Peninsula</p>
     <h1>The Best Peninsula Towns to Base Yourself With a Dog</h1>

--- a/next/src/pages/journal/dog-friendly-mornington-peninsula.astro
+++ b/next/src/pages/journal/dog-friendly-mornington-peninsula.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Dog-Friendly Mornington Peninsula', item: 'https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Dog-Friendly Mornington Peninsula — Where to Go with Your Dog" },
+];
 ---
 
 <BaseLayout
@@ -68,6 +75,8 @@ const breadcrumbSchema = {
   canonical="https://peninsulainsider.com.au/journal/dog-friendly-mornington-peninsula"
   ogType="article"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/free-things-to-do-mornington-peninsula.astro
+++ b/next/src/pages/journal/free-things-to-do-mornington-peninsula.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Free Things to Do', item: 'https://peninsulainsider.com.au/journal/free-things-to-do-mornington-peninsula' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Free Things to Do on the Mornington Peninsula" },
+];
 ---
 
 <BaseLayout
@@ -69,6 +76,8 @@ const breadcrumbSchema = {
   ogType="article"
   modifiedTime="2026-04-14"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-day-trip.astro
+++ b/next/src/pages/journal/mornington-peninsula-day-trip.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Mornington Peninsula Day Trip from Melbourne', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-day-trip' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula Day Trip from Melbourne — The Best One-Day Plan" },
+];
 ---
 
 <BaseLayout
@@ -68,6 +75,8 @@ const breadcrumbSchema = {
   canonical="https://peninsulainsider.com.au/journal/mornington-peninsula-day-trip"
   ogType="article"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-hot-springs-guide.astro
+++ b/next/src/pages/journal/mornington-peninsula-hot-springs-guide.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Hot Springs Guide', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-hot-springs-guide' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula Hot Springs — The Honest Guide" },
+];
 ---
 
 <BaseLayout
@@ -69,6 +76,8 @@ const breadcrumbSchema = {
   ogType="article"
   modifiedTime="2026-04-14"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-in-autumn.astro
+++ b/next/src/pages/journal/mornington-peninsula-in-autumn.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Mornington Peninsula in Autumn', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-in-autumn' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula in Autumn — What to Do, Eat & See" },
+];
 ---
 
 <BaseLayout
@@ -68,6 +75,8 @@ const breadcrumbSchema = {
   canonical="https://peninsulainsider.com.au/journal/mornington-peninsula-in-autumn"
   ogType="article"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-in-winter.astro
+++ b/next/src/pages/journal/mornington-peninsula-in-winter.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Peninsula in Winter', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-in-winter' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula in Winter — Why the Cold Season Is Underrated" },
+];
 ---
 
 <BaseLayout
@@ -69,6 +76,8 @@ const breadcrumbSchema = {
   ogType="article"
   modifiedTime="2026-04-14"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-itinerary.astro
+++ b/next/src/pages/journal/mornington-peninsula-itinerary.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -41,6 +42,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Mornington Peninsula 3-Day Itinerary', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-itinerary' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula 3-Day Itinerary — The Best Weekend Plan" },
+];
 ---
 
 <BaseLayout
@@ -52,6 +59,8 @@ const breadcrumbSchema = {
   modifiedTime="2026-04-14"
   noindex={true}
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-wedding-venues.astro
+++ b/next/src/pages/journal/mornington-peninsula-wedding-venues.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Wedding Venues', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-wedding-venues' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula Wedding Venues — The Honest Guide" },
+];
 ---
 
 <BaseLayout
@@ -69,6 +76,8 @@ const breadcrumbSchema = {
   ogType="article"
   modifiedTime="2026-04-14"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/mornington-peninsula-with-kids.astro
+++ b/next/src/pages/journal/mornington-peninsula-with-kids.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const articleSchema = {
@@ -59,6 +60,12 @@ const breadcrumbSchema = {
     { '@type': 'ListItem', position: 3, name: 'Mornington Peninsula with Kids', item: 'https://peninsulainsider.com.au/journal/mornington-peninsula-with-kids' },
   ],
 };
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "Mornington Peninsula with Kids — The Honest Family Guide" },
+];
 ---
 
 <BaseLayout
@@ -68,6 +75,8 @@ const breadcrumbSchema = {
   canonical="https://peninsulainsider.com.au/journal/mornington-peninsula-with-kids"
   ogType="article"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/next/src/pages/journal/what-to-do-on-the-peninsula-with-a-dog-when-its-wet-or-busy.astro
+++ b/next/src/pages/journal/what-to-do-on-the-peninsula-with-a-dog-when-its-wet-or-busy.astro
@@ -1,8 +1,17 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Journal", href: "/journal/" },
+  { label: "What to Do on the Peninsula With a Dog When It’s Wet or Busy" },
+];
 ---
 
 <BaseLayout title="What to Do on the Peninsula With a Dog When It’s Wet or Busy | Peninsula Insider" description="A practical wet-weather and busy-day guide for doing the Mornington Peninsula with the dog." section="explore">
+  <Breadcrumbs items={breadcrumbItems} />
+
   <main class="article-shell container prose" style="padding: 3rem 0 4rem; max-width: 820px;">
     <p class="label label--accent">Dog-Friendly Peninsula</p>
     <h1>What to Do on the Peninsula With a Dog When It’s Wet or Busy</h1>

--- a/next/src/pages/newsletter.astro
+++ b/next/src/pages/newsletter.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
 import SubscribeForm from '../components/SubscribeForm.astro';
 
 const breadcrumbItems = [
@@ -15,6 +16,8 @@ const breadcrumbItems = [
   canonical="https://peninsulainsider.com.au/newsletter/"
   ogImage="/images/sourced/article-sorrento-weekend-01.webp"
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <!-- ═══════════════════════════════════════════════════════════════
        1. HERO, typographic publication front page.
           No photo, no scrim, no glass form. Type, voice, white card.

--- a/next/src/pages/partners/apply.astro
+++ b/next/src/pages/partners/apply.astro
@@ -5,15 +5,24 @@
  * Editorial firewall: Tyler reviews every submission. No paid placements without disclosure.
  */
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 
 const API_URL = import.meta.env.PUBLIC_CONCIERGE_API_URL || 'http://localhost:8787';
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Partners", href: "/partners/" },
+  { label: "Tell us about your venue" },
+];
 ---
 
 <BaseLayout
   title="Tell us about your venue  -  Peninsula Insider"
   description="Two ways to get in touch with Peninsula Insider. Editorial submission for venues we should be writing about. Commercial enquiry for partnerships and placement."
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <main class="apply-page">
 
     <section class="apply-hero">

--- a/next/src/pages/partners/index.astro
+++ b/next/src/pages/partners/index.astro
@@ -11,14 +11,23 @@
  * (Astro ignores _-prefixed folders during compile.)
  */
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { editableText } from '../../lib/inline-edit/attrs';
+
+const breadcrumbItems = [
+  { label: "Home", href: "/" },
+  { label: "Partners", href: "/partners/" },
+  { label: "Partner with Peninsula Insider" },
+];
 ---
 
 <BaseLayout
   title="Partner with Peninsula Insider"
   description="Reach people already planning where to eat, stay, explore and spend time on the Mornington Peninsula. Peninsula Insider partners selectively with businesses whose quality and atmosphere align with the editorial."
 >
+  <Breadcrumbs items={breadcrumbItems} />
+
   <main class="partners-page">
 
     <!-- HERO -->


### PR DESCRIPTION
## Summary
Adds Breadcrumbs to every content page that was still missing one after the recent CMS Wave 1+2 PR landed.

The audit started at 76 "missing" pages but most were intentional skips. Net result: **15 real content pages patched**.

### Patched
**12 journal hand-builts** (long-form editorial bypassing journal/[slug].astro):
`best-brunch`, `dog-friendly`, `free-things-to-do`, `mornington-peninsula-day-trip`, `hot-springs-guide`, `in-autumn`, `in-winter`, `itinerary`, `wedding-venues`, `with-kids`, `best-towns-to-base-with-a-dog`, `what-to-do-with-a-dog-when-wet-or-busy`

**Partners:** `partners/index.astro`, `partners/apply.astro`

**Newsletter:** wired up the orphan `breadcrumbItems` const that already existed in frontmatter.

All get the canonical pattern `Home › <Section> › <Title>`, with the title extracted from the first `<h1>` (or BaseLayout `title` prop as fallback).

### Intentionally NOT patched (verified)
- ~30 redirect pages (Redirect component / meta-refresh shells — non-rendering)
- 4 PrintLayout PDF generators (`guides/*`, partner kits — printed to PDF, no chrome)
- Dynamic `[slug]` pages that already render breadcrumbs via their template component (`places`, `eat`, `stay`, `wine`, wine-subregion)
- Utility/logged-in surfaces: 404, ask, index, account/*, plan/index

## Test plan
- [ ] Build green locally (verified — 1360 pages, 33s)
- [ ] Live: spot-check 2-3 patched journal articles and confirm breadcrumb sits below the masthead with correct hierarchy
- [ ] Live: confirm `/newsletter/`, `/partners/`, `/partners/apply/` all show breadcrumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
