### PR TITLE
feat(cms): Sanity dual-read for all remaining entities

### DIFF
--- a/next/src/components/SectionHero.astro
+++ b/next/src/components/SectionHero.astro
@@ -11,6 +11,8 @@
 
 import { editableImage, editableText, type CmsEntityType } from '../lib/inline-edit/attrs';
 import { loadOverrides } from '../lib/inline-edit/overrides';
+import { sanityReadEnabled } from '../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../lib/sanity/singletons-adapter';
 
 export interface Props {
   eyebrow?: string;
@@ -39,16 +41,29 @@ const {
 
 const editable = !!entitySlug;
 
-// Build-time override consult — eliminate flash where the default
-// title / dek / hero paints before the client-side patcher swaps.
-const overrides = editable ? await loadOverrides(entityType, entitySlug!) : null;
-const titleOverride = overrides?.text['hero.title'];
-const dekOverride = overrides?.text['hero.dek'];
-const imageOverride = overrides?.image['hero'];
+// Override resolution: Sanity pageHero singleton when flag is on,
+// otherwise the legacy Supabase override path.
+let resolvedTitle = title;
+let resolvedDek = dek;
+let resolvedHeroImage = heroImage;
 
-const resolvedTitle = titleOverride ?? title;
-const resolvedDek = dekOverride ?? dek;
-const resolvedHeroImage = imageOverride?.src ?? heroImage;
+const isPageEntity = entityType === 'page' && !!entitySlug;
+if (isPageEntity && sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity(entitySlug!);
+  if (ph) {
+    if (ph.title) resolvedTitle = ph.title;
+    if (ph.dek) resolvedDek = ph.dek;
+    if (ph.imageSrc) resolvedHeroImage = ph.imageSrc;
+  }
+} else if (editable) {
+  const overrides = await loadOverrides(entityType, entitySlug!);
+  const titleOverride = overrides.text['hero.title'];
+  const dekOverride = overrides.text['hero.dek'];
+  const imageOverride = overrides.image['hero'];
+  if (titleOverride) resolvedTitle = titleOverride;
+  if (dekOverride) resolvedDek = dekOverride;
+  if (imageOverride?.src) resolvedHeroImage = imageOverride.src;
+}
 
 const gradClass = `section-hero__visual hero-grad--${gradient}`;
 const heroStyle = resolvedHeroImage ? `background-image: url(${resolvedHeroImage})` : undefined;

--- a/next/src/components/SubpageHero.astro
+++ b/next/src/components/SubpageHero.astro
@@ -12,6 +12,8 @@
  */
 import { editableText, editableImage, type CmsEntityType } from '../lib/inline-edit/attrs';
 import { loadOverrides } from '../lib/inline-edit/overrides';
+import { sanityReadEnabled } from '../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../lib/sanity/singletons-adapter';
 
 export interface Props {
   /** Section label shown in accent colour before the rule — e.g. "Eat & Drink" */
@@ -50,16 +52,32 @@ const {
 
 const editable = !!entitySlug;
 
-// Build-time override consult — apply published title / hero overrides
-// to the initial markup so there's no flash where the default paints
-// before the client-side patcher runs.
-const overrides = editable ? await loadOverrides(entityType, entitySlug!) : null;
-const titleOverride = overrides?.text['hero.title'];
-const imageOverride = overrides?.image['hero'];
+// Override resolution: Sanity pageHero singleton (when page-level flag is
+// on AND entityType is 'page') wins. Otherwise legacy Supabase override.
+let resolvedTitle = title;
+let resolvedImageSrc = heroImage;
+let resolvedImageAlt = imageAlt;
 
-const resolvedTitle = titleOverride ?? title;
-const resolvedImageSrc = imageOverride?.src ?? heroImage;
-const resolvedImageAlt = imageOverride?.alt ?? imageAlt;
+const isPageEntity = entityType === 'page' && !!entitySlug;
+if (isPageEntity && sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity(entitySlug!);
+  if (ph) {
+    if (ph.title) resolvedTitle = ph.title;
+    if (ph.imageSrc) {
+      resolvedImageSrc = ph.imageSrc;
+      resolvedImageAlt = ph.imageAlt ?? imageAlt;
+    }
+  }
+} else if (editable) {
+  const overrides = await loadOverrides(entityType, entitySlug!);
+  const titleOverride = overrides.text['hero.title'];
+  const imageOverride = overrides.image['hero'];
+  if (titleOverride) resolvedTitle = titleOverride;
+  if (imageOverride?.src) {
+    resolvedImageSrc = imageOverride.src;
+    resolvedImageAlt = imageOverride.alt ?? imageAlt;
+  }
+}
 
 const titleAttrs = editable
   ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.title', label: `${entitySlug} hero title` })

--- a/next/src/components/v4/V4MegaRail.astro
+++ b/next/src/components/v4/V4MegaRail.astro
@@ -10,6 +10,8 @@
 import type { V4MegaRail } from '../../lib/v4-nav';
 import { editableImage } from '../../lib/inline-edit/attrs';
 import { loadOverrides } from '../../lib/inline-edit/overrides';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchMegaRailFromSanity } from '../../lib/sanity/singletons-adapter';
 
 export interface Props {
   rail: V4MegaRail;
@@ -21,14 +23,26 @@ export interface Props {
 }
 const { rail, pillarKey } = Astro.props;
 
-// Build-time override consult — fetch any published mega-menu image
-// overrides at build, so the static HTML ships with the editor's choice
-// already in place. Eliminates the flash where the default image paints
-// before the client-side patcher swaps it.
-const globalOverrides = await loadOverrides('page', '_global');
-const overrideImage = globalOverrides.image[`mega-rail.${pillarKey}`];
-const imageSrc = overrideImage?.src ?? rail.image;
-const imageAlt = overrideImage?.alt ?? rail.imageAlt;
+// Image resolution: Sanity singleton (when flag on) → legacy Supabase
+// override (when off) → component default.
+let imageSrc = rail.image;
+let imageAlt = rail.imageAlt;
+
+if (sanityReadEnabled('page-level')) {
+  const entries = await fetchMegaRailFromSanity();
+  const entry = entries?.find((e) => e.key === pillarKey);
+  if (entry?.imageSrc) {
+    imageSrc = entry.imageSrc;
+    imageAlt = entry.imageAlt ?? rail.imageAlt;
+  }
+} else {
+  const globalOverrides = await loadOverrides('page', '_global');
+  const overrideImage = globalOverrides.image[`mega-rail.${pillarKey}`];
+  if (overrideImage?.src) {
+    imageSrc = overrideImage.src;
+    imageAlt = overrideImage.alt ?? rail.imageAlt;
+  }
+}
 ---
 
 <a class="v4-mega__rail" href={rail.href}>

--- a/next/src/pages/explore/[slug].astro
+++ b/next/src/pages/explore/[slug].astro
@@ -10,6 +10,8 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { placeLabel, routeSlug, titleize, venueHrefPrefix, heroBackgroundStyle } from '../../lib/editorial';
 import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 import { loadOverrides } from '../../lib/inline-edit/overrides';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchExperienceFromSanity } from '../../lib/sanity/phase5-adapters';
 
 const difficultyLabel: Record<string, string> = {
   easy: 'Easy',
@@ -50,7 +52,13 @@ export async function getStaticPaths() {
   }));
 }
 
-const { experience } = Astro.props;
+let { experience } = Astro.props;
+
+// Dual-read: swap for Sanity when flag is on.
+if (sanityReadEnabled('experiences')) {
+  const sanityExp = await fetchExperienceFromSanity(routeSlug(experience));
+  if (sanityExp) experience = sanityExp as any;
+}
 const allExperiences = await getCollection('experiences');
 const venues = await getCollection('venues');
 const itineraries = await getCollection('itineraries');

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -30,6 +30,8 @@ import NewsletterBlock from '../components/NewsletterBlock.astro';
 import ScrollReveal from '../components/react/ScrollReveal.tsx';
 import { routeSlug, currentSeason, seasonBlurb, dispatchWeekend } from '../lib/editorial';
 import { loadPublishedHomepageOverrides } from '../lib/content/homepage';
+import { sanityReadEnabled } from '../lib/sanity/client';
+import { fetchHomepageCoverFromSanity } from '../lib/sanity/singletons-adapter';
 import { editableText, editableImage } from '../lib/inline-edit/attrs';
 
 // CMS-driven overrides for editor-controlled fields on the homepage. Empty
@@ -223,7 +225,7 @@ const scenes: Scene[] = [
 // Apply the override to the active scene rather than burying it in
 // scenes[2] which only fires if that scene gets promoted to [0].
 const activeScene = scenes[0];
-const ssrScene: Scene = coverImageOverride
+let ssrScene: Scene = coverImageOverride
   ? {
       ...activeScene,
       image: coverImageOverride.src,
@@ -231,6 +233,28 @@ const ssrScene: Scene = coverImageOverride
       caption: coverImageOverride.caption ?? activeScene.caption,
     }
   : activeScene;
+
+// Dual-read: hydrate the cover from Sanity's homepageCover singleton
+// when the page-level flag is on. Replaces both the inline `scenes[]`
+// array AND the legacy Supabase cover.image override.
+if (sanityReadEnabled('page-level')) {
+  const sanityCover = await fetchHomepageCoverFromSanity();
+  if (sanityCover && sanityCover.scenes.length > 0) {
+    const sc = sanityCover.scenes[Math.min(sanityCover.activeIndex, sanityCover.scenes.length - 1)];
+    ssrScene = {
+      id: sc.id,
+      label: sc.label,
+      hours: sc.hours,
+      image: sc.image,
+      imageAlt: sc.imageAlt,
+      caption: sc.caption,
+      headline: sc.headline,
+      dispatch: sc.dispatch,
+      primaryHref: sc.primaryHref,
+      primaryLabel: sc.primaryLabel,
+    };
+  }
+}
 
 // Editorial meta line: cover-essay date. Hardcoded for the prototype;
 // when the cover becomes CMS-driven (or rotates from articles) this should

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -17,6 +17,9 @@ import { pickRelatedArticles, resolveRefs } from '../../lib/related';
 import { isPeninsulaThisWeekend, ptwArchivePath } from '../../lib/peninsula-this-weekend';
 import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 import { loadOverrides } from '../../lib/inline-edit/overrides';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchArticleFromSanity } from '../../lib/sanity/article-adapter';
+import PortableTextBody from '../../components/PortableTextBody.astro';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ data }) => data.status === 'published');
@@ -26,7 +29,19 @@ export async function getStaticPaths() {
   }));
 }
 
-const { article } = Astro.props;
+let { article } = Astro.props;
+
+// Dual-read. When the flag is on AND the article exists in Sanity, swap
+// it in. Body becomes Portable Text (rendered by <PortableTextBody />
+// below instead of Astro's render()).
+let sanityBody: Array<Record<string, unknown>> | null = null;
+if (sanityReadEnabled('articles')) {
+  const sanityArt = await fetchArticleFromSanity(routeSlug(article));
+  if (sanityArt) {
+    article = sanityArt as any;
+    sanityBody = sanityArt.body;
+  }
+}
 
 // Plans articles live at /plans/[slug] — redirect with 301 so inbound
 // /journal/ URLs resolve cleanly without serving duplicate content.
@@ -42,9 +57,14 @@ if (article.data.section === 'plans') {
 // URL rather than the article content. See lib/peninsula-this-weekend.ts.
 const ptwRedirectTo = isPeninsulaThisWeekend(article) ? ptwArchivePath(article) : null;
 
+// Astro's render() can't be called on a Sanity-sourced article. When
+// sanityBody is set we render the body via <PortableTextBody> further
+// down; Content stays null here. TOC headings from PT are deferred.
 const { Content, headings } = ptwRedirectTo
   ? { Content: null as any, headings: [] as Array<{ slug: string; text: string; depth: number }> }
-  : await render(article);
+  : sanityBody
+    ? { Content: null as any, headings: [] as Array<{ slug: string; text: string; depth: number }> }
+    : await render(article);
 
 // Hub-guide treatment: planning-utility articles (regional reference, hub
 // guides, trail guides, venue guides) read as scan-first reference rather
@@ -300,7 +320,7 @@ export const prerender = true;
         )}
 
         <div class="prose has-drop-cap" data-pi-prose-root data-pi-entity-type="article" data-pi-entity-slug={slug}>
-          <Content />
+          {sanityBody ? <PortableTextBody blocks={sanityBody} /> : <Content />}
         </div>
 
         {/* Pre-paint block-override patcher. Reads the JSON blob below and

--- a/next/src/pages/places/[slug].astro
+++ b/next/src/pages/places/[slug].astro
@@ -5,6 +5,8 @@ import PlaceDetailTemplate from '../../components/PlaceDetailTemplate.astro';
 import PlaceMap from '../../components/PlaceMap.astro';
 import EventStrip from '../../components/EventStrip.astro';
 import { routeSlug, stayTypes, wineTypes, isUpcoming } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPlaceFromSanity } from '../../lib/sanity/place-adapter';
 
 export async function getStaticPaths() {
   const places = await getCollection('places');
@@ -14,7 +16,13 @@ export async function getStaticPaths() {
   }));
 }
 
-const { place } = Astro.props;
+let { place } = Astro.props;
+
+// Dual-read: swap focused place for Sanity when flag is on.
+if (sanityReadEnabled('places')) {
+  const sanityPlace = await fetchPlaceFromSanity(routeSlug(place));
+  if (sanityPlace) place = sanityPlace as any;
+}
 const allVenues = await getCollection('venues');
 const places = await getCollection('places');
 const allExperiences = await getCollection('experiences');

--- a/next/src/pages/plans/[slug].astro
+++ b/next/src/pages/plans/[slug].astro
@@ -40,6 +40,8 @@ import {
 } from '../../lib/escape';
 import { editableText, editableImage } from '../../lib/inline-edit/attrs';
 import { loadOverrides } from '../../lib/inline-edit/overrides';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchItineraryFromSanity } from '../../lib/sanity/itinerary-adapter';
 
 const timeOfDayLabel: Record<string, string> = {
   morning: 'Morning',
@@ -75,7 +77,13 @@ export async function getStaticPaths() {
   return [...itineraryPaths, ...articlePaths];
 }
 
-const { itinerary, articleData } = Astro.props;
+let { itinerary, articleData } = Astro.props;
+
+// Dual-read for itinerary branch (article branch handled in journal flow).
+if (articleData == null && itinerary && sanityReadEnabled('itineraries')) {
+  const sanityItn = await fetchItineraryFromSanity(routeSlug(itinerary));
+  if (sanityItn) itinerary = sanityItn as any;
+}
 
 // ─── Plans-article branch data ─────────────────────────────────────────────
 const isArticle = articleData != null;

--- a/next/src/pages/tour-packages/[slug].astro
+++ b/next/src/pages/tour-packages/[slug].astro
@@ -8,6 +8,8 @@ import TourPackageCard from '../../components/TourPackageCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { buildTourPackageSchema } from '../../lib/schema';
 import { editableText } from '../../lib/inline-edit/attrs';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchTourPackageFromSanity } from '../../lib/sanity/phase5-adapters';
 
 export async function getStaticPaths() {
   const packages = await getCollection('tourPackages');
@@ -17,9 +19,15 @@ export async function getStaticPaths() {
   }));
 }
 
-const { pkg } = Astro.props;
+let { pkg } = Astro.props;
+const slug = pkg.id ?? pkg.data.slug;
+
+// Dual-read.
+if (sanityReadEnabled('tour-packages')) {
+  const sanityPkg = await fetchTourPackageFromSanity(slug);
+  if (sanityPkg) pkg = sanityPkg as any;
+}
 const data = pkg.data;
-const slug = pkg.id ?? data.slug;
 
 const allTours = await getCollection('tours');
 const allOperators = await getCollection('tourOperators');

--- a/next/src/pages/tour/[slug].astro
+++ b/next/src/pages/tour/[slug].astro
@@ -6,6 +6,8 @@ import SubpageHero from '../../components/SubpageHero.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { buildTourSchema } from '../../lib/schema';
 import { editableText } from '../../lib/inline-edit/attrs';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchTourFromSanity } from '../../lib/sanity/phase5-adapters';
 
 export async function getStaticPaths() {
   const tours = await getCollection('tours');
@@ -15,7 +17,14 @@ export async function getStaticPaths() {
   }));
 }
 
-const { tour } = Astro.props;
+let { tour } = Astro.props;
+
+// Dual-read.
+if (sanityReadEnabled('tours')) {
+  const slug = tour.id ?? tour.data.slug;
+  const sanityTour = await fetchTourFromSanity(slug);
+  if (sanityTour) tour = sanityTour as any;
+}
 const data = tour.data;
 
 const allOperators = await getCollection('tourOperators');

--- a/next/src/pages/tour/operators/[slug].astro
+++ b/next/src/pages/tour/operators/[slug].astro
@@ -6,6 +6,8 @@ import SubpageHero from '../../../components/SubpageHero.astro';
 import TourCard from '../../../components/TourCard.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
 import { buildOperatorProfileSchema } from '../../../lib/schema';
+import { sanityReadEnabled } from '../../../lib/sanity/client';
+import { fetchTourOperatorFromSanity } from '../../../lib/sanity/phase5-adapters';
 
 export async function getStaticPaths() {
   const operators = await getCollection('tourOperators');
@@ -15,9 +17,15 @@ export async function getStaticPaths() {
   }));
 }
 
-const { operator } = Astro.props;
+let { operator } = Astro.props;
+const slug = operator.id ?? operator.data.slug;
+
+// Dual-read.
+if (sanityReadEnabled('tour-operators')) {
+  const sanityOp = await fetchTourOperatorFromSanity(slug);
+  if (sanityOp) operator = sanityOp as any;
+}
 const data = operator.data;
-const slug = operator.id ?? data.slug;
 
 const allTours = await getCollection('tours');
 const operatorTours = allTours.filter(t => t.data.operatorSlug === data.slug);

--- a/next/src/pages/whats-on/[slug].astro
+++ b/next/src/pages/whats-on/[slug].astro
@@ -25,6 +25,8 @@ import {
   weatherCopy,
 } from '../../lib/editorial';
 import { editableText, editableImage } from '../../lib/inline-edit/attrs';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchEventFromSanity } from '../../lib/sanity/event-adapter';
 
 export async function getStaticPaths() {
   const events = await getCollection('events');
@@ -34,7 +36,13 @@ export async function getStaticPaths() {
   }));
 }
 
-const { event } = Astro.props;
+let { event } = Astro.props;
+
+// Dual-read.
+if (sanityReadEnabled('events')) {
+  const sanityEvent = await fetchEventFromSanity(routeSlug(event));
+  if (sanityEvent) event = sanityEvent as any;
+}
 const place = event.data.place ? await getEntry(event.data.place).catch(() => null) : null;
 const venue = event.data.venue ? await getEntry(event.data.venue).catch(() => null) : null;
 


### PR DESCRIPTION
Adds the if-flag-then-Sanity pattern to every entity surface PR #167 didn't cover. All gated behind `SANITY_*_ENABLED` flags — defaults stay off. After merge, flip each flag independently to migrate each entity one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)