### PR TITLE
fix(projectors): venue href derived from type so concierge cards don't 404

### DIFF
--- a/next/scripts/refresh-content-registry.mjs
+++ b/next/scripts/refresh-content-registry.mjs
@@ -40,9 +40,24 @@ if (!SUPABASE_KEY) {
   process.exit(1);
 }
 
+// Per-venue routing — venues live at /stay/, /eat/, or /wine/ depending on
+// type. Mirrors next/src/lib/editorial.ts venueHrefPrefix(). Hardcoding
+// '/stay/' for all venues produces 404 links for restaurants/cafes/wineries
+// (the largest source of "this result isn't on the website" reports).
+const STAY_TYPES = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'];
+const WINE_TYPES = ['winery', 'producer', 'brewery', 'distillery'];
+// All other venue types (restaurant, cafe, bakery, pub, market) → /eat/.
+
+function venueHrefPrefix(type) {
+  if (STAY_TYPES.includes(type)) return '/stay/';
+  if (WINE_TYPES.includes(type)) return '/wine/';
+  return '/eat/';
+}
+
 /** Collections to walk: collection folder → { entityType, hrefPrefix } */
 const COLLECTIONS = [
-  { folder: 'venues',         entityType: 'venue',         hrefPrefix: '/stay/' },
+  // venues get hrefPrefix=null — derived per-row via venueHrefPrefix(d.type)
+  { folder: 'venues',         entityType: 'venue',         hrefPrefix: null },
   { folder: 'places',         entityType: 'place',         hrefPrefix: '/places/' },
   { folder: 'articles',       entityType: 'article',       hrefPrefix: '/journal/' },
   { folder: 'events',         entityType: 'event',         hrefPrefix: '/whats-on/' },
@@ -146,7 +161,7 @@ async function main() {
         entity_type: entityType,
         entity_slug: d.slug,
         title:       d.name || d.title || d.slug,
-        href:        hrefPrefix + d.slug + '/',
+        href:        (hrefPrefix ?? venueHrefPrefix(d.type)) + d.slug + '/',
         refreshed_at: new Date().toISOString(),
       }));
 

--- a/next/scripts/refresh-entity-index.mjs
+++ b/next/scripts/refresh-entity-index.mjs
@@ -76,8 +76,22 @@ for (const fields of Object.values(taxonomy.mappings)) {
 // entityType, folder, hrefPrefix mirror refresh-content-registry.mjs.
 // titleField names the JSON field that holds the display title (varies
 // between `name` and `title`).
+// Per-venue routing — venues live at /stay/, /eat/, or /wine/ depending on
+// type. Mirrors next/src/lib/editorial.ts venueHrefPrefix(). Hardcoding
+// '/stay/' for all venues produces 404 links from search, planner, and
+// concierge tiles for restaurants/cafes/wineries.
+const STAY_TYPES = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'];
+const WINE_TYPES = ['winery', 'producer', 'brewery', 'distillery'];
+
+function venueHrefPrefix(type) {
+  if (STAY_TYPES.includes(type)) return '/stay/';
+  if (WINE_TYPES.includes(type)) return '/wine/';
+  return '/eat/';
+}
+
 const COLLECTIONS = [
-  { folder: 'venues',         entityType: 'venue',         hrefPrefix: '/stay/',     titleField: 'name'  },
+  // hrefPrefix=null on venues → derived per-row via venueHrefPrefix(entry.type)
+  { folder: 'venues',         entityType: 'venue',         hrefPrefix: null,         titleField: 'name'  },
   { folder: 'experiences',    entityType: 'experience',    hrefPrefix: '/explore/',  titleField: 'name'  },
   { folder: 'places',         entityType: 'place',         hrefPrefix: '/places/',   titleField: 'name'  },
   { folder: 'articles',       entityType: 'article',       hrefPrefix: '/journal/',  titleField: 'title' },
@@ -208,7 +222,7 @@ function buildIndexRow({ entry, entityType, folder, hrefPrefix, titleField, face
     coordinates: coords,
     starts_at:    startsAt ? new Date(startsAt).toISOString() : null,
     ends_at:      endsAt ? new Date(endsAt).toISOString() : null,
-    href:         hrefPrefix + slug + '/',
+    href:         (hrefPrefix ?? venueHrefPrefix(entry.type)) + slug + '/',
     hero_image:   entry.heroImage || null,
     taxonomy_version: String(taxonomy.version || '0'),
     refreshed_at: new Date().toISOString(),


### PR DESCRIPTION
## What the user reported

Concierge recommendation tiles for venues like Mr Vincenzo's, Thai Orchid, Azuma Japanese (visible in screenshot) — \"items coming up in search that are not on the website anymore.\"

## Root cause

Both \`refresh-content-registry.mjs\` and \`refresh-entity-index.mjs\` hard-coded \`hrefPrefix: '/stay/'\` for ALL venues. But the live site routes by venue type:
- \`stayTypes\` (hotel, villa, cottage, glamping, farm-stay, spa) → \`/stay/\`
- \`wineTypes\` (winery, producer, brewery, distillery) → \`/wine/\`
- everything else (restaurant, cafe, bakery, pub, market) → \`/eat/\`

The hardcoded prefix meant ~70 non-stay venues had \`href = /stay/<slug>/\` in both \`pi.content_registry\` and \`pi.entity_index\`. The concierge backend and search overlay use those hrefs to build click-through links → 404 for everything that wasn't a hotel or spa → \"isn't on the website.\"

## Fix

Introduce \`venueHrefPrefix(type)\` in both scripts, mirroring [\`next/src/lib/editorial.ts\`](next/src/lib/editorial.ts#L177) \`venueHrefPrefix()\`. \`COLLECTIONS\` entries for venues now carry \`hrefPrefix: null\` signalling per-row derivation:

\`\`\`js
href: (hrefPrefix ?? venueHrefPrefix(d.type)) + d.slug + '/'
\`\`\`

## Already re-projected against live data

- \`pi.content_registry\`: 596 entities refreshed
- \`pi.entity_index\`: 568 rows, 2,399 attributes
- Verified six representative venues:

| Venue | Type | New href | HTTP |
|---|---|---|---|
| alba-thermal-springs | spa | /stay/alba-thermal-springs/ | 200 |
| avani-wines | winery | /wine/avani-wines/ | 200 |
| dromana-estate | winery | /wine/dromana-estate/ | 200 |
| azuma-japanese | restaurant | /eat/azuma-japanese/ | 200 |
| mr-vincenzos | restaurant | /eat/mr-vincenzos/ | 200 |
| thai-orchid-mornington | restaurant | /eat/thai-orchid-mornington/ | 200 |

The concierge tiles in the user's screenshot will now link to the correct pages.

## Investigated and ruled out

A \`sitemapExclude\`-based explanation. That flag means \"noindex + drop from maps/rankings\", not \"off the site\" — Alba Thermal Springs has the flag too and is very much live. Patches filtering on it were reverted before commit.

## Test plan

- [x] Local: both projector scripts run clean
- [x] Live: 6 verification URLs return 200
- [ ] CI green on this PR
- [ ] Post-merge: concierge tiles render with correct \`/eat/\` and \`/wine/\` links
- [ ] (Recommended) Audit: any other places in the codebase that synthesize venue URLs from a hard-coded prefix should adopt the same \`venueHrefPrefix\` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)