### PR TITLE
fix(cms): correct @sanity/visual-editing import path

### DIFF
--- a/next/src/components/admin/SanityVisualEditing.astro
+++ b/next/src/components/admin/SanityVisualEditing.astro
@@ -23,7 +23,7 @@ const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === tr
   <script>
     // Lazy-import keeps the visual-editing bundle off any page that
     // isn't actually rendering inside Studio.
-    import('@sanity/visual-editing/astro').then(({ enableVisualEditing }) => {
+    import('@sanity/visual-editing').then(({ enableVisualEditing }) => {
       enableVisualEditing({ zIndex: 9999 });
     });
   </script>


### PR DESCRIPTION
Hybrid SSR build was failing because `@sanity/visual-editing/astro` subpath doesn't exist. Root import is what the package documents. Unblocks PI_ADMIN_HYBRID=1 production deploy.