### PR TITLE
feat(cms): extend Sanity preview passthrough to all content pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ ops/config/
 ops/tokens/
 ops/data/
 ops/logs/
+.claude/

--- a/next/src/lib/sanity/article-adapter.ts
+++ b/next/src/lib/sanity/article-adapter.ts
@@ -8,7 +8,7 @@
  * to a Portable Text renderer for the body. All other fields render
  * via the existing template paths.
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
 
 const img = `{ asset->{_id}, alt, credit, caption, license }`
@@ -83,8 +83,8 @@ export interface AdaptedArticle {
   }
 }
 
-export async function fetchArticleFromSanity(slug: string): Promise<AdaptedArticle | null> {
-  const d: any = await sanityClient.fetch(articleBySlugQuery, {slug})
+export async function fetchArticleFromSanity(slug: string, opts: {preview?: boolean} = {}): Promise<AdaptedArticle | null> {
+  const d: any = await getSanityReadClient(opts.preview ?? false).fetch(articleBySlugQuery, {slug})
   if (!d) return null
 
   const refs = (slugs: string[] | null | undefined, c: any) =>

--- a/next/src/lib/sanity/event-adapter.ts
+++ b/next/src/lib/sanity/event-adapter.ts
@@ -7,7 +7,7 @@
  * (the existing template renders it as plain prose; Portable Text
  * rendering for events isn't needed in the initial migration).
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
 
 const img = `{ asset->{_id}, alt, credit, caption, license }`
@@ -54,8 +54,8 @@ function imageOrFallback(image: SanityImageRef, fallbackAlt: string) {
   }
 }
 
-export async function fetchEventFromSanity(slug: string) {
-  const d: any = await sanityClient.fetch(eventBySlugQuery, {slug})
+export async function fetchEventFromSanity(slug: string, opts: {preview?: boolean} = {}) {
+  const d: any = await getSanityReadClient(opts.preview ?? false).fetch(eventBySlugQuery, {slug})
   if (!d) return null
   return {
     id: d.slug,

--- a/next/src/lib/sanity/itinerary-adapter.ts
+++ b/next/src/lib/sanity/itinerary-adapter.ts
@@ -5,7 +5,7 @@
  * itinerary branch consumes it unchanged. Venue references are unpacked
  * from Sanity refs back into legacy {id, collection: 'venues'} shape.
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
 
 const imageProjection = `{ asset->{_id}, alt, credit, caption, license }`
@@ -103,8 +103,8 @@ function imageRefToAstroShape(img: SanityImageRef, fallbackAlt: string) {
   }
 }
 
-export async function fetchItineraryFromSanity(slug: string) {
-  const doc = (await sanityClient.fetch(itineraryBySlugQuery, {slug})) as SanityItinerary | null
+export async function fetchItineraryFromSanity(slug: string, opts: {preview?: boolean} = {}) {
+  const doc = (await getSanityReadClient(opts.preview ?? false).fetch(itineraryBySlugQuery, {slug})) as SanityItinerary | null
   if (!doc) return null
   return {
     id: doc.slug,

--- a/next/src/lib/sanity/phase5-adapters.ts
+++ b/next/src/lib/sanity/phase5-adapters.ts
@@ -7,7 +7,7 @@
  * map heroImage to a Sanity CDN URL, return a `{id, data}` envelope so
  * existing Astro pages consume it without changes.
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
 
 const img = `{ asset->{_id}, alt, credit, caption, license }`
@@ -55,8 +55,8 @@ const experienceQuery = `*[_type == "experience" && slug.current == $slug][0]{
   heroImage ${img}
 }`
 
-export async function fetchExperienceFromSanity(slug: string) {
-  const d: any = await sanityClient.fetch(experienceQuery, {slug})
+export async function fetchExperienceFromSanity(slug: string, opts: {preview?: boolean} = {}) {
+  const d: any = await getSanityReadClient(opts.preview ?? false).fetch(experienceQuery, {slug})
   if (!d) return null
   return {
     id: d.slug,
@@ -103,8 +103,8 @@ const tourOperatorQuery = `*[_type == "tourOperator" && slug.current == $slug][0
   heroImage ${img}
 }`
 
-export async function fetchTourOperatorFromSanity(slug: string) {
-  const d: any = await sanityClient.fetch(tourOperatorQuery, {slug})
+export async function fetchTourOperatorFromSanity(slug: string, opts: {preview?: boolean} = {}) {
+  const d: any = await getSanityReadClient(opts.preview ?? false).fetch(tourOperatorQuery, {slug})
   if (!d) return null
   return {
     id: d.slug,
@@ -144,8 +144,8 @@ const tourQuery = `*[_type == "tour" && slug.current == $slug][0]{
   heroImage ${img}
 }`
 
-export async function fetchTourFromSanity(slug: string) {
-  const d: any = await sanityClient.fetch(tourQuery, {slug})
+export async function fetchTourFromSanity(slug: string, opts: {preview?: boolean} = {}) {
+  const d: any = await getSanityReadClient(opts.preview ?? false).fetch(tourQuery, {slug})
   if (!d) return null
   return {
     id: d.slug,
@@ -198,8 +198,8 @@ const tourPackageQuery = `*[_type == "tourPackage" && slug.current == $slug][0]{
   heroImage ${img}
 }`
 
-export async function fetchTourPackageFromSanity(slug: string) {
-  const d: any = await sanityClient.fetch(tourPackageQuery, {slug})
+export async function fetchTourPackageFromSanity(slug: string, opts: {preview?: boolean} = {}) {
+  const d: any = await getSanityReadClient(opts.preview ?? false).fetch(tourPackageQuery, {slug})
   if (!d) return null
   return {
     id: d.slug,

--- a/next/src/lib/sanity/place-adapter.ts
+++ b/next/src/lib/sanity/place-adapter.ts
@@ -4,7 +4,7 @@
  * Mirrors the existing Astro content-collection place shape so
  * PlaceDetailTemplate.astro consumes it unchanged.
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
 
 const imageProjection = `{ asset->{_id}, alt, credit, caption, license }`
@@ -139,8 +139,8 @@ function adapt(doc: SanityPlace): AdaptedPlace {
   }
 }
 
-export async function fetchPlaceFromSanity(slug: string): Promise<AdaptedPlace | null> {
-  const doc = (await sanityClient.fetch(placeBySlugQuery, {slug})) as SanityPlace | null
+export async function fetchPlaceFromSanity(slug: string, opts: {preview?: boolean} = {}): Promise<AdaptedPlace | null> {
+  const doc = (await getSanityReadClient(opts.preview ?? false).fetch(placeBySlugQuery, {slug})) as SanityPlace | null
   if (!doc) return null
   return adapt(doc)
 }

--- a/next/src/pages/eat/[slug].astro
+++ b/next/src/pages/eat/[slug].astro
@@ -121,7 +121,6 @@ const venueSchema = {
   ...(venue.data.phone ? { telephone: venue.data.phone } : {}),
   // priceRange intentionally omitted (BRAND-PI 2026-05-15: no pricing on site).
 };
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/explore/[slug].astro
+++ b/next/src/pages/explore/[slug].astro
@@ -56,7 +56,9 @@ let { experience } = Astro.props;
 
 // Dual-read: swap for Sanity when flag is on.
 if (sanityReadEnabled('experiences')) {
-  const sanityExp = await fetchExperienceFromSanity(routeSlug(experience));
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityExp = await fetchExperienceFromSanity(routeSlug(experience), {preview: previewMode});
   if (sanityExp) experience = sanityExp as any;
 }
 const allExperiences = await getCollection('experiences');
@@ -157,7 +159,6 @@ if (experience.data.type === 'golf-course') {
     (experienceSchema as any).publicAccess = golfData.access === 'public';
   }
 }
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -36,7 +36,9 @@ let { article } = Astro.props;
 // below instead of Astro's render()).
 let sanityBody: Array<Record<string, unknown>> | null = null;
 if (sanityReadEnabled('articles')) {
-  const sanityArt = await fetchArticleFromSanity(routeSlug(article));
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityArt = await fetchArticleFromSanity(routeSlug(article), {preview: previewMode});
   if (sanityArt) {
     article = sanityArt as any;
     sanityBody = sanityArt.body;
@@ -218,7 +220,6 @@ const faqSchema = article.data.faq && article.data.faq.length > 0 ? {
     acceptedAnswer: { '@type': 'Answer', text: answer },
   })),
 } : null;
-export const prerender = true;
 ---
 
 {ptwRedirectTo ? (

--- a/next/src/pages/places/[slug].astro
+++ b/next/src/pages/places/[slug].astro
@@ -20,7 +20,9 @@ let { place } = Astro.props;
 
 // Dual-read: swap focused place for Sanity when flag is on.
 if (sanityReadEnabled('places')) {
-  const sanityPlace = await fetchPlaceFromSanity(routeSlug(place));
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityPlace = await fetchPlaceFromSanity(routeSlug(place), {preview: previewMode});
   if (sanityPlace) place = sanityPlace as any;
 }
 const allVenues = await getCollection('venues');
@@ -324,7 +326,6 @@ const placeSchema = {
   },
   url: canonical,
 };
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/plans/[slug].astro
+++ b/next/src/pages/plans/[slug].astro
@@ -81,7 +81,9 @@ let { itinerary, articleData } = Astro.props;
 
 // Dual-read for itinerary branch (article branch handled in journal flow).
 if (articleData == null && itinerary && sanityReadEnabled('itineraries')) {
-  const sanityItn = await fetchItineraryFromSanity(routeSlug(itinerary));
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityItn = await fetchItineraryFromSanity(routeSlug(itinerary), {preview: previewMode});
   if (sanityItn) itinerary = sanityItn as any;
 }
 
@@ -334,7 +336,6 @@ const canonical = data ? `https://peninsulainsider.com.au/plans/${slug}/` : '';
 const ogImage = data
   ? (data.heroImage?.src && !data.heroImage.src.includes('placeholder') ? data.heroImage.src : '/images/sourced/home-cover.webp')
   : '';
-export const prerender = true;
 ---
 
 {isArticle ? (

--- a/next/src/pages/stay/[slug].astro
+++ b/next/src/pages/stay/[slug].astro
@@ -89,7 +89,6 @@ const venueSchema = {
   ...(venue.data.phone ? { telephone: venue.data.phone } : {}),
   // priceRange intentionally omitted (BRAND-PI 2026-05-15: no pricing on site).
 };
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/tour-packages/[slug].astro
+++ b/next/src/pages/tour-packages/[slug].astro
@@ -24,7 +24,9 @@ const slug = pkg.id ?? pkg.data.slug;
 
 // Dual-read.
 if (sanityReadEnabled('tour-packages')) {
-  const sanityPkg = await fetchTourPackageFromSanity(slug);
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityPkg = await fetchTourPackageFromSanity(slug, {preview: previewMode});
   if (sanityPkg) pkg = sanityPkg as any;
 }
 const data = pkg.data;
@@ -70,7 +72,6 @@ const breadcrumbItems = [
   { label: 'Tour Packages', href: '/tour-packages/' },
   { label: data.name },
 ];
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/tour/[slug].astro
+++ b/next/src/pages/tour/[slug].astro
@@ -22,7 +22,9 @@ let { tour } = Astro.props;
 // Dual-read.
 if (sanityReadEnabled('tours')) {
   const slug = tour.id ?? tour.data.slug;
-  const sanityTour = await fetchTourFromSanity(slug);
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityTour = await fetchTourFromSanity(slug, {preview: previewMode});
   if (sanityTour) tour = sanityTour as any;
 }
 const data = tour.data;
@@ -86,7 +88,6 @@ const breadcrumbItems = [
   { label: 'Tours', href: '/tour/' },
   { label: data.name },
 ];
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/tour/operators/[slug].astro
+++ b/next/src/pages/tour/operators/[slug].astro
@@ -22,7 +22,9 @@ const slug = operator.id ?? operator.data.slug;
 
 // Dual-read.
 if (sanityReadEnabled('tour-operators')) {
-  const sanityOp = await fetchTourOperatorFromSanity(slug);
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityOp = await fetchTourOperatorFromSanity(slug, {preview: previewMode});
   if (sanityOp) operator = sanityOp as any;
 }
 const data = operator.data;
@@ -49,7 +51,6 @@ const breadcrumbItems = [
   { label: 'Operators', href: '/tour/operators/' },
   { label: data.name },
 ];
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/whats-on/[slug].astro
+++ b/next/src/pages/whats-on/[slug].astro
@@ -40,7 +40,9 @@ let { event } = Astro.props;
 
 // Dual-read.
 if (sanityReadEnabled('events')) {
-  const sanityEvent = await fetchEventFromSanity(routeSlug(event));
+  const previewMode = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+
+  const sanityEvent = await fetchEventFromSanity(routeSlug(event), {preview: previewMode});
   if (sanityEvent) event = sanityEvent as any;
 }
 const place = event.data.place ? await getEntry(event.data.place).catch(() => null) : null;
@@ -83,7 +85,6 @@ const breadcrumbItems = [
   { label: "What's On", href: '/whats-on' },
   { label: event.data.title },
 ];
-export const prerender = true;
 ---
 
 <BaseLayout

--- a/next/src/pages/wine/[slug].astro
+++ b/next/src/pages/wine/[slug].astro
@@ -91,7 +91,6 @@ schemas.push(
     { name: venue.data.name },
   ])
 );
-export const prerender = true;
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary
- Drop `prerender=true` on 11 entity `[slug]` pages (eat, wine, stay, whats-on, tour, tour/operators, tour-packages, plans, places, journal, explore)
- Adapters now accept `{preview}` and swap to the stega-encoded preview client
- Pages pass `{preview: Astro.locals.sanityPreview}` to their adapters

## Why
Prerendered pages skip middleware, so the `pi-sanity-preview` cookie was ignored everywhere except the few SSR carve-outs. This was the blocker behind 'Unable to connect' in Studio Presentation.

## Trade-off
Content pages move from static to SSR. Public traffic stays fast via Vercel edge cache (cookie variants are minor); preview cookie pulls fresh stega-encoded HTML for editors.

## After merge
Sanity Presentation click-to-edit lights up on every Sanity-backed entity page, not just venues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)