### PR TITLE
fix(lint): allow Sanity adapter price fields

### DIFF
--- a/next/scripts/lint-no-pricing.mjs
+++ b/next/scripts/lint-no-pricing.mjs
@@ -32,6 +32,13 @@ const ROOT = path.resolve('src');
 // price-aware admin view later without losing historical data.
 const ALLOW = new Set([
   'content.config.ts', // Zod schema field declarations only
+  // Sanity adapters — data-layer passthrough from Sanity → Astro shape.
+  // Same justification as content.config.ts: the FIELDS are preserved so
+  // historical data survives, but the templates that consume the
+  // adapters don't render them. If a price field ever appears in an
+  // .astro template, the rule still fires on that file.
+  'lib/sanity/event-adapter.ts',
+  'lib/sanity/phase5-adapters.ts',
 ]);
 
 const violations = [];


### PR DESCRIPTION
Fixes the Vercel build failure on main: lint-no-pricing was catching priceLow/priceHigh/priceRange field references in next/src/lib/sanity/event-adapter.ts and phase5-adapters.ts. Same situation as content.config.ts (already in ALLOW): data-layer passthrough, not template renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)