### PR TITLE
fix(map): swap base tile to CARTO Voyager — restore land/water contrast

### DIFF
--- a/next/src/components/PlaceMap.astro
+++ b/next/src/components/PlaceMap.astro
@@ -290,7 +290,7 @@ const mapId = `placeMap-${placeSlug}`;
         map.on('click', function () { map.scrollWheelZoom.enable(); });
 
         // CARTO Positron — minimal editorial base. See map.astro for rationale.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', {
           maxZoom: 19,
           subdomains: 'abcd',
           attribution: '© OpenStreetMap contributors © CARTO',

--- a/next/src/pages/insiders-30/map.astro
+++ b/next/src/pages/insiders-30/map.astro
@@ -136,7 +136,7 @@ const breadcrumbItems = [
         map.on('click', function () { map.scrollWheelZoom.enable(); });
 
         // CARTO Positron — minimal editorial base. See map.astro for rationale.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', {
           maxZoom: 19,
           subdomains: 'abcd',
           attribution: '© OpenStreetMap contributors © CARTO',

--- a/next/src/pages/map.astro
+++ b/next/src/pages/map.astro
@@ -264,7 +264,7 @@ const categoryLegend: Array<{ key: MapEntry['category']; label: string; count: n
         // the brand-coloured pin layer reads as the figure, not the ground.
         // {r} is the retina suffix (@2x on hi-DPI displays). No API key
         // required; attribution covers both OSM and CARTO per their terms.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', {
           maxZoom: 19,
           subdomains: 'abcd',
           attribution: '© OpenStreetMap contributors © CARTO',

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -9160,37 +9160,35 @@ body.menu-open .subscribe-pill {
 }
 
 /* =========================================================
-   MAP TILES — editorial monochrome treatment
+   MAP TILES — editorial treatment on CARTO Voyager
    ---------------------------------------------------------
-   Applies a graphic black-and-white treatment to the CARTO
-   Positron base tiles so the map reads as an editorial spread
-   rather than a navigational utility. Brand-coloured pins
-   (.map-pin--*) sit on top as the figure against this muted
-   ground.
-
-   2026-05-16 — restore land/water contrast. The previous
-   100% grayscale + sepia 6% stack collapsed land and water to
-   the same warm-grey tone, so the Peninsula coastline disappeared.
-   Holding back to 85% grayscale keeps a ~15% blue cast on water
-   while leaving the land effectively monochrome. Sepia is removed
-   entirely — it was the main culprit muddying the two surfaces
-   together. Contrast bumped to 1.28 to sharpen outlines now that
-   we're not relying on grayscale alone to do that work.
+   2026-05-16 — switched base tile from CARTO Positron to Voyager.
+   Positron's native palette was too pale; pushing grayscale on
+   it produced no-contrast maps (land and water collapsed into
+   one warm-grey surface and the Peninsula coastline disappeared).
+   Voyager has the editorial palette we want natively: warm cream
+   land, distinct cool-grey water, soft pencil roads, serif-style
+   labels. The filter below is now a gentle mute rather than a
+   transformation — keeps the editorial feel without erasing the
+   coastline.
 
    Stylization stack:
-     - grayscale(85%) — strip most hue, preserve faint blue in water
-     - contrast(1.28) — sharpen outlines toward a Toner-like line
-     - brightness(1.03) — lift the paper so the surface reads warm-grey
+     - saturate(0.45) — pull saturation down 55% so the map reads
+                        muted-editorial. Preserves hue cues (water
+                        still reads cool, land still reads warm)
+                        but quiets every tone.
+     - contrast(1.05) — gentle line sharpening
+     - brightness(0.98) — drop a hair so the paper reads creamy,
+                          not bleached. Helps coastline register.
 
-   Dial-up controls:
-     - Push contrast to 1.4 for harder outlines
-     - Reintroduce sepia (max ~4%) for a paper tint — but verify
-       land/water contrast stays visible first
-     - Swap CARTO 'light_all' to 'light_nolabels' to drop labels
-       entirely (pure outlines, PI pins become the only text)
+   Dial controls:
+     - saturate(0)  → full black-and-white (lose hue cues)
+     - contrast(1.15) → harder outlines
+     - swap `voyager` → `voyager_nolabels` in the three tile URLs
+       to drop labels entirely (PI pins become the only text)
    ========================================================= */
 .pi-map-tiles {
-  filter: grayscale(85%) contrast(1.28) brightness(1.03);
+  filter: saturate(0.45) contrast(1.05) brightness(0.98);
 }
 
 .map-pin-toggle {


### PR DESCRIPTION
Per James — `it's really not looking good, just go ahead and implement`.

**Root cause** of the previous three rounds: CARTO Positron was the wrong base. Its native palette is too washed-out for any meaningful editorial filter to work on top — pushing grayscale just collapsed land and water into one warm-grey surface, hiding the Peninsula coastline.

**Fix:** swap tile source to CARTO Voyager. Same provider family, same free tier, no API key. Native palette is editorial-leaning out of the box: warm cream land, distinct cool-grey water, pencil roads, serif labels. The coastline registers cleanly without any filter at all.

Filter on top is rewritten as a gentle mute: `saturate(0.45) contrast(1.05) brightness(0.98)`. Preserves the hue cues that make land and water readable while quieting all tones so the surface stays editorial. Pin layer untouched.