### PR TITLE
fix(footer): correct Facebook URL

### DIFF
--- a/next/src/components/Footer.astro
+++ b/next/src/components/Footer.astro
@@ -137,7 +137,7 @@ const legalLinks: Link[] = [
               </svg>
             </a>
             <a
-              href="https://www.facebook.com/peninsulainsider"
+              href="https://www.facebook.com/profile.php?id=61568754749670"
               rel="me noopener"
               target="_blank"
               aria-label="Peninsula Insider on Facebook (opens in new tab)"


### PR DESCRIPTION
Replaces the placeholder Facebook slug with the real profile URL: https://www.facebook.com/profile.php?id=61568754749670

Hotfix on top of #157. Supersedes #159 (had a merge conflict from being branched off pre-squash history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)