### PR TITLE
fix(cms): use trailing-slash preview endpoints in Studio config

### DIFF
--- a/studio-peninsula-insider/sanity.config.ts
+++ b/studio-peninsula-insider/sanity.config.ts
@@ -27,8 +27,13 @@ export default defineConfig({
         origin: PREVIEW_URL,
         preview: '/',
         previewMode: {
-          enable: '/api/preview/enable',
-          disable: '/api/preview/disable',
+          // Trailing slashes are mandatory: Vercel does a 308 trailing-slash
+          // redirect on the bare path, and the 308 response strips the
+          // Set-Cookie header. Without the slash, the preview cookie never
+          // lands and the Visual Editing overlay fails with "Unable to
+          // connect" because middleware never sees sanityPreview=true.
+          enable: '/api/preview/enable/',
+          disable: '/api/preview/disable/',
         },
       },
       resolve: {


### PR DESCRIPTION
## Summary
- Visual Editing overlay was failing with "Unable to connect" because Vercel 308-redirects /api/preview/enable to /api/preview/enable/ and strips Set-Cookie on the 308. Cookie never lands → middleware never flips sanityPreview → overlay can't open its channel.
- Fix: pin Studio's previewMode endpoints to the trailing-slash variants so the handler executes on the first hop.

## Test plan
- [ ] Deploy Studio (this is a Studio-config change, not Astro)
- [ ] Open Presentation in Studio → confirm overlay loads without the "Unable to connect" dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)