### PR TITLE
fix(footer): correct Facebook URL

### DIFF
--- a/next/src/components/Footer.astro
+++ b/next/src/components/Footer.astro
@@ -1,33 +1,85 @@
 ---
-/* Footer — V2 design (colophon).
-   Strangler-fig migration of the legacy three-column footer.
-   Keeps the dynamic places-collection pattern from the legacy
-   Footer.astro so newly-published places surface automatically.
-   Namespaced .v2-colophon* / .v2-col-sect* for clean coexistence
-   with anything else; CSS inline so the component is self-contained. */
-
-import { getCollection } from 'astro:content';
-import {
-  footerAboutLinks as aboutLinks,
-  footerUtilityLinks as utilityLinks,
-  buildFooterPlaceLinks,
-} from '../lib/nav';
-import { v4FooterDepartments as sectionLinks } from '../lib/v4-nav';
+/**
+ * Footer — Project Awesome Footer (May 2026 rebuild).
+ *
+ * Editorial-publication footer with newsletter band, 5-column link grid
+ * (Sections / The Insider / Do Business / Readers / Contact + Social),
+ * Acknowledgement of Country, and a full legal line naming the trading
+ * entity (Optiflows Pty Ltd) with ABN and ACN.
+ *
+ * Replaces the prior V2 colophon. Namespaced .pi-foot-* for clean
+ * cohabitation; CSS inline so the component is self-contained.
+ */
 
 const year = new Date().getFullYear();
-const places = await getCollection('places');
-const placeLinks = buildFooterPlaceLinks(places);
+
+type Link = { href: string; label: string };
+
+const sectionLinks: Link[] = [
+  { href: '/eat/', label: 'Eat & Drink' },
+  { href: '/stay/', label: 'Stay' },
+  { href: '/explore/', label: 'Do' },
+  { href: '/wine/', label: 'Wine' },
+  { href: '/plans/', label: 'Plans' },
+  { href: '/whats-on/', label: "What's On" },
+  { href: '/journal/', label: 'Journal' },
+  { href: '/picks/', label: 'Picks' },
+  { href: '/map/', label: 'Map' },
+];
+
+const insiderLinks: Link[] = [
+  { href: '/about/', label: 'About' },
+  { href: '/editorial-approach/', label: 'Editorial Approach' },
+  { href: '/corrections/', label: 'Corrections' },
+  { href: '/ethics/', label: 'Code of Ethics' },
+  { href: '/complaints/', label: 'Complaints' },
+];
+
+const businessLinks: Link[] = [
+  { href: '/partners/advertising-kit/', label: 'Advertise' },
+  { href: '/partners/', label: 'Partner with us' },
+  { href: '/submit/', label: 'Submit a tip' },
+  { href: '/submit/?type=event', label: 'Submit an event' },
+  { href: '/contact/', label: 'Press inquiries' },
+  { href: '/careers/', label: 'Careers' },
+];
+
+const readerLinks: Link[] = [
+  { href: '/account/', label: 'Sign in' },
+  { href: '/pass/', label: 'Pass' },
+  { href: '/account/saved/', label: 'Saved & Plans' },
+  { href: '/newsletter/', label: 'Newsletters' },
+  { href: '/feed.xml', label: 'RSS' },
+  { href: '/site-index/', label: 'Sitemap' },
+  { href: '/accessibility/', label: 'Accessibility' },
+];
+
+const contactEmails: Link[] = [
+  { href: 'mailto:hello@peninsulainsider.com.au', label: 'hello@peninsulainsider.com.au' },
+  { href: 'mailto:tips@peninsulainsider.com.au', label: 'tips@peninsulainsider.com.au' },
+  { href: 'mailto:corrections@peninsulainsider.com.au', label: 'corrections@peninsulainsider.com.au' },
+  { href: 'mailto:advertising@peninsulainsider.com.au', label: 'advertising@peninsulainsider.com.au' },
+];
+
+const legalLinks: Link[] = [
+  { href: '/privacy/', label: 'Privacy' },
+  { href: '/terms/', label: 'Terms' },
+  { href: '/editorial-approach/', label: 'Editorial Approach' },
+  { href: '/corrections/', label: 'Corrections' },
+];
 ---
 
-<footer class="v2-colophon">
-  <div class="v2-colophon__container">
-    <div class="v2-colophon__head">
-      <div class="v2-colophon__wordmark">Peninsula <em>Insider</em></div>
+<footer class="pi-foot" role="contentinfo">
+  <div class="pi-foot__container">
+
+    <div class="pi-foot__masthead">
+      <div class="pi-foot__wordmark">Peninsula <em>Insider</em></div>
+      <div class="pi-foot__motto">Built on the Peninsula, for the Peninsula.</div>
     </div>
 
-    <div class="v2-colophon__grid">
-      <nav class="v2-col-sect" aria-label="Browse">
-        <p class="v2-col-sect__title">Browse</p>
+    <div class="pi-foot__grid">
+      <nav class="pi-foot__col" aria-labelledby="pi-foot-sections">
+        <h2 id="pi-foot-sections" class="pi-foot__col-title">Sections</h2>
         <ul>
           {sectionLinks.map((link) => (
             <li><a href={link.href}>{link.label}</a></li>
@@ -35,70 +87,118 @@ const placeLinks = buildFooterPlaceLinks(places);
         </ul>
       </nav>
 
-      <nav class="v2-col-sect" aria-label="Places">
-        <p class="v2-col-sect__title">Places</p>
+      <nav class="pi-foot__col" aria-labelledby="pi-foot-insider">
+        <h2 id="pi-foot-insider" class="pi-foot__col-title">The Insider</h2>
         <ul>
-          {placeLinks.map((link) => (
+          {insiderLinks.map((link) => (
             <li><a href={link.href}>{link.label}</a></li>
           ))}
         </ul>
       </nav>
 
-      <nav class="v2-col-sect" aria-label="About">
-        <p class="v2-col-sect__title">About</p>
+      <nav class="pi-foot__col" aria-labelledby="pi-foot-business">
+        <h2 id="pi-foot-business" class="pi-foot__col-title">Do Business</h2>
         <ul>
-          {aboutLinks.map((link) => (
-            <li>
-              <a href={link.href}>{link.label}</a>
-            </li>
+          {businessLinks.map((link) => (
+            <li><a href={link.href}>{link.label}</a></li>
           ))}
         </ul>
       </nav>
-    </div>
 
-    <nav class="v2-colophon__utility" aria-label="Utility">
-      <ul class="v2-colophon__utility-list">
-        {utilityLinks.map((link) => (
-          <li>
+      <nav class="pi-foot__col" aria-labelledby="pi-foot-readers">
+        <h2 id="pi-foot-readers" class="pi-foot__col-title">Readers</h2>
+        <ul>
+          {readerLinks.map((link) => (
+            <li><a href={link.href}>{link.label}</a></li>
+          ))}
+        </ul>
+      </nav>
+
+      <div class="pi-foot__col" aria-labelledby="pi-foot-contact">
+        <h2 id="pi-foot-contact" class="pi-foot__col-title">Contact</h2>
+        <ul class="pi-foot__contact">
+          {contactEmails.map((link) => (
+            <li><a href={link.href}>{link.label}</a></li>
+          ))}
+        </ul>
+        <div class="pi-foot__social">
+          <h3 class="pi-foot__social-title">Follow</h3>
+          <div class="pi-foot__social-row">
             <a
-              href={link.href}
-              data-pi-consent={link.key === 'cookies' ? 'open' : undefined}
-            >{link.label}</a>
-          </li>
+              href="https://www.instagram.com/peninsula_insider/"
+              rel="me noopener"
+              target="_blank"
+              aria-label="Peninsula Insider on Instagram (opens in new tab)"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5"/>
+                <circle cx="12" cy="12" r="4"/>
+                <circle cx="17.5" cy="6.5" r="0.6" fill="currentColor"/>
+              </svg>
+            </a>
+            <a
+              href="https://www.facebook.com/peninsulainsider"
+              rel="me noopener"
+              target="_blank"
+              aria-label="Peninsula Insider on Facebook (opens in new tab)"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M13.5 21v-7.5h2.52l.38-2.93H13.5V8.7c0-.85.24-1.43 1.46-1.43h1.56V4.65c-.27-.04-1.2-.12-2.28-.12-2.26 0-3.8 1.38-3.8 3.9v2.17H7.92v2.93h2.52V21h3.06Z"/>
+              </svg>
+            </a>
+            <a
+              href="https://www.linkedin.com/company/peninsula-insider"
+              rel="me noopener"
+              target="_blank"
+              aria-label="Peninsula Insider on LinkedIn (opens in new tab)"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M6.94 8.5H4.06V20h2.88V8.5ZM5.5 4.25a1.66 1.66 0 1 0 0 3.33 1.66 1.66 0 0 0 0-3.33ZM20 20h-2.88v-5.6c0-1.34-.02-3.07-1.87-3.07-1.87 0-2.16 1.46-2.16 2.97V20H10.2V8.5h2.77v1.57h.04c.39-.74 1.34-1.52 2.76-1.52 2.95 0 3.5 1.94 3.5 4.47V20Z"/>
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <p class="pi-foot__aoc">
+      Peninsula Insider is published on the unceded lands of the Bunurong / Boon Wurrung
+      people of the Kulin Nation. We pay our respects to Elders past and present and
+      acknowledge their continuing connection to land, waters and culture.
+    </p>
+
+    <div class="pi-foot__legal">
+      <div class="pi-foot__legal-copy">
+        &copy; {year} <strong>Peninsula Insider</strong>, a trading name of Optiflows Pty Ltd
+        <span class="pi-foot__dot">·</span> ABN 71 155 199 637
+        <span class="pi-foot__dot">·</span> ACN 155 199 637
+      </div>
+      <ul class="pi-foot__legal-links">
+        {legalLinks.map((link) => (
+          <li><a href={link.href}>{link.label}</a></li>
         ))}
+        <li><a href="#cookie-settings" data-pi-consent="open">Cookie settings</a></li>
       </ul>
-    </nav>
-
-    <div class="v2-colophon__disclaimer">
-      <p>Peninsula Insider is an editorial platform sharing curated recommendations based on our own research and experience. While we aim to keep information accurate, details such as opening hours, pricing, and availability may change. Please confirm directly with venues before visiting.</p>
-      <p>From time to time, we may work with partners or accept invitations. Where this occurs, it will be disclosed within the relevant content. Our recommendations remain independently curated.</p>
     </div>
 
-    <div class="v2-colophon__social">
-      <a href="https://www.instagram.com/peninsula_insider/" target="_blank" rel="noopener noreferrer" class="v2-colophon__social-link">Instagram</a>
-    </div>
-
-    <div class="v2-colophon__foot">
-      <span>© {year} Peninsula Insider <span class="v2-col-sect__ornament">·</span> All rights reserved.</span>
-      <span><em>Built on the Peninsula, for the Peninsula.</em></span>
-    </div>
   </div>
 </footer>
 
 <style is:global>
-  .v2-colophon {
+  .pi-foot {
     background: var(--paper-warm, #F3EDDE);
-    padding: clamp(4rem, 7vw, 6rem) 0 2rem;
+    padding: clamp(4rem, 7vw, 6rem) 0 1.5rem;
     border-top: 4px solid var(--ink, #171413);
     color: var(--ink-soft, #3A3531);
     font-family: var(--sans, 'Inter', system-ui, sans-serif);
   }
-  .v2-colophon__container {
+  .pi-foot__container {
     max-width: 1280px;
     margin: 0 auto;
     padding: 0 clamp(1.25rem, 4vw, 2.5rem);
   }
-  .v2-colophon__head {
+
+  .pi-foot__masthead {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -108,7 +208,7 @@ const placeLinks = buildFooterPlaceLinks(places);
     flex-wrap: wrap;
     gap: 1rem;
   }
-  .v2-colophon__wordmark {
+  .pi-foot__wordmark {
     font-family: var(--serif, 'Newsreader', Georgia, serif);
     font-size: clamp(1.6rem, 3vw, 2rem);
     font-weight: 500;
@@ -116,114 +216,37 @@ const placeLinks = buildFooterPlaceLinks(places);
     color: var(--ink, #171413);
     font-variation-settings: 'opsz' 48;
   }
-  .v2-colophon__wordmark em {
+  .pi-foot__wordmark em {
     color: var(--ochre, #A0541F);
     font-style: italic;
     font-weight: 300;
   }
-  .v2-colophon__motto {
+  .pi-foot__motto {
     font-family: var(--serif, 'Newsreader', Georgia, serif);
     font-style: italic;
     font-size: 0.95rem;
     color: var(--ink-muted, #6E655C);
     font-variation-settings: 'opsz' 18;
   }
-  .v2-colophon__grid {
+
+  .pi-foot__grid {
     display: grid;
-    grid-template-columns: 1.4fr 1fr 1fr 1fr;
-    gap: clamp(2rem, 4vw, 3.5rem);
-    margin-bottom: 3rem;
+    grid-template-columns: repeat(5, 1fr);
+    gap: clamp(1.75rem, 3vw, 2.5rem);
+    margin-bottom: 2.5rem;
   }
-  @media (max-width: 880px) {
-    .v2-colophon__grid {
-      grid-template-columns: 1fr 1fr;
-    }
+  @media (max-width: 1024px) {
+    .pi-foot__grid { grid-template-columns: repeat(3, 1fr); }
   }
-  @media (max-width: 560px) {
-    .v2-colophon__grid {
-      grid-template-columns: 1fr;
-      gap: 2rem;
-    }
+  @media (max-width: 720px) {
+    .pi-foot__grid { grid-template-columns: repeat(2, 1fr); gap: 2rem; }
   }
-  .v2-colophon__disclaimer {
-    border-top: 1px solid var(--line, #D9D1BE);
-    padding-top: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-  .v2-colophon__disclaimer p {
-    font-size: 0.78rem;
-    color: var(--ink-muted, #6E655C);
-    line-height: 1.6;
-    margin-bottom: 0.5rem;
-    max-width: 72ch;
-  }
-  .v2-colophon__social {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-  }
-  .v2-colophon__social-link {
-    font-size: 0.82rem;
-    color: var(--ink-soft, #3A3531);
-    text-decoration: none;
-    transition: color .18s ease;
-  }
-  .v2-colophon__social-link:hover { color: var(--ochre, #A0541F); }
-  .v2-colophon__utility {
-    border-top: 1px solid var(--line-soft, #E8E2D1);
-    padding-top: 1rem;
-    margin-bottom: 1rem;
-  }
-  .v2-colophon__utility-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.6rem 1.4rem;
-  }
-  .v2-colophon__utility-list a {
-    font-size: 0.78rem;
-    color: var(--ink-muted, #6E655C);
-    text-decoration: none;
-    transition: color .18s ease;
-  }
-  .v2-colophon__utility-list a:hover { color: var(--ochre, #A0541F); }
-  .v2-colophon__foot {
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--line-soft, #E8E2D1);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.8rem;
-    font-size: 0.78rem;
-    color: var(--ink-muted, #6E655C);
-  }
-  .v2-colophon__foot em {
-    font-family: var(--serif, 'Newsreader', Georgia, serif);
-    font-style: italic;
-    font-variation-settings: 'opsz' 16;
+  @media (max-width: 480px) {
+    .pi-foot__grid { grid-template-columns: 1fr; }
   }
 
-  .v2-col-sect ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-  }
-  .v2-col-sect a {
-    font-size: 0.9rem;
-    color: var(--ink-soft, #3A3531);
-    text-decoration: none;
-    transition: color .18s ease;
-  }
-  .v2-col-sect a:hover { color: var(--ochre, #A0541F); }
-  .v2-col-sect__title {
+  .pi-foot__col-title {
+    font-family: var(--sans, 'Inter', system-ui, sans-serif);
     font-size: 0.62rem;
     font-weight: 700;
     letter-spacing: 0.24em;
@@ -233,25 +256,119 @@ const placeLinks = buildFooterPlaceLinks(places);
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--ink, #171413);
   }
-  .v2-col-sect__ornament {
+  .pi-foot__col ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+  .pi-foot__col a {
+    font-size: 0.9rem;
+    color: var(--ink-soft, #3A3531);
+    text-decoration: none;
+    transition: color .18s ease;
+  }
+  .pi-foot__col a:hover,
+  .pi-foot__col a:focus-visible { color: var(--ochre, #A0541F); }
+  .pi-foot__col a:focus-visible { outline: 2px solid var(--ochre, #A0541F); outline-offset: 2px; }
+
+  .pi-foot__contact a {
+    font-family: var(--serif, 'Newsreader', Georgia, serif);
+    font-style: italic;
+    font-size: 0.92rem;
+    word-break: break-all;
+  }
+
+  .pi-foot__social {
+    margin-top: 1.4rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--line, #D9D1BE);
+  }
+  .pi-foot__social-title {
+    font-family: var(--sans, 'Inter', system-ui, sans-serif);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--ink, #171413);
+    margin: 0 0 0.75rem;
+  }
+  .pi-foot__social-row {
+    display: flex;
+    gap: 0.7rem;
+  }
+  .pi-foot__social-row a {
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--ink, #171413);
+    border-radius: 50%;
+    color: var(--ink, #171413);
+    transition: background .18s ease, color .18s ease, border-color .18s ease;
+  }
+  .pi-foot__social-row a:hover,
+  .pi-foot__social-row a:focus-visible {
+    background: var(--ink, #171413);
+    color: var(--paper-warm, #F3EDDE);
+    border-color: var(--ink, #171413);
+  }
+  .pi-foot__social-row a:focus-visible {
+    outline: 2px solid var(--ochre, #A0541F);
+    outline-offset: 2px;
+  }
+  .pi-foot__social-row svg { width: 16px; height: 16px; }
+
+  .pi-foot__aoc {
+    margin: 0 auto 1.5rem;
+    padding: 1.5rem 0;
+    border-top: 1px solid var(--line, #D9D1BE);
+    border-bottom: 1px solid var(--line, #D9D1BE);
+    max-width: 72ch;
+    text-align: center;
+    font-family: var(--serif, 'Newsreader', Georgia, serif);
+    font-style: italic;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--ink-soft, #3A3531);
+    font-variation-settings: 'opsz' 18;
+  }
+
+  .pi-foot__legal {
+    padding-top: 1.25rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.8rem 1.5rem;
+    font-size: 0.78rem;
+    color: var(--ink-muted, #6E655C);
+  }
+  .pi-foot__legal-copy strong {
+    color: var(--ink-soft, #3A3531);
+    font-weight: 500;
+  }
+  .pi-foot__dot {
     color: var(--ochre, #A0541F);
     margin: 0 0.2rem;
   }
-  .v2-col-sect--brand p {
-    font-family: var(--serif, 'Newsreader', Georgia, serif);
-    font-size: 0.98rem;
-    line-height: 1.55;
-    color: var(--ink-soft, #3A3531);
-    margin: 0 0 1rem;
-    font-variation-settings: 'opsz' 18;
-    max-width: 36ch;
+  .pi-foot__legal-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1.1rem;
   }
-  .v2-col-sect__label {
-    font-family: var(--sans, 'Inter', system-ui, sans-serif);
-    font-size: 0.68rem;
-    font-style: italic;
+  .pi-foot__legal-links a {
     color: var(--ink-muted, #6E655C);
-    font-variation-settings: 'opsz' 16;
-    font-weight: 400;
+    text-decoration: none;
+    transition: color .18s ease;
   }
+  .pi-foot__legal-links a:hover,
+  .pi-foot__legal-links a:focus-visible { color: var(--ochre, #A0541F); }
+  .pi-foot__legal-links a:focus-visible { outline: 2px solid var(--ochre, #A0541F); outline-offset: 2px; }
 </style>

--- a/next/src/components/Footer.astro
+++ b/next/src/components/Footer.astro
@@ -137,7 +137,7 @@ const legalLinks: Link[] = [
               </svg>
             </a>
             <a
-              href="https://www.facebook.com/peninsulainsider"
+              href="https://www.facebook.com/profile.php?id=61568754749670"
               rel="me noopener"
               target="_blank"
               aria-label="Peninsula Insider on Facebook (opens in new tab)"

--- a/next/src/pages/accessibility.astro
+++ b/next/src/pages/accessibility.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Accessibility' },
+];
+
+const lastUpdated = '17 May 2026';
+---
+
+<BaseLayout
+  title="Accessibility | Peninsula Insider"
+  description="Peninsula Insider's accessibility commitment — what we aim for, how to get help, and how to flag issues."
+  section="home"
+  canonical="https://peninsulainsider.com.au/accessibility/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="legal">
+    <div class="container">
+      <div class="legal__header">
+        <p class="label label--accent">Reader experience</p>
+        <h1 class="legal__title">Accessibility</h1>
+        <p class="legal__updated">Last updated: {lastUpdated}</p>
+      </div>
+
+      <div class="legal__body prose">
+        <p>Peninsula Insider is built to be read comfortably by as many people as possible, on as many devices as possible. We treat accessibility as an editorial responsibility, not a checkbox.</p>
+
+        <h2>What we aim for</h2>
+        <p>We aim to meet <a href="https://www.w3.org/TR/WCAG22/" target="_blank" rel="noopener">Web Content Accessibility Guidelines 2.2 at Level AA</a> across our editorial pages. In practice that means:</p>
+        <ul>
+          <li>Sufficient colour contrast between text and background</li>
+          <li>Resizable text without loss of content or function</li>
+          <li>Keyboard-accessible navigation, search and forms</li>
+          <li>Descriptive alternative text on editorial imagery</li>
+          <li>Semantic page structure that works with screen readers</li>
+          <li>Captions or transcripts on substantive video and audio</li>
+        </ul>
+
+        <h2>Where we know we have work to do</h2>
+        <p>We are an active editorial product and the bar moves. Areas we are actively working on:</p>
+        <ul>
+          <li>Tightening focus states across interactive elements</li>
+          <li>Improving alt text on legacy imagery</li>
+          <li>Expanding captioning on archive video content</li>
+        </ul>
+
+        <h2>Reporting an issue</h2>
+        <p>If you have hit an accessibility barrier on this site — anything that has stopped you reading, navigating or using a feature — please tell us. We treat accessibility issues as priority bugs.</p>
+        <p>Email <a href="mailto:hello@peninsulainsider.com.au?subject=Accessibility">hello@peninsulainsider.com.au</a> with the page URL, a short description of the issue, and (where relevant) the device, browser and assistive technology you were using.</p>
+
+        <h2>Alternative formats</h2>
+        <p>If you need a Peninsula Insider article in an alternative format — large text, plain text, or read aloud — write to the address above and we will help where we can.</p>
+
+        <h2>Standards</h2>
+        <p>This statement reflects our position under the <em>Disability Discrimination Act 1992</em> (Cth) and our intent to align with WCAG 2.2 AA.</p>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/next/src/pages/careers.astro
+++ b/next/src/pages/careers.astro
@@ -1,0 +1,54 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Careers' },
+];
+---
+
+<BaseLayout
+  title="Careers | Peninsula Insider"
+  description="Work with Peninsula Insider — editorial, photography, partnerships and product. Open roles and how to express interest."
+  section="home"
+  canonical="https://peninsulainsider.com.au/careers/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="legal">
+    <div class="container">
+      <div class="legal__header">
+        <p class="label label--accent">Working with us</p>
+        <h1 class="legal__title">Careers</h1>
+      </div>
+
+      <div class="legal__body prose">
+        <p>Peninsula Insider is a small, independent editorial publication built around the Mornington Peninsula. We work with a tight group of writers, photographers, editors and operators, and we are slow and deliberate about who we bring in.</p>
+
+        <h2>Current openings</h2>
+        <p>We do not have formal openings advertised right now.</p>
+
+        <h2>How we tend to work</h2>
+        <ul>
+          <li><strong>Contributing writers</strong> — commissioned per piece for editorial features, profiles and seasonal coverage.</li>
+          <li><strong>Photographers</strong> — engaged for venue, place and event coverage with a long-form, on-the-Peninsula brief.</li>
+          <li><strong>Editors and producers</strong> — occasional engagements as the publication's rhythm expands.</li>
+        </ul>
+
+        <h2>Pitching or expressing interest</h2>
+        <p>If you would like to pitch a story or contribute editorially, write to <a href="mailto:stories@peninsulainsider.com.au?subject=Pitch">stories@peninsulainsider.com.au</a> with a short pitch (one paragraph), one or two clips, and a sense of how you'd cover it.</p>
+        <p>For general expressions of interest in working with us — editorial, photographic, partnerships or product — write to <a href="mailto:hello@peninsulainsider.com.au?subject=Careers">hello@peninsulainsider.com.au</a> with a brief note and a CV or portfolio link.</p>
+        <p>We read everything that comes in. We can't always respond individually, but we keep notes and reach out when a relevant brief opens up.</p>
+
+        <h2>What we look for</h2>
+        <ul>
+          <li>Genuine connection to and knowledge of the Mornington Peninsula</li>
+          <li>Editorial judgement — the ability to choose what's worth covering and what isn't</li>
+          <li>Care for accuracy and the people we write about</li>
+          <li>Independent, reader-first instincts</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/next/src/pages/complaints.astro
+++ b/next/src/pages/complaints.astro
@@ -1,0 +1,67 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Complaints' },
+];
+
+const lastUpdated = '17 May 2026';
+---
+
+<BaseLayout
+  title="Complaints | Peninsula Insider"
+  description="How to raise a complaint about Peninsula Insider editorial content, and how we handle it."
+  section="home"
+  canonical="https://peninsulainsider.com.au/complaints/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="legal">
+    <div class="container">
+      <div class="legal__header">
+        <p class="label label--accent">Reader recourse</p>
+        <h1 class="legal__title">Complaints</h1>
+        <p class="legal__updated">Last updated: {lastUpdated}</p>
+      </div>
+
+      <div class="legal__body prose">
+        <p>We aim to publish editorial that is accurate, fair and consistent with our <a href="/editorial-approach/">editorial approach</a> and <a href="/ethics/">code of ethics</a>. If something we have published falls short, we want to know.</p>
+
+        <h2>Before you complain</h2>
+        <p>If the issue is a factual error or out-of-date detail, the fastest path is our <a href="/corrections/">corrections process</a>. Email <a href="mailto:corrections@peninsulainsider.com.au">corrections@peninsulainsider.com.au</a> with the URL and the issue. We typically action corrections within one business day.</p>
+
+        <h2>Lodging a complaint</h2>
+        <p>For matters beyond a simple correction — for example, concerns about fairness, accuracy, conduct or breach of our code of ethics — please write to <a href="mailto:hello@peninsulainsider.com.au?subject=Complaint">hello@peninsulainsider.com.au</a> with <strong>"Complaint"</strong> in the subject line. Include:</p>
+        <ul>
+          <li>The URL or title of the article in question</li>
+          <li>A description of your concern, in your own words</li>
+          <li>What outcome you are seeking (correction, clarification, removal, right of reply, apology, other)</li>
+          <li>Your name and a contact email or phone</li>
+        </ul>
+
+        <h2>How we handle it</h2>
+        <ol>
+          <li><strong>Acknowledge</strong> receipt within two business days.</li>
+          <li><strong>Review</strong> the complaint against the original copy, sources and our editorial standards.</li>
+          <li><strong>Respond</strong> with our findings, typically within ten business days. Where the matter is complex, we will keep you updated on timing.</li>
+          <li><strong>Act</strong> — issue a correction, clarification, update or apology where warranted; or explain why we believe the original stands.</li>
+        </ol>
+
+        <h2>If you remain dissatisfied</h2>
+        <p>We will tell you in writing why we have reached our conclusion. If you still believe the matter is unresolved, you are free to escalate it externally. Peninsula Insider is currently developing its external accountability framework, and we will update this page when that is in place.</p>
+
+        <h2>Vexatious complaints</h2>
+        <p>We treat all complaints seriously. We reserve the right to decline to engage further with complaints that are repetitive, abusive or made in bad faith.</p>
+
+        <h2>Related</h2>
+        <ul>
+          <li><a href="/editorial-approach/">Editorial approach</a></li>
+          <li><a href="/ethics/">Code of ethics</a></li>
+          <li><a href="/corrections/">Corrections</a></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/next/src/pages/corrections.astro
+++ b/next/src/pages/corrections.astro
@@ -1,0 +1,66 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Corrections' },
+];
+
+const lastUpdated = '17 May 2026';
+---
+
+<BaseLayout
+  title="Corrections | Peninsula Insider"
+  description="How Peninsula Insider handles corrections, clarifications and editorial updates. Spotted something wrong? Tell us."
+  section="home"
+  canonical="https://peninsulainsider.com.au/corrections/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="legal">
+    <div class="container">
+      <div class="legal__header">
+        <p class="label label--accent">Editorial standards</p>
+        <h1 class="legal__title">Corrections &amp; clarifications</h1>
+        <p class="legal__updated">Policy last updated: {lastUpdated}</p>
+      </div>
+
+      <div class="legal__body prose">
+        <p>Peninsula Insider takes accuracy seriously. If something we have published is wrong, incomplete or misleading, we correct it. Quickly, openly and on the page where the error appeared.</p>
+
+        <h2>What counts as a correction</h2>
+        <p>We treat the following as material errors that require a correction:</p>
+        <ul>
+          <li>Factual inaccuracies in editorial copy (names, dates, prices, addresses, opening hours, ownership)</li>
+          <li>Misattributed quotes or mischaracterised positions</li>
+          <li>Out-of-date information that materially misleads a reader planning a visit</li>
+          <li>Photo credits or captions that are wrong or missing</li>
+          <li>Broken or misdirected booking and ticketing links</li>
+        </ul>
+        <p>Minor copy edits, typo fixes and structural improvements are made silently. Material corrections are noted.</p>
+
+        <h2>How we handle them</h2>
+        <ol>
+          <li><strong>Verify</strong> the error against the original source or a fresh check with the venue or organiser.</li>
+          <li><strong>Update</strong> the page with the correct information.</li>
+          <li><strong>Note</strong> the correction at the foot of the article where the change is material, with the date.</li>
+          <li><strong>Reply</strong> to the reader who flagged it, where contact details were provided.</li>
+        </ol>
+
+        <h2>Reporting an error</h2>
+        <p>If you have spotted something that needs fixing, write to <a href="mailto:corrections@peninsulainsider.com.au">corrections@peninsulainsider.com.au</a>. Include the page URL and a brief description of the issue. We act on corrections promptly, typically within one business day.</p>
+
+        <h2>If you remain dissatisfied</h2>
+        <p>If you have raised a correction and feel it has not been handled properly, you can escalate through our <a href="/complaints/">complaints process</a>.</p>
+
+        <h2>Related</h2>
+        <ul>
+          <li><a href="/editorial-approach/">Editorial approach</a></li>
+          <li><a href="/ethics/">Code of ethics</a></li>
+          <li><a href="/complaints/">Complaints</a></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/next/src/pages/ethics.astro
+++ b/next/src/pages/ethics.astro
@@ -1,0 +1,65 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Code of Ethics' },
+];
+
+const lastUpdated = '17 May 2026';
+---
+
+<BaseLayout
+  title="Code of Ethics | Peninsula Insider"
+  description="The editorial code Peninsula Insider operates by — honesty, independence, fairness, and respect for the people and places we cover."
+  section="home"
+  canonical="https://peninsulainsider.com.au/ethics/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="legal">
+    <div class="container">
+      <div class="legal__header">
+        <p class="label label--accent">Editorial standards</p>
+        <h1 class="legal__title">Code of ethics</h1>
+        <p class="legal__updated">Last updated: {lastUpdated}</p>
+      </div>
+
+      <div class="legal__body prose">
+        <p>Peninsula Insider is an independent editorial publication. The code below sets the standards we hold ourselves to. It is informed by the <a href="https://www.meaa.org/meaa-media/code-of-ethics/" target="_blank" rel="noopener">MEAA Journalist Code of Ethics</a> and shaped by the practical realities of covering a region we live in and care about.</p>
+
+        <h2>Honesty</h2>
+        <p>We report and recommend what we believe to be true. We do not fabricate experiences, invent quotes, manipulate images in ways that mislead, or present sponsored content as independent editorial.</p>
+
+        <h2>Independence</h2>
+        <p>Editorial decisions are made on editorial grounds. Coverage is not for sale. Commercial relationships do not buy favourable reviews, top-of-list placement, or coverage that wouldn't otherwise be warranted. Where a commercial relationship exists, it is disclosed clearly on the page where it appears.</p>
+
+        <h2>Firsthand experience</h2>
+        <p>Recommendations are grounded in genuine visits and editorial judgement. Where information comes from public listings, event submissions or operator-supplied detail, we say so.</p>
+
+        <h2>Fairness</h2>
+        <p>We give venues, organisers and people the chance to respond to material criticism before publishing. We correct errors openly and quickly through our <a href="/corrections/">corrections process</a>.</p>
+
+        <h2>Respect for the Peninsula</h2>
+        <p>We cover the Mornington Peninsula because we value it. We acknowledge the Bunurong / Boon Wurrung people of the Kulin Nation as the Traditional Owners and Custodians of these lands, and we take care not to amplify uses or volumes of visitation that would damage the places we love.</p>
+
+        <h2>Privacy and dignity</h2>
+        <p>We treat the people we write about with respect. We do not publish private information without a clear public-interest justification, and we avoid intrusion on grief or hardship.</p>
+
+        <h2>Disclosure</h2>
+        <p>Where editorial judgement could reasonably be questioned because of a personal or commercial relationship, we disclose it. This includes paid partnerships, hosted visits, affiliate links and meaningful personal ties to a venue.</p>
+
+        <h2>Accountability</h2>
+        <p>If you believe we have fallen short of this code, write to <a href="mailto:hello@peninsulainsider.com.au">hello@peninsulainsider.com.au</a> or escalate through our <a href="/complaints/">complaints process</a>. We take concerns seriously and respond.</p>
+
+        <h2>Related</h2>
+        <ul>
+          <li><a href="/editorial-approach/">Editorial approach</a></li>
+          <li><a href="/corrections/">Corrections</a></li>
+          <li><a href="/complaints/">Complaints</a></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/next/src/pages/feed.xml.ts
+++ b/next/src/pages/feed.xml.ts
@@ -1,0 +1,73 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+const SITE_URL = 'https://peninsulainsider.com.au';
+const FEED_TITLE = 'Peninsula Insider';
+const FEED_DESC =
+  'Editorial coverage of the Mornington Peninsula — eat, stay, do, wine, and the weekend curated.';
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function rfc822(d: Date): string {
+  return d.toUTCString();
+}
+
+export const GET: APIRoute = async () => {
+  const articles = await getCollection(
+    'articles',
+    ({ data }) => data.status === 'published'
+  );
+
+  const items = articles
+    .map((a) => ({
+      slug: a.slug,
+      title: a.data.title as string,
+      description: (a.data.dek ?? '') as string,
+      pubDate: (a.data.publishedAt as Date | undefined) ?? new Date(),
+    }))
+    .sort((x, y) => y.pubDate.getTime() - x.pubDate.getTime())
+    .slice(0, 40);
+
+  const lastBuildDate = items[0]?.pubDate ?? new Date();
+
+  const itemsXml = items
+    .map((item) => {
+      const link = `${SITE_URL}/journal/${item.slug}/`;
+      return `    <item>
+      <title>${xmlEscape(item.title)}</title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <pubDate>${rfc822(item.pubDate)}</pubDate>
+      <description>${xmlEscape(item.description)}</description>
+    </item>`;
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${xmlEscape(FEED_TITLE)}</title>
+    <link>${SITE_URL}/</link>
+    <description>${xmlEscape(FEED_DESC)}</description>
+    <language>en-au</language>
+    <lastBuildDate>${rfc822(lastBuildDate)}</lastBuildDate>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml" />
+${itemsXml}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/next/src/pages/picks.astro
+++ b/next/src/pages/picks.astro
@@ -1,0 +1,72 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import NewsletterBlock from '../components/NewsletterBlock.astro';
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Picks' },
+];
+
+// Pull the most recent weekend-picks entries to preview the curation.
+const allPicks = await getCollection('weekend-picks');
+const recent = allPicks
+  .sort((a, b) => (a.data.weekendStart < b.data.weekendStart ? 1 : -1))
+  .slice(0, 4);
+---
+
+<BaseLayout
+  title="Peninsula Insider Picks | The weekend, curated"
+  description="Peninsula Insider Picks — a tight editorial shortlist of the weekend on the Mornington Peninsula. New each Sunday."
+  section="home"
+  canonical="https://peninsulainsider.com.au/picks/"
+>
+  <Breadcrumbs items={breadcrumbItems} />
+
+  <section class="legal">
+    <div class="container">
+      <div class="legal__header">
+        <p class="label label--accent">The weekend, curated</p>
+        <h1 class="legal__title">Peninsula Insider Picks</h1>
+        <p class="legal__updated">A tight editorial shortlist for the weekend ahead</p>
+      </div>
+
+      <div class="legal__body prose">
+        <p>Peninsula Insider Picks is a short, hand-picked list of what's worth your Saturday and Sunday on the Mornington Peninsula. Each weekend, the editor selects a small slate — markets, openings, dinners, walks, exhibitions — with a verdict on why each one made the cut.</p>
+
+        <p>Selectivity is the point. The list is short on purpose.</p>
+
+        <h2>This weekend</h2>
+        <p>The current weekend's Picks live on the <a href="/whats-on/"><strong>What's On</strong></a> page, where they sit alongside the wider event calendar.</p>
+
+        <h2>Get them in your inbox</h2>
+        <p>Picks are also delivered as <a href="/newsletter/"><strong>The Dispatch</strong></a> — a single Sunday email with the weekend laid out.</p>
+
+        {recent.length > 0 && (
+          <>
+            <h2>Recent weekends</h2>
+            <ul>
+              {recent.map((entry) => (
+                <li>
+                  <strong>{entry.data.weekendLabel}</strong>
+                  {entry.data.editorIntro && (
+                    <> &mdash; {entry.data.editorIntro}</>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        <h2>How Picks are made</h2>
+        <p>Picks are editor-selected, grounded in firsthand experience, local knowledge and what is actually on. Coverage is not bought or traded — see our <a href="/editorial-approach/">editorial approach</a> and <a href="/ethics/">code of ethics</a>.</p>
+      </div>
+    </div>
+  </section>
+
+  <NewsletterBlock
+    title="The Dispatch — Peninsula Insider Picks, every Sunday."
+    body="A single email with the weekend laid out — markets, openings, dinners, walks, exhibitions. Free. Unsubscribe anytime."
+  />
+</BaseLayout>


### PR DESCRIPTION
Replaces the placeholder Facebook slug with the real profile URL: https://www.facebook.com/profile.php?id=61568754749670

Hotfix on top of #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)