### PR TITLE
feat(search): Phase D consumer rollout — search.astro RPC-first, /plans/build/ planner, concierge backend patch

### DIFF
--- a/docs/patches/concierge-attribute-aware-retrieval-2026-05-17.md
+++ b/docs/patches/concierge-attribute-aware-retrieval-2026-05-17.md
@@ -1,0 +1,220 @@
+# Concierge — attribute-aware retrieval layered on chunk RAG
+
+**Phase D wave 4 of the data architecture rollout.**
+
+Vault context: `07-projects/peninsula-insider/data-architecture-assessment-2026-05-16.md`.
+
+This patch lives **outside this repo** — apply in `apps/api/src/routes/concierge.ts`
+(the platform API repo). The PI site only calls
+`POST $PUBLIC_CONCIERGE_API_URL/concierge/ask/stream`; the change here is
+the backend.
+
+## Why
+
+The concierge today retrieves from `concierge_chunks` (semantic-only,
+project `mvdtkgsfuhmkioygxgge`). It can't enforce *hard* attribute
+filters — when a user says "dog-friendly cellar door with kids", the LLM
+might still recommend a venue with `dogFriendly: false` because the
+ranking is similarity-only.
+
+`pi.search()` (project `tjjhpvslpysfklwpqmgz`, Phase C) returns
+attribute-filtered entity hits via the canonical taxonomy. Layering
+*both* gives:
+- hard guarantees (dog-friendly stays dog-friendly)
+- prose-quality answers (chunk RAG still drives the answer text)
+- a single canonical taxonomy across web, planner, concierge, and iOS
+
+## Architecture
+
+```
+user query
+   │
+   ▼
+parse intent  ──►  facet predicates  ──►  pi.search(q, filters, ...)
+   │                                          │
+   ▼                                          ▼
+chunk RAG (concierge_chunks)            entity hits
+   │                                          │
+   └─────────►  rerank chunks by facet match ◄┘
+                         │
+                         ▼
+                LLM with grounded entity context
+```
+
+Stage by stage:
+
+1. **Intent parsing** — parse the free-text query into facet predicates.
+   Two implementations possible:
+   - **Rule layer:** synonym map keyed off `facet-taxonomy.yaml`
+     (download from this repo at deploy time; cached in memory).
+     Cheap. Catches 70% of common queries.
+   - **LLM classifier:** Haiku-class call. ~50–100ms. Use for the long
+     tail; fall back to chunk-only retrieval if it errors.
+
+2. **Hard-filter retrieval** — `pi.search()` returns up to ~25 entity
+   matches that satisfy the facet predicates.
+
+3. **Chunk retrieval** — existing `concierge_chunks` query against the
+   user's full message (semantic similarity). Returns ~25 chunks.
+
+4. **Rerank** — boost chunks whose `source_entity_slug` matches one of
+   the entity hits from step 2. Weight: +0.5 in the combined score.
+   Drop chunks whose entity *contradicts* a hard filter ("dog-friendly:
+   yes" was asked, but this chunk's entity has `dog-friendly: no").
+
+5. **Generate** — pass top-N reranked chunks to the LLM as grounding
+   context. Existing prompt + streaming pipeline unchanged.
+
+## Diff (illustrative)
+
+```ts
+// apps/api/src/routes/concierge.ts
+
+import { createClient } from '@supabase/supabase-js';
+
+// New: PI runtime client (separate project from the concierge corpus)
+const piRuntime = createClient(
+  process.env.PI_RUNTIME_SUPABASE_URL!,     // tjjhpvslpysfklwpqmgz
+  process.env.PI_RUNTIME_SUPABASE_ANON_KEY!,
+  { auth: { persistSession: false }, db: { schema: 'pi' } }
+);
+
+interface ParsedIntent {
+  facets: Record<string, string[]>;
+  entityTypes?: string[];
+}
+
+// Stage 1 — rule-layer intent parser. Loads facet-taxonomy.yaml at boot.
+async function parseIntent(q: string, taxonomy: Taxonomy): Promise<ParsedIntent> {
+  const lower = q.toLowerCase();
+  const facets: Record<string, Set<string>> = {};
+  for (const [family, defn] of Object.entries(taxonomy.facets)) {
+    for (const [value, meta] of Object.entries(defn.values)) {
+      const alts = [value, ...(meta.synonyms || [])];
+      if (alts.some((a) => lower.includes(a.replace(/-/g, ' '))
+                        || lower.includes(a))) {
+        (facets[family] ??= new Set()).add(value);
+      }
+    }
+  }
+  return {
+    facets: Object.fromEntries(
+      Object.entries(facets).map(([k, s]) => [k, [...s]])
+    ),
+  };
+}
+
+// Stage 2 — pi.search RPC
+async function piSearchEntities(q: string, intent: ParsedIntent) {
+  const { data, error } = await piRuntime.rpc('search', {
+    q,
+    filters: intent.facets,
+    entity_types: intent.entityTypes ?? null,
+    result_limit: 25,
+  });
+  if (error) {
+    console.warn('[concierge] pi.search failed, skipping attribute layer', error);
+    return [];
+  }
+  return data as SearchHit[];
+}
+
+// Stage 4 — rerank chunks by entity match
+function rerankChunks(
+  chunks: ConciergeChunk[],
+  entityHits: SearchHit[],
+  intent: ParsedIntent
+): ConciergeChunk[] {
+  const entitySlugs = new Set(
+    entityHits.map((h) => `${h.entity_type}:${h.entity_slug}`)
+  );
+  // Build a contradicts predicate: any facet the user explicitly asked
+  // for, an entity that has the negation, drop the chunk.
+  const isContradiction = (chunkEntity: { type: string; slug: string }) => {
+    const hit = entityHits.find(
+      (h) => h.entity_type === chunkEntity.type && h.entity_slug === chunkEntity.slug
+    );
+    if (!hit) return false; // unknown to pi.entity_index — let through
+    // Example: if user asked dog-friendly=yes, entity facets must include 'yes'.
+    for (const [k, vs] of Object.entries(intent.facets)) {
+      if (!hit.facets[k] || !vs.some((v) => hit.facets[k].includes(v))) {
+        return true; // entity does not satisfy this required facet
+      }
+    }
+    return false;
+  };
+
+  return chunks
+    .filter((c) => !isContradiction({ type: c.source_entity_type, slug: c.source_entity_slug }))
+    .map((c) => {
+      const matched = entitySlugs.has(`${c.source_entity_type}:${c.source_entity_slug}`);
+      return { ...c, score: c.score + (matched ? 0.5 : 0) };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+// Main handler (existing endpoint) — modified
+export async function POST(req: Request) {
+  const { q } = await req.json();
+  const intent = await parseIntent(q, await getTaxonomy());
+
+  // Run both retrievals in parallel
+  const [entityHits, chunkHits] = await Promise.all([
+    piSearchEntities(q, intent),
+    existingConciergeChunkRetrieval(q),   // unchanged
+  ]);
+
+  const reranked = rerankChunks(chunkHits, entityHits, intent);
+  return streamAnswer(q, reranked.slice(0, 12), entityHits.slice(0, 6));
+}
+```
+
+## Environment variables to add to the platform-api service
+
+```
+PI_RUNTIME_SUPABASE_URL=https://tjjhpvslpysfklwpqmgz.supabase.co
+PI_RUNTIME_SUPABASE_ANON_KEY=<anon key from tjjhpvslpysfklwpqmgz project>
+```
+
+The anon key suffices — `pi.search()` has `GRANT EXECUTE TO anon`.
+Do **not** use the service role key here; the concierge is a public
+read-only consumer.
+
+## Taxonomy distribution
+
+The intent parser needs `facet-taxonomy.yaml` from this repo. Two options:
+
+1. **Build-time copy** — concierge build job pulls
+   `https://raw.githubusercontent.com/richmondjw/peninsula-insider/main/next/src/taxonomy/facet-taxonomy.yaml`
+   and bakes the parsed object into the bundle. Refresh on every deploy.
+2. **Runtime fetch + cache** — fetch the YAML on container start, cache
+   in memory, refresh hourly. Simpler ops, slightly slower cold start.
+
+(1) is recommended — atomic with the deploy.
+
+## Eval
+
+Existing eval harness at `ops/scripts/insider-eval-runner.mjs` (this
+repo) calls `${API}/concierge/ask`. After the change, expect:
+- recall up on "find me X with attribute Y" queries
+- precision up — no more "dog-friendly: yes" answers recommending
+  no-dog venues
+- latency +50–150ms (pi.search RPC + intent parse)
+
+## Rollout
+
+- ship behind `CONCIERGE_ATTRIBUTE_RERANK=1` env flag for a week
+- compare against a side-by-side run with the flag off via the eval
+  harness
+- flip the default once recall + precision are at parity or better
+
+## Operational follow-up after this lands
+
+The taxonomy is now read by three consumers:
+1. PI site (`pi.search` via Astro)
+2. Concierge backend (this patch)
+3. iOS app (Sprint 2, queued)
+
+Make `next/src/taxonomy/facet-taxonomy.yaml` the contracted spec across
+all three. Any breaking change requires bumping `version:` and a
+coordinated release of all consumers.

--- a/next/src/pages/plans/build.astro
+++ b/next/src/pages/plans/build.astro
@@ -1,0 +1,337 @@
+---
+/**
+ * /plans/build/ — Phase D wave 2 of the data architecture rollout.
+ *
+ * Interactive planner that runs pi.search against the canonical
+ * facet taxonomy. The user picks any combination of audience, mood,
+ * theme, season, weather, dog-friendly, kids-grade, price band, zone
+ * — plus a free-text query — and gets a live ranked result set powered
+ * by the hybrid lexical + semantic + facet RPC.
+ *
+ * No Pagefind fallback on this page. The whole point of /plans/build/ is
+ * to expose the attribute-aware query layer; if the RPC is unreachable
+ * we render a graceful "search service unavailable" message and point
+ * the user back to /plans/ for the editorial curated experience.
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Plans', href: '/plans/' },
+  { label: 'Build a plan' },
+];
+
+// Facet families surfaced in the filter UI. Values mirror the canonical
+// facet-taxonomy.yaml; if a value is added there, add it here too (and
+// vice-versa). Editorial decision: keep this list curated, not auto-
+// generated, so the UI stays readable rather than exposing every facet.
+const FACETS = [
+  {
+    key: 'audience',
+    label: 'Who',
+    values: ['couples', 'families', 'friends', 'solo', 'groups', 'first-timers', 'locals', 'adults-only'],
+  },
+  {
+    key: 'theme',
+    label: 'Theme',
+    values: ['food', 'wine', 'food+wine', 'wellness', 'coastal', 'hinterland', 'golf', 'cycling', 'walking', 'fishing', 'boating', 'cultural', 'history', 'garden', 'producer', 'wildlife', 'live-music'],
+  },
+  {
+    key: 'mood',
+    label: 'Mood',
+    values: ['slow', 'indulgent', 'adventurous', 'romantic', 'social', 'contemplative', 'cosy', 'scenic', 'wellness'],
+  },
+  {
+    key: 'occasion',
+    label: 'Occasion',
+    values: ['anniversary', 'birthday', 'proposal', 'honeymoon', 'babymoon', 'hens', 'bucks', 'corporate', 'family-reunion', 'milestone'],
+  },
+  {
+    key: 'season',
+    label: 'Season',
+    values: ['spring', 'summer', 'autumn', 'winter', 'school-holidays', 'whale-season', 'christmas-period', 'easter-period', 'rainy', 'year-round'],
+  },
+  {
+    key: 'weather',
+    label: 'Weather',
+    values: ['all-weather', 'wet-friendly', 'rainy-day-rescue', 'fair-weather-only'],
+  },
+  {
+    key: 'price-band',
+    label: 'Price',
+    values: ['free', '$', '$$', '$$$', '$$$$'],
+  },
+  {
+    key: 'dog-friendly',
+    label: 'Dog-friendly',
+    values: ['yes', 'outdoors-only'],
+  },
+  {
+    key: 'kids-grade',
+    label: 'Kids',
+    values: ['A', 'B', 'C'],
+  },
+  {
+    key: 'zone',
+    label: 'Where',
+    values: ['bayside', 'hinterland', 'red-hill-plateau', 'ocean-coast', 'back-beaches', 'tip'],
+  },
+];
+
+const ENTITY_TYPES = [
+  { value: '',          label: 'Everything' },
+  { value: 'venue',     label: 'Venues' },
+  { value: 'experience', label: 'Experiences' },
+  { value: 'event',     label: "What's on" },
+  { value: 'itinerary', label: 'Itineraries' },
+  { value: 'place',     label: 'Places' },
+  { value: 'article',   label: 'Journal' },
+];
+---
+
+<BaseLayout
+  title="Build a plan · Peninsula Insider"
+  description="Build a Peninsula plan by picking who you're travelling with, what you want, and what kind of trip you're after. Hybrid search across venues, events, walks, stays, and journal pieces."
+  section="home"
+  noindex={false}
+  searchExclude={false}
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <main class="plan-builder">
+
+    <section class="plan-builder__hero">
+      <div class="container">
+        <p class="plan-builder__eyebrow">Peninsula Insider · Build a plan</p>
+        <h1 class="plan-builder__title">Build your Peninsula plan</h1>
+        <p class="plan-builder__lead">
+          Pick a vibe, a who, a where. We'll match the venues, walks, stays, and editorial pieces that fit. Combine
+          as many filters as you like.
+        </p>
+
+        <form class="plan-builder__search" id="planBuilderForm" autocomplete="off" role="search" aria-label="Plan builder">
+          <input
+            type="search"
+            id="planBuilderQ"
+            class="plan-builder__q"
+            placeholder="Optional — long lunch, fireplace, rainy day…"
+            aria-label="Free-text query"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <label class="plan-builder__type-wrap" for="planBuilderType">
+            <span class="plan-builder__type-label">Show</span>
+            <select id="planBuilderType" class="plan-builder__type">
+              {ENTITY_TYPES.map((t) => <option value={t.value}>{t.label}</option>)}
+            </select>
+          </label>
+        </form>
+      </div>
+    </section>
+
+    <section class="plan-builder__filters" aria-label="Filters">
+      <div class="container">
+        {FACETS.map((f) => (
+          <fieldset class="plan-builder__facet" data-facet={f.key}>
+            <legend class="plan-builder__facet-label">{f.label}</legend>
+            <div class="plan-builder__chips">
+              {f.values.map((v) => (
+                <label class="plan-builder__chip">
+                  <input type="checkbox" data-facet-value={v} />
+                  <span>{v}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+        ))}
+
+        <div class="plan-builder__actions">
+          <button type="button" id="planBuilderClear" class="plan-builder__btn plan-builder__btn--ghost">Clear all</button>
+          <p id="planBuilderCount" class="plan-builder__count" aria-live="polite">Pick a filter or type to see results.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="plan-builder__results-section">
+      <div class="container">
+        <div id="planBuilderResults" class="plan-builder__results" aria-live="polite"></div>
+        <div id="planBuilderUnavailable" class="plan-builder__unavailable" hidden>
+          <p>The live planner isn't reachable right now. Try the <a href="/plans/">curated plans hub</a>, or ask <a href="/ask/">The Insider</a> directly.</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <script is:inline>
+    (function () {
+      const form  = document.getElementById('planBuilderForm');
+      const input = document.getElementById('planBuilderQ');
+      const sel   = document.getElementById('planBuilderType');
+      const clear = document.getElementById('planBuilderClear');
+      const out   = document.getElementById('planBuilderResults');
+      const meta  = document.getElementById('planBuilderCount');
+      const off   = document.getElementById('planBuilderUnavailable');
+
+      let token = 0;
+
+      function escapeHtml(s) {
+        return String(s || '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+      }
+
+      function collectFilters() {
+        const filters = {};
+        document.querySelectorAll('.plan-builder__facet').forEach((fs) => {
+          const key = fs.dataset.facet;
+          const vals = Array.from(fs.querySelectorAll('input[type=checkbox]:checked'))
+            .map((cb) => cb.dataset.facetValue);
+          if (vals.length > 0) filters[key] = vals;
+        });
+        return filters;
+      }
+
+      function kindLabel(t) {
+        const m = {
+          venue: 'Venue', experience: 'Experience', event: 'Event',
+          place: 'Place', itinerary: 'Plan', tour: 'Tour',
+          'tour-package': 'Tour package', article: 'Journal',
+          'quick-note': 'Quick note', 'local-secret': 'Local secret',
+        };
+        return m[t] || 'Guide';
+      }
+
+      function renderResults(hits) {
+        if (!out) return;
+        if (hits.length === 0) {
+          out.innerHTML = '<p class="plan-builder__empty">No matches yet. Loosen a filter, broaden the query, or try a different combination.</p>';
+          return;
+        }
+        out.innerHTML = '<ul class="plan-builder__list">' + hits.map((h) => {
+          const img = h.hero_image && h.hero_image.src;
+          const dek = h.dek ? escapeHtml(h.dek).slice(0, 220) : '';
+          const facetSummary = Object.keys(h.facets || {}).slice(0, 3).map((k) => k + ': ' + (h.facets[k] || []).slice(0, 2).join(', ')).join(' · ');
+          return (
+            '<li class="plan-builder__item">' +
+              '<a href="' + escapeHtml(h.href) + '" class="plan-builder__card">' +
+                (img ? '<span class="plan-builder__card-img" style="background-image: url(' + JSON.stringify(img) + ');"></span>' : '<span class="plan-builder__card-img plan-builder__card-img--blank"></span>') +
+                '<span class="plan-builder__card-body">' +
+                  '<span class="plan-builder__card-kind">' + escapeHtml(kindLabel(h.entity_type)) + '</span>' +
+                  '<span class="plan-builder__card-title">' + escapeHtml(h.title) + '</span>' +
+                  (dek ? '<span class="plan-builder__card-dek">' + dek + '</span>' : '') +
+                  (facetSummary ? '<span class="plan-builder__card-facets">' + escapeHtml(facetSummary) + '</span>' : '') +
+                '</span>' +
+              '</a>' +
+            '</li>'
+          );
+        }).join('') + '</ul>';
+      }
+
+      async function runSearch() {
+        const myToken = ++token;
+        const filters = collectFilters();
+        const q = (input && input.value || '').trim();
+        const t = sel && sel.value;
+        const hasFilters = Object.keys(filters).length > 0;
+        if (!q && !hasFilters && !t) {
+          if (out) out.innerHTML = '';
+          if (meta) meta.textContent = 'Pick a filter or type to see results.';
+          return;
+        }
+        if (meta) meta.textContent = 'Searching…';
+        const rpc = window.PISearchRpc;
+        if (!rpc || !rpc.available) {
+          if (off) off.hidden = false;
+          if (meta) meta.textContent = 'Search service unavailable.';
+          return;
+        }
+        try {
+          const hits = await rpc.search({
+            q: q || undefined,
+            filters,
+            entityTypes: t ? [t] : undefined,
+            limit: 40,
+          });
+          if (myToken !== token) return;
+          renderResults(hits || []);
+          if (meta) meta.textContent = (hits && hits.length ? hits.length : 0) + ' result' + ((hits && hits.length === 1) ? '' : 's') + '.';
+        } catch (err) {
+          console.warn('[plan-builder] RPC error', err);
+          if (off) off.hidden = false;
+          if (meta) meta.textContent = 'Search failed. Try refreshing.';
+        }
+      }
+
+      // Debounce input + selection
+      let deb = null;
+      function debounced() {
+        clearTimeout(deb);
+        deb = setTimeout(runSearch, 120);
+      }
+
+      form?.addEventListener('submit', (e) => { e.preventDefault(); runSearch(); });
+      input?.addEventListener('input', debounced);
+      sel?.addEventListener('change', runSearch);
+      document.querySelectorAll('.plan-builder__facet input[type=checkbox]').forEach((cb) => {
+        cb.addEventListener('change', debounced);
+      });
+      clear?.addEventListener('click', () => {
+        if (input) input.value = '';
+        if (sel) sel.value = '';
+        document.querySelectorAll('.plan-builder__facet input[type=checkbox]:checked').forEach((cb) => { cb.checked = false; });
+        runSearch();
+      });
+    })();
+  </script>
+
+  <!-- Phase D wave 2: expose pi.search RPC to the inline planner script. -->
+  <script>
+    import { search, typeahead } from '../../lib/search-client.ts';
+    function isAvailable() {
+      const sb = (window as any).__PI_SB;
+      return Boolean(sb && sb.url && sb.key);
+    }
+    (window as any).PISearchRpc = {
+      get available() { return isAvailable(); },
+      search,
+      typeahead,
+    };
+  </script>
+
+  <style>
+    .plan-builder { padding: 0 0 4rem; }
+    .plan-builder__hero { padding: 2rem 0 1.5rem; border-bottom: 1px solid var(--c-rule, #e6e1d8); }
+    .plan-builder__eyebrow { font-size: 0.8rem; letter-spacing: 0.12em; text-transform: uppercase; opacity: 0.7; }
+    .plan-builder__title { font-family: var(--ff-serif, Georgia, serif); font-size: clamp(1.8rem, 4vw, 2.6rem); margin: 0.4rem 0 0.5rem; }
+    .plan-builder__lead { max-width: 60ch; opacity: 0.85; }
+    .plan-builder__search { display: flex; gap: 0.6rem; margin-top: 1.2rem; flex-wrap: wrap; }
+    .plan-builder__q { flex: 1; min-width: 16rem; padding: 0.7rem 0.9rem; font-size: 1rem; border: 1px solid var(--c-rule, #d4cec0); border-radius: 6px; }
+    .plan-builder__type-wrap { display: inline-flex; align-items: center; gap: 0.4rem; }
+    .plan-builder__type-label { font-size: 0.85rem; opacity: 0.7; }
+    .plan-builder__type { padding: 0.55rem 0.6rem; font-size: 0.95rem; border: 1px solid var(--c-rule, #d4cec0); border-radius: 6px; background: white; }
+    .plan-builder__filters { padding: 1.4rem 0; border-bottom: 1px solid var(--c-rule, #e6e1d8); }
+    .plan-builder__facet { border: none; margin: 0 0 0.9rem; padding: 0; }
+    .plan-builder__facet-label { font-size: 0.78rem; letter-spacing: 0.12em; text-transform: uppercase; opacity: 0.7; margin-right: 0.6rem; padding: 0; }
+    .plan-builder__chips { display: inline-flex; flex-wrap: wrap; gap: 0.35rem; }
+    .plan-builder__chip { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.3rem 0.65rem; border: 1px solid var(--c-rule, #d4cec0); border-radius: 999px; font-size: 0.85rem; cursor: pointer; user-select: none; }
+    .plan-builder__chip input { margin: 0; }
+    .plan-builder__chip:has(input:checked) { background: var(--c-accent, #1f3f3a); color: white; border-color: var(--c-accent, #1f3f3a); }
+    .plan-builder__actions { display: flex; align-items: center; gap: 1rem; margin-top: 0.8rem; flex-wrap: wrap; }
+    .plan-builder__btn { padding: 0.45rem 0.9rem; border: 1px solid var(--c-rule, #d4cec0); border-radius: 6px; background: white; cursor: pointer; font-size: 0.9rem; }
+    .plan-builder__btn--ghost:hover { background: var(--c-paper-tint, #f6f3eb); }
+    .plan-builder__count { margin: 0; font-size: 0.85rem; opacity: 0.7; }
+    .plan-builder__results-section { padding: 1.4rem 0; }
+    .plan-builder__list { list-style: none; padding: 0; margin: 0; display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr)); }
+    .plan-builder__card { display: grid; grid-template-rows: 9rem 1fr; text-decoration: none; color: inherit; border: 1px solid var(--c-rule, #e6e1d8); border-radius: 10px; overflow: hidden; background: white; transition: transform 120ms ease; }
+    .plan-builder__card:hover { transform: translateY(-2px); }
+    .plan-builder__card-img { background-size: cover; background-position: center; background-color: var(--c-paper-tint, #f0ece2); }
+    .plan-builder__card-img--blank { background: linear-gradient(135deg, #ece8de, #d8d3c4); }
+    .plan-builder__card-body { padding: 0.8rem 0.9rem 1rem; display: flex; flex-direction: column; gap: 0.3rem; }
+    .plan-builder__card-kind { font-size: 0.7rem; letter-spacing: 0.12em; text-transform: uppercase; opacity: 0.7; }
+    .plan-builder__card-title { font-family: var(--ff-serif, Georgia, serif); font-size: 1.05rem; line-height: 1.25; }
+    .plan-builder__card-dek { font-size: 0.85rem; opacity: 0.8; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .plan-builder__card-facets { font-size: 0.72rem; opacity: 0.55; margin-top: auto; }
+    .plan-builder__empty { padding: 2rem 0; opacity: 0.7; }
+    .plan-builder__unavailable { padding: 2rem 1rem; background: var(--c-paper-tint, #f6f3eb); border-radius: 8px; }
+  </style>
+</BaseLayout>

--- a/next/src/pages/plans/index.astro
+++ b/next/src/pages/plans/index.astro
@@ -136,6 +136,17 @@ const faqSchema = {
     entitySlug="plans"
   />
 
+  <div class="plans-build-cta container">
+    <a href="/plans/build/" class="plans-build-cta__link">
+      Build your own Peninsula plan with the live planner →
+    </a>
+  </div>
+  <style is:inline>
+    .plans-build-cta { padding: 0.8rem 0 0.4rem; }
+    .plans-build-cta__link { display: inline-block; padding: 0.6rem 1rem; border: 1px solid var(--c-rule, #d4cec0); border-radius: 6px; text-decoration: none; color: inherit; font-size: 0.95rem; }
+    .plans-build-cta__link:hover { background: var(--c-paper-tint, #f6f3eb); }
+  </style>
+
   <!-- ═══════════════════════════════════════════════════════════════
        EDITORIAL SURFACE — Slow Weekend (Level 2)
        Post-hero, pre-grid. One surface per hub. Phase 1: PI voice only.

--- a/next/src/pages/search.astro
+++ b/next/src/pages/search.astro
@@ -317,12 +317,65 @@ const KIND_CHIPS = [
         if (page !== 1 && list) list.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
 
+      // ── Phase D wave 1: kind chip → RPC predicates ────────────────────
+      // Chip values are legacy Pagefind labels (Eat, Stay, Wine, etc).
+      // Translate each into a combination of (entityTypes, facets) the
+      // pi.search RPC understands. "all" returns null/{} so the RPC
+      // doesn't narrow on type.
+      function kindToRpcPredicates(kind) {
+        switch (kind) {
+          case 'Eat':       return { entityTypes: ['venue'], facets: { theme: ['food','food+wine','coffee'] } };
+          case 'Stay':      return { entityTypes: ['venue'], facets: {} }; // venue.type narrows further in result rendering
+          case 'Wine':      return { entityTypes: ['venue'], facets: { theme: ['wine'] } };
+          case 'Explore':   return { entityTypes: ['experience'], facets: {} };
+          case 'Plans':     return { entityTypes: ['itinerary','tour','tour-package'], facets: {} };
+          case "What's On": return { entityTypes: ['event'], facets: {} };
+          case 'Journal':   return { entityTypes: ['article','quick-note','local-secret'], facets: {} };
+          case 'Places':    return { entityTypes: ['place'], facets: {} };
+          default:          return { entityTypes: null, facets: {} };
+        }
+      }
+
+      function rpcKindLabel(entityType) {
+        const m = {
+          venue: 'Venue', experience: 'Explore', event: "What's On",
+          place: 'Places', itinerary: 'Plans', tour: 'Plans',
+          'tour-package': 'Plans', article: 'Journal',
+          'quick-note': 'Journal', 'local-secret': 'Journal',
+        };
+        return m[entityType] || 'Guide';
+      }
+
+      // Shape a SearchHit into the Pagefind-result shape `renderResults`
+      // expects. We wrap in a shim with a `.data()` method so the
+      // pagination path (which lazily resolves each handle) works
+      // unchanged for both retrieval sources.
+      function rpcHitToHandle(hit, query) {
+        const q = (query || '').toLowerCase();
+        const dek = hit.dek || '';
+        let excerpt = escapeHtml(dek.slice(0, 260));
+        if (q && excerpt.toLowerCase().includes(q)) {
+          const i = excerpt.toLowerCase().indexOf(q);
+          excerpt = excerpt.slice(0, i) + '<mark>' + excerpt.slice(i, i + q.length) + '</mark>' + excerpt.slice(i + q.length);
+        }
+        const data = {
+          url:     hit.href,
+          meta:    {
+            title: hit.title,
+            kind:  rpcKindLabel(hit.entity_type),
+            image: hit.hero_image?.src || '',
+          },
+          excerpt,
+        };
+        return { data: async () => data, _rpc: true };
+      }
+
       async function runSearch() {
         const q = (input?.value || '').trim();
         currentQuery = q;
         currentDataPage = new Map();
 
-        if (!q) {
+        if (!q && currentKind === 'all') {
           currentResults = [];
           renderIdle();
           updateUrl(q);
@@ -332,6 +385,39 @@ const KIND_CHIPS = [
         renderLoading();
         const myToken = ++searchToken;
 
+        // ── Path 1: pi.search RPC (Phase D wave 1) ──────────────────────
+        const rpc = window.PISearchRpc;
+        if (rpc && rpc.available) {
+          try {
+            const preds = kindToRpcPredicates(currentKind);
+            const hits = await rpc.search({
+              q: q || undefined,
+              filters: preds.facets,
+              entityTypes: preds.entityTypes,
+              limit: 96,
+            });
+            if (myToken !== searchToken) return;
+            if (Array.isArray(hits) && hits.length > 0) {
+              currentResults = hits.map((h) => rpcHitToHandle(h, q));
+              await showPage(1);
+              logSearch(q, hits.length, currentKind);
+              updateUrl(q);
+              return;
+            }
+            // Empty hits → fall through to Pagefind so we don't 0-result
+            // when the RPC simply has no embedding for a niche query.
+          } catch (err) {
+            console.warn('[search] RPC failed, falling back to Pagefind:', err);
+          }
+        }
+
+        // ── Path 2: Pagefind (legacy path, retained as fallback) ───────
+        if (!q) {
+          currentResults = [];
+          renderIdle();
+          updateUrl(q);
+          return;
+        }
         try {
           const pf = await loadPagefind();
           const filters = currentKind === 'all' ? undefined : { kind: currentKind };
@@ -445,5 +531,25 @@ const KIND_CHIPS = [
 
       input?.focus();
     })();
+  </script>
+
+  <!--
+    Phase D wave 1: expose pi.search RPC to the inline script.
+    Same pattern as SearchOverlay — module script bundled by Astro,
+    imports search-client which carries supabase-js. `available` is
+    false when window.__PI_SB is missing, so the inline runSearch
+    falls through to Pagefind without any visible regression.
+  -->
+  <script>
+    import { search, typeahead } from '../lib/search-client.ts';
+    function isAvailable() {
+      const sb = (window as any).__PI_SB;
+      return Boolean(sb && sb.url && sb.key);
+    }
+    (window as any).PISearchRpc = {
+      get available() { return isAvailable(); },
+      search,
+      typeahead,
+    };
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Cuts over three consumers to the Phase B + C data layer + drafts the backend patch for the fourth.

## Wave 1 — \`/search.astro\` RPC-first

Same pattern as SearchOverlay (Phase C, #148): try \`pi.search\` first, fall back to Pagefind on error / empty / no-config. Pagefind preserved as the crawl-time safety net.

The kind filter chips translate into RPC predicates:

| Chip | entity_types | facets |
|---|---|---|
| All | – | – |
| Eat | venue | theme: food, food+wine, coffee |
| Stay | venue | – |
| Wine | venue | theme: wine |
| Explore | experience | – |
| Plans | itinerary, tour, tour-package | – |
| What's On | event | – |
| Journal | article, quick-note, local-secret | – |
| Places | place | – |

Pagination is preserved by wrapping RPC hits in a \`{data: async () => obj}\` shim so the existing lazy-resolution path works unchanged across both retrieval sources.

## Wave 2 — \`/plans/build/\` (new route)

Focused new page exposing the attribute-aware query layer directly. **No Pagefind fallback** — the whole point is to surface the structured facet layer. If the RPC is unreachable, renders a graceful "unavailable" message pointing at \`/plans/\` and \`/ask/\`.

Filter UI:
- 10 facet families as checkbox groups: audience, theme, mood, occasion, season, weather, price-band, dog-friendly, kids-grade, zone
- Free-text query (RPC \`q\`)
- Entity-type select (Everything / Venues / Experiences / Events / Itineraries / Places / Journal)
- Debounced re-run on every change (~120ms)

Linked from \`/plans/\` via a small CTA above the existing editorial hero. \`/plans/\` curation untouched.

## Wave 3 — \`/explore/*\` pages (intentionally deferred)

The 8+ \`/explore/\` filter pages (dog-friendly, family-friendly, free, beaches, best-walks, day-trips, golf, etc.) each have their own editorial layout that should **not** be ripped out wholesale. The plan is to add a small "live filter" augmentation alongside the curated content in a follow-up PR, not to replace the curated pages.

## Wave 4 — Concierge backend patch (docs artefact)

Self-contained patch at:
- [\`docs/patches/concierge-attribute-aware-retrieval-2026-05-17.md\`](docs/patches/concierge-attribute-aware-retrieval-2026-05-17.md)

Lives in this repo so it travels alongside the data-layer change it depends on. Apply in \`apps/api/src/routes/concierge.ts\` (the platform API repo).

Architecture: intent parsing → \`pi.search\` hard-filter retrieval → existing \`concierge_chunks\` chunk retrieval → rerank chunks by entity match → LLM with grounded context. Two-stage retrieval preserves prose-quality answers while adding hard attribute guarantees. Behind a \`CONCIERGE_ATTRIBUTE_RERANK=1\` flag for safe rollout.

Anon key suffices (\`pi.search\` has \`GRANT EXECUTE TO anon\`). New env vars to add to the platform-api service:

\`\`\`
PI_RUNTIME_SUPABASE_URL=https://tjjhpvslpysfklwpqmgz.supabase.co
PI_RUNTIME_SUPABASE_ANON_KEY=<anon key>
\`\`\`

## Build

\`\`\`
$ npx astro build → 1361 pages (3 new for /plans/build/), 45.74s
\`\`\`

## Test plan

- [x] \`npx astro build\` green
- [ ] CI green on this PR
- [ ] Live: visit \`/search/?q=cellar%20door\` — DevTools network shows \`rpc/search\` call before any Pagefind activity
- [ ] Live: visit \`/plans/build/\`, tick "theme: wine" + "audience: couples" — results render from RPC
- [ ] Live: disable \`__PI_SB\` global on \`/search/\` (e.g. \`window.__PI_SB = null\`), confirm Pagefind path still works
- [ ] Live: visit \`/plans/build/\` with RPC unreachable — graceful "unavailable" message shows
- [ ] Concierge: apply \`docs/patches/concierge-attribute-aware-retrieval-2026-05-17.md\` in the platform-api repo

## Operational follow-ups

1. (Deferred) Explore pages augmentation
2. Apply the concierge patch in the platform-api repo
3. iOS Sprint 2 — point the filter UI at \`pi.search\` from day one

🤖 Generated with [Claude Code](https://claude.com/claude-code)