### PR TITLE
ops(backups): fix Sanity dataset backup workflow

### DIFF
--- a/.github/workflows/sanity-backup.yml
+++ b/.github/workflows/sanity-backup.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Sanity CLI
-        run: npm install -g sanity@latest
+      - name: Install Sanity CLI globally
+        run: npm install -g @sanity/cli@latest
 
       - name: Export dataset
         env:
@@ -30,10 +30,12 @@ jobs:
         run: |
           DATE=$(date -u +%Y-%m-%d)
           mkdir -p ops/backups
-          # `sanity dataset export` produces a tar.gz with all docs + assets refs.
-          # Run from the studio directory so the CLI picks up project context.
-          (cd studio-peninsula-insider && sanity dataset export production "../ops/backups/sanity-$DATE.tar.gz" --no-drafts)
-          ls -lh ops/backups/sanity-$DATE.tar.gz
+          # Use --project to avoid needing the local Studio's sanity.cli.ts
+          # config (which depends on the Studio's node_modules being installed).
+          sanity dataset export production "ops/backups/sanity-$DATE.tar.gz" \
+            --project a062b30n \
+            --no-drafts
+          ls -lh "ops/backups/sanity-$DATE.tar.gz"
 
       - name: Prune older than 90 days
         run: |


### PR DESCRIPTION
## Summary
- Fix Sanity backup workflow that failed with "CLI config cannot be loaded"
- Install @sanity/cli (the actual CLI package) and run from repo root with --project a062b30n so it does not need studio node_modules

## Test plan
- [ ] Merge then trigger workflow_dispatch on `Sanity dataset backup`
- [ ] Verify tarball appears under `ops/backups/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)