### PR TITLE
revert: restore original OSM map tiles

### DIFF
--- a/next/src/components/PlaceMap.astro
+++ b/next/src/components/PlaceMap.astro
@@ -289,12 +289,9 @@ const mapId = `placeMap-${placeSlug}`;
         canvas.addEventListener('blur', function () { map.scrollWheelZoom.disable(); });
         map.on('click', function () { map.scrollWheelZoom.enable(); });
 
-        // CARTO Positron — minimal editorial base. See map.astro for rationale.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', {
-          maxZoom: 19,
-          subdomains: 'abcd',
-          attribution: '© OpenStreetMap contributors © CARTO',
-          className: 'pi-map-tiles',
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 18,
+          attribution: '© OpenStreetMap contributors',
         }).addTo(map);
 
         var iconFor = function (cat) {

--- a/next/src/pages/insiders-30/map.astro
+++ b/next/src/pages/insiders-30/map.astro
@@ -135,12 +135,9 @@ const breadcrumbItems = [
         canvas.addEventListener('blur',  function () { map.scrollWheelZoom.disable(); });
         map.on('click', function () { map.scrollWheelZoom.enable(); });
 
-        // CARTO Positron — minimal editorial base. See map.astro for rationale.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', {
-          maxZoom: 19,
-          subdomains: 'abcd',
-          attribution: '© OpenStreetMap contributors © CARTO',
-          className: 'pi-map-tiles',
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 18,
+          attribution: '© OpenStreetMap contributors',
         }).addTo(map);
 
         function escapeHtml(s) {

--- a/next/src/pages/map.astro
+++ b/next/src/pages/map.astro
@@ -259,16 +259,9 @@ const categoryLegend: Array<{ key: MapEntry['category']; label: string; count: n
         // Click on map to enable scroll zoom (desktop convenience).
         map.on('click', function () { map.scrollWheelZoom.enable(); });
 
-        // CARTO Positron base map — minimal, light grey, editorial.
-        // Replaces the noisy default OSM raster with an outline-led look so
-        // the brand-coloured pin layer reads as the figure, not the ground.
-        // {r} is the retina suffix (@2x on hi-DPI displays). No API key
-        // required; attribution covers both OSM and CARTO per their terms.
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}{r}.png', {
-          maxZoom: 19,
-          subdomains: 'abcd',
-          attribution: '© OpenStreetMap contributors © CARTO',
-          className: 'pi-map-tiles',
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 18,
+          attribution: '© OpenStreetMap contributors',
         }).addTo(map);
 
         // Per-category icon. We use Leaflet DivIcons so we don't need image

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -9159,38 +9159,6 @@ body.menu-open .subscribe-pill {
   border-bottom: 1px solid var(--border);
 }
 
-/* =========================================================
-   MAP TILES — editorial treatment on CARTO Voyager
-   ---------------------------------------------------------
-   2026-05-16 — switched base tile from CARTO Positron to Voyager.
-   Positron's native palette was too pale; pushing grayscale on
-   it produced no-contrast maps (land and water collapsed into
-   one warm-grey surface and the Peninsula coastline disappeared).
-   Voyager has the editorial palette we want natively: warm cream
-   land, distinct cool-grey water, soft pencil roads, serif-style
-   labels. The filter below is now a gentle mute rather than a
-   transformation — keeps the editorial feel without erasing the
-   coastline.
-
-   Stylization stack:
-     - saturate(0.45) — pull saturation down 55% so the map reads
-                        muted-editorial. Preserves hue cues (water
-                        still reads cool, land still reads warm)
-                        but quiets every tone.
-     - contrast(1.05) — gentle line sharpening
-     - brightness(0.98) — drop a hair so the paper reads creamy,
-                          not bleached. Helps coastline register.
-
-   Dial controls:
-     - saturate(0)  → full black-and-white (lose hue cues)
-     - contrast(1.15) → harder outlines
-     - swap `voyager` → `voyager_nolabels` in the three tile URLs
-       to drop labels entirely (PI pins become the only text)
-   ========================================================= */
-.pi-map-tiles {
-  filter: saturate(0.45) contrast(1.05) brightness(0.98);
-}
-
 .map-pin-toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Per James — four iterations of editorial-monochrome map styling failed to land. Reverting to the original OSM tile config on all three map surfaces. `.pi-map-tiles` filter block deleted from `global.css`. Postmortem in commit message; proper editorial-map options (paid Stadia Toner, or static SVG base) noted but deferred.