### PR TITLE
fix(cms): register signature-event pages in content_registry

### DIFF
--- a/next/scripts/refresh-content-registry.mjs
+++ b/next/scripts/refresh-content-registry.mjs
@@ -53,6 +53,27 @@ const COLLECTIONS = [
   { folder: 'tour-packages',  entityType: 'tour-package',  hrefPrefix: '/plans/' },
 ];
 
+/**
+ * "Page-tagged" collections: content collections whose detail pages aren't
+ * tagged with a first-class entityType in the templates, so the inline
+ * editor's auto-detect falls back to (entity_type='page', entity_slug=<URL
+ * path slugified>). We mirror that derivation here so the integrity trigger
+ * accepts overrides on those pages.
+ *
+ * Derived slug rule: same as client.ts currentPageSlug() — drop slashes,
+ * lowercase, replace `/` with `-`. e.g. `/events/portsea-polo/` becomes
+ * `events-portsea-polo`.
+ */
+const PAGE_COLLECTIONS = [
+  { folder: 'signature-events', pathPrefix: '/events/' },
+];
+
+function pageSlugFromPath(path) {
+  const trimmed = String(path).replace(/^\/+|\/+$/g, '');
+  if (trimmed.length === 0) return 'home';
+  return trimmed.toLowerCase().replace(/[^a-z0-9/_-]/g, '-').replace(/\//g, '-');
+}
+
 async function loadJsonFiles(folder) {
   const dir = join(CONTENT_ROOT, folder);
   let files;
@@ -114,6 +135,31 @@ async function main() {
     console.log(`[refresh-registry] ${entityType}: ${rows.length} rows upserted`);
     total += rows.length;
   }
+
+  // Page-tagged collections (signature-events etc.) → emit (page, derived-slug)
+  // rows that match the inline editor's client-side auto-detect convention.
+  // Fixes "no matching row in pi.content_registry" rejections on pages that
+  // don't have first-class CMS entityType wiring in their templates.
+  for (const { folder, pathPrefix } of PAGE_COLLECTIONS) {
+    const items = await loadJsonFiles(folder);
+    const rows = items
+      .filter((d) => d.slug)
+      .map((d) => {
+        const href = pathPrefix + d.slug + '/';
+        return {
+          entity_type: 'page',
+          entity_slug: pageSlugFromPath(href),
+          title:       d.name || d.title || d.slug,
+          href,
+          refreshed_at: new Date().toISOString(),
+        };
+      });
+    if (rows.length === 0) continue;
+    await upsertBatch(rows);
+    console.log(`[refresh-registry] page (${folder}): ${rows.length} rows upserted`);
+    total += rows.length;
+  }
+
   console.log(`[refresh-registry] Done — ${total} entities refreshed in pi.content_registry`);
 }
 


### PR DESCRIPTION
Per James — image upload on /events/portsea-polo/ was failing with:

> Upload failed: DB insert failed: CMS override for (page, events-portsea-polo) refused: no matching row in pi.content_registry.

**Root cause:** `events/[slug].astro` renders signature events but has no first-class CMS entityType wiring. The inline editor falls back to `(entity_type='page', entity_slug=<URL path slugified>)`. `refresh-content-registry.mjs` never emitted those `(page, *)` rows because `signature-events` wasn't in `COLLECTIONS`, so the integrity trigger rejected every override on every signature-event page.

**Fix:** new `PAGE_COLLECTIONS` list in the refresh script that mirrors the client-side slug derivation. Each entry maps a content folder to a path prefix; the script upserts `(page, derived-slug)` rows for every JSON in that folder. Added `signature-events → /events/`.

After this deploy, all 10 signature-event pages become editable (Portsea Polo, Sorrento Writers Festival, Peninsula Film Festival, Mornington Winter Music Festival, Portsea Swim Classic, etc.).

The PAGE_COLLECTIONS scaffold extends easily — one line per added folder if we ever need to register other 'page-tagged' collections.

## Test plan
- [x] Local smoke-test: script parses, walks files, builds batch (401 expected without prod key)
- [ ] On merge, watch the deploy log for `page (signature-events): 10 rows upserted`
- [ ] Reload /events/portsea-polo/ and retry the image upload