### PR TITLE
explore/golf: fix National course count + add Insider Read line per card

### DIFF
--- a/next/src/content/experiences/eagle-ridge-golf-course.json
+++ b/next/src/content/experiences/eagle-ridge-golf-course.json
@@ -46,7 +46,8 @@
     "access": "public",
     "holes": 18,
     "bookingUrl": "https://www.eagleridge.com.au/",
-    "approximateGreenFeeNote": "Verify current green fees directly. One of the better-value Peninsula rounds; midweek rates are particularly good."
+    "approximateGreenFeeNote": "Verify current green fees directly. One of the better-value Peninsula rounds; midweek rates are particularly good.",
+    "localRead": "Tight off the tee — locals rate it the lesser of the Peninsula courses for that reason. The flip side: during daylight savings, the after-3pm twilight deals on cart and green fees are some of the best on the Peninsula."
   },
   "lastVerified": "2026-04-14",
   "publishedAt": "2026-04-14"

--- a/next/src/content/experiences/flinders-golf-club.json
+++ b/next/src/content/experiences/flinders-golf-club.json
@@ -46,7 +46,8 @@
     "access": "semi-private",
     "holes": 9,
     "bookingUrl": "https://www.flindersgolf.com.au/",
-    "approximateGreenFeeNote": "Verify current green fees directly. Small member's club; ring ahead for visitor access."
+    "approximateGreenFeeNote": "Verify current green fees directly. Small member's club; ring ahead for visitor access.",
+    "localRead": "Word of mouth from Peninsula club golfers: more a friendly drinkers' club than an architectural pilgrimage. The views are still world-class — go for the cliffs and the post-round beer, not the design conversation."
   },
   "lastVerified": "2026-04-14",
   "publishedAt": "2026-04-14"

--- a/next/src/content/experiences/mornington-golf-club.json
+++ b/next/src/content/experiences/mornington-golf-club.json
@@ -47,7 +47,8 @@
     "access": "semi-private",
     "holes": 18,
     "bookingUrl": "https://www.morningtongolf.com.au/",
-    "approximateGreenFeeNote": "Verify current green fees directly. Closest Peninsula course to Melbourne; weekday rates are strong value."
+    "approximateGreenFeeNote": "Verify current green fees directly. Closest Peninsula course to Melbourne; weekday rates are strong value.",
+    "localRead": "Word of mouth from Peninsula club golfers: a sociable, accessible local club rather than a tournament destination. Pairs well with a Mornington foreshore lunch and a relaxed afternoon."
   },
   "lastVerified": "2026-04-14",
   "publishedAt": "2026-04-14"

--- a/next/src/content/experiences/rosebud-country-club.json
+++ b/next/src/content/experiences/rosebud-country-club.json
@@ -48,7 +48,8 @@
     "access": "public",
     "holes": 27,
     "bookingUrl": "https://www.rosebudcountryclub.com.au/",
-    "approximateGreenFeeNote": "Verify current green fees directly. One of the more affordable Peninsula rounds; twilight and midweek rates are strong."
+    "approximateGreenFeeNote": "Verify current green fees directly. One of the more affordable Peninsula rounds; twilight and midweek rates are strong.",
+    "localRead": "Rated by locals as one of the two best bang-for-buck rounds on the Peninsula, alongside St Andrews Beach. The 27-hole mix-and-match format is the practical advantage."
   },
   "lastVerified": "2026-04-14",
   "publishedAt": "2026-04-14",

--- a/next/src/content/experiences/st-andrews-beach-golf-course.json
+++ b/next/src/content/experiences/st-andrews-beach-golf-course.json
@@ -53,7 +53,8 @@
       "World top 100 in recent global rankings — verify year and currency before publishing specific ranking claims"
     ],
     "bookingUrl": "https://www.standrewsbeachgolf.com.au/",
-    "approximateGreenFeeNote": "Verify live green fees directly at time of booking — do not publish dollar figures without current confirmation."
+    "approximateGreenFeeNote": "Verify live green fees directly at time of booking — do not publish dollar figures without current confirmation.",
+    "localRead": "Rated by locals as one of the two best bang-for-buck rounds on the Peninsula. World-ranked architecture at a public green fee is the pitch — and it lands."
   },
   "lastVerified": "2026-04-14",
   "publishedAt": "2026-04-14"

--- a/next/src/content/experiences/the-national-golf-club.json
+++ b/next/src/content/experiences/the-national-golf-club.json
@@ -48,7 +48,8 @@
     "rankings": [
       "Widely regarded as Australia's strongest four-course private golf property"
     ],
-    "approximateGreenFeeNote": "Private members' club. Access via reciprocal rights, corporate days, or member invitation only."
+    "approximateGreenFeeNote": "Private members' club. Access via reciprocal rights, corporate days, or member invitation only.",
+    "localRead": "The Gunnamatta course is known affectionately by locals as 'doesn't matter' — a forgiving Greg Norman layout where you can spray it off the tee and still score well. The reputation is as the fun course; the uplifter when your form has gone."
   },
   "lastVerified": "2026-04-14",
   "publishedAt": "2026-04-14"

--- a/next/src/content/experiences/the-national-golf-club.json
+++ b/next/src/content/experiences/the-national-golf-club.json
@@ -15,7 +15,7 @@
     "autumn",
     "spring"
   ],
-  "editorNote": "The National is the Peninsula's most ambitious golf property — three championship courses on one sweeping Cape Schanck site, designed by Robert Trent Jones Jr (Old), Peter Thomson (Moonah), and Greg Norman (Gunnamatta). Together they form arguably the strongest 54-hole golf address in Australia. The caveat is access. The National is a private members' club. Non-member play is possible through reciprocal rights, corporate days, and occasional open days — but it is not a walk-up booking in the way St Andrews Beach or Moonah Links are. For Peninsula Insider readers, that changes the editorial framing. The National matters as context — Peninsula golf would be less serious without it — but it is not the course to build a visitor's weekend around unless you have a member connection. If you do have access, the Moonah is the most architecturally interesting, the Old is the grandest, and the Gunnamatta is the wildest. The views across the Southern Ocean from the clifftop holes are the best on any Australian course. The clubhouse is strong. The conditioning is meticulous. Everything you would expect from one of the country's top private clubs is delivered.",
+  "editorNote": "The National is the Peninsula's most ambitious golf property — four championship courses across two sites. Three sit on one sweeping Cape Schanck plateau: the Old (Robert Trent Jones Jr), the Moonah (Peter Thomson), and the Gunnamatta (Greg Norman). The fourth, the Long Island course, sits 50 minutes north at Frankston. Together they form arguably the strongest four-course private golf address in Australia. The caveat is access. The National is a private members' club. Non-member play is possible through reciprocal rights, corporate days, and occasional open days — but it is not a walk-up booking in the way St Andrews Beach or Moonah Links are. For Peninsula Insider readers, that changes the editorial framing. The National matters as context — Peninsula golf would be less serious without it — but it is not the course to build a visitor's weekend around unless you have a member connection. If you do have access, the Moonah is the most architecturally interesting, the Old is the grandest, and the Gunnamatta is the wildest. The views across the Southern Ocean from the clifftop holes are the best on any Australian course. The clubhouse is strong. The conditioning is meticulous. Everything you would expect from one of the country's top private clubs is delivered.",
   "tags": {
     "mood": [
       "golf",
@@ -39,14 +39,14 @@
   "golf": {
     "tier": "tier-1",
     "access": "private",
-    "holes": 54,
+    "holes": 72,
     "designers": [
       "Robert Trent Jones Jr",
       "Peter Thomson",
       "Greg Norman"
     ],
     "rankings": [
-      "Widely regarded as Australia's strongest 54-hole property"
+      "Widely regarded as Australia's strongest four-course private golf property"
     ],
     "approximateGreenFeeNote": "Private members' club. Access via reciprocal rights, corporate days, or member invitation only."
   },

--- a/next/src/pages/explore/golf.astro
+++ b/next/src/pages/explore/golf.astro
@@ -250,6 +250,9 @@ const breadcrumbItems = [
                   <p class="golf-card__ranking">{g.rankings[0]}</p>
                 )}
                 <p class="golf-card__note">{firstSentences(d.editorNote, 3)}</p>
+                {g.localRead && (
+                  <p class="golf-card__local"><span class="golf-card__local-tag">Insider read</span>{g.localRead}</p>
+                )}
               </div>
               <div class="golf-card__footer">
                 <a href={`/explore/${slug}/`} class="golf-card__cta">Course guide →</a>
@@ -305,6 +308,9 @@ const breadcrumbItems = [
                   <p class="golf-card__ranking">{g.rankings[0]}</p>
                 )}
                 <p class="golf-card__note">{firstSentences(d.editorNote, 2)}</p>
+                {g.localRead && (
+                  <p class="golf-card__local"><span class="golf-card__local-tag">Insider read</span>{g.localRead}</p>
+                )}
               </div>
               <div class="golf-card__footer">
                 <a href={`/explore/${slug}/`} class="golf-card__cta">Course guide →</a>
@@ -814,6 +820,27 @@ const breadcrumbItems = [
     color: #44372b;
     line-height: 1.65;
     margin: 0;
+  }
+  .golf-card__local {
+    font-size: 0.82rem;
+    color: #5a4a38;
+    line-height: 1.6;
+    margin: 0.85rem 0 0;
+    padding: 0.65rem 0.85rem;
+    background: rgba(182, 154, 107, 0.09);
+    border-left: 3px solid rgba(182, 154, 107, 0.55);
+    border-radius: 0 0.35rem 0.35rem 0;
+    font-style: italic;
+  }
+  .golf-card__local-tag {
+    display: inline-block;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #7a5f2a;
+    font-style: normal;
+    margin-right: 0.5rem;
   }
 
   /* ── Card footer ── */

--- a/next/src/pages/explore/golf.astro
+++ b/next/src/pages/explore/golf.astro
@@ -189,8 +189,8 @@ const breadcrumbItems = [
       label: 'Cape Schanck / Fingal',
       title: 'World-ranked. Exposed. Worth the drive to the tip.',
       rows: [
-        { label: 'Flagship courses', value: 'St Andrews Beach (Tom Doak), Moonah Links (Peter Thomson), The National (Trent Jones Jr, Thomson, Greg Norman)' },
-        { label: 'Access', value: 'St Andrews Beach and Moonah Links are fully public. The National Ocean Course accepts green fees; the Moonah and Gunnamatta courses are private.' },
+        { label: 'Flagship courses', value: 'St Andrews Beach (Tom Doak), Moonah Links (Peter Thomson), The National (Trent Jones Jr, Thomson, Greg Norman) — three of The National\'s four courses sit here; the fourth, Long Island, is at Frankston.' },
+        { label: 'Access', value: 'St Andrews Beach and Moonah Links are fully public. The National\'s four courses are private members-only across both the Cape Schanck and Long Island sites.' },
         { label: 'Conditions', value: 'Coastal duneland. Exposed to Bass Strait wind. The same course plays differently on every visit.' },
         { label: 'Best for', value: 'Serious golfers. Destination weekends. Groups who want the bucket-list round. Stay-and-play packages.' },
         { label: 'Combine with', value: 'Peninsula Hot Springs (15 min). Cape Schanck boardwalk. Fingal or Flinders for lunch.' },
@@ -449,8 +449,8 @@ const breadcrumbItems = [
 
         <article class="architect-card">
           <div class="architect-card__name">Robert Trent Jones Jr</div>
-          <div class="architect-card__course">The National Old Course; RACV Cape Schanck Resort</div>
-          <p class="architect-card__note">The global modernist. RTJ Jr's Peninsula footprint covers both private and resort golf, running from the Cape Schanck headland to the RACV property. His Old Course at The National is the grandest of the three National layouts, designed for a club that was always intended to rival the best in the world. The RACV design is more accessible and suits the resort context it was built for.</p>
+          <div class="architect-card__course">The National Old Course; The National Long Island; RACV Cape Schanck Resort</div>
+          <p class="architect-card__note">The global modernist. RTJ Jr's Peninsula footprint runs from the Cape Schanck headland north to Frankston, covering two of The National's four courses (the Old at Cape Schanck and the Long Island course at Frankston) plus the RACV resort layout. His Old Course at The National is the grandest of the four National layouts, designed for a club that was always intended to rival the best in the world. The RACV design is more accessible and suits the resort context it was built for.</p>
         </article>
 
         <article class="architect-card">
@@ -633,7 +633,7 @@ const breadcrumbItems = [
         <details class="golf-faq__item">
           <summary class="golf-faq__q">What is the difference between the Cape Schanck and bay corridor courses?</summary>
           <div class="golf-faq__a">
-            <p>The Cape Schanck / Fingal cluster contains the Peninsula's world-ranked courses: St Andrews Beach, Moonah Links, and The National. All sit in coastal duneland exposed to Bass Strait weather. The terrain is Links-adjacent and the quality of the design architecture is the highest on the Peninsula.</p>
+            <p>The Cape Schanck / Fingal cluster contains the Peninsula's world-ranked courses: St Andrews Beach, Moonah Links, and three of The National's four courses (Old, Moonah, Gunnamatta). The fourth National course, Long Island, sits 50 minutes north at Frankston and is the club's gateway from Melbourne. All sit in coastal duneland exposed to Bass Strait weather. The terrain is Links-adjacent and the quality of the design architecture is the highest on the Peninsula.</p>
             <p>The bay corridor runs from Mornington to Portsea, with a mix of clifftop (Flinders), parkland (Eagle Ridge), dune-links (The Dunes), and bayside (Mornington, Sorrento, Portsea) layouts. More varied in character, generally more accessible in access and pricing, and better suited to a combined golf-and-winery day without driving to the Peninsula tip.</p>
           </div>
         </details>


### PR DESCRIPTION
## Summary

Two related commits responding to expert feedback on [/explore/golf](https://peninsulainsider.com.au/explore/golf/) from a regular Peninsula club golfer.

**Commit 1 — fix(explore/golf): correct The National's course count to four**
The page repeatedly described The National as a three-course Cape Schanck property. Expert flagged: The National operates **four** courses — Old, Moonah, Gunnamatta at Cape Schanck plus Long Island at Frankston. Fixed in:
- `experiences/the-national-golf-club.json` (editorNote, holes 54→72, ranking line)
- `explore/golf.astro` orientation compare block
- `explore/golf.astro` architects card for Robert Trent Jones Jr
- `explore/golf.astro` FAQ on Cape Schanck vs bay corridor

**Commit 2 — feat(explore/golf): add Insider Read line to course cards**
New italic "Insider read" line in each card body, sourced from the same expert. Field is optional (`experience.golf.localRead`), so only courses with genuine local intelligence get the treatment. Seeded notes in this PR:

- **The National** — Gunnamatta nickname ("doesn't matter"), forgiving Norman layout, uplifter when form's gone
- **Eagle Ridge** — tight off the tee (locals rate it lesser of Pen courses); daylight-savings after-3pm twilight cart/green-fee deals are some of the best on the Peninsula
- **Rosebud Country Club** — best bang for buck, paired with St Andrews
- **St Andrews Beach** — world-ranked architecture at a public green fee; the other half of the value pairing
- **Flinders Golf Club** — drinkers' club tone, world-class views; not an architectural pilgrimage
- **Mornington Golf Club** — sociable, accessible local club; pairs with a foreshore lunch

Schema already permits — `golf` is `z.any().optional()` in `content.config.ts` (no schema change). Adds `.golf-card__local` + `.golf-card__local-tag` CSS.

## Flagged for editor (not changed in this PR)

The page (FAQ + handicap selector + ItemList schema) still refers to **"The National Ocean Course"** as accepting public green fees. The experience JSON has The National as fully private across all four courses; the architects section correctly uses "Old Course" for RTJ Jr. The "Ocean Course / public access" usage looks like a naming + access error that needs a separate editorial call. Happy to draft the follow-up once a direction is set.

## Out of scope but recommended next

From the same expert review:
- Per-card "Best for" chips (best value · most forgiving · best clubhouse · twilight deals)
- Long Island deserves its own mini-card or a "Northern gateway" sub-bucket (currently mentioned in editorial copy but no entity card)
- Tonal rewrite of Flinders + Mornington course summaries to match the Insider Read voice
- Pull-quote of "Gunnamatta = doesn't matter" into the architects section sidebar
- Named expert contributor on page footer ("Reviewed with…")

## Test plan
- [ ] `npm run build` in `next/` succeeds, golf page renders
- [ ] All six golf cards display the new "Insider read" line where seeded
- [ ] The four non-seeded cards (Moonah Links, The Dunes, RACV Cape Schanck, Sorrento, Portsea) render cleanly without the line
- [ ] The National card in the Cape cluster reads as a four-course property
- [ ] Architects section RTJ Jr card mentions Long Island
- [ ] FAQ "Cape Schanck vs bay corridor" mentions Long Island at Frankston

🤖 Generated with [Claude Code](https://claude.com/claude-code)