### PR TITLE
fix(cms): restore SSR override bake — Sorrento + 6 other surfaces

### DIFF
--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -32,6 +32,7 @@ import ArticleCard from './ArticleCard.astro';
 import NewsletterBlock from './NewsletterBlock.astro';
 import { titleize, resolveHeroSrc, formatHeroCredit } from '../lib/editorial';
 import { editableText, editableImage } from '../lib/inline-edit/attrs';
+import { loadOverrides } from '../lib/inline-edit/overrides';
 
 export interface Props {
   place: any;
@@ -57,9 +58,17 @@ const {
 
 const zoneLabel = titleize(place.data.zone);
 const kindLabel = titleize(place.data.kind);
-const heroSrc = resolveHeroSrc(place.data);
-const heroCredit = formatHeroCredit(place.data.heroImage?.credit);
 const placeSlug = place.id ?? place.slug ?? place.data?.slug ?? place.data?.id;
+
+// CMS override consult at SSR — if an editor uploaded a place-specific
+// hero via the inline editor, it wins over the content-JSON default and
+// ships in the static HTML. No client-side swap, no flicker. Restores the
+// override propagation the client-side patcher used to provide before
+// PR #162 gated it to admin-click.
+const placeOverrides = placeSlug ? await loadOverrides('place', placeSlug) : null;
+const overrideHero = placeOverrides?.image['hero'];
+const heroSrc = overrideHero?.src ?? resolveHeroSrc(place.data);
+const heroCredit = formatHeroCredit(place.data.heroImage?.credit);
 
 // Category sub-page lookup — editorial, not file-system-driven.
 // Extend this map as new place-specific sub-pages are created.

--- a/next/src/pages/explore/[slug].astro
+++ b/next/src/pages/explore/[slug].astro
@@ -9,6 +9,7 @@ import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { placeLabel, routeSlug, titleize, venueHrefPrefix, heroBackgroundStyle } from '../../lib/editorial';
 import { editableText, editableImage } from '../../lib/inline-edit/attrs';
+import { loadOverrides } from '../../lib/inline-edit/overrides';
 
 const difficultyLabel: Record<string, string> = {
   easy: 'Easy',
@@ -84,7 +85,14 @@ const seasonBest = experience.data.seasonBest?.length
 const duration = experience.data.durationMinutes ? `${experience.data.durationMinutes} min` : null;
 const difficulty = experience.data.difficulty ? difficultyLabel[experience.data.difficulty] ?? titleize(experience.data.difficulty) : null;
 const heroClass = heroVariant[experience.data.type] ?? 'feature__image-block--hinterland';
-const heroStyle = heroBackgroundStyle(experience.data);
+
+// CMS override consult at SSR — bake the editor's uploaded hero into
+// the static HTML if there's a published override for this experience.
+const experienceOverrides = await loadOverrides('experience', slug);
+const overrideHero = experienceOverrides.image['hero'];
+const heroStyle = overrideHero?.src
+  ? `background-image: url('${overrideHero.src.replace(/["\\]/g, (m: string) => `\\${m}`)}'); background-size: cover; background-position: center;`
+  : heroBackgroundStyle(experience.data);
 
 const canonical = `https://peninsulainsider.com.au/explore/${slug}/`;
 const ogImage = experience.data.heroImage?.src && !experience.data.heroImage.src.includes('placeholder')

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -217,7 +217,20 @@ const scenes: Scene[] = [
   },
 ];
 
-const ssrScene = scenes[0];
+// The <img> in the cover block is tagged `page/home/cover.image`, so
+// whichever scene is active (scenes[0]) must render the override when
+// one's published — or the image disagrees with what editors uploaded.
+// Apply the override to the active scene rather than burying it in
+// scenes[2] which only fires if that scene gets promoted to [0].
+const activeScene = scenes[0];
+const ssrScene: Scene = coverImageOverride
+  ? {
+      ...activeScene,
+      image: coverImageOverride.src,
+      imageAlt: coverImageOverride.alt ?? activeScene.imageAlt,
+      caption: coverImageOverride.caption ?? activeScene.caption,
+    }
+  : activeScene;
 
 // Editorial meta line: cover-essay date. Hardcoded for the prototype;
 // when the cover becomes CMS-driven (or rotates from articles) this should

--- a/next/src/pages/plans/[slug].astro
+++ b/next/src/pages/plans/[slug].astro
@@ -39,6 +39,7 @@ import {
   themeLabel,
 } from '../../lib/escape';
 import { editableText, editableImage } from '../../lib/inline-edit/attrs';
+import { loadOverrides } from '../../lib/inline-edit/overrides';
 
 const timeOfDayLabel: Record<string, string> = {
   morning: 'Morning',
@@ -117,6 +118,11 @@ const aBreadcrumbs = isArticle
 // ─── Itinerary branch data ─────────────────────────────────────────────────
 const data = isArticle ? null : itinerary.data;
 const slug = isArticle ? '' : routeSlug(itinerary);
+
+// CMS override consult for the itinerary hero — baked at SSR so the
+// editor's uploaded image ships in the static HTML.
+const itineraryOverrides = !isArticle && slug ? await loadOverrides('itinerary', slug) : null;
+const itineraryHeroOverride = itineraryOverrides?.image['hero'];
 
 const allItineraries = isArticle ? [] : await getCollection('itineraries');
 const allVenues = isArticle ? allVenuesRaw : allVenuesRaw;
@@ -546,10 +552,16 @@ const ogImage = data
       <div
         class="itinerary-detail__hero feature__image-block feature__image-block--sand"
         aria-hidden="true"
-        style={heroBackgroundStyle(data!)}
+        style={itineraryHeroOverride?.src
+          ? `background-image: url('${itineraryHeroOverride.src.replace(/["\\]/g, (m: string) => `\\${m}`)}'); background-size: cover; background-position: center;`
+          : heroBackgroundStyle(data!)}
+        {...editableImage({
+          entityType: 'itinerary', entitySlug: slug, fieldPath: 'hero',
+          label: `${data!.title} hero`, purpose: 'hero',
+        })}
       >
         <div class="itinerary-detail__hero-fog"></div>
-        <span class="itinerary-detail__hero-label">{data!.heroImage.alt}</span>
+        <span class="itinerary-detail__hero-label">{itineraryHeroOverride?.alt ?? data!.heroImage.alt}</span>
       </div>
 
       <div class="itinerary-detail__grid">

--- a/next/src/pages/tour-packages/[slug].astro
+++ b/next/src/pages/tour-packages/[slug].astro
@@ -81,6 +81,8 @@ const breadcrumbItems = [
     title={data.name}
     heroImage={data.heroImage.src}
     imageAlt={data.heroImage.alt}
+    entityType="tour-package"
+    entitySlug={slug}
   >
     <div class="prose">
       <p {...editableText({

--- a/next/src/pages/tour/[slug].astro
+++ b/next/src/pages/tour/[slug].astro
@@ -97,6 +97,8 @@ const breadcrumbItems = [
     heroImage={data.heroImage.src}
     imageAlt={data.heroImage.alt}
     imageCaption={data.departsFrom ?? undefined}
+    entityType="tour"
+    entitySlug={slug}
   >
     <div class="prose">
       <p {...editableText({

--- a/next/src/pages/tour/operators/[slug].astro
+++ b/next/src/pages/tour/operators/[slug].astro
@@ -60,6 +60,8 @@ const breadcrumbItems = [
     title={data.name}
     heroImage={data.heroImage.src}
     imageAlt={data.heroImage.alt}
+    entityType="tour-operator"
+    entitySlug={slug}
   >
     <div class="prose">
       <p>{data.intro}</p>


### PR DESCRIPTION
## Summary

Restores image-override propagation to the live site after PR #162
inadvertently broke it. Surgical 7-file change, +54 / -6 lines.

## What broke

PR #162 (the flicker fix) gated the client-side `applyOverridesOnLoad()`
patcher to admin-click only. That killed the post-paint image flicker,
but it also removed the only path Supabase image overrides had to reach
the live site. After the merge, the live Sorrento page reverted to the
JSON content (boats image) instead of showing the editor's recently
uploaded hero (stairs image) that's still sitting in `pi.cms_image_slots`.

## The fix

Add `loadOverrides()` server-side consult at build time on the 7
surfaces that used to rely on the client-side patcher:

| Surface | Change |
|---|---|
| `PlaceDetailTemplate.astro` | `loadOverrides('place', slug)` → prefer override.src over `resolveHeroSrc` |
| `pages/index.astro` | Apply `coverImageOverride` to the active scene (scenes[0]) not just scenes[2] |
| `explore/[slug].astro` | `loadOverrides('experience', slug)` → prefer override in heroStyle |
| `plans/[slug].astro` itinerary branch | `loadOverrides('itinerary', slug)` + tag hero with editableImage |
| `tour/[slug].astro` | Pass `entityType="tour"` + `entitySlug={slug}` to SubpageHero |
| `tour/operators/[slug].astro` | Pass `entityType="tour-operator"` + `entitySlug={slug}` |
| `tour-packages/[slug].astro` | Pass `entityType="tour-package"` + `entitySlug={slug}` |

SubpageHero already does `loadOverrides()` on main when given the right
props, so those three pages just needed the props added.

## Verification

After this merges and the GH Actions deploy completes:

- `https://peninsulainsider.com.au/places/sorrento/` should render the
  Supabase override image (uploaded 2026-05-17), not the JSON boats image
- No client-side image swap, no flicker
- Sanity Studio and the live site visually agree on Sorrento's hero

## Honest framing

This is the SSR side of the original flicker fix that I should have
shipped together with PR #162 instead of cherry-picking only the client
part. Owning the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)