### PR TITLE
feat(entity-index): Phase D follow-ups — MD/MDX registry, quick-note/local-secret types, deploy integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,40 @@ jobs:
         run: |
           node next/scripts/refresh-content-registry.mjs
 
+      - name: Refresh entity index (Phase B projector)
+        # Projects every Astro content collection through the canonical
+        # facet taxonomy (next/src/taxonomy/facet-taxonomy.yaml) and upserts
+        # pi.entity_index + pi.entity_attributes. Read by pi.search() at
+        # runtime to power typeahead, planner, concierge, and the iOS app.
+        #
+        # Same continue-on-error stance as refresh-content-registry above:
+        # the deploy proceeds even if the projector fails (e.g. transient
+        # Supabase auth). The runtime falls back to Pagefind in that case.
+        continue-on-error: true
+        env:
+          PUBLIC_SUPABASE_URL: ${{ vars.PUBLIC_SUPABASE_URL || secrets.PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          node next/scripts/refresh-entity-index.mjs --apply
+
+      - name: Embed entity index (Phase C)
+        # Populates pi.entity_index.embedding for rows whose content_hash
+        # has drifted since the last run. Uses text-embedding-3-small
+        # (same model as the concierge corpus, no second pipeline).
+        # Skipped silently when OPENAI_API_KEY is not configured —
+        # pi.search() still works with lexical + facet, just no semantic.
+        continue-on-error: true
+        env:
+          PUBLIC_SUPABASE_URL: ${{ vars.PUBLIC_SUPABASE_URL || secrets.PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "::notice::OPENAI_API_KEY not configured; skipping embedding refresh."
+            exit 0
+          fi
+          node next/scripts/embed-entity-index.mjs --apply
+
       - name: Build Astro site
         working-directory: next
         env:

--- a/next/scripts/refresh-content-registry.mjs
+++ b/next/scripts/refresh-content-registry.mjs
@@ -51,6 +51,8 @@ const COLLECTIONS = [
   { folder: 'tours',          entityType: 'tour',          hrefPrefix: '/tours/' },
   { folder: 'tour-operators', entityType: 'tour-operator', hrefPrefix: '/tour-operators/' },
   { folder: 'tour-packages',  entityType: 'tour-package',  hrefPrefix: '/plans/' },
+  { folder: 'quick-notes',    entityType: 'quick-note',    hrefPrefix: '/quick-note/' },
+  { folder: 'local-secrets',  entityType: 'local-secret',  hrefPrefix: '/journal/local-secrets/' },
 ];
 
 /**
@@ -84,10 +86,28 @@ async function loadJsonFiles(folder) {
   }
   const rows = [];
   for (const file of files) {
-    if (!file.endsWith('.json') || file.startsWith('_')) continue;
+    if (file.startsWith('_')) continue;
+    const isJson = file.endsWith('.json');
+    const isMd = file.endsWith('.md') || file.endsWith('.mdx');
+    if (!isJson && !isMd) continue;
     try {
       const raw = await readFile(join(dir, file), 'utf8');
-      rows.push(JSON.parse(raw));
+      if (isJson) {
+        rows.push(JSON.parse(raw));
+      } else {
+        // Astro derives slug from filename when not in frontmatter. Mirror
+        // that so MD/MDX collections (articles, species, fishing-*, etc.)
+        // are upserted with the same slug the renderer uses.
+        const baseSlug = file.replace(/\.(md|mdx)$/i, '');
+        // Extract title from frontmatter if present, else fall back to slug.
+        const fmMatch = /^---\n([\s\S]*?)\n---/.exec(raw);
+        let title = baseSlug;
+        if (fmMatch) {
+          const titleLine = /^title:\s*"?([^"\n]+)"?/m.exec(fmMatch[1]);
+          if (titleLine) title = titleLine[1].trim().replace(/^"|"$/g, '');
+        }
+        rows.push({ slug: baseSlug, title });
+      }
     } catch (err) {
       console.warn(`[refresh-registry] Skipping ${folder}/${file}: ${err.message}`);
     }

--- a/next/scripts/refresh-entity-index.mjs
+++ b/next/scripts/refresh-entity-index.mjs
@@ -43,10 +43,11 @@ const CONTENT_ROOT = resolve(NEXT_ROOT, 'src/content');
 const TAXONOMY_PATH = resolve(NEXT_ROOT, 'src/taxonomy/facet-taxonomy.yaml');
 
 const args = process.argv.slice(2);
-const opts = { apply: false, report: false, limit: null };
+const opts = { apply: false, report: false, sql: false, limit: null };
 for (const a of args) {
   if (a === '--apply') opts.apply = true;
   else if (a === '--report') opts.report = true;
+  else if (a === '--sql') opts.sql = true;
   else if (a === '--dry-run') opts.apply = false;
   else if (a.startsWith('--limit=')) opts.limit = parseInt(a.slice('--limit='.length), 10);
 }
@@ -284,6 +285,62 @@ function buildCoverageReport() {
 }
 
 // ─── output ──────────────────────────────────────────────────────────────
+// ─── SQL emit mode ───────────────────────────────────────────────────────
+// Emits the entire projection as batched INSERT ... ON CONFLICT DO UPDATE
+// statements suitable for piping through Supabase MCP execute_sql when a
+// service key isn't available. Batches of 50 rows so each statement fits
+// well under MCP's payload ceiling.
+function sqlQuote(v) {
+  if (v == null) return 'null';
+  if (typeof v === 'number') return String(v);
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (v instanceof Date) return `'${v.toISOString()}'::timestamptz`;
+  if (typeof v === 'object') return `'${JSON.stringify(v).replaceAll("'", "''")}'::jsonb`;
+  return `'${String(v).replaceAll("'", "''")}'`;
+}
+
+if (opts.sql) {
+  process.stdout.write('-- pi.entity_index rows\n');
+  const cols = ['entity_type','entity_slug','title','dek','body','facets','zone','place_slug','coordinates','starts_at','ends_at','href','hero_image','taxonomy_version','refreshed_at'];
+  const BATCH = 50;
+  for (let i = 0; i < indexRows.length; i += BATCH) {
+    const batch = indexRows.slice(i, i + BATCH);
+    const values = batch.map((r) => {
+      const c = r.coordinates ? `'${r.coordinates}'::geography` : 'null';
+      return `(${[
+        sqlQuote(r.entity_type), sqlQuote(r.entity_slug), sqlQuote(r.title),
+        sqlQuote(r.dek), sqlQuote(r.body), sqlQuote(r.facets), sqlQuote(r.zone),
+        sqlQuote(r.place_slug), c,
+        r.starts_at ? `'${r.starts_at}'::timestamptz` : 'null',
+        r.ends_at ? `'${r.ends_at}'::timestamptz` : 'null',
+        sqlQuote(r.href), sqlQuote(r.hero_image),
+        sqlQuote(r.taxonomy_version), sqlQuote(r.refreshed_at),
+      ].join(', ')})`;
+    }).join(',\n');
+    const updates = cols.filter((c) => c !== 'entity_type' && c !== 'entity_slug')
+      .map((c) => `${c} = excluded.${c}`).join(', ');
+    process.stdout.write(
+      `insert into pi.entity_index (${cols.join(', ')}) values\n${values}\n` +
+      `on conflict (entity_type, entity_slug) do update set ${updates};\n\n`
+    );
+  }
+  process.stdout.write('-- pi.entity_attributes rows\n');
+  const acols = ['entity_type','entity_slug','facet_key','facet_value','source','refreshed_at'];
+  for (let i = 0; i < attributeRows.length; i += BATCH) {
+    const batch = attributeRows.slice(i, i + BATCH);
+    const values = batch.map((r) => `(${[
+      sqlQuote(r.entity_type), sqlQuote(r.entity_slug),
+      sqlQuote(r.facet_key), sqlQuote(r.facet_value),
+      sqlQuote(r.source), sqlQuote(r.refreshed_at),
+    ].join(', ')})`).join(',\n');
+    process.stdout.write(
+      `insert into pi.entity_attributes (${acols.join(', ')}) values\n${values}\n` +
+      `on conflict (entity_type, entity_slug, facet_key, facet_value) do update set source = excluded.source, refreshed_at = excluded.refreshed_at;\n\n`
+    );
+  }
+  process.exit(0);
+}
+
 if (opts.report) {
   const rows = buildCoverageReport();
   process.stdout.write(`# Entity-attribute coverage\n\n`);

--- a/ops/migrations/2026-05-17-pi-content-registry-extend-types.sql
+++ b/ops/migrations/2026-05-17-pi-content-registry-extend-types.sql
@@ -1,0 +1,39 @@
+-- Migration: extend pi.content_registry + cms_text_fields + cms_image_slots
+--            entity_type CHECK constraints to include quick-note and
+--            local-secret.
+-- Date: 2026-05-17
+-- Project: PI auth Supabase (tjjhpvslpysfklwpqmgz)
+-- Schema: pi
+--
+-- Phase D follow-up to Phase B (vault: 07-projects/peninsula-insider/
+-- data-architecture-assessment-2026-05-16.md). The Phase B projector
+-- populates 21 collections, but `quick-note` (59 entities) and
+-- `local-secret` (0 entities today, grows from reader submissions) were
+-- rejected by the pre-existing constraint set on 2026-05-11. This
+-- migration adds them.
+--
+-- Idempotent: drop + recreate the CHECK constraints.
+
+alter table pi.content_registry drop constraint if exists content_registry_entity_type_check;
+alter table pi.content_registry
+  add constraint content_registry_entity_type_check
+  check (entity_type in (
+    'article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary',
+    'tour', 'tour-operator', 'tour-package', 'quick-note', 'local-secret'
+  ));
+
+alter table pi.cms_image_slots drop constraint if exists cms_image_slots_entity_type_check;
+alter table pi.cms_image_slots
+  add constraint cms_image_slots_entity_type_check
+  check (entity_type in (
+    'article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary',
+    'tour', 'tour-operator', 'tour-package', 'quick-note', 'local-secret'
+  ));
+
+alter table pi.cms_text_fields drop constraint if exists cms_text_fields_entity_type_check;
+alter table pi.cms_text_fields
+  add constraint cms_text_fields_entity_type_check
+  check (entity_type in (
+    'article', 'page', 'event', 'place', 'venue', 'experience', 'itinerary',
+    'tour', 'tour-operator', 'tour-package', 'quick-note', 'local-secret'
+  ));


### PR DESCRIPTION
## Summary

Three follow-ups identified during the Phase B/C population runs, bundled per James's go.

Operationally **already executed in this session** against the PI auth Supabase project (`tjjhpvslpysfklwpqmgz`) — this PR makes the same outcome reproducible on every future deploy.

## 1. \`refresh-content-registry.mjs\` walks MD/MDX

Latent bug: the script only loaded \`.json\`. Articles (174 MDX), species, fishing-locations, fishing-charters, boat-ramps, boat-hire, quick-notes, local-secrets were never being kept current by it — they'd been seeded directly months ago and were silently drifting. New articles like \`insider-picks-2026-05-14\` weren't reaching the registry, and then the Phase B projector rejected them at the integrity trigger.

\`loadJsonFiles\` now also handles \`.md\`/\`.mdx\`, deriving slug from filename (Astro's convention) and title from frontmatter.

## 2. Extend \`entity_type\` CHECK constraint

[\`ops/migrations/2026-05-17-pi-content-registry-extend-types.sql\`](ops/migrations/2026-05-17-pi-content-registry-extend-types.sql) adds \`quick-note\` and \`local-secret\` to the CHECK on \`pi.content_registry\`, \`pi.cms_image_slots\`, and \`pi.cms_text_fields\`. **Applied already** via MCP.

\`refresh-entity-index\` COLLECTIONS list re-includes both — they are now valid registry types. **Net effect:** 62 quick-notes now index, embed, and search alongside the original 501. Total entity_index population: **563 rows**.

## 3. Wire projector + embedder into \`deploy.yml\`

Two new steps in the deploy workflow, run after the existing \`refresh-content-registry\` step and before \`npm run build:search\`:

- **Refresh entity index (Phase B projector)** — \`refresh-entity-index --apply\`
- **Embed entity index (Phase C)** — \`embed-entity-index --apply\`

Both \`continue-on-error: true\` so a transient Supabase/OpenAI issue doesn't fail the whole deploy. The embedder no-ops cleanly when \`OPENAI_API_KEY\` is not configured in repo secrets, leaving \`pi.search()\` running on lexical + facet retrieval only.

## Bonus: \`--sql\` mode on the projector

\`refresh-entity-index --sql\` emits batched INSERT statements to stdout. Fallback tooling for ops scenarios where the PI service key isn't available, e.g. piping through Supabase MCP \`execute_sql\`. Used internally during the original Phase B population debug; left in place for future ops parity.

## Build green

\`\`\`
$ npx astro build → 1358 pages, 36.28s
\`\`\`

## Test plan

- [x] Migration applied to Supabase via MCP
- [x] Registry refresh with MD/MDX walker confirmed: 591 entities (including 174 articles + 62 quick-notes)
- [x] Projector apply confirmed: 563 entities + 2,688 attribute rows in \`pi.entity_index\` / \`pi.entity_attributes\`
- [x] Embedder confirmed: 563/563 rows embedded
- [x] \`pi.search()\` verified across lexical (\"cellar door\"), facet (\`theme:wine + audience:couples\`), and spatial (10km of Sorrento) paths
- [ ] CI green on this PR
- [ ] First post-merge deploy runs the two new steps successfully (\`continue-on-error\` makes a failure non-fatal regardless)

## Operational follow-ups still open

- Rotate \`SUPABASE_SERVICE_KEY\` repo secret (the key James pasted in chat earlier should be considered compromised and rotated; the deploy workflow currently expects this secret to match \`tjjhpvslpysfklwpqmgz\`)
- Add \`OPENAI_API_KEY\` repo secret if you want the embedder to run on deploys (otherwise it cleanly skips)
- Editorial: backfill the high-value Phase B attribute gaps (\`weather\`, \`accessibility\`, \`indoor-outdoor\`, \`kids-grade\` on venues + experiences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)