### PR TITLE
feat(search): Phase C — pi.search() hybrid RPC + RPC-first SearchOverlay

### DIFF
--- a/next/scripts/embed-entity-index.mjs
+++ b/next/scripts/embed-entity-index.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * embed-entity-index.mjs
+ *
+ * Phase C embedding population. Backfills the `embedding` column on
+ * pi.entity_index using the same OpenAI model the concierge corpus uses
+ * (text-embedding-3-small, 1536 dim). No second embedding pipeline.
+ *
+ * Behaviour
+ * ---------
+ * - Pulls rows where embedding is null OR the content_hash of title|dek|body
+ *   has changed since the last embed.
+ * - Embeds in batches (OpenAI accepts arrays). Default batch = 32.
+ * - Upserts the row's embedding + a content_hash sidecar column so the next
+ *   run can detect drift.
+ *
+ * Modes
+ * -----
+ *   --dry-run         (default) Count rows that need embedding. No API calls.
+ *   --apply                     Embed and write back to Supabase.
+ *   --force                     Re-embed every row even if hash unchanged.
+ *   --limit=N                   Cap total rows embedded this run.
+ *
+ * Env
+ * ---
+ *   OPENAI_API_KEY              Required when --apply.
+ *   SUPABASE_SERVICE_KEY        Required when --apply (write to pi.entity_index).
+ *   PUBLIC_SUPABASE_URL         Optional override.
+ *   EMBEDDING_MODEL             Default: text-embedding-3-small.
+ *
+ * Wired into deploy after Phase B is live and SUPABASE_SERVICE_KEY is rotated.
+ */
+
+import { createHash } from 'node:crypto';
+
+const args = process.argv.slice(2);
+const opts = { apply: false, force: false, limit: null };
+for (const a of args) {
+  if (a === '--apply') opts.apply = true;
+  else if (a === '--force') opts.force = true;
+  else if (a.startsWith('--limit=')) opts.limit = parseInt(a.slice('--limit='.length), 10);
+}
+
+const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL || 'https://tjjhpvslpysfklwpqmgz.supabase.co';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+const OPENAI_KEY = process.env.OPENAI_API_KEY;
+const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL || 'text-embedding-3-small';
+const BATCH = 32;
+
+if (!SUPABASE_KEY) {
+  console.error('[FATAL] SUPABASE_SERVICE_KEY required');
+  process.exit(1);
+}
+
+function hashContent(parts) {
+  return createHash('sha256').update(parts.filter(Boolean).join('\n\n')).digest('hex');
+}
+
+async function fetchPi(path, { method = 'GET', body = null, prefer = null } = {}) {
+  const headers = {
+    'Content-Type':    'application/json',
+    'apikey':          SUPABASE_KEY,
+    'Authorization':   `Bearer ${SUPABASE_KEY}`,
+    'Accept-Profile':  'pi',
+    'Content-Profile': 'pi',
+  };
+  if (prefer) headers['Prefer'] = prefer;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method, headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`Supabase ${method} ${path} ${res.status}: ${await res.text()}`);
+  return res.status === 204 ? null : res.json();
+}
+
+async function embed(texts) {
+  const res = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENAI_KEY}`,
+      'Content-Type':  'application/json',
+    },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: texts }),
+  });
+  if (!res.ok) throw new Error(`OpenAI ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.data.map((d) => d.embedding);
+}
+
+// ─── load candidate rows ─────────────────────────────────────────────────
+// Select rows needing embedding. content_hash column (added by this script
+// on first apply) lives in entity_index. When the hash differs from the
+// hash of title|dek|body, the row is stale.
+const select = opts.force
+  ? '*'
+  : 'entity_type,entity_slug,title,dek,body,content_hash,embedding';
+
+let rows = await fetchPi(`entity_index?select=${select}&order=refreshed_at.desc`);
+const needsEmbed = [];
+for (const r of rows) {
+  const h = hashContent([r.title, r.dek, r.body]);
+  const stale = opts.force || r.content_hash !== h || !r.embedding;
+  if (stale) needsEmbed.push({ row: r, hash: h });
+  if (opts.limit && needsEmbed.length >= opts.limit) break;
+}
+
+console.log(`[embed] candidates: ${rows.length}`);
+console.log(`[embed] needs embedding: ${needsEmbed.length}`);
+console.log(`[embed] model: ${EMBEDDING_MODEL}`);
+
+if (!opts.apply) {
+  console.log(`[embed] DRY RUN. Run with --apply (requires OPENAI_API_KEY + SUPABASE_SERVICE_KEY).`);
+  process.exit(0);
+}
+if (!OPENAI_KEY) {
+  console.error('[FATAL] --apply requires OPENAI_API_KEY');
+  process.exit(1);
+}
+
+// ─── batched embed + upsert ──────────────────────────────────────────────
+for (let i = 0; i < needsEmbed.length; i += BATCH) {
+  const batch = needsEmbed.slice(i, i + BATCH);
+  const texts = batch.map(({ row }) =>
+    [row.title, row.dek, row.body].filter(Boolean).join('\n\n').slice(0, 8192)
+  );
+  let vectors;
+  try {
+    vectors = await embed(texts);
+  } catch (err) {
+    console.error(`[embed] batch ${i / BATCH + 1} failed: ${err.message}`);
+    process.exit(1);
+  }
+  // Upsert in parallel within the batch.
+  await Promise.all(batch.map(async ({ row, hash }, j) => {
+    const v = vectors[j];
+    if (!v) return;
+    const path = `entity_index?entity_type=eq.${encodeURIComponent(row.entity_type)}&entity_slug=eq.${encodeURIComponent(row.entity_slug)}`;
+    await fetchPi(path, {
+      method: 'PATCH',
+      body: { embedding: `[${v.join(',')}]`, content_hash: hash },
+      prefer: 'return=minimal',
+    });
+  }));
+  console.log(`[embed] batch ${i / BATCH + 1}/${Math.ceil(needsEmbed.length / BATCH)} done (${batch.length} rows)`);
+}
+
+console.log(`[embed] complete. ${needsEmbed.length} rows embedded.`);

--- a/next/src/components/SearchOverlay.astro
+++ b/next/src/components/SearchOverlay.astro
@@ -256,10 +256,63 @@
       }
     }
 
+    // Capitalise an entity_type for the result-kind chip.
+    function kindLabel(entityType) {
+      if (!entityType) return 'Guide';
+      const map = {
+        venue: 'Venue', experience: 'Experience', event: 'Event',
+        place: 'Place', itinerary: 'Plan', tour: 'Tour',
+        'tour-package': 'Tour package', article: 'Journal',
+        'quick-note': 'Quick note', 'local-secret': 'Local secret',
+      };
+      return map[entityType] || (entityType.charAt(0).toUpperCase() + entityType.slice(1));
+    }
+
+    // Shape RPC SearchHit rows into the form showResults expects so the
+    // Pagefind-shaped renderer keeps working unchanged.
+    function rpcToResults(hits, query) {
+      const q = (query || '').toLowerCase();
+      return hits.map((h) => {
+        const dek = h.dek || '';
+        // Lightweight highlight: wrap the first query-word match in <mark>.
+        let excerpt = escapeHtml(dek.slice(0, 220));
+        if (q && excerpt.toLowerCase().includes(q)) {
+          const i = excerpt.toLowerCase().indexOf(q);
+          excerpt = excerpt.slice(0, i) + '<mark>' + excerpt.slice(i, i + q.length) + '</mark>' + excerpt.slice(i + q.length);
+        }
+        return {
+          url: h.href,
+          meta: { title: h.title, kind: kindLabel(h.entity_type) },
+          excerpt,
+        };
+      });
+    }
+
+    // Try the Phase C RPC first; fall back to Pagefind on empty/error.
+    // Pagefind stays as the crawl-time backup so SEO + offline are unaffected.
     async function runSearch(els, query) {
       const q = (query || '').trim();
       if (!q) { showSuggestions(els); return; }
       const myToken = ++state.searchToken;
+
+      // ── Path 1: hybrid RPC (Phase C) ──────────────────────────────────
+      const rpc = window.PISearchRpc;
+      if (rpc && rpc.available) {
+        try {
+          const hits = await rpc.typeahead(q, 6);
+          if (myToken !== state.searchToken) return;
+          if (Array.isArray(hits) && hits.length > 0) {
+            showResults(els, rpcToResults(hits, q), q);
+            logSearch(q, hits.length);
+            return;
+          }
+        } catch (err) {
+          // Swallow — fall through to Pagefind below.
+          console.warn('[search] RPC failed, falling back to Pagefind:', err);
+        }
+      }
+
+      // ── Path 2: Pagefind (existing path) ──────────────────────────────
       try {
         const pf = await loadPagefind();
         if (myToken !== state.searchToken) return;
@@ -358,4 +411,27 @@
     initOverlayInstance();
     document.addEventListener('astro:page-load', initOverlayInstance);
   })();
+</script>
+
+<!--
+  Phase C bootstrap. Exposes window.PISearchRpc = { available, search, typeahead }
+  to the inline script above. The bootstrap is a module so Astro bundles
+  search-client.ts + supabase-js together; it loads once per page-shell.
+  `available` is false when window.__PI_SB is missing or when @supabase
+  cannot construct a client — the runSearch path falls back to Pagefind
+  in that case.
+-->
+<script>
+  import { search, typeahead } from '../lib/search-client.ts';
+
+  function isAvailable() {
+    const sb = (window as any).__PI_SB;
+    return Boolean(sb && sb.url && sb.key);
+  }
+
+  (window as any).PISearchRpc = {
+    get available() { return isAvailable(); },
+    search,
+    typeahead,
+  };
 </script>

--- a/next/src/lib/search-client.ts
+++ b/next/src/lib/search-client.ts
@@ -1,0 +1,106 @@
+/**
+ * Peninsula Insider — Hybrid search client.
+ *
+ * Wraps the pi.search() RPC (Phase C of the data architecture plan).
+ * SearchOverlay + /search.astro try this client first and fall back to
+ * Pagefind on error or empty result. Pagefind stays as the crawl-time
+ * static fallback so SEO + offline behaviour are unaffected.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+// `pi` is a non-default schema, so the inferred client type does not match
+// the public-default SupabaseClient. Treat the client opaquely.
+type SupabaseClient = ReturnType<typeof createClient<any, 'pi'>>;
+
+export interface SearchHit {
+  entity_type:    string;
+  entity_slug:    string;
+  title:          string;
+  dek:            string | null;
+  href:           string;
+  facets:         Record<string, string[]>;
+  zone:           string | null;
+  place_slug:     string | null;
+  hero_image:     { src: string; alt: string; credit?: string; license?: string } | null;
+  starts_at:      string | null;
+  ends_at:        string | null;
+  distance_km:    number | null;
+  lexical_score:  number;
+  vector_score:   number;
+  facet_score:    number;
+  combined_score: number;
+}
+
+export interface SearchParams {
+  q?:               string;
+  filters?:         Record<string, string[]>;
+  near?:            { lat: number; lng: number; km?: number };
+  when?:            { from?: string; to?: string };
+  entityTypes?:     string[];
+  embedding?:       number[];
+  limit?:           number;
+  weights?:         { lexical?: number; vector?: number; facet?: number };
+}
+
+let _client: SupabaseClient | null = null;
+
+function getClient(): SupabaseClient | null {
+  if (_client) return _client;
+  // Read from runtime config — set in BaseLayout via window.__PI_SUPABASE.
+  // Falls back to null when neither URL nor key is present (caller must
+  // handle and route to Pagefind).
+  // BaseLayout sets `window.__PI_SB = { url, key }` (see layouts/BaseLayout.astro).
+  const cfg = typeof window !== 'undefined' ? (window as any).__PI_SB : null;
+  const url = cfg?.url || (import.meta as any).env?.PUBLIC_SUPABASE_URL;
+  const key = cfg?.key || (import.meta as any).env?.PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+  _client = createClient(url, key, {
+    auth: { persistSession: false },
+    db:   { schema: 'pi' },
+  });
+  return _client;
+}
+
+/**
+ * Run a hybrid search. Returns an empty array when:
+ *   - Supabase client cannot be initialised (caller falls back to Pagefind)
+ *   - RPC errors
+ *   - RPC returns no rows
+ *
+ * Callers MUST treat an empty array as "no results from the RPC layer" and
+ * decide whether to fall back to Pagefind. This client never throws.
+ */
+export async function search(params: SearchParams): Promise<SearchHit[]> {
+  const client = getClient();
+  if (!client) return [];
+  const { data, error } = await client.rpc('search', {
+    q:               params.q ?? null,
+    filters:         params.filters ?? {},
+    near_lat:        params.near?.lat ?? null,
+    near_lng:        params.near?.lng ?? null,
+    near_km:         params.near?.km ?? null,
+    when_from:       params.when?.from ?? null,
+    when_to:         params.when?.to ?? null,
+    entity_types:    params.entityTypes ?? null,
+    query_embedding: params.embedding ?? null,
+    result_limit:    params.limit ?? 25,
+    weight_lexical:  params.weights?.lexical ?? 0.4,
+    weight_vector:   params.weights?.vector ?? 0.4,
+    weight_facet:    params.weights?.facet ?? 0.2,
+  });
+  if (error) {
+    if (typeof console !== 'undefined') console.warn('[pi.search] RPC error, falling back', error);
+    return [];
+  }
+  return (data as SearchHit[]) ?? [];
+}
+
+/**
+ * Convenience: typeahead query. Trades vector recall for low latency by
+ * skipping the embedding path. Lexical + facet only. The trigram index on
+ * title kicks in below ~4 chars; tsvector picks up at ≥4 chars.
+ */
+export async function typeahead(q: string, limit = 8): Promise<SearchHit[]> {
+  if (!q || q.trim().length < 2) return [];
+  return search({ q, limit, weights: { lexical: 0.7, vector: 0, facet: 0.3 } });
+}

--- a/ops/migrations/2026-05-17-pi-search-rpc.sql
+++ b/ops/migrations/2026-05-17-pi-search-rpc.sql
@@ -1,0 +1,254 @@
+-- Migration: pi.search() hybrid search RPC
+-- Date: 2026-05-17
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+-- Depends on: 2026-05-16-pi-entity-attributes-and-index.sql
+--
+-- Phase C of the data architecture plan
+-- (vault: 07-projects/peninsula-insider/data-architecture-assessment-2026-05-16.md).
+--
+-- Purpose
+-- -------
+-- Single SQL RPC that powers both the typeahead and the planner. Combines:
+--   - Lexical retrieval over pi.entity_index.body_tsv (websearch_to_tsquery)
+--   - Semantic retrieval over pi.entity_index.embedding (cosine via HNSW)
+--   - JSONB facet predicates (theme, audience, mood, weather, etc.)
+--   - Spatial filter (geography distance) for "near me"
+--   - Time-window filter for events
+--   - Optional entity_type restriction
+--
+-- All filters are optional. With no arguments, returns the most-recently-
+-- refreshed entities. The function is SECURITY DEFINER and runs as the
+-- table owner so anon callers can hit it directly via PostgREST without
+-- needing select on pi.entity_index.
+--
+-- Idempotent: drop + recreate.
+--
+-- How to apply
+-- ------------
+--   1. Block on Phase B migration being applied (pi.entity_index must exist).
+--   2. Supabase Studio → SQL editor for the PI auth project
+--   3. Paste this file
+--   4. Run. Expect <1s.
+--   5. Test:
+--        select entity_type, title, combined_score
+--          from pi.search(q => 'cellar door', result_limit => 5);
+--
+-- Frontend integration
+-- --------------------
+-- next/src/lib/search-client.ts wraps this RPC via supabase-js. SearchOverlay
+-- and /search.astro try the RPC first and fall back to Pagefind if it errors
+-- or returns no rows. Pagefind stays as the static crawl-time backup.
+
+-- ─── content_hash column for embedding drift detection ──────────────────
+-- next/scripts/embed-entity-index.mjs writes the sha256 of title|dek|body
+-- when it embeds a row, so the next run skips unchanged content.
+alter table pi.entity_index
+  add column if not exists content_hash text;
+
+-- ─── helper: facet-match score ───────────────────────────────────────────
+-- Returns the count of (key, value) pairs in `filters` that also appear in
+-- `facets`. Used to rank entities by how many required facets they match.
+create or replace function pi.facet_match_count(facets jsonb, filters jsonb)
+returns int
+language sql
+immutable
+as $$
+  select coalesce(
+    sum(
+      case
+        when facets ? key
+         and (
+           select bool_and(facets -> key @> to_jsonb(v))
+             from jsonb_array_elements_text(value) v
+         )
+        then jsonb_array_length(value)
+        else 0
+      end
+    )::int,
+    0
+  )
+  from jsonb_each(coalesce(filters, '{}'::jsonb))
+  where jsonb_typeof(value) = 'array';
+$$;
+
+-- ─── main RPC ────────────────────────────────────────────────────────────
+drop function if exists pi.search(text, jsonb, double precision, double precision, numeric, timestamptz, timestamptz, text[], vector, int, numeric, numeric, numeric);
+
+create or replace function pi.search(
+  q                text          default null,
+  filters          jsonb         default '{}'::jsonb,
+  near_lat         double precision default null,
+  near_lng         double precision default null,
+  near_km          numeric       default null,
+  when_from        timestamptz   default null,
+  when_to          timestamptz   default null,
+  entity_types     text[]        default null,
+  query_embedding  vector(1536)  default null,
+  result_limit     int           default 25,
+  weight_lexical   numeric       default 0.4,
+  weight_vector    numeric       default 0.4,
+  weight_facet     numeric       default 0.2
+)
+returns table (
+  entity_type     text,
+  entity_slug     text,
+  title           text,
+  dek             text,
+  href            text,
+  facets          jsonb,
+  zone            text,
+  place_slug      text,
+  hero_image      jsonb,
+  starts_at       timestamptz,
+  ends_at         timestamptz,
+  distance_km     numeric,
+  lexical_score   real,
+  vector_score    real,
+  facet_score     int,
+  combined_score  numeric
+)
+language sql
+stable
+security definer
+set search_path = pi, public, pg_catalog
+as $$
+  with
+    -- 1. Resolve the lexical query (if any). websearch_to_tsquery handles
+    --    natural-language input like "rainy day with the dog" gracefully.
+    qts as (
+      select case when q is null or length(trim(q)) = 0
+                  then null
+                  else websearch_to_tsquery('english', q)
+             end as tsq
+    ),
+    -- 2. Optional geography point for near-me distance.
+    qpt as (
+      select case
+               when near_lat is null or near_lng is null then null
+               else ST_SetSRID(ST_MakePoint(near_lng, near_lat), 4326)::geography
+             end as pt
+    ),
+    -- 3. Scored candidates. We intentionally evaluate every row that passes
+    --    the hard filters; entity_index is small (~600 rows), so per-row
+    --    cost is fine. Indexes still help when filters narrow aggressively.
+    candidates as (
+      select
+        ei.entity_type,
+        ei.entity_slug,
+        ei.title,
+        ei.dek,
+        ei.href,
+        ei.facets,
+        ei.zone,
+        ei.place_slug,
+        ei.hero_image,
+        ei.starts_at,
+        ei.ends_at,
+        case
+          when (select pt from qpt) is not null and ei.coordinates is not null
+          then (ST_Distance(ei.coordinates, (select pt from qpt)) / 1000.0)::numeric
+          else null
+        end as distance_km,
+        case
+          when (select tsq from qts) is null then 0::real
+          else ts_rank_cd(ei.body_tsv, (select tsq from qts))::real
+        end as lexical_score,
+        case
+          when query_embedding is null or ei.embedding is null then 0::real
+          else (1 - (ei.embedding <=> query_embedding))::real
+        end as vector_score,
+        pi.facet_match_count(ei.facets, filters) as facet_score
+      from pi.entity_index ei
+      where
+        -- Hard filter: entity type
+        (entity_types is null or ei.entity_type = any(entity_types))
+        -- Hard filter: time window (for events)
+        and (when_from is null or ei.ends_at is null or ei.ends_at >= when_from)
+        and (when_to   is null or ei.starts_at is null or ei.starts_at <= when_to)
+        -- Hard filter: spatial radius
+        and (
+          (select pt from qpt) is null
+          or near_km is null
+          or ei.coordinates is null
+          or ST_DWithin(ei.coordinates, (select pt from qpt), near_km * 1000)
+        )
+        -- Hard filter: lexical query, when provided
+        and (
+          (select tsq from qts) is null
+          or ei.body_tsv @@ (select tsq from qts)
+          or query_embedding is not null   -- bypass lexical filter when semantic provided
+        )
+    )
+  select
+    c.entity_type,
+    c.entity_slug,
+    c.title,
+    c.dek,
+    c.href,
+    c.facets,
+    c.zone,
+    c.place_slug,
+    c.hero_image,
+    c.starts_at,
+    c.ends_at,
+    c.distance_km,
+    c.lexical_score,
+    c.vector_score,
+    c.facet_score,
+    (
+      coalesce(weight_lexical, 0.4) * c.lexical_score +
+      coalesce(weight_vector,  0.4) * c.vector_score +
+      coalesce(weight_facet,   0.2) * least(c.facet_score, 5) / 5.0
+    )::numeric as combined_score
+  from candidates c
+  -- Drop rows that match nothing meaningful.
+  where (
+    c.lexical_score > 0
+    or c.vector_score > 0
+    or c.facet_score > 0
+    or ((select tsq from qts) is null and query_embedding is null)
+  )
+  order by
+    combined_score desc nulls last,
+    -- Tie-break by recency
+    c.starts_at desc nulls last,
+    c.title asc
+  limit greatest(result_limit, 1);
+$$;
+
+comment on function pi.search is
+  'Hybrid lexical + semantic + facet + spatial + temporal search over pi.entity_index. Phase C. Pagefind stays as crawl-time fallback. See ops/migrations/2026-05-17-pi-search-rpc.sql for parameter docs.';
+
+-- Allow anon + authenticated to call the function via PostgREST.
+grant execute on function pi.search to anon, authenticated;
+grant execute on function pi.facet_match_count(jsonb, jsonb) to anon, authenticated;
+
+-- ─── verification ────────────────────────────────────────────────────────
+-- After applying + populating entity_index:
+--
+--   -- 1. Plain text query
+--   select entity_type, title, combined_score
+--     from pi.search(q => 'cellar door', result_limit => 5);
+--
+--   -- 2. Facet filter only
+--   select entity_type, title from pi.search(
+--     filters => '{"theme": ["wine"], "audience": ["couples"]}'::jsonb,
+--     result_limit => 10
+--   );
+--
+--   -- 3. Combined: "dog-friendly cellar doors near Sorrento, open Sunday"
+--   select entity_type, title, distance_km from pi.search(
+--     q        => 'cellar door',
+--     filters  => '{"dog-friendly": ["yes"]}'::jsonb,
+--     near_lat => -38.3367, near_lng => 144.7470, near_km => 15,
+--     result_limit => 10
+--   );
+--
+--   -- 4. Future-event window
+--   select title, starts_at from pi.search(
+--     entity_types => array['event'],
+--     when_from    => now(),
+--     when_to      => now() + interval '7 days',
+--     result_limit => 20
+--   );


### PR DESCRIPTION
Re-opened from #146 after stack rebase. Cherry-picked onto current main (Phase A + B already landed).

See [#146](https://github.com/richmondjw/peninsula-insider/pull/146) for full description, build verification, example queries, and operational steps.

Safe-rollout property: this PR can land before any Supabase migration is applied. SearchOverlay falls through to Pagefind when the RPC is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)