### PR TITLE
feat(cms): add /preview/ SSR landing for Sanity Presentation

### DIFF
--- a/next/src/pages/preview/index.astro
+++ b/next/src/pages/preview/index.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Sanity Presentation default landing.
+ *
+ * The Presentation tool opens this URL when no document is selected. It
+ * must be SSR (not statically prerendered) so the Visual Editing
+ * channel handshake can complete — the BaseLayout's
+ * <SanityVisualEditing /> overlay only mounts when
+ * Astro.locals.sanityPreview is true, which requires the request to
+ * hit the server (cookie read in middleware).
+ *
+ * Without this page Presentation lands on `/` (statically prerendered,
+ * no overlay script in the HTML) and the iframe shows "Unable to
+ * connect, check the browser console for more information."
+ *
+ * Editors don't see this for long — picking any document on the left
+ * navigates the iframe to `/preview/<section>/<slug>/`.
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export const prerender = false;
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+---
+
+<BaseLayout
+  title="Preview · Peninsula Insider"
+  description="Sanity Presentation preview landing page."
+  section="preview"
+  canonical="https://peninsulainsider.com.au/preview/"
+  noindex={true}
+>
+  <main class="container" style="padding: 4rem 1.5rem; max-width: 56rem;">
+    <p class="label label--accent" style="margin-bottom: 0.5rem;">Sanity Presentation</p>
+    <h1 style="font-family: var(--font-display); font-size: clamp(2rem, 4vw, 3rem); line-height: 1.1; margin: 0 0 1rem;">
+      Pick a document to preview.
+    </h1>
+    <p style="font-size: 1.125rem; color: var(--color-ink-muted); max-width: 38rem;">
+      Select any document from the list on the left. This pane will jump to
+      its <code>/preview/&lt;section&gt;/&lt;slug&gt;/</code> route and the
+      Visual Editing overlay will activate — click any field on the
+      rendered page to open it in the editor.
+    </p>
+    {!isPreview && (
+      <p style="margin-top: 2rem; padding: 1rem; border-left: 3px solid #d97757; background: #fff7ed; color: #7c2d12; font-size: 0.95rem;">
+        <strong>Preview cookie not detected.</strong> If you arrived here
+        directly, click the <em>Refresh</em> button in the Presentation
+        toolbar, or open this page from Sanity Studio.
+      </p>
+    )}
+  </main>
+</BaseLayout>

--- a/studio-peninsula-insider/sanity.config.ts
+++ b/studio-peninsula-insider/sanity.config.ts
@@ -25,7 +25,11 @@ export default defineConfig({
     presentationTool({
       previewUrl: {
         origin: PREVIEW_URL,
-        preview: '/',
+        // SSR landing (next/src/pages/preview/index.astro). Must be a
+        // /preview/ route so the Visual Editing overlay mounts on the
+        // default-no-doc-selected iframe — public paths like '/' are
+        // statically prerendered and can't host the channel handshake.
+        preview: '/preview/',
         previewMode: {
           // Trailing slashes are mandatory: Vercel does a 308 trailing-slash
           // redirect on the bare path, and the 308 response strips the


### PR DESCRIPTION
## Summary
- Adds `next/src/pages/preview/index.astro` — SSR landing (prerender false)
- Switches Studio's `previewUrl.preview` from `/` to `/preview/`
- Fixes the \"Unable to connect\" error when Presentation opens with no document selected

## Why
Per the #177 architecture, only `/preview/<section>/<slug>/` routes are SSR with stega encoding. Public URLs (`/`, `/eat/`, `/places/...`) are statically prerendered for cache/speed. So when Presentation lands on the default `previewUrl.preview = '/'`, the static HTML has no Visual Editing script, the channel handshake never completes, and the iframe shows the yellow \"Unable to connect\" overlay.

Replacing the default landing with a tiny SSR page under `/preview/` keeps the public homepage prerendered while giving Presentation a valid handshake target.

## Test plan
- [ ] After deploy, open Studio → Presentation with no document selected
- [ ] iframe should land on `/preview/` and show \"Pick a document to preview\" with no overlay error
- [ ] Click any venue/place/article in the left rail → iframe navigates to `/preview/<section>/<slug>/` and Visual Editing overlay activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)