### PR TITLE
feat(cms): make longform journal article heroes editable from Studio

### DIFF
--- a/next/src/pages/journal/best-brunch-mornington-peninsula.astro
+++ b/next/src/pages/journal/best-brunch-mornington-peninsula.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/place-mornington-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/best-brunch-mornington-peninsula', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -104,7 +113,7 @@ export const prerender = true;
       <h1 class="article__title">Best Brunch on the Mornington Peninsula</h1>
       <p class="article__dek">Not Melbourne. Fewer options, less competition, but the best ones use excellent local produce and aren't trying to be anything they're not.</p>
 
-      <div class="article__hero feature__image-block" aria-hidden="true" style="background-image: url(/images/sourced/place-mornington-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Mornington foreshore morning</span>
       </div>

--- a/next/src/pages/journal/dog-friendly-mornington-peninsula.astro
+++ b/next/src/pages/journal/dog-friendly-mornington-peninsula.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/place-rye-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/dog-friendly-mornington-peninsula', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -103,7 +112,7 @@ export const prerender = true;
       <h1 class="article__title">Dog-Friendly Mornington Peninsula — Where to Go with Your Dog</h1>
       <p class="article__dek">The Mornington Peninsula is one of Victoria's better destinations for dogs, provided you know which beaches allow them, which cafés will actually welcome them, and where you can stay without the awkward conversation at check-in.</p>
 
-      <div class="article__hero feature__image-block feature__image-block--sand" aria-hidden="true" style="background-image: url(/images/sourced/place-rye-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block feature__image-block--sand" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Rye foreshore, Mornington Peninsula</span>
       </div>

--- a/next/src/pages/journal/free-things-to-do-mornington-peninsula.astro
+++ b/next/src/pages/journal/free-things-to-do-mornington-peninsula.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/explore-bushrangers-bay-walk-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/free-things-to-do-mornington-peninsula', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -104,7 +113,7 @@ export const prerender = true;
       <h1 class="article__title">Free Things to Do on the Mornington Peninsula</h1>
       <p class="article__dek">Every beach is free. The best walks cost nothing. The markets charge no entry. You can fill a full weekend without spending a dollar on activities.</p>
 
-      <div class="article__hero feature__image-block" aria-hidden="true" style="background-image: url(/images/sourced/explore-bushrangers-bay-walk-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Bushrangers Bay, Cape Schanck</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-day-trip.astro
+++ b/next/src/pages/journal/mornington-peninsula-day-trip.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/place-red-hill-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-day-trip', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -103,7 +112,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula Day Trip from Melbourne — The Best One-Day Plan</h1>
       <p class="article__dek">You don't need a weekend. A well-structured day covers the cellar doors, a proper lunch, a coastal walk, and a swim — and gets you home before dark.</p>
 
-      <div class="article__hero feature__image-block feature__image-block--vineyard" aria-hidden="true" style="background-image: url(/images/sourced/place-red-hill-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block feature__image-block--vineyard" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Red Hill plateau, Mornington Peninsula</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-hot-springs-guide.astro
+++ b/next/src/pages/journal/mornington-peninsula-hot-springs-guide.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/place-rye-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-hot-springs-guide', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -104,7 +113,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula Hot Springs — The Honest Guide</h1>
       <p class="article__dek">Two springs, different propositions. When to go, which session, and the single most important piece of advice no other guide gives you.</p>
 
-      <div class="article__hero feature__image-block" aria-hidden="true" style="background-image: url(/images/sourced/place-rye-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Fingal, Mornington Peninsula</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-in-autumn.astro
+++ b/next/src/pages/journal/mornington-peninsula-in-autumn.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/article-cellar-door-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-in-autumn', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -101,7 +110,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula in Autumn — What to Do, Eat & See</h1>
       <p class="article__dek">Vintage season on the ridge, cellar door fires, pinot lunches in low sun, and the quiet that follows the summer crowds. This is the Peninsula at its most considered.</p>
 
-      <div class="article__hero feature__image-block feature__image-block--hinterland" aria-hidden="true" style="background-image: url(/images/sourced/article-cellar-door-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block feature__image-block--hinterland" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Red Hill plateau, Mornington Peninsula — Autumn</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-in-winter.astro
+++ b/next/src/pages/journal/mornington-peninsula-in-winter.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/article-cellar-door-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-in-winter', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -104,7 +113,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula in Winter — Why the Cold Season Is Underrated</h1>
       <p class="article__dek">Fog through the vineyards, empty coastal walks, fires in tasting rooms, and restaurants that actually have tables. Winter strips the performance away.</p>
 
-      <div class="article__hero feature__image-block" aria-hidden="true" style="background-image: url(/images/sourced/article-cellar-door-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Cellar door season, Red Hill plateau</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-itinerary.astro
+++ b/next/src/pages/journal/mornington-peninsula-itinerary.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/place-red-hill-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-itinerary', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -87,7 +96,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula 3-Day Itinerary — The Best Weekend Plan</h1>
       <p class="article__dek">Three days is the sweet spot. Enough time to eat properly, drink without rushing, walk a stretch of coast, and actually relax — which is the whole point.</p>
 
-      <div class="article__hero feature__image-block feature__image-block--vineyard" aria-hidden="true" style="background-image: url(/images/sourced/place-red-hill-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block feature__image-block--vineyard" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Red Hill plateau, Mornington Peninsula</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-wedding-venues.astro
+++ b/next/src/pages/journal/mornington-peninsula-wedding-venues.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/article-vineyard-villa-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-wedding-venues', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -104,7 +113,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula Wedding Venues — The Honest Guide</h1>
       <p class="article__dek">Vineyard estates, coastal terraces, and boutique properties. What each venue is actually like for a wedding — not what their Instagram suggests.</p>
 
-      <div class="article__hero feature__image-block" aria-hidden="true" style="background-image: url(/images/sourced/article-vineyard-villa-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Vineyard estate, Red Hill South</span>
       </div>

--- a/next/src/pages/journal/mornington-peninsula-with-kids.astro
+++ b/next/src/pages/journal/mornington-peninsula-with-kids.astro
@@ -2,6 +2,15 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchPageHeroFromSanity } from '../../lib/sanity/singletons-adapter';
+
+const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
+let heroImage = '/images/sourced/place-mornington-01.webp';
+if (isPreview || sanityReadEnabled('page-level')) {
+  const ph = await fetchPageHeroFromSanity('journal/mornington-peninsula-with-kids', {preview: isPreview});
+  if (ph?.imageSrc) heroImage = ph.imageSrc;
+}
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -103,7 +112,7 @@ export const prerender = true;
       <h1 class="article__title">Mornington Peninsula with Kids — The Honest Family Guide</h1>
       <p class="article__dek">A day that punishes no one. Which beaches are actually safe for children, what activities work across age ranges, and the things the brochures suggest that aren't worth the detour.</p>
 
-      <div class="article__hero feature__image-block feature__image-block--bay" aria-hidden="true" style="background-image: url(/images/sourced/place-mornington-01.webp); background-size: cover; background-position: center;">
+      <div class="article__hero feature__image-block feature__image-block--bay" aria-hidden="true" style={`background-image: url(${heroImage}); background-size: cover; background-position: center;`}>
         <div class="article__hero-fog"></div>
         <span class="article__hero-caption">Mornington foreshore — Port Phillip Bay</span>
       </div>

--- a/studio-peninsula-insider/scripts/seed-longform-journal-heroes.ts
+++ b/studio-peninsula-insider/scripts/seed-longform-journal-heroes.ts
@@ -1,0 +1,146 @@
+/**
+ * Seed pageHero singletons for the 10 hardcoded longform journal articles
+ * (PR B of the click-to-edit-everywhere series).
+ *
+ * These articles live as standalone .astro files under
+ * next/src/pages/journal/<slug>.astro and have handcrafted hero blocks
+ * with hardcoded background-image URLs. After this script runs, each
+ * page's dual-read will resolve its pageHero singleton by pathSlug
+ * (e.g. "journal/mornington-peninsula-with-kids") and swap the hero
+ * image to the asset uploaded here.
+ *
+ *   Usage: SANITY_AUTH_TOKEN=<write-token> npx tsx scripts/seed-longform-journal-heroes.ts
+ *
+ * Idempotent: createOrReplace keyed by a deterministic _id derived from
+ * the slug. Re-running uploads the asset again (Sanity dedupes by hash)
+ * and replaces the singleton doc.
+ */
+import {createClient} from '@sanity/client'
+import {readFile} from 'node:fs/promises'
+import {join, dirname, basename} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const imagesRoot = join(repoRoot, 'next', 'public')
+
+const client = createClient({
+  projectId: 'a062b30n',
+  dataset: 'production',
+  apiVersion: '2025-01-01',
+  token: process.env.SANITY_AUTH_TOKEN ?? process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+})
+
+interface HeroSeed {
+  slug: string
+  imageSrc: string
+  title: string
+}
+
+const HEROES: HeroSeed[] = [
+  {
+    slug: 'journal/mornington-peninsula-with-kids',
+    imageSrc: '/images/sourced/place-mornington-01.webp',
+    title: 'The Peninsula with kids',
+  },
+  {
+    slug: 'journal/mornington-peninsula-day-trip',
+    imageSrc: '/images/sourced/place-red-hill-01.webp',
+    title: 'A perfect day trip',
+  },
+  {
+    slug: 'journal/best-brunch-mornington-peninsula',
+    imageSrc: '/images/sourced/place-mornington-01.webp',
+    title: 'Best brunch on the Peninsula',
+  },
+  {
+    slug: 'journal/dog-friendly-mornington-peninsula',
+    imageSrc: '/images/sourced/place-rye-01.webp',
+    title: 'Dog-friendly Peninsula',
+  },
+  {
+    slug: 'journal/mornington-peninsula-wedding-venues',
+    imageSrc: '/images/sourced/article-vineyard-villa-01.webp',
+    title: 'Wedding venues',
+  },
+  {
+    slug: 'journal/mornington-peninsula-in-autumn',
+    imageSrc: '/images/sourced/article-cellar-door-01.webp',
+    title: 'The Peninsula in autumn',
+  },
+  {
+    slug: 'journal/mornington-peninsula-itinerary',
+    imageSrc: '/images/sourced/place-red-hill-01.webp',
+    title: 'Peninsula itinerary',
+  },
+  {
+    slug: 'journal/free-things-to-do-mornington-peninsula',
+    imageSrc: '/images/sourced/explore-bushrangers-bay-walk-01.webp',
+    title: 'Free things to do',
+  },
+  {
+    slug: 'journal/mornington-peninsula-hot-springs-guide',
+    imageSrc: '/images/sourced/place-rye-01.webp',
+    title: 'Hot springs guide',
+  },
+  {
+    slug: 'journal/mornington-peninsula-in-winter',
+    imageSrc: '/images/sourced/article-cellar-door-01.webp',
+    title: 'The Peninsula in winter',
+  },
+]
+
+async function uploadImage(src: string): Promise<string | null> {
+  try {
+    const buf = await readFile(join(imagesRoot, src.replace(/^\/+/, '')))
+    const filename = basename(src)
+    const a = await client.assets.upload('image', buf, {filename})
+    return a._id
+  } catch (err) {
+    console.error(`  ! upload failed ${src}: ${(err as Error).message}`)
+    return null
+  }
+}
+
+function singletonIdForSlug(slug: string): string {
+  // pageHero-journal-<slug>; Sanity _id allows letters, digits, dashes, underscores.
+  return `pageHero-${slug.replace(/[^a-zA-Z0-9]+/g, '-')}`
+}
+
+async function seedOne(h: HeroSeed) {
+  const assetId = await uploadImage(h.imageSrc)
+  if (!assetId) {
+    console.warn(`  - ${h.slug}: skipped (asset upload failed)`)
+    return
+  }
+  const _id = singletonIdForSlug(h.slug)
+  await client.createOrReplace({
+    _id,
+    _type: 'pageHero',
+    pathSlug: h.slug,
+    title: h.title,
+    image: {
+      _type: 'imageRef',
+      asset: {_type: 'reference', _ref: assetId},
+      alt: h.title,
+      credit: 'venue-media-kit',
+      license: 'venue-media-kit',
+    },
+  })
+  console.log(`  ✓ ${_id}  (${h.slug})`)
+}
+
+async function main() {
+  if (!process.env.SANITY_AUTH_TOKEN && !process.env.SANITY_WRITE_TOKEN) {
+    console.error('SANITY_AUTH_TOKEN (or SANITY_WRITE_TOKEN) not set.')
+    process.exit(1)
+  }
+  console.log('→ longform journal pageHero singletons')
+  for (const h of HEROES) {
+    await seedOne(h)
+  }
+  console.log(`\nDone. ${HEROES.length} pageHero docs created/replaced.`)
+}
+
+void main()


### PR DESCRIPTION
## Summary

PR B of the click-to-edit-everywhere series (after #179 SSR landing + #181 home/hero preview routes).

Wires the **10 hardcoded longform journal article pages** under `next/src/pages/journal/<slug>.astro` to the existing `pageHero` Sanity singleton via the same dual-read pattern used elsewhere. Each hero image becomes editable from Sanity Studio Presentation once the seed script has run.

- 10 pages get a tiny frontmatter dual-read that calls `fetchPageHeroFromSanity('journal/<slug>')` and overrides only the hero `background-image` URL when `SANITY_PAGE_LEVEL_ENABLED` is on or the request is in preview mode.
- Each page keeps its current hardcoded `/images/sourced/...` path as the fallback — unauthenticated production renders are byte-identical to before.
- H1, dek, body, captions, and surrounding markup are untouched.
- New seed script at `studio-peninsula-insider/scripts/seed-longform-journal-heroes.ts` uploads the 10 current images as Sanity assets and `createOrReplace`s a `pageHero` doc per `pathSlug` (`journal/<slug>`).

### One-shot manual step (post-merge)

Run once locally before Studio editors can override:

```
cd studio-peninsula-insider
SANITY_AUTH_TOKEN=<write-token> npx tsx scripts/seed-longform-journal-heroes.ts
```

Until that runs, the existing fallback paths in each page continue to render. Backwards compatible.

## Test plan

- [x] `node scripts/lint-no-pricing.mjs` passes (no pricing renders introduced)
- [ ] Verify Astro build succeeds on Vercel preview
- [ ] After seed script runs against production dataset, click any of the 10 hero images from Studio Presentation and confirm the Visual Editing overlay highlights the `pageHero.image` field
- [ ] Confirm unauthenticated production HTML for any of the 10 pages is byte-identical pre/post merge (until `SANITY_PAGE_LEVEL_ENABLED=true`, fallback fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)