### PR TITLE
feat(cms): preview routes for singletons (homepageCover, megaRail, pageHero)

### DIFF
--- a/next/src/components/SectionHero.astro
+++ b/next/src/components/SectionHero.astro
@@ -48,8 +48,9 @@ let resolvedDek = dek;
 let resolvedHeroImage = heroImage;
 
 const isPageEntity = entityType === 'page' && !!entitySlug;
-if (isPageEntity && sanityReadEnabled('page-level')) {
-  const ph = await fetchPageHeroFromSanity(entitySlug!);
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+if (isPageEntity && (isPreview || sanityReadEnabled('page-level'))) {
+  const ph = await fetchPageHeroFromSanity(entitySlug!, {preview: isPreview});
   if (ph) {
     if (ph.title) resolvedTitle = ph.title;
     if (ph.dek) resolvedDek = ph.dek;

--- a/next/src/components/SubpageHero.astro
+++ b/next/src/components/SubpageHero.astro
@@ -59,8 +59,9 @@ let resolvedImageSrc = heroImage;
 let resolvedImageAlt = imageAlt;
 
 const isPageEntity = entityType === 'page' && !!entitySlug;
-if (isPageEntity && sanityReadEnabled('page-level')) {
-  const ph = await fetchPageHeroFromSanity(entitySlug!);
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+if (isPageEntity && (isPreview || sanityReadEnabled('page-level'))) {
+  const ph = await fetchPageHeroFromSanity(entitySlug!, {preview: isPreview});
   if (ph) {
     if (ph.title) resolvedTitle = ph.title;
     if (ph.imageSrc) {

--- a/next/src/components/v4/V4MegaRail.astro
+++ b/next/src/components/v4/V4MegaRail.astro
@@ -28,8 +28,9 @@ const { rail, pillarKey } = Astro.props;
 let imageSrc = rail.image;
 let imageAlt = rail.imageAlt;
 
-if (sanityReadEnabled('page-level')) {
-  const entries = await fetchMegaRailFromSanity();
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+if (isPreview || sanityReadEnabled('page-level')) {
+  const entries = await fetchMegaRailFromSanity({preview: isPreview});
   const entry = entries?.find((e) => e.key === pillarKey);
   if (entry?.imageSrc) {
     imageSrc = entry.imageSrc;

--- a/next/src/lib/sanity/singletons-adapter.ts
+++ b/next/src/lib/sanity/singletons-adapter.ts
@@ -6,8 +6,10 @@
  *   - siteSettings   → drives masthead label, edition, footer links
  *   - pageHero(slug) → drives the SubpageHero override for a given hub
  */
-import {sanityClient} from './client'
+import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
+
+type FetchOpts = {preview?: boolean}
 
 const img = `{ asset->{_id}, alt, credit, caption, license }`
 
@@ -48,12 +50,12 @@ export interface HomepageCoverScene {
   primaryLabel: string
 }
 
-export async function fetchHomepageCoverFromSanity(): Promise<{
+export async function fetchHomepageCoverFromSanity(opts: FetchOpts = {}): Promise<{
   scenes: HomepageCoverScene[]
   activeIndex: number
   coverDate: string | null
 } | null> {
-  const d: any = await sanityClient.fetch(homepageCoverQuery)
+  const d: any = await getSanityReadClient(opts.preview).fetch(homepageCoverQuery)
   if (!d?.scenes?.length) return null
   return {
     scenes: d.scenes.map((s: any) => {
@@ -94,8 +96,8 @@ export interface MegaRailEntry {
   imageAlt?: string
 }
 
-export async function fetchMegaRailFromSanity(): Promise<MegaRailEntry[] | null> {
-  const d: any = await sanityClient.fetch(megaRailQuery)
+export async function fetchMegaRailFromSanity(opts: FetchOpts = {}): Promise<MegaRailEntry[] | null> {
+  const d: any = await getSanityReadClient(opts.preview).fetch(megaRailQuery)
   if (!d?.entries?.length) return null
   return d.entries.map((e: any) => {
     if (!e.image?.asset) return {key: e.key, label: e.label, href: e.href, eyebrow: e.eyebrow}
@@ -128,8 +130,8 @@ export interface SiteSettings {
   social: {instagram?: string; facebook?: string; twitter?: string}
 }
 
-export async function fetchSiteSettingsFromSanity(): Promise<SiteSettings | null> {
-  const d: any = await sanityClient.fetch(siteSettingsQuery)
+export async function fetchSiteSettingsFromSanity(opts: FetchOpts = {}): Promise<SiteSettings | null> {
+  const d: any = await getSanityReadClient(opts.preview).fetch(siteSettingsQuery)
   if (!d) return null
   return {
     mastheadLabel: d.mastheadLabel ?? 'Peninsula Insider',
@@ -149,7 +151,7 @@ const pageHeroQuery = `*[_type == "pageHero" && pathSlug == $slug][0]{
   "image": image ${img}
 }`
 
-export async function fetchPageHeroFromSanity(slug: string): Promise<{
+export async function fetchPageHeroFromSanity(slug: string, opts: FetchOpts = {}): Promise<{
   title?: string
   eyebrow?: string
   category?: string
@@ -157,7 +159,7 @@ export async function fetchPageHeroFromSanity(slug: string): Promise<{
   imageSrc?: string
   imageAlt?: string
 } | null> {
-  const d: any = await sanityClient.fetch(pageHeroQuery, {slug})
+  const d: any = await getSanityReadClient(opts.preview).fetch(pageHeroQuery, {slug})
   if (!d) return null
   let imageSrc: string | undefined
   let imageAlt: string | undefined

--- a/next/src/pages/preview/hero/[...pathSlug].astro
+++ b/next/src/pages/preview/hero/[...pathSlug].astro
@@ -1,0 +1,81 @@
+---
+/**
+ * Sanity preview — pageHero singleton (any pathSlug).
+ *
+ * SSR route. Renders SectionHero for the given pathSlug with the
+ * Sanity preview client → stega encoded → click-to-edit from
+ * Presentation. The pageHero singleton's resolve.locations in
+ * sanity.config.ts routes here.
+ *
+ * 71 hub/subpage routes in the public site bind to pageHero. Rather
+ * than duplicating every public template as a /preview/ twin (huge
+ * maintenance burden, most of the template body is content-collection
+ * driven and unrelated to the hero), this single route renders just
+ * the hero block. Editors get an isolated preview of just the editable
+ * surface; the public layout is intact at the public URL.
+ */
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import SectionHero from '../../../components/SectionHero.astro';
+import {fetchPageHeroFromSanity} from '../../../lib/sanity/singletons-adapter';
+
+export const prerender = false;
+
+(Astro.locals as Record<string, unknown>).sanityPreview = true;
+
+const {pathSlug} = Astro.params as {pathSlug?: string};
+const slug = pathSlug ?? '';
+
+// Touch the fetcher once so a 404 short-circuits to a useful message
+// rather than rendering an empty hero with no clue what went wrong.
+const hero = slug ? await fetchPageHeroFromSanity(slug, {preview: true}) : null;
+
+const title = hero?.title ?? slug;
+const dek = hero?.dek ?? 'Sanity preview — click the title, dek, or image to edit.';
+const eyebrow = hero?.eyebrow ?? 'Peninsula Insider';
+---
+
+<BaseLayout
+  title={`Preview · ${title} hero`}
+  description="Sanity preview — pageHero singleton."
+  canonical={`https://peninsulainsider.com.au/preview/hero/${slug}/`}
+  noindex={true}
+>
+  {hero ? (
+    <SectionHero
+      eyebrow={eyebrow}
+      title={title}
+      dek={dek}
+      entitySlug={slug}
+      entityType="page"
+    />
+  ) : (
+    <main class="container" style="padding: 4rem 1.5rem; max-width: 56rem;">
+      <p class="label label--accent" style="margin-bottom: 0.5rem;">Sanity preview · pageHero</p>
+      <h1 style="font-family: var(--font-display); font-size: clamp(2rem, 4vw, 3rem); line-height: 1.1; margin: 0 0 1rem;">
+        No pageHero singleton for "{slug}"
+      </h1>
+      <p style="font-size: 1.125rem; color: var(--color-ink-muted); max-width: 38rem;">
+        Create a pageHero document with <code>pathSlug = {slug}</code> in
+        Studio, publish, then refresh this preview.
+      </p>
+    </main>
+  )}
+
+  <p class="preview-notice">
+    <strong>Preview only.</strong> Click the title, dek, or hero image to
+    edit. Mega rail (top of page) is also editable.
+    Public page lives at <a href={`/${slug}/`}>/{slug}/</a>.
+  </p>
+</BaseLayout>
+
+<style>
+  .preview-notice {
+    max-width: 56rem;
+    margin: 2rem auto;
+    padding: 1rem 1.5rem;
+    border-left: 3px solid #d97757;
+    background: #fff7ed;
+    color: #7c2d12;
+    font-size: .95rem;
+  }
+</style>

--- a/next/src/pages/preview/home/index.astro
+++ b/next/src/pages/preview/home/index.astro
@@ -1,0 +1,96 @@
+---
+/**
+ * Sanity preview — homepage cover singleton.
+ *
+ * SSR route that renders a focused preview of the homepageCover scene
+ * with stega encoding active, so editors can click the cover image /
+ * headline / dispatch text directly from Sanity Presentation.
+ *
+ * The mega menu rail also re-reads through the preview client when
+ * Astro.locals.sanityPreview is true (see V4MegaRail.astro), so the
+ * five pillar rail images on this preview load are also clickable —
+ * the entire homepage chrome is editable from this one route.
+ *
+ * The page deliberately renders ONLY the cover — replicating the full
+ * homepage body (content collections, weekend picker, shortlist, etc.)
+ * is out of scope for visual editing. Editors who want to preview the
+ * full public layout open `/` in a new tab.
+ */
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import {fetchHomepageCoverFromSanity} from '../../../lib/sanity/singletons-adapter';
+
+export const prerender = false;
+
+// Force preview mode on so BaseLayout's <SanityVisualEditing /> and the
+// V4MegaRail dual-read switch to the preview client + stega.
+(Astro.locals as Record<string, unknown>).sanityPreview = true;
+
+const cover = await fetchHomepageCoverFromSanity({preview: true});
+const scene = cover && cover.scenes.length > 0
+  ? cover.scenes[Math.min(cover.activeIndex, cover.scenes.length - 1)]
+  : null;
+---
+
+<BaseLayout
+  title="Preview · Homepage cover · Peninsula Insider"
+  description="Sanity preview — homepage cover singleton."
+  canonical="https://peninsulainsider.com.au/preview/home/"
+  noindex={true}
+>
+  <section
+    class="cover"
+    style={scene ? `background-image: linear-gradient(rgba(0,0,0,.3), rgba(0,0,0,.6)), url(${scene.image}); background-size: cover; background-position: center;` : ''}
+    aria-label="Homepage cover preview"
+  >
+    <div class="cover__inner">
+      {scene ? (
+        <>
+          <p class="cover__label">{scene.label} · {scene.hours}</p>
+          <h1 class="cover__headline">{scene.headline}</h1>
+          <p class="cover__dispatch">{scene.dispatch}</p>
+          {scene.primaryHref && (
+            <a class="cover__primary" href={scene.primaryHref}>{scene.primaryLabel}</a>
+          )}
+          <p class="cover__caption">{scene.caption}</p>
+        </>
+      ) : (
+        <p class="cover__empty">
+          No homepageCover singleton scene found. Add a scene in Studio,
+          publish, then refresh this preview.
+        </p>
+      )}
+    </div>
+  </section>
+
+  <p class="cover__notice">
+    <strong>Preview only.</strong> Click any element above to open it for
+    editing. The mega-menu rail (top of page) is also editable —
+    click any of its five rail images.
+  </p>
+</BaseLayout>
+
+<style>
+  .cover {
+    min-height: 70vh;
+    display: flex;
+    align-items: center;
+    color: white;
+    padding: 4rem 1.5rem;
+  }
+  .cover__inner { max-width: 56rem; margin: 0 auto; }
+  .cover__label { font-size: .9rem; letter-spacing: .08em; text-transform: uppercase; opacity: .8; margin: 0 0 1rem; }
+  .cover__headline { font-family: var(--font-display, Georgia, serif); font-size: clamp(2.5rem, 6vw, 4.5rem); line-height: 1.05; margin: 0 0 1.5rem; }
+  .cover__dispatch { font-size: 1.25rem; line-height: 1.5; margin: 0 0 1.5rem; max-width: 44rem; }
+  .cover__primary { display: inline-block; padding: .75rem 1.5rem; background: white; color: black; text-decoration: none; font-weight: 600; border-radius: 999px; margin-bottom: 1.5rem; }
+  .cover__caption { font-size: .9rem; opacity: .8; margin: 0; }
+  .cover__empty { font-size: 1.125rem; opacity: .9; padding: 2rem; background: rgba(0,0,0,.4); border-radius: 8px; }
+  .cover__notice {
+    max-width: 56rem;
+    margin: 2rem auto;
+    padding: 1rem 1.5rem;
+    border-left: 3px solid #d97757;
+    background: #fff7ed;
+    color: #7c2d12;
+    font-size: .95rem;
+  }
+</style>

--- a/studio-peninsula-insider/sanity.config.ts
+++ b/studio-peninsula-insider/sanity.config.ts
@@ -117,20 +117,25 @@ export default defineConfig({
                 ? {locations: [{title: doc?.name ?? doc.slug, href: `/preview/tour-packages/${doc.slug}/`}]}
                 : null,
           }),
+          // Singletons resolve to /preview/ SSR routes (added in feat/preview-singletons)
+          // rather than the public URLs. Public hub pages are statically prerendered
+          // and can't host the Visual Editing channel — only SSR routes carry stega.
           homepageCover: defineLocations({
-            resolve: () => ({locations: [{title: 'Homepage', href: '/'}]}),
+            resolve: () => ({locations: [{title: 'Homepage cover', href: '/preview/home/'}]}),
           }),
           megaRail: defineLocations({
-            resolve: () => ({locations: [{title: 'Homepage', href: '/'}]}),
+            // Mega rail renders in every page's header; the homepage preview is the
+            // most convenient surface to edit it from.
+            resolve: () => ({locations: [{title: 'Mega menu rail', href: '/preview/home/'}]}),
           }),
           siteSettings: defineLocations({
-            resolve: () => ({locations: [{title: 'Homepage', href: '/'}]}),
+            resolve: () => ({locations: [{title: 'Site settings', href: '/preview/home/'}]}),
           }),
           pageHero: defineLocations({
             select: {pathSlug: 'pathSlug'},
             resolve: (doc) =>
               doc?.pathSlug
-                ? {locations: [{title: doc.pathSlug, href: `/${doc.pathSlug}/`}]}
+                ? {locations: [{title: doc.pathSlug, href: `/preview/hero/${doc.pathSlug}/`}]}
                 : null,
           }),
         },


### PR DESCRIPTION
Layer 2 of the image-editability audit. Adds `/preview/home/` and `/preview/hero/<pathSlug>/` SSR routes so the singleton-backed hero / cover / rail images become click-to-edit in Presentation. Public URLs stay statically prerendered for speed.