### PR TITLE
ops(cms): auto-deploy Sanity Studio on main changes

### DIFF
--- a/.github/workflows/sanity-studio-deploy.yml
+++ b/.github/workflows/sanity-studio-deploy.yml
@@ -1,0 +1,49 @@
+name: Sanity Studio deploy
+
+# Auto-deploy the hosted Studio at peninsula-insider.sanity.studio when
+# any file under studio-peninsula-insider/ changes on main. Previously
+# this required `npx sanity deploy` from a developer's laptop after
+# every Studio config / schema edit, which meant changes silently
+# drifted from the deployed Studio until someone remembered.
+#
+# Requires repo secret SANITY_DEPLOY_TOKEN — a token created in
+# manage.sanity.io with role "Deploy Studio" (or Administrator).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'studio-peninsula-insider/**'
+      - '.github/workflows/sanity-studio-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sanity-studio-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: studio-peninsula-insider
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: studio-peninsula-insider/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Deploy Studio
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_DEPLOY_TOKEN }}
+        run: npx sanity deploy


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sanity-studio-deploy.yml`
- Triggers on push to main when files under `studio-peninsula-insider/**` change (plus manual dispatch)
- Runs `npx sanity deploy` headlessly using `SANITY_AUTH_TOKEN` from `SANITY_DEPLOY_TOKEN` repo secret

## Why
Until now, the hosted Studio at `peninsula-insider.sanity.studio` only updated when someone ran `npx sanity deploy` from their laptop. This caused silent drift — e.g. PR #178 fixed the trailing-slash bug in `sanity.config.ts` but the fix never reached the hosted Studio until a manual deploy ran today.

## Setup required
Before merging, add repo secret:
- Name: `SANITY_DEPLOY_TOKEN`
- Value: token from manage.sanity.io → project `a062b30n` → API → Tokens → Add API token, role **Deploy Studio**

## Test plan
- [ ] Add the secret
- [ ] Merge
- [ ] Trigger via Actions → Sanity Studio deploy → Run workflow (no Studio change needed; should no-op-deploy successfully)
- [ ] Future Studio edits auto-deploy on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)