### PR TITLE
feat(cms): bind explore card grids to journal Sanity docs

### DIFF
--- a/next/src/pages/explore/golf.astro
+++ b/next/src/pages/explore/golf.astro
@@ -11,6 +11,40 @@ import {
   buildFaqSchema,
   buildBreadcrumbSchema,
 } from '../../lib/schema';
+import { routeSlug } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchArticleFromSanity } from '../../lib/sanity/article-adapter';
+
+// ── Editorial-card hero lookup ────────────────────────────────────────────────
+// Cards in section 8 ("Golf editorial") all link to journal articles. Their
+// background image is bound to each article's heroImage so editors can change
+// the card art by editing the article in Sanity (or its frontmatter), with the
+// hardcoded path retained as a build-time fallback.
+const allArticles = await getCollection('articles', ({ data }) => data.status === 'published');
+async function resolveArticleHero(slug: string, fallback: string): Promise<string> {
+  if (sanityReadEnabled('articles')) {
+    const sanityArt = await fetchArticleFromSanity(slug);
+    if (sanityArt?.data.heroImage?.src) return sanityArt.data.heroImage.src;
+  }
+  const local = allArticles.find((a) => routeSlug(a) === slug);
+  return (local?.data as any)?.heroImage?.src ?? fallback;
+}
+const heroGolfGuide = await resolveArticleHero(
+  'mornington-peninsula-golf-guide',
+  '/images/sourced/golf-rye-sunrise-01.webp',
+);
+const heroGolfTier = await resolveArticleHero(
+  'best-golf-courses-mornington-peninsula',
+  '/images/sourced/golf-rye-sunrise-01.webp',
+);
+const heroGolfStayPlay = await resolveArticleHero(
+  'mornington-peninsula-golf-stay-and-play',
+  '/images/sourced/article-sorrento-weekend-01.webp',
+);
+const heroStAndrews = await resolveArticleHero(
+  'st-andrews-beach-golf-course',
+  '/images/sourced/place-cape-schanck-01.webp',
+);
 
 // ── Load golf courses from experiences collection ─────────────────────────────
 const allExperiences = await getCollection('experiences');
@@ -520,7 +554,7 @@ export const prerender = true;
       <div class="golf-articles">
 
         <a href="/journal/mornington-peninsula-golf-guide/" class="golf-article-card">
-          <div class="golf-article-card__img" style="background-image: url('/images/sourced/golf-rye-sunrise-01.webp')" aria-hidden="true"></div>
+          <div class="golf-article-card__img" style={`background-image: url('${heroGolfGuide}')`} aria-hidden="true"></div>
           <div class="golf-article-card__body">
             <p class="golf-article-card__tag">Editor's perspective</p>
             <h3 class="golf-article-card__title">Why the Peninsula is Australia's best golf region</h3>
@@ -530,7 +564,7 @@ export const prerender = true;
         </a>
 
         <a href="/journal/best-golf-courses-mornington-peninsula/" class="golf-article-card">
-          <div class="golf-article-card__img" style="background-image: url('/images/sourced/golf-rye-sunrise-01.webp')" aria-hidden="true"></div>
+          <div class="golf-article-card__img" style={`background-image: url('${heroGolfTier}')`} aria-hidden="true"></div>
           <div class="golf-article-card__body">
             <p class="golf-article-card__tag">Tier guide</p>
             <h3 class="golf-article-card__title">The best golf courses ranked — honest tier guide</h3>
@@ -540,7 +574,7 @@ export const prerender = true;
         </a>
 
         <a href="/journal/mornington-peninsula-golf-stay-and-play/" class="golf-article-card">
-          <div class="golf-article-card__img" style="background-image: url('/images/sourced/article-sorrento-weekend-01.webp')" aria-hidden="true"></div>
+          <div class="golf-article-card__img" style={`background-image: url('${heroGolfStayPlay}')`} aria-hidden="true"></div>
           <div class="golf-article-card__body">
             <p class="golf-article-card__tag">Stay and play</p>
             <h3 class="golf-article-card__title">Stay and play — accommodation near every course</h3>
@@ -550,7 +584,7 @@ export const prerender = true;
         </a>
 
         <a href="/journal/st-andrews-beach-golf-course/" class="golf-article-card">
-          <div class="golf-article-card__img" style="background-image: url('/images/sourced/place-cape-schanck-01.webp')" aria-hidden="true"></div>
+          <div class="golf-article-card__img" style={`background-image: url('${heroStAndrews}')`} aria-hidden="true"></div>
           <div class="golf-article-card__body">
             <p class="golf-article-card__tag">Course deep-dive</p>
             <h3 class="golf-article-card__title">St Andrews Beach — the world-ranked course anyone can book</h3>

--- a/next/src/pages/explore/markets.astro
+++ b/next/src/pages/explore/markets.astro
@@ -11,6 +11,29 @@ import {
   buildFaqSchema,
   buildBreadcrumbSchema,
 } from '../../lib/schema';
+import { routeSlug } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchArticleFromSanity } from '../../lib/sanity/article-adapter';
+
+// ── Editorial-card hero lookup ────────────────────────────────────────────────
+// Cards in section 6 ("Markets editorial") that link to a journal article bind
+// their background image to that article's heroImage so an editor changing the
+// hero in Sanity (or the article frontmatter) updates the explore-page card.
+// Cards that link to hubs or place guides have no article doc to bind to and
+// keep their hardcoded image until a parent doc exists.
+const allArticlesForCards = await getCollection('articles', ({ data }) => data.status === 'published');
+async function resolveArticleHero(slug: string, fallback: string): Promise<string> {
+  if (sanityReadEnabled('articles')) {
+    const sanityArt = await fetchArticleFromSanity(slug);
+    if (sanityArt?.data.heroImage?.src) return sanityArt.data.heroImage.src;
+  }
+  const local = allArticlesForCards.find((a) => routeSlug(a) === slug);
+  return (local?.data as any)?.heroImage?.src ?? fallback;
+}
+const heroRedHillSaturday = await resolveArticleHero(
+  'how-to-build-a-red-hill-saturday',
+  '/images/sourced/article-red-hill-saturday-01.webp',
+);
 
 // ── Load markets in editorial order ───────────────────────────────────────────
 const allExperiences = await getCollection('experiences');
@@ -372,7 +395,7 @@ export const prerender = true;
       </div>
       <div class="market-articles">
         <a href="/journal/how-to-build-a-red-hill-saturday/" class="market-article-card">
-          <div class="market-article-card__img" style="background-image: url('/images/sourced/article-red-hill-saturday-01.webp')" aria-hidden="true"></div>
+          <div class="market-article-card__img" style={`background-image: url('${heroRedHillSaturday}')`} aria-hidden="true"></div>
           <div class="market-article-card__body">
             <p class="market-article-card__tag">Editor's perspective</p>
             <h3 class="market-article-card__title">How to build a Red Hill Saturday</h3>
@@ -380,6 +403,13 @@ export const prerender = true;
             <span class="market-article-card__cta">Read →</span>
           </div>
         </a>
+        {/*
+          The three cards below link to hub/place routes (/wine/, /places/red-hill/,
+          /places/balnarring/), not to journal articles. There's no parent editorial
+          doc to bind these images to today, so they stay hardcoded. When a Sanity
+          schema for place/hub hero images lands these can be wired the same way as
+          the Red Hill Saturday card above.
+        */}
         <a href="/wine/" class="market-article-card">
           <div class="market-article-card__img" style="background-image: url('/images/sourced/category-cottage-01.webp')" aria-hidden="true"></div>
           <div class="market-article-card__body">


### PR DESCRIPTION
## Summary

Section "Markets editorial" on `/explore/markets` and section "Golf editorial" on `/explore/golf` each have a 4-card grid where the background image was hardcoded. This PR is part of the image-editability migration (PR D of 4):

- **5 of 8 cards** link to journal articles. Their background image is now resolved from the article's `heroImage.src` via the existing Sanity dual-read adapter (`fetchArticleFromSanity` + `sanityReadEnabled('articles')`), with the prior hardcoded path retained as a build-time fallback. Editors who change the hero on the journal article now also change the explore-page card art.
- **3 of 8 cards** in markets link to hub/place routes (`/wine/`, `/places/red-hill/`, `/places/balnarring/`), not journal articles. There's no parent editorial doc to bind them to today, so they stay hardcoded with an inline comment explaining why and where to wire them when a place/hub hero schema lands.

No new Sanity schemas. No new deps. Uses the same dual-read pattern as `journal/[slug].astro`.

## Visual change

For two journal cards, the bound `heroImage` differs from the previous hardcoded path:

| Card link | Was | Now (from article) |
|---|---|---|
| `/journal/mornington-peninsula-golf-stay-and-play/` | `article-sorrento-weekend-01.webp` | `golf-rye-sunrise-01.webp` |
| `/journal/st-andrews-beach-golf-course/` | `place-cape-schanck-01.webp` | `placeholder-golf.svg` |

The editorial intent of these cards is to mirror the linked article, so binding is the correct outcome. The St Andrews article hero (`placeholder-golf.svg`) is a placeholder that an editor can now upgrade in one place and have it propagate to the explore card.

The remaining three journal cards bind to the same path they already hardcoded — byte-identical output for those.

## Test plan

- [ ] Run `astro check` — no new errors introduced for `explore/markets.astro` or `explore/golf.astro` (warnings only, all pre-existing)
- [ ] Verify `/explore/markets/` renders all 4 editorial cards with correct background images
- [ ] Verify `/explore/golf/` renders all 4 editorial cards with correct background images
- [ ] Edit a bound article's `heroImage.src` in Sanity and confirm the explore card updates on rebuild