### PR TITLE
ops(backups): store Sanity export as workflow artifact

### DIFF
--- a/.github/workflows/sanity-backup.yml
+++ b/.github/workflows/sanity-backup.yml
@@ -37,19 +37,13 @@ jobs:
             --no-drafts
           ls -lh "ops/backups/sanity-$DATE.tar.gz"
 
-      - name: Prune older than 90 days
-        run: |
-          find ops/backups -name 'sanity-*.tar.gz' -mtime +90 -print -delete || true
-
-      - name: Commit backup
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ops/backups/
-          if git diff --cached --quiet; then
-            echo "No changes to commit (export already current)."
-          else
-            DATE=$(date -u +%Y-%m-%d)
-            git commit -m "ops(backups): sanity dataset export $DATE [skip ci]"
-            git push
-          fi
+      - name: Upload backup as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          # Export tarball is ~180 MB, exceeding GitHub's 100 MB per-file
+          # limit in the repo. Store as a workflow artifact instead, with
+          # 90-day retention to match the previous prune policy.
+          name: sanity-backup-${{ github.run_id }}
+          path: ops/backups/sanity-*.tar.gz
+          retention-days: 90
+          if-no-files-found: error


### PR DESCRIPTION
Tarball is ~180 MB (exceeds GitHub's 100 MB file limit). Switch to upload-artifact with 90-day retention.