### PR TITLE
feat(cms): Sanity Visual Editing — Presentation tool + stega + preview mode

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -10,10 +10,11 @@
       "dependencies": {
         "@astrojs/mdx": "5.0.3",
         "@astrojs/react": "^5.0.4",
-        "@astrojs/vercel": "^10.0.6",
+        "@astrojs/vercel": "^10.0.7",
         "@portabletext/to-html": "^5.0.2",
         "@sanity/client": "^7.22.0",
         "@sanity/image-url": "^2.1.1",
+        "@sanity/visual-editing": "^5.3.6",
         "@sanity/webhook": "^4.0.4",
         "@supabase/supabase-js": "^2.105.1",
         "@tailwindcss/vite": "^4.3.0",
@@ -231,12 +232,12 @@
       }
     },
     "node_modules/@astrojs/vercel": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-10.0.6.tgz",
-      "integrity": "sha512-Ubd1M77QWqXXluFNL8/ynmfyZCfIUVuL6QRpPXGYOIQ8Dv3QBXM34e0CMig3OgmihSIWNv9sqQHzEHDyDJV9QQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-10.0.7.tgz",
+      "integrity": "sha512-g9ruRlog9VEkCU9ERjcY6+4dedAJr0ylBO+9OqJ+wTqx/31xO/5QOl9w2rRsa26EVapmopdG2eZMytF9e3zW1w==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/internal-helpers": "0.9.1",
         "@vercel/analytics": "^1.6.1",
         "@vercel/functions": "^3.4.3",
         "@vercel/nft": "^1.3.2",
@@ -249,9 +250,9 @@
       }
     },
     "node_modules/@astrojs/vercel/node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
-      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
+      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
       "license": "MIT",
       "dependencies": {
         "picomatch": "^4.0.4"
@@ -716,6 +717,23 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -1131,6 +1149,44 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
@@ -2107,6 +2163,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
@@ -2720,6 +2782,38 @@
         "node": ">=20"
       }
     },
+    "node_modules/@sanity/color": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.6.tgz",
+      "integrity": "sha512-2TjYEvOftD0v7ukx3Csdh9QIu44P2z7NDJtlC3qITJRYV36J7R6Vfd3trVhFnN77/7CZrGjqngrtohv8VqO5nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sanity/comlink": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-4.0.1.tgz",
+      "integrity": "sha512-vdGOd6sxNjqTo2H3Q3L2/Gepy+cDBiQ1mr9ck7c/A9o4NnmBLoDliifsNHIwgNwBUz37oH4+EIz/lIjNy8hSew==",
+      "license": "MIT",
+      "dependencies": {
+        "rxjs": "^7.8.2",
+        "uuid": "^13.0.0",
+        "xstate": "^5.24.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@sanity/diff-match-patch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff-match-patch/-/diff-match-patch-3.2.0.tgz",
+      "integrity": "sha512-4hPADs0qUThFZkBK/crnfKKHg71qkRowfktBljH2UIxGHHTxIzt8g8fBiXItyCjxkuNy+zpYOdRMifQNv8+Yww==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
     "node_modules/@sanity/eventsource": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
@@ -2730,6 +2824,18 @@
         "@types/eventsource": "1.1.15",
         "event-source-polyfill": "1.0.31",
         "eventsource": "2.0.2"
+      }
+    },
+    "node_modules/@sanity/icons": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.7.4.tgz",
+      "integrity": "sha512-O9MnckiDsphFwlRS8Q3kj3n+JYUZ0UzKRujnSikMZOKI0dayucRe4U2XvxikRhJnFhcEJXW2RkWJoBaCoup9Sw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/@sanity/image-url": {
@@ -2744,6 +2850,105 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@sanity/insert-menu": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-3.0.7.tgz",
+      "integrity": "sha512-PiiDvD8uCZMwTpFXMd3dlYs2NjygI3a7S70kD5VoYrFbdWcZOXnAw4m6CIbw43z49tkht+Xv6RXCJkpt20MWGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^3.7.4",
+        "@sanity/ui": "^3.1.14",
+        "lodash-es": "^4.17.23",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@sanity/types": "*",
+        "react": "^19.2"
+      }
+    },
+    "node_modules/@sanity/media-library-types": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/media-library-types/-/media-library-types-1.4.0.tgz",
+      "integrity": "sha512-DZwNT+dDSc1JPW4e7U5C+IJELq5IAeU2A1UcY1079gl+Hakx2USvu5LyY1hrjb1eifRPAhL8uwOVcMNBUmSmzg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@sanity/mutate": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.16.1.tgz",
+      "integrity": "sha512-400OooNtiafgJEOCzj0E5atuWlaKp1z6LU/LB/xZUVVywNj3WuT52U6qeVOfGlZeWKhYMCdGFX2ZnMbIrME95w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^7.9.0",
+        "@sanity/diff-match-patch": "^3.2.0",
+        "@sanity/uuid": "^3.0.2",
+        "hotscript": "^1.0.13",
+        "lodash": "^4.17.21",
+        "mendoza": "^3.0.8",
+        "nanoid": "^5.1.3",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "xstate": "^5.19.0"
+      },
+      "peerDependenciesMeta": {
+        "xstate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/mutate/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@sanity/presentation-comlink": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-2.0.1.tgz",
+      "integrity": "sha512-D0S2CfVyda99cd/8SnXxQ2tsVlVuRq4CAOjxRuF53evYmBhpWezSEpWKqAa0e1lunGBKK1EroxmOzb5ofNRwMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/comlink": "^4.0.1",
+        "@sanity/visual-editing-types": "^1.1.8"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@sanity/preview-url-secret": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-4.0.6.tgz",
+      "integrity": "sha512-Q0Qmag3HaLq1NVWrKw0Ey+N9OFyE4i2tS+1xLDZh5PorFx2JOrFfSwcetGKy1H+gKzQZmDEkc3TlKAOF1K5RDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/uuid": "3.0.2"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^7.22.0"
+      }
+    },
     "node_modules/@sanity/signed-urls": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@sanity/signed-urls/-/signed-urls-2.0.4.tgz",
@@ -2752,6 +2957,169 @@
       "dependencies": {
         "@noble/ed25519": "^3.1.0",
         "@noble/hashes": "^2.2.0"
+      }
+    },
+    "node_modules/@sanity/types": {
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-5.25.1.tgz",
+      "integrity": "sha512-GKkt8w1C/7y7ldQ/0CmVXhAtZyrnz2VaKV5qV5A/v9ApeBIckutQoBvJOkm8PesJHLo0RmaBoDDXSoD6RHbnqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sanity/client": "^7.21.0",
+        "@sanity/media-library-types": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.2"
+      }
+    },
+    "node_modules/@sanity/ui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.2.0.tgz",
+      "integrity": "sha512-bWi2zz8ixZcGHh1YXsgliHRaA9Vw11V5lkJN6SGZcuvbrwPFm6j71Cc3jL1l2MQ11I0HmUYmQ5E76+cT4SznYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.6",
+        "@juggle/resize-observer": "^3.4.0",
+        "@sanity/color": "^3.0.6",
+        "@sanity/icons": "^3.7.4",
+        "csstype": "^3.1.3",
+        "motion": "^12.23.24",
+        "react-compiler-runtime": "1.0.0",
+        "react-refractor": "^4.0.0",
+        "use-effect-event": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || >=19.0.0-0",
+        "react-dom": "^18 || >=19.0.0-0",
+        "react-is": "^18 || >=19.0.0-0",
+        "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/@sanity/uuid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/uuid/-/uuid-3.0.2.tgz",
+      "integrity": "sha512-vzdhqOrX7JGbMyK40KuIwwyXHm7GMLOGuYgn3xlC09e4ZVNofUO5mgezQqnRv0JAMthIRhofqs9f6ufUjMKOvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^8.0.0",
+        "uuid": "^8.0.0"
+      }
+    },
+    "node_modules/@sanity/uuid/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@sanity/visual-editing": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing/-/visual-editing-5.3.6.tgz",
+      "integrity": "sha512-vfPeielbWwo5istevdoAvNHI1I+wkgrYoOp74wHAJO+Uva3Ek6iiJv+3LoAl+QTDGMzg5Wjbfr0dZTOyKAXh3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/comlink": "^4.0.1",
+        "@sanity/icons": "^3.7.4",
+        "@sanity/insert-menu": "^3.0.7",
+        "@sanity/mutate": "^0.16.1",
+        "@sanity/presentation-comlink": "^2.0.1",
+        "@sanity/preview-url-secret": "^4.0.6",
+        "@sanity/ui": "^3.1.14",
+        "@sanity/visual-editing-csm": "^3.0.8",
+        "@vercel/stega": "^1.1.0",
+        "dequal": "^2.0.3",
+        "rxjs": "^7.8.2",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "xstate": "^5.26.0"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^7.22.0",
+        "@sveltejs/kit": ">= 2",
+        "next": ">=16.0.0-0",
+        "react": "^19.2",
+        "react-dom": "^19.2",
+        "react-router": ">= 7",
+        "styled-components": "^6.1",
+        "svelte": ">= 4"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/visual-editing-csm": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-csm/-/visual-editing-csm-3.0.8.tgz",
+      "integrity": "sha512-YzESUeUz/LA1ICW5bMl39PSUmLsQUqPEQpqF9JTmp6APV3n5WJgExDEmRfq9INUNUpJAfSXAFQT+OFnycOVKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/visual-editing-types": "^2.0.7",
+        "valibot": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^7.22.0"
+      }
+    },
+    "node_modules/@sanity/visual-editing-csm/node_modules/@sanity/visual-editing-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-2.0.7.tgz",
+      "integrity": "sha512-W9SbxubSjJ+5E9DeqIjKdkQT+MFFHqDcImhDKvdMhoTH5B+szGdPAHe5U/jIMNotiT6GQq/eitKaW3bPl8CgvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^7.22.0",
+        "@sanity/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/visual-editing-types": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.8.tgz",
+      "integrity": "sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^7.11.2",
+        "@sanity/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sanity/webhook": {
@@ -3338,6 +3706,12 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -3362,6 +3736,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -3496,6 +3876,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@vercel/stega": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-1.1.0.tgz",
+      "integrity": "sha512-DFOm3Gk78nKDkppQEG5aj8Wj8R8hPKu/xrz4Rtp0AfiaNbZNCoJbxn7VI6iMxqhGeLdUDy/8mTuTWMz/izAtPA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -4227,6 +4613,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -4452,6 +4848,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -4522,6 +4924,16 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -4536,6 +4948,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -4600,8 +5024,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -5789,6 +6212,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hotscript": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/hotscript/-/hotscript-1.0.13.tgz",
+      "integrity": "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ==",
+      "license": "ISC"
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -6501,6 +6930,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -6869,6 +7310,15 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mendoza": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.8.tgz",
+      "integrity": "sha512-iwxgEpSOx9BDLJMD0JAzNicqo9xdrvzt6w/aVwBKMndlA6z/DH41+o60H2uHB0vCR1Xr37UOgu9xFWJHvYsuKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -7684,6 +8134,32 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
@@ -8262,6 +8738,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/potrace": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/potrace/-/potrace-2.1.8.tgz",
@@ -8439,6 +8922,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-compiler-runtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-1.0.0.tgz",
+      "integrity": "sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
@@ -8449,6 +8941,29 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT"
+    },
+    "node_modules/react-refractor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-4.0.0.tgz",
+      "integrity": "sha512-2VMRH3HA/Nu+tMFzyQwdBK0my0BIZy1pkWHhjuSrplMyf8ZLx/Gw7tUXV0t2JbEsbSNHbEc9TbHhq3sUx2seVA==",
+      "license": "MIT",
+      "dependencies": {
+        "refractor": "^5.0.0",
+        "unist-util-filter": "^5.0.1",
+        "unist-util-visit-parents": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -8553,6 +9068,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -8955,6 +9486,15 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -9198,6 +9738,50 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/styled-components": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+      "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/svgo": {
       "version": "4.0.1",
@@ -9524,6 +10108,17 @@
         "ohash": "^2.0.11"
       }
     },
+    "node_modules/unist-util-filter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
+      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      }
+    },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
@@ -9824,6 +10419,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-effect-event": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.3.tgz",
+      "integrity": "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
+      }
+    },
     "node_modules/utif": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
@@ -9838,6 +10442,33 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.0.tgz",
+      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -10355,6 +10986,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xstate": {
+      "version": "5.31.1",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.31.1.tgz",
+      "integrity": "sha512-3P7t7GQ61BvLu+8Cj6Zq7rcS34vecL9pvfN2ucUWmIFIUG+rAREviOs4Xy4OO3BuJHSz6RLU8eqDXxSbVotjDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
       }
     },
     "node_modules/xtend": {

--- a/next/package.json
+++ b/next/package.json
@@ -38,6 +38,7 @@
     "@portabletext/to-html": "^5.0.2",
     "@sanity/client": "^7.22.0",
     "@sanity/image-url": "^2.1.1",
+    "@sanity/visual-editing": "^5.3.6",
     "@sanity/webhook": "^4.0.4",
     "@supabase/supabase-js": "^2.105.1",
     "@tailwindcss/vite": "^4.3.0",

--- a/next/src/components/admin/SanityVisualEditing.astro
+++ b/next/src/components/admin/SanityVisualEditing.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Sanity Visual Editing overlay — renders only when the request is in
+ * preview mode (Astro.locals.sanityPreview, set by middleware).
+ *
+ * The overlay script:
+ *   - Reads stega-encoded markers attached to every string field by the
+ *     sanityPreviewClient (see lib/sanity/client.ts)
+ *   - Listens for postMessage from the parent Studio frame
+ *   - Renders clickable hotspots over each stega-marked element
+ *   - When the editor clicks one, opens the corresponding field in
+ *     Sanity Studio's Presentation panel
+ *
+ * The script is inert outside the Studio Presentation iframe (no parent
+ * frame to message), so shipping it on a non-Studio preview load is
+ * harmless. We still gate render on `sanityPreview` to keep the bundle
+ * off the public site entirely.
+ */
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+---
+
+{isPreview && (
+  <script>
+    // Lazy-import keeps the visual-editing bundle off any page that
+    // isn't actually rendering inside Studio.
+    import('@sanity/visual-editing/astro').then(({ enableVisualEditing }) => {
+      enableVisualEditing({ zIndex: 9999 });
+    });
+  </script>
+)}

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -27,6 +27,7 @@ import CookieBanner from '../components/CookieBanner.astro';
 import SaveSiteController from '../components/SaveSiteController.astro';
 import CloudSync from '../components/CloudSync.astro';
 import InlineEditor from '../components/admin/InlineEditor.astro';
+import SanityVisualEditing from '../components/admin/SanityVisualEditing.astro';
 
 export interface Props {
   title: string;
@@ -294,6 +295,9 @@ const isAskPage = rawPathname.startsWith('/ask');
        session and lights up [data-pi-edit] elements for click-to-edit text
        and right-click-to-replace images. Inert for non-admin visitors. -->
   <InlineEditor />
+
+  <!-- Sanity Visual Editing overlay (renders only when Astro.locals.sanityPreview is true). -->
+  <SanityVisualEditing />
 
   <script is:inline>
     (function () {

--- a/next/src/lib/sanity/client.ts
+++ b/next/src/lib/sanity/client.ts
@@ -1,26 +1,13 @@
 /**
  * Peninsula Insider — Sanity client.
- *
- * Two clients are exported:
- *   - `sanityClient` — published-content reads. Token-less in dev (uses the
- *     public dataset), token-authenticated in production builds for higher
- *     rate limits and access to draft preview when explicitly requested.
- *   - `sanityPreviewClient` — same as above but with `perspective: 'previewDrafts'`,
- *     used by the secret preview routes to render draft content.
- *
- * The CDN-cached client is the default for normal SSR; build steps that need
- * fresh-from-origin data import `sanityClientFresh` instead.
- *
- * Tokens come from env vars only. Never hard-coded, never logged. If
- * `SANITY_READ_TOKEN` is missing in production, the client falls back to
- * anonymous reads of the public dataset — fine for the published view, but
- * preview won't work.
+ * Three clients: published (CDN), fresh (no-CDN), preview (drafts + stega).
  */
 import {createClient, type ClientConfig} from '@sanity/client'
 
 const projectId = 'a062b30n'
 const dataset = 'production'
 const apiVersion = '2025-01-01'
+const studioUrl = 'https://peninsula-insider.sanity.studio'
 
 const baseConfig: ClientConfig = {
   projectId,
@@ -35,26 +22,27 @@ export const sanityClient = createClient({
   token: process.env.SANITY_READ_TOKEN,
 })
 
-/** Bypass the CDN — for build-time fetches that need the latest write. */
 export const sanityClientFresh = createClient({
   ...baseConfig,
   useCdn: false,
   token: process.env.SANITY_READ_TOKEN,
 })
 
-/** Preview-drafts client — only used by the secret preview routes. */
 export const sanityPreviewClient = createClient({
   ...baseConfig,
   useCdn: false,
   perspective: 'previewDrafts',
   token: process.env.SANITY_PREVIEW_TOKEN,
+  stega: {
+    enabled: true,
+    studioUrl,
+  },
 })
 
-/**
- * Per-entity feature flag. Returns true when the entity should be read from
- * Sanity. Otherwise the Astro page should fall back to its existing JSON
- * `getCollection()` path. Master kill-switch is `SANITY_READ_ENABLED`.
- */
+export function getSanityReadClient(preview: boolean = false) {
+  return preview ? sanityPreviewClient : sanityClient
+}
+
 export function sanityReadEnabled(
   entity:
     | 'venues'

--- a/next/src/lib/sanity/venue-adapter.ts
+++ b/next/src/lib/sanity/venue-adapter.ts
@@ -11,7 +11,7 @@
  * can be inlined into a single Sanity-native template and the legacy shape
  * dropped. For now, the adapter is the seam.
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
 import {venueBySlugQuery, allVenueSlugsQuery} from './queries'
 
@@ -236,8 +236,12 @@ function adapt(doc: SanityVenue): AdaptedVenue {
 }
 
 /** Fetch a single venue from Sanity. Returns null if not found. */
-export async function fetchVenueFromSanity(slug: string): Promise<AdaptedVenue | null> {
-  const doc = (await sanityClient.fetch(venueBySlugQuery, {slug})) as SanityVenue | null
+export async function fetchVenueFromSanity(
+  slug: string,
+  opts: {preview?: boolean} = {},
+): Promise<AdaptedVenue | null> {
+  const client = getSanityReadClient(opts.preview ?? false)
+  const doc = (await client.fetch(venueBySlugQuery, {slug})) as SanityVenue | null
   if (!doc) return null
   return adapt(doc)
 }
@@ -245,6 +249,6 @@ export async function fetchVenueFromSanity(slug: string): Promise<AdaptedVenue |
 /** All venue slugs in Sanity. Used to build getStaticPaths during the
  *  Sanity-only phase; for dual-run, the page still derives paths from JSON. */
 export async function fetchAllVenueSlugsFromSanity(): Promise<string[]> {
-  const rows = (await sanityClient.fetch(allVenueSlugsQuery)) as Array<{slug: string}>
+  const rows = (await getSanityReadClient(false).fetch(allVenueSlugsQuery)) as Array<{slug: string}>
   return rows.map((r) => r.slug)
 }

--- a/next/src/middleware.ts
+++ b/next/src/middleware.ts
@@ -11,18 +11,42 @@ import {
 import { resolveCmsAccess } from './lib/cms/server';
 
 /**
- * Hybrid admin gate.
+ * Two responsibilities:
  *
- * Default (production): a request can only reach `/admin` or `/admin/api/*`
- * when the user has a valid Supabase session AND is flagged as an editor
- * (RLS-backed `pi.profiles.is_editor` check inside `resolveCmsAccess`).
+ * 1. Sanity Visual Editing preview-mode detection. Sets
+ *    Astro.locals.sanityPreview = true when the request carries the
+ *    `pi-sanity-preview` cookie OR a valid `?sanity-preview=<secret>`
+ *    query param. Adapter code reads this and switches to the stega-
+ *    encoded preview client.
  *
- * Legacy fallback (Phase 1 QA): when `PI_ADMIN_LEGACY_GATE=1` is set, the
- * transitional `?admin=1` / `pi_admin=1` cookie seam still grants access.
- * This lets local development keep working without a real Supabase session
- * during the cutover, but is intentionally off by default.
+ * 2. Hybrid admin gate. When PI_ADMIN_HYBRID=1, /admin/* and
+ *    /admin/api/* require a valid Supabase session + editor flag.
  */
 export const onRequest = defineMiddleware(async (context, next) => {
+  // ── Preview-mode detection (runs on every request, cheap) ────────────
+  const previewSecret =
+    (import.meta as any).env?.SANITY_PREVIEW_SECRET ?? process.env.SANITY_PREVIEW_SECRET;
+  const queryPreview = context.url.searchParams.get('sanity-preview');
+  const cookiePreview = context.cookies.get('pi-sanity-preview')?.value === '1';
+  const isPreviewRequest =
+    cookiePreview || (!!queryPreview && !!previewSecret && queryPreview === previewSecret);
+
+  (context.locals as Record<string, unknown>).sanityPreview = isPreviewRequest;
+
+  // Set the cookie if entering preview via query param so subsequent
+  // navigation stays in preview mode. Short-lived (1 hour) so it
+  // doesn't accidentally persist past an editing session.
+  if (!cookiePreview && queryPreview && previewSecret && queryPreview === previewSecret) {
+    context.cookies.set('pi-sanity-preview', '1', {
+      path: '/',
+      maxAge: 3600,
+      httpOnly: false,
+      sameSite: 'none',
+      secure: true,
+    });
+  }
+
+  // ── Admin gate ───────────────────────────────────────────────────────
   if (!isAdminHybridEnabled()) {
     return next();
   }
@@ -31,24 +55,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const isAdminRoute = isAdminPath(pathname) || isAdminApiPath(pathname);
   const isLogin = isAdminLoginPath(pathname);
 
-  // Cheap exit: nothing here we have to gate.
   if (!isAdminRoute && !isLogin) {
     return next();
   }
 
   const cookieHeader = context.request.headers.get('cookie');
-
-  // Real session validation by default. We only run the (slightly more
-  // expensive) Supabase calls for routes that actually care.
   const access = await resolveCmsAccess(cookieHeader);
   let allowed = access.ok;
 
-  // Optional legacy fallback for Phase 1 QA.
   if (!allowed && isAdminLegacyGateEnabled()) {
     allowed = canAccessAdmin(context.url, cookieHeader);
   }
 
-  // If they're already signed in and hit the login page, send them home.
   if (isLogin && allowed) {
     return context.redirect('/admin/');
   }

--- a/next/src/pages/api/preview/disable.ts
+++ b/next/src/pages/api/preview/disable.ts
@@ -1,0 +1,13 @@
+/**
+ * Disable Sanity preview mode for the requesting browser session.
+ * Clears the `pi-sanity-preview` cookie.
+ */
+import type {APIRoute} from 'astro'
+
+export const prerender = false
+
+export const GET: APIRoute = ({cookies, redirect, url}) => {
+  cookies.delete('pi-sanity-preview', {path: '/'})
+  const slug = url.searchParams.get('slug') || '/'
+  return redirect(slug)
+}

--- a/next/src/pages/api/preview/enable.ts
+++ b/next/src/pages/api/preview/enable.ts
@@ -1,0 +1,27 @@
+/**
+ * Enable Sanity preview mode for the requesting browser session.
+ * Called by Studio's Presentation tool on iframe load. Verifies the
+ * `secret` query param against SANITY_PREVIEW_SECRET, then sets a
+ * 1-hour cookie so subsequent navigation stays in preview mode.
+ */
+import type {APIRoute} from 'astro'
+
+export const prerender = false
+
+export const GET: APIRoute = ({url, cookies, redirect}) => {
+  const expected =
+    (import.meta as any).env?.SANITY_PREVIEW_SECRET ?? process.env.SANITY_PREVIEW_SECRET
+  const provided = url.searchParams.get('secret')
+  if (!expected || provided !== expected) {
+    return new Response('Invalid preview secret.', {status: 401})
+  }
+  cookies.set('pi-sanity-preview', '1', {
+    path: '/',
+    maxAge: 3600,
+    httpOnly: false,
+    sameSite: 'none',
+    secure: true,
+  })
+  const slug = url.searchParams.get('slug') || '/'
+  return redirect(slug)
+}

--- a/next/src/pages/eat/[slug].astro
+++ b/next/src/pages/eat/[slug].astro
@@ -26,8 +26,13 @@ const slug = routeSlug(venue);
 // Sanity-sourced equivalent. If Sanity returns null (doc unpublished or
 // missing), the JSON-loaded venue stays in place. Related/article/event
 // lookups below remain on JSON until their own phase migrates.
+// Preview mode: when an editor opens the page inside Studio's
+// Presentation iframe, Astro.locals.sanityPreview is true (set by
+// middleware) and the adapter switches to the stega-encoded preview
+// client so the Visual Editing overlay can attach clickable hotspots.
+const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
 if (sanityReadEnabled('venues')) {
-  const sanityVenue = await fetchVenueFromSanity(slug);
+  const sanityVenue = await fetchVenueFromSanity(slug, {preview: previewMode});
   if (sanityVenue) venue = sanityVenue as any;
 }
 

--- a/next/src/pages/stay/[slug].astro
+++ b/next/src/pages/stay/[slug].astro
@@ -23,8 +23,9 @@ let { venue } = Astro.props;
 const slug = routeSlug(venue);
 
 // Dual-read: swap focused venue for Sanity when flag is on.
+const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
 if (sanityReadEnabled('venues')) {
-  const sanityVenue = await fetchVenueFromSanity(slug);
+  const sanityVenue = await fetchVenueFromSanity(slug, {preview: previewMode});
   if (sanityVenue) venue = sanityVenue as any;
 }
 

--- a/next/src/pages/wine/[slug].astro
+++ b/next/src/pages/wine/[slug].astro
@@ -30,8 +30,9 @@ let { venue } = Astro.props;
 const slug = routeSlug(venue);
 
 // Dual-read: swap focused venue for Sanity when flag is on.
+const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
 if (sanityReadEnabled('venues')) {
-  const sanityVenue = await fetchVenueFromSanity(slug);
+  const sanityVenue = await fetchVenueFromSanity(slug, {preview: previewMode});
   if (sanityVenue) venue = sanityVenue as any;
 }
 

--- a/studio-peninsula-insider/sanity.config.ts
+++ b/studio-peninsula-insider/sanity.config.ts
@@ -1,7 +1,10 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
+import {presentationTool, defineLocations} from 'sanity/presentation'
 import {schemaTypes} from './schemaTypes'
+
+const PREVIEW_URL = 'https://peninsulainsider.com.au'
 
 export default defineConfig({
   name: 'default',
@@ -10,7 +13,120 @@ export default defineConfig({
   projectId: 'a062b30n',
   dataset: 'production',
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [
+    structureTool(),
+
+    /**
+     * Presentation tool — Visual Editing.
+     * Opens the live site in a split-screen iframe alongside the
+     * document form. Editors click on rendered elements; the
+     * corresponding field opens for editing.
+     */
+    presentationTool({
+      previewUrl: {
+        origin: PREVIEW_URL,
+        preview: '/',
+        previewMode: {
+          enable: '/api/preview/enable',
+          disable: '/api/preview/disable',
+        },
+      },
+      resolve: {
+        locations: {
+          venue: defineLocations({
+            select: {name: 'name', slug: 'slug.current', type: 'type'},
+            resolve: (doc) => {
+              const slug = doc?.slug
+              if (!slug) return null
+              const type = String(doc?.type ?? '')
+              const wineTypes = ['winery', 'producer', 'brewery', 'distillery']
+              const stayTypes = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa']
+              const prefix = wineTypes.includes(type)
+                ? '/wine'
+                : stayTypes.includes(type)
+                  ? '/stay'
+                  : '/eat'
+              return {locations: [{title: doc?.name ?? slug, href: `${prefix}/${slug}/`}]}
+            },
+          }),
+          place: defineLocations({
+            select: {name: 'name', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.name ?? doc.slug, href: `/places/${doc.slug}/`}]}
+                : null,
+          }),
+          article: defineLocations({
+            select: {title: 'title', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.title ?? doc.slug, href: `/journal/${doc.slug}/`}]}
+                : null,
+          }),
+          experience: defineLocations({
+            select: {name: 'name', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.name ?? doc.slug, href: `/explore/${doc.slug}/`}]}
+                : null,
+          }),
+          itinerary: defineLocations({
+            select: {title: 'title', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.title ?? doc.slug, href: `/plans/${doc.slug}/`}]}
+                : null,
+          }),
+          event: defineLocations({
+            select: {title: 'title', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.title ?? doc.slug, href: `/whats-on/${doc.slug}/`}]}
+                : null,
+          }),
+          tour: defineLocations({
+            select: {name: 'name', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.name ?? doc.slug, href: `/tour/${doc.slug}/`}]}
+                : null,
+          }),
+          tourOperator: defineLocations({
+            select: {name: 'name', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.name ?? doc.slug, href: `/tour/operators/${doc.slug}/`}]}
+                : null,
+          }),
+          tourPackage: defineLocations({
+            select: {name: 'name', slug: 'slug.current'},
+            resolve: (doc) =>
+              doc?.slug
+                ? {locations: [{title: doc?.name ?? doc.slug, href: `/tour-packages/${doc.slug}/`}]}
+                : null,
+          }),
+          homepageCover: defineLocations({
+            resolve: () => ({locations: [{title: 'Homepage', href: '/'}]}),
+          }),
+          megaRail: defineLocations({
+            resolve: () => ({locations: [{title: 'Homepage', href: '/'}]}),
+          }),
+          siteSettings: defineLocations({
+            resolve: () => ({locations: [{title: 'Homepage', href: '/'}]}),
+          }),
+          pageHero: defineLocations({
+            select: {pathSlug: 'pathSlug'},
+            resolve: (doc) =>
+              doc?.pathSlug
+                ? {locations: [{title: doc.pathSlug, href: `/${doc.pathSlug}/`}]}
+                : null,
+          }),
+        },
+      },
+    }),
+
+    visionTool(),
+  ],
 
   schema: {
     types: schemaTypes,


### PR DESCRIPTION
## Summary
- Wires Sanity's Presentation tool + `@sanity/visual-editing` overlay to the live Astro site so editors can click any rendered element and jump straight to the field in Studio.
- Adds a stega-encoded preview client (`sanityPreviewClient`) and a `getSanityReadClient(preview)` helper; venues already opt-in via the dual-read path.
- Adds `/api/preview/enable` + `/api/preview/disable` cookie toggle routes, middleware preview detection (`Astro.locals.sanityPreview`), and a `SanityVisualEditing.astro` overlay that only mounts under preview.
- Studio config now declares `presentationTool` with `defineLocations` for every doc type, pointing at `peninsulainsider.com.au` with `previewMode.enable: '/api/preview/enable'`.

## Post-merge
1. `SANITY_PREVIEW_SECRET` already set in Vercel (prod/preview/dev).
2. Studio already deployed (`https://peninsula-insider.sanity.studio/`).
3. Verify: open Studio → Presentation → load `/wine/pt-leo-estate/` → click a field → confirm jump to the right doc/field.

## Test plan
- [ ] Production deploy green on Vercel
- [ ] `/api/preview/enable?secret=...&slug=/wine/pt-leo-estate/` sets cookie + redirects
- [ ] Presentation tool overlay renders click hotspots on a venue page
- [ ] Non-preview public hits return clean HTML (no stega markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)