### PR TITLE
seo(experiment 2026-05-17-01): CTR rewrite on /wine/ hub (813 impr → 0.12% CTR)

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/mdx": "5.0.3",
         "@astrojs/react": "^5.0.4",
         "@astrojs/vercel": "^10.0.6",
+        "@rollup/rollup-win32-x64-msvc": "*",
         "@supabase/supabase-js": "^2.105.1",
         "@tailwindcss/vite": "^4.3.0",
         "framer-motion": "^12.38.0",
@@ -28,7 +29,8 @@
         "typescript": "^5.5.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.60.2"
+        "@rollup/rollup-linux-x64-gnu": "^4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "^4.60.4"
       }
     },
     "node_modules/@astrojs/check": {
@@ -2632,9 +2634,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -8677,6 +8679,19 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/sax": {
       "version": "1.6.0",

--- a/next/package.json
+++ b/next/package.json
@@ -39,6 +39,7 @@
     "tailwindcss": "^4.3.0"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.60.2"
+    "@rollup/rollup-linux-x64-gnu": "^4.60.2",
+    "@rollup/rollup-win32-x64-msvc": "^4.60.4"
   }
 }

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -88,11 +88,11 @@ const faqSchema = {
 ---
 
 <BaseLayout
-  title="Best Wineries Mornington Peninsula · Peninsula Insider"
-  description="The best cellar doors on the Mornington Peninsula, Pinot Noir, Chardonnay, cool-climate producers, breweries, and distilleries. Appointment tastings and walk-in cellar doors. Updated for autumn."
+  title="Best Cellar Doors on the Mornington Peninsula 2026 Guide"
+  description="The cellar doors worth the appointment, the Pinot worth the cellar, and the producers you should know in 2026. The Peninsula's honest wine guide."
   section="wine"
   canonical="https://peninsulainsider.com.au/wine"
-  modifiedTime="2026-04-30"
+  modifiedTime="2026-05-17"
   ogImage="/images/sourced/article-cellar-door-01.webp"
 >
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />

--- a/ops/reports/seo/daily-log.md
+++ b/ops/reports/seo/daily-log.md
@@ -673,3 +673,135 @@ Reverse-engineered the GSC Page Indexing report by inspecting all 418 known URLs
 1. Pull GSC data and check whether the indexation chart ticks up further past 76.
 2. Re-run `discover-unindexed.mjs` mid-week (2026-05-08) to see early movement on the three experiments.
 3. Pick next experiment from the remaining 140 Discovered. Strong candidates: the 32 unindexed `/explore/` walks (similar pattern to journal, link equity), or the 4 noindex pages (verify intentional).
+
+---
+
+## 2026-05-16 — daily pull
+
+Property: `sc-domain:peninsulainsider.com.au`
+Window (last 7d): 2026-05-08 → 2026-05-14
+
+### Headline (last 7d vs previous 7d)
+
+| Metric | Last 7d | Prev 7d | Δ | Last 28d |
+|---|---:|---:|---:|---:|
+| Clicks | 98 | 37 | 98  (+61 ↑) | 145 |
+| Impressions | 8,862 | 2,945 | 8,862  (+5,917 ↑) | 13,590 |
+| CTR | 1.11% | 1.26% | 1.11%  (-0.15% ↓) | 1.07% |
+| Avg position | 22.8 | 15.7 | 22.8  (+7.0 ↓) | 20.6 |
+
+### Indexation (priority URLs): 14 / 14 indexed
+
+| URL | Verdict | Coverage |
+|---|---|---|
+| `/` | PASS | Submitted and indexed |
+| `/eat/best-restaurants/` | PASS | Submitted and indexed |
+| `/wine/best-cellar-doors/` | PASS | Submitted and indexed |
+| `/explore/best-walks/` | PASS | Submitted and indexed |
+| `/stay/best-accommodation/` | PASS | Submitted and indexed |
+| `/journal/mornington-peninsula-day-trip/` | PASS | Submitted and indexed |
+| `/journal/mornington-peninsula-in-autumn/` | PASS | Submitted and indexed |
+| `/journal/mornington-peninsula-with-kids/` | PASS | Submitted and indexed |
+| `/journal/dog-friendly-mornington-peninsula/` | PASS | Submitted and indexed |
+| `/places/sorrento/` | PASS | Submitted and indexed |
+| `/places/red-hill/` | PASS | Submitted and indexed |
+| `/places/flinders/` | PASS | Submitted and indexed |
+| `/places/mornington/` | PASS | Submitted and indexed |
+| `/places/rye/` | PASS | Submitted and indexed |
+
+### Top 10 queries by clicks (last 28d)
+
+| # | Query | Clicks | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | alba hot springs vs peninsula hot springs | 3 | 15 | 20.00% | 4.0 |
+| 2 | alba vs peninsula hot springs | 3 | 34 | 8.82% | 5.6 |
+| 3 | alba thermal springs vs peninsula hot springs | 2 | 14 | 14.29% | 4.6 |
+| 4 | alba hot springs reviews | 1 | 1 | 100.00% | 4.0 |
+| 5 | autumn winery walk | 1 | 9 | 11.11% | 4.0 |
+| 6 | best brunch mornington peninsula | 1 | 14 | 7.14% | 8.6 |
+| 7 | bloody long walk mornington peninsula 2026 | 1 | 8 | 12.50% | 6.8 |
+| 8 | boneo market | 1 | 20 | 5.00% | 9.3 |
+| 9 | endota sorrento | 1 | 26 | 3.85% | 6.0 |
+| 10 | gummy shark size limit | 1 | 2 | 50.00% | 8.5 |
+
+### Top 10 queries by impressions (last 28d)
+
+| # | Query | Impr | Clicks | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | 34 western parade point leo vic 3916 | 78 | 0 | 0.00% | 32.0 |
+| 2 | accommodation near peninsula hot springs | 62 | 0 | 0.00% | 48.6 |
+| 3 | 20 junction road merricks north vic 3926 | 55 | 0 | 0.00% | 36.0 |
+| 4 | a dog-friendly guide mornington peninsula | 47 | 0 | 0.00% | 8.4 |
+| 5 | winter wine weekend 2026 | 39 | 1 | 2.56% | 4.5 |
+| 6 | 42 brasser avenue dromana vic 3936 | 39 | 0 | 0.00% | 32.2 |
+| 7 | alba vs peninsula hot springs | 34 | 3 | 8.82% | 5.6 |
+| 8 | endota sorrento | 26 | 1 | 3.85% | 6.0 |
+| 9 | boneo market | 20 | 1 | 5.00% | 9.3 |
+| 10 | balnarring market | 20 | 0 | 0.00% | 9.5 |
+
+### CTR opportunity queries (≥20 impr, <2% CTR)
+
+| # | Query | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|
+| 1 | 34 western parade point leo vic 3916 | 78 | 0.00% | 32.0 |
+| 2 | accommodation near peninsula hot springs | 62 | 0.00% | 48.6 |
+| 3 | 20 junction road merricks north vic 3926 | 55 | 0.00% | 36.0 |
+| 4 | a dog-friendly guide mornington peninsula | 47 | 0.00% | 8.4 |
+| 5 | 42 brasser avenue dromana vic 3936 | 39 | 0.00% | 32.2 |
+| 6 | balnarring market | 20 | 0.00% | 9.5 |
+
+### Top 10 pages by clicks (last 28d)
+
+| # | Page | Clicks | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|---:|
+| 1 | `/` | 14 | 143 | 9.79% | 2.2 |
+| 2 | `/journal/dog-friendly-cafes-pubs-wineries-mornington-peninsula/` | 11 | 233 | 4.72% | 10.1 |
+| 3 | `/journal/peninsula-hot-springs-vs-alba/` | 10 | 186 | 5.38% | 8.4 |
+| 4 | `/eat/` | 6 | 630 | 0.95% | 43.1 |
+| 5 | `/journal/peninsula-hot-springs-vs-alba` | 6 | 189 | 3.17% | 9.3 |
+| 6 | `/whats-on/autumn-winery-walk-2026/` | 5 | 36 | 13.89% | 3.8 |
+| 7 | `/whats-on/peninsula-hot-springs-kodomo-no-hi/` | 4 | 11 | 36.36% | 4.0 |
+| 8 | `/fishing/locations/gunnamatta-beach/` | 3 | 36 | 8.33% | 6.6 |
+| 9 | `/whats-on/pier-10-mothers-day-lunch-2026/` | 3 | 60 | 5.00% | 12.8 |
+| 10 | `/whats-on/winter-wine-weekend-june/` | 3 | 122 | 2.46% | 8.8 |
+
+### CTR opportunity pages (≥30 impr, <2% CTR)
+
+| # | Page | Impr | CTR | Pos |
+|---:|---|---:|---:|---:|
+| 1 | `/wine/` | 813 | 0.12% | 25.5 |
+| 2 | `/eat/` | 630 | 0.95% | 43.1 |
+| 3 | `/journal/dog-friendly-mornington-peninsula/` | 489 | 0.20% | 22.0 |
+| 4 | `/journal/where-to-eat-mornington-peninsula/` | 305 | 0.33% | 38.0 |
+| 5 | `/places/red-hill/` | 237 | 0.42% | 29.4 |
+| 6 | `/journal/luxury-hotels-mornington-peninsula/` | 234 | 0.43% | 25.5 |
+| 7 | `/whats-on/` | 185 | 0.54% | 26.8 |
+| 8 | `/whats-on/heart-of-the-community-market-rosebud/` | 148 | 0.68% | 10.4 |
+| 9 | `/whats-on/mornington-racecourse-market-may-2026/` | 146 | 1.37% | 6.5 |
+| 10 | `/whats-on/mornington-peninsula-winter-wine-weekend-2026/` | 144 | 1.39% | 6.7 |
+
+### Devices (last 28d)
+
+| Device | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| MOBILE | 92 | 4,242 | 2.17% | 11.7 |
+| DESKTOP | 50 | 9,272 | 0.54% | 24.8 |
+| TABLET | 3 | 76 | 3.95% | 7.9 |
+
+### Top countries (last 28d)
+
+| Country | Clicks | Impr | CTR | Pos |
+|---|---:|---:|---:|---:|
+| aus | 143 | 9,768 | 1.46% | 24.2 |
+| hkg | 1 | 20 | 5.00% | 14.8 |
+| sgp | 1 | 34 | 2.94% | 14.9 |
+| ago | 0 | 1 | 0.00% | 1.0 |
+| alb | 0 | 2 | 0.00% | 17.5 |
+| are | 0 | 7 | 0.00% | 14.3 |
+| arg | 0 | 27 | 0.00% | 22.8 |
+| arm | 0 | 1 | 0.00% | 1.0 |
+
+---
+
+### Notes
+_Add interpretation, decisions, and actions taken below._

--- a/ops/reports/seo/experiments.md
+++ b/ops/reports/seo/experiments.md
@@ -16,6 +16,24 @@ Every shipped SEO change is logged here as a hypothesis-driven experiment. Wins 
 
 ## Active experiments
 
+### 2026-05-17-01 — CTR snippet rewrite on /wine/ hub
+
+- **Status**: shipped to worktree branch 2026-05-17. Awaiting deploy.
+- **PR**: pending
+- **Pages affected**: `/wine/` (the wine hub, single page)
+- **Baseline (May 16 pull, 28d window Apr 17–May 14)**: 813 impressions, 1 click, **0.12% CTR**, average position 25.5. Page is the #1 page by impressions site-wide that is not converting. Single click came from the query "pt leo estate" (1 impression at pos 6).
+- **Query mix diagnosis (top queries this page ranks for)**:
+  - **~170 impressions on street-address searches** ("34 western parade point leo vic 3916" 78 impr pos 32, "20 junction road merricks north vic 3926" 52 impr pos 36, "42 brasser avenue dromana vic 3936" 39 impr pos 32). Zero clicks — users want maps, not a wine hub. **No snippet can fix these** (separate noindex/structural work needed).
+  - **~50 impressions on specific winery name searches** ("main ridge winery", "merricks winery", "kerri greens winery", "flinders winery", "crittenden estate", etc) at positions 50–100. These should land on venue pages, not the hub.
+  - **~20 impressions on genuine hub-intent queries** ("best wineries mornington peninsula" variants, "best mornington peninsula pinot noir", "cellar doors"). One query "best wineries in mornington peninsula" ranks position 1 but only 1 impression in 28d.
+- **Hypothesis**: rewriting title + meta to target the genuine hub-intent queries will lift CTR from 0.12% to ≥1.5% within 14 days. Specifically: by 2026-05-31, this page earns ≥5 clicks per 7-day window with similar impression volume (~200/week). Address-query CTR will remain 0% (out of scope).
+- **Mechanism**: old title "Best Wineries Mornington Peninsula · Peninsula Insider" was generic, with brand suffix consuming character budget. Old meta was 200 chars (Google truncates at ~155). New title front-loads "Cellar Doors" (a more specific phrase used by intent-led searchers, distinct from generic "wineries"), adds year freshness signal, drops the brand suffix. New meta has editorial voice ("worth the appointment", "Pinot worth the cellar"), promises specific value props, fits in 148 chars.
+- **Files changed**: `next/src/pages/wine/index.astro` lines 91–92 (BaseLayout title + description). Also bumped `modifiedTime` to 2026-05-17 to signal freshness.
+- **Verification** (2026-05-17): rebuilt locally — 1356 pages, no errors. New title `Best Cellar Doors on the Mornington Peninsula 2026 Guide` (56 chars) and meta (148 chars) confirmed in `dist/wine/index.html`.
+- **Measurement**: read `/wine/` page-level CTR in `daily-log.md` on 2026-05-24 (7d) and 2026-05-31 (14d). Headline metric: 7d clicks on `/wine/` in the CTR opportunity pages table.
+- **Followups not in this experiment**: address-query indexing (separate problem — likely the wine hub appears for these because it contains venue addresses; may need a way to exclude or move address content to venue pages). Specific winery names ranking the hub instead of venue pages is also a separate indexation/internal-linking issue.
+- **Outcome (filled later)**: _pending — measure 2026-05-24 and 2026-05-31_
+
 ### 2026-05-05-01 — Push the 5 unindexed top-level hubs into the index
 
 - **Status**: shipped to worktree branch 2026-05-05.


### PR DESCRIPTION
## Summary

The `/wine/` hub was the #1 page by impressions site-wide that wasn't converting: **813 impressions, 1 click, 0.12% CTR** over the May 16 28d window. Rewrote title + meta to target the genuine hub-intent queries.

## Diagnosis — why the page was earning so many impressions but no clicks

Pulled query-level data via `urlInspection`. Three distinct buckets:

| Query type | Impressions | Why CTR was 0 |
|---|---:|---|
| Street-address searches (e.g. "34 western parade point leo vic 3916") | ~170 | Users want maps. Not snippet-fixable. |
| Specific winery names (e.g. "main ridge winery", "kerri greens") | ~50 | Hub matching at positions 50-100. Should rank venue pages instead. Indexation/IL issue, not snippet. |
| Genuine hub-intent ("best wineries", "best pinot noir", "cellar doors") | ~20 | **This is what the rewrite targets.** |

## Changes

### Title
- **Before** (52 chars): `Best Wineries Mornington Peninsula · Peninsula Insider`
- **After** (56 chars): `Best Cellar Doors on the Mornington Peninsula 2026 Guide`

Front-loads "Cellar Doors" (more specific intent phrase than generic "Wineries"), adds year freshness signal, drops brand suffix (Google appends site name automatically).

### Meta description
- **Before** (200 chars, truncated by Google): `The best cellar doors on the Mornington Peninsula, Pinot Noir, Chardonnay, cool-climate producers, breweries, and distilleries. Appointment tastings and walk-in cellar doors. Updated for autumn.`
- **After** (148 chars, fits): `The cellar doors worth the appointment, the Pinot worth the cellar, and the producers you should know in 2026. The Peninsula's honest wine guide.`

Editorial voice, specific value props, fits in Google's display budget.

### Also bumped `modifiedTime` from 2026-04-30 → 2026-05-17 to signal freshness.

## Bundled fix

`next/package.json` + lockfile: added `@rollup/rollup-win32-x64-msvc` to `optionalDependencies`. This fixes an npm bug that was breaking local Windows builds (known issue: https://github.com/npm/cli/issues/4828). Linux CI ignores this optional dep, so safe.

## Hypothesis (in `ops/reports/seo/experiments.md`)

By **2026-05-31** (14d), `/wine/` CTR rises from 0.12% to ≥1.5% and the page earns ≥5 clicks per 7-day window. Address-query CTR stays 0% (out of scope).

Measurement: read `/wine/` row in the daily-log CTR opportunity pages table on 2026-05-24 (7d) and 2026-05-31 (14d).

## Verification

`npm run build` → 1356 pages built in 39.7s, no errors. New title + meta confirmed in `dist/wine/index.html`.

## Followups (NOT in this PR)

- **Address-query indexing**: hub is appearing for street-address searches because it contains venue addresses in markup. Worth investigating whether to suppress or move content to venue pages.
- **Specific winery names rank the hub, not venue pages**: indexation + internal-linking issue. Same pattern as the Day 5 hub fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)