### PR TITLE
feat(cms): make eat/ and tour/ subpage heroes editable

### DIFF
--- a/next/src/pages/eat/bakeries.astro
+++ b/next/src/pages/eat/bakeries.astro
@@ -85,7 +85,8 @@ export const prerender = true;
   heroImage="/images/sourced/explore-dromana-beach-01.webp"
   imageAlt="Dromana beach morning light, Mornington Peninsula"
   imageCaption="Mornington Peninsula"
-  entitySlug="eat-bakeries"
+  entitySlug="eat/bakeries"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula bakery scene is smaller than the cafe scene and better for it. There are six bakeries worth knowing about, scattered across the Peninsula from Mornington to Flinders. Each has a reason: a particular loaf, a particular morning, a particular detour that makes it worth the drive from wherever you are staying.</p>

--- a/next/src/pages/eat/best-restaurants.astro
+++ b/next/src/pages/eat/best-restaurants.astro
@@ -87,7 +87,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-hatted-restaurants-01.webp"
   imageAlt="Open kitchen at a Peninsula fine dining restaurant — hatted dining on the Mornington Peninsula"
   imageCaption="Peninsula fine dining"
-  entitySlug="eat-best-restaurants"
+  entitySlug="eat/best-restaurants"
+  entityType="page"
 >
   <div class="prose">
     <p>The Mornington Peninsula runs on the Sunday long lunch. From the ridge-top dining rooms of Red Hill to the fisherman's-wharf-adjacent tables of Mornington, the dining options are deep, opinionated, and worth the drive. This list is built on editorial judgement — every entry has been visited and earned its sentence. No advertising, no paid placement, no sponsored rankings. If a restaurant appears here, it's because the meal was worth the drive and the editor was willing to say so.</p>

--- a/next/src/pages/eat/brunch.astro
+++ b/next/src/pages/eat/brunch.astro
@@ -91,7 +91,8 @@ export const prerender = true;
   heroImage="/images/sourced/explore-mount-martha-beach-01.webp"
   imageAlt="Mount Martha beach, Mornington Peninsula — morning light and bay views"
   imageCaption="Mount Martha · Mornington Peninsula"
-  entitySlug="eat-brunch"
+  entitySlug="eat/brunch"
+  entityType="page"
 >
   <div class="prose">
     <p>Brunch on the Mornington Peninsula means either a specialty coffee destination in Mornington or a village cafe you would drive forty minutes for if you were not already nearby. The Peninsula's brunch scene is not a destination category in itself — it is the first half of a Peninsula day, the thing you do before the cellar door or the beach walk.</p>

--- a/next/src/pages/eat/cafes.astro
+++ b/next/src/pages/eat/cafes.astro
@@ -89,7 +89,8 @@ export const prerender = true;
   heroImage="/images/sourced/explore-mprg-01.webp"
   imageAlt="Mornington Peninsula Regional Gallery and foreshore, Mornington"
   imageCaption="Mornington"
-  entitySlug="eat-cafes"
+  entitySlug="eat/cafes"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula's cafe scene concentrates in Mornington and the hinterland villages. Commonfolk Coffee in Mornington is the benchmark for specialty coffee — a house roaster, an excellent kitchen, and the kind of back courtyard that makes a weekday morning feel like a weekend decision. Below it, a scattered set of village cafes and general stores doing honest work without trying to be anything they are not.</p>

--- a/next/src/pages/eat/cellar-door-lunch.astro
+++ b/next/src/pages/eat/cellar-door-lunch.astro
@@ -97,7 +97,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-cellar-door-01.webp"
   imageAlt="Peninsula cellar door wine tasting — estate dining on the Mornington Peninsula"
   imageCaption="Red Hill plateau"
-  entitySlug="eat-cellar-door-lunch"
+  entitySlug="eat/cellar-door-lunch"
+  entityType="page"
 >
   <div class="prose">
     <p>The cellar door lunch is the Peninsula's most distinctive food experience. A winery with a kitchen — estate wine poured from the vineyard outside, produce grown or sourced within a few kilometres, and a dining room that exists because the place earned it rather than because a marketing brief suggested it would convert tastings.</p>

--- a/next/src/pages/eat/date-night.astro
+++ b/next/src/pages/eat/date-night.astro
@@ -26,7 +26,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-couples-weekend-01.webp"
   imageAlt="Couples weekend at a Mornington Peninsula vineyard estate — Peninsula date night"
   imageCaption="Mornington Peninsula"
-  entitySlug="eat-date-night"
+  entitySlug="eat/date-night"
+  entityType="page"
 >
   <div class="prose">
     <p>A Peninsula date night works best when you resist the temptation to over-programme it. Pick one destination: dinner at a hatted room, or a long late-afternoon at a vineyard restaurant, then somewhere comfortable to stay. Trying to fit a cellar door tasting, a sunset walk, and a dinner at a restaurant forty minutes away never improves the evening.</p><p>The Peninsula's strongest date-night rooms are intimate: Tedesca Osteria (30 seats), Polperro (small, seasonal, vineyard), and Bistro Elba in Sorrento (French-inflected, dinner-focused, village-based). For the most impressive setting, Laura at Pt. Leo Estate has no peer in Victoria. For the most dramatic interior, Doot Doot Doot at Jackalope Hotel is the answer.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/dog-friendly.astro
+++ b/next/src/pages/eat/dog-friendly.astro
@@ -91,7 +91,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-dog-friendly-01.webp"
   imageAlt="Dog-friendly Peninsula — outdoor dining and café culture on the Mornington Peninsula"
   imageCaption="Mornington Peninsula"
-  entitySlug="eat-dog-friendly"
+  entitySlug="eat/dog-friendly"
+  entityType="page"
 >
   <div class="prose">
     <p style="background:rgba(180,100,40,0.08);border-left:3px solid var(--accent);padding:1rem 1.25rem;border-radius:0 4px 4px 0"><strong>Dog policies change.</strong> This list is based on outdoor-seating policies as of April 2026. Verify directly with the venue before you visit with a dog.</p>

--- a/next/src/pages/eat/family-friendly.astro
+++ b/next/src/pages/eat/family-friendly.astro
@@ -26,7 +26,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-kids-peninsula-01.webp"
   imageAlt="Family day out on the Mornington Peninsula — dining with kids"
   imageCaption="Mornington Peninsula"
-  entitySlug="eat-family-friendly"
+  entitySlug="eat/family-friendly"
+  entityType="page"
 >
   <div class="prose">
     <p>Family-friendly dining on the Peninsula means outdoor seating, formats that do not require children to sit completely still for two hours, and venues where the staff have seen a high chair before. The list is shorter than the general dining list, but it is honest: these are the places that work with kids rather than merely tolerating them.</p><p>Red Gum BBQ in Red Hill is the clearest call — BBQ format, outdoor tables, and food that children actually want to eat. Montalto Piazza is the best family-friendly winery option: walk-in daily, sculpture trail on the property, outdoor seating, and a kitchen that does not require advance planning. Village cafes and pub beer gardens fill in the practical gaps.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/fine-dining.astro
+++ b/next/src/pages/eat/fine-dining.astro
@@ -97,7 +97,8 @@ export const prerender = true;
   heroImage="/images/sourced/venue-lindenderry-01.webp"
   imageAlt="Lindenderry at Red Hill — boutique hotel and fine dining on the Mornington Peninsula"
   imageCaption="Red Hill · Mornington Peninsula"
-  entitySlug="eat-fine-dining"
+  entitySlug="eat/fine-dining"
+  entityType="page"
 >
   <div class="prose">
     <p>Fine dining on the Mornington Peninsula is not city fine dining. The format here is embedded in vineyard estates, working farms, and converted heritage buildings. You eat in a 40-seat room in a converted 1940s farmhouse where the kitchen garden is outside the window. Or in a glass-walled dining room above a sculpture park overlooking Western Port Bay. Or under a 10,000-globe chandelier in a boutique winery hotel.</p>

--- a/next/src/pages/eat/hatted-restaurants.astro
+++ b/next/src/pages/eat/hatted-restaurants.astro
@@ -100,7 +100,8 @@ export const prerender = true;
   heroImage="/images/sourced/venue-pt-leo-sculpture-01.webp"
   imageAlt="Pt. Leo Estate sculpture park and fine dining, Merricks — two-hat Peninsula restaurant"
   imageCaption="Pt. Leo Estate · Merricks"
-  entitySlug="eat-hatted-restaurants"
+  entitySlug="eat/hatted-restaurants"
+  entityType="page"
 >
   <div class="prose">
     <p>The Good Food Guide awarded 15 hats across 11 Peninsula venues. Four venues carry two hats — the highest recognition in the region. What distinguishes the Peninsula's hatted scene is its context: these are not city strip restaurants. You eat in a converted 1940s farmhouse on a biodynamic property, a 40-seat room inside a sculpture park estate, or a cave-like dining room beneath a boutique winery hotel. The long lunch is the defining format.</p>

--- a/next/src/pages/eat/long-lunch.astro
+++ b/next/src/pages/eat/long-lunch.astro
@@ -98,7 +98,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-long-lunch-01.webp"
   imageAlt="Long lunch at a Peninsula vineyard restaurant — wine country dining on the Mornington Peninsula"
   imageCaption="Peninsula wine country"
-  entitySlug="eat-long-lunch"
+  entitySlug="eat/long-lunch"
+  entityType="page"
 >
   <div class="prose">
     <p>The long lunch is the Peninsula's defining dining format. A two-to-three-hour table, estate wine from the vineyard outside, produce grown within five kilometres, and an unhurried service rhythm that makes a Melbourne city restaurant feel rushed by comparison. The Peninsula does this better than almost anywhere else in Victoria.</p>

--- a/next/src/pages/eat/markets.astro
+++ b/next/src/pages/eat/markets.astro
@@ -25,7 +25,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-red-hill-saturday-01.webp"
   imageAlt="Red Hill Saturday morning, Mornington Peninsula — market day"
   imageCaption="Red Hill · Saturday morning"
-  entitySlug="eat-markets"
+  entitySlug="eat/markets"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula has three established food markets, each with a different character. Red Hill Market is the one worth planning a morning around — a large monthly market on the first Saturday of the month at Red Hill Showgrounds, with Peninsula produce, artisan food, and a coffee and brunch scene that makes the visit feel like an event rather than a shopping errand.</p><p>Mornington Farmers' Market runs every Wednesday at Craig's Reserve and is the best option for fresh local produce during the week — smaller, more focused, and less tourist-facing than Red Hill. Balnarring Farmers' Market is the most genuinely local of the three — a village-scale market with strong produce and a relaxed pace.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/no-booking.astro
+++ b/next/src/pages/eat/no-booking.astro
@@ -26,7 +26,8 @@ export const prerender = true;
   heroImage="/images/sourced/explore-mornington-foreshore-01.webp"
   imageAlt="Mornington foreshore and harbour — casual dining and walk-in venues on the Peninsula"
   imageCaption="Mornington"
-  entitySlug="eat-no-booking"
+  entitySlug="eat/no-booking"
+  entityType="page"
 >
   <div class="prose">
     <p>Most serious Peninsula restaurants require bookings — often weeks or months in advance for hatted venues. But there are genuine walk-in options, and two of them are hatted: Rare Hare at Willow Creek takes no reservations at all and is walk-in only from 2pm on weekends; Foxeys Hangout accepts no bookings and has a maximum group size of 6.</p><p>Below the hatted tier, Montalto Piazza (daily, 11am–5pm), most of the Peninsula's village cafes and bakeries, and most pub bistros operate on a walk-in basis. If you have arrived on the Peninsula without a booking for the destination you wanted, this list is where to start.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/paddock-to-plate.astro
+++ b/next/src/pages/eat/paddock-to-plate.astro
@@ -26,7 +26,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-producer-trail-01.webp"
   imageAlt="Peninsula producer trail — farm-to-table dining on the Mornington Peninsula"
   imageCaption="Red Hill hinterland"
-  entitySlug="eat-paddock-to-plate"
+  entitySlug="eat/paddock-to-plate"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula has more genuine farm-to-table dining than almost any other regional destination in Victoria. The landscape produces it: the cool plateau grows some of Australia's best cool-climate produce, the Bass Strait coast supplies exceptional seafood, and the farm density in the Red Hill hinterland means short supply chains are the rule rather than the exception.</p><p>The strongest example is Tedesca Osteria — a biodynamic property in Red Hill where Brigitte Hafner keeps chickens, beehives, and Wiltshire Horn sheep that supply the kitchen alongside an on-site garden. It is the most fully realised farm restaurant on the Peninsula and one of the most serious in Victoria. Below it, Barragunda (estate-grown organic vegetables, hibachi-charred proteins), Green Olive (olive grove, orchard, kitchen garden), and a set of cellar door restaurants where the wine and food share the same landscape.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/pubs.astro
+++ b/next/src/pages/eat/pubs.astro
@@ -25,7 +25,8 @@ export const prerender = true;
   heroImage="/images/sourced/place-portsea-01.webp"
   imageAlt="Portsea coastline, Mornington Peninsula — gateway to the Peninsula's best pubs"
   imageCaption="Portsea · Mornington Peninsula"
-  entitySlug="eat-pubs"
+  entitySlug="eat/pubs"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula's pub scene is spread across its towns and coastal villages rather than concentrated in one area. Portsea Hotel leads for setting — the clifftop position above Portsea beach, bay views, and a dog-friendly beer garden make it the strongest pub experience on the Peninsula. Balnarring Pub is the most local and genuinely village-feeling. The Bay Hotel Mornington works as a practical stop for anyone based in or passing through town.</p><p>Peninsula pub kitchens range from honest bistro meals to better-than-expected seasonal menus. The general rule: pub food here is not the reason to drive; the setting is. Pair any pub stop with a coastal walk or afternoon activity nearby to get the most from it.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/seafood.astro
+++ b/next/src/pages/eat/seafood.astro
@@ -26,7 +26,8 @@ export const prerender = true;
   heroImage="/images/sourced/article-seafood-01.webp"
   imageAlt="Fresh seafood on the Mornington Peninsula — waterfront dining and fish kitchens"
   imageCaption="Mornington Peninsula coast"
-  entitySlug="eat-seafood"
+  entitySlug="eat/seafood"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula's seafood scene is concentrated around its waterfront towns and fishing piers. Pier Street Kitchen in Flinders is the strongest all-round seafood dining room — one GFG hat, a proper kitchen, and a setting that justifies the southern drive. The Baths at Sorrento is the waterfront experience, and Flinders Pier Takeaway is the benchmark for a genuinely good casual stop that does not pretend to be anything else.</p><p>The Peninsula's fish is primarily sourced locally or from the southern Victorian coast — king george whiting, calamari, abalone in season, and Mornington Peninsula oysters when available. The category rewards finding the right venue for the right kind of afternoon.</p><p style="font-size:0.8rem;color:var(--soft)">Last fact-verified: 23 April 2026</p></div>

--- a/next/src/pages/eat/waterfront.astro
+++ b/next/src/pages/eat/waterfront.astro
@@ -94,7 +94,8 @@ export const prerender = true;
   heroImage="/images/sourced/explore-sorrento-ferry-01.webp"
   imageAlt="Sorrento waterfront and Queenscliff ferry, Port Phillip Bay — Peninsula waterfront dining"
   imageCaption="Sorrento · Port Phillip Bay"
-  entitySlug="eat-waterfront"
+  entitySlug="eat/waterfront"
+  entityType="page"
 >
   <div class="prose">
     <p>The Peninsula's waterfront dining concentrates on Port Phillip Bay — the calmer, bay-facing side rather than the ocean. Three venues define the category. The Baths at Sorrento for special-occasion seafood with panoramic views. The Rocks at Mornington for casual waterfront dining at the marina. The Portsea Hotel for a pub setting with the most dramatic bay outlook of any pub on the Peninsula.</p>

--- a/next/src/pages/tour/fishing-tours.astro
+++ b/next/src/pages/tour/fishing-tours.astro
@@ -79,6 +79,8 @@ export const prerender = true;
     dek="Operator-led fishing as a bookable experience. Snapper-season charters, Western Port whiting and flathead, mid-size group bookings, and Bass Strait offshore. The booking-first view; the editorial comparison lives at /fishing/charters/."
     gradient="vineyard"
     heroImage="/images/sourced/explore-portsea-front-beach-01.webp"
+    entitySlug="tour/fishing-tours"
+    entityType="page"
   />
 
   <section class="experience-index" data-bf-article>

--- a/next/src/pages/tour/for-couples.astro
+++ b/next/src/pages/tour/for-couples.astro
@@ -43,7 +43,8 @@ export const prerender = true;
     heroImage="/images/sourced/article-picnic-01.webp"
     imageAlt="Picnic among the vineyards on the Mornington Peninsula — tours for couples"
     imageCaption="Red Hill Plateau"
-  entitySlug="tour-for-couples"
+  entitySlug="tour/for-couples"
+  entityType="page"
   >
     <div class="prose">
       <p>The Peninsula's guided tour options for couples concentrate around wine and private charters. A small-group wine tour is the practical starting point — you cover multiple cellar doors in a single day, no one has to drive, and the format is comfortable for two people joining a shared group.</p>

--- a/next/src/pages/tour/for-families.astro
+++ b/next/src/pages/tour/for-families.astro
@@ -36,7 +36,8 @@ export const prerender = true;
     heroImage="/images/sourced/explore-two-bays-walk-01.webp"
     imageAlt="Two Bays Walking Track on the Mornington Peninsula — family-friendly tours"
     imageCaption="Mornington Peninsula"
-  entitySlug="tour-for-families"
+  entitySlug="tour/for-families"
+  entityType="page"
   >
     <div class="prose">
       <p>The Peninsula's family-suited guided tours concentrate around wildlife experiences, coastal activities, and walking tours that work for a range of ages. Most wine-focused tours are adult-oriented — the family-friendly options tend to sit in the wildlife, nature, and activity categories.</p>

--- a/next/src/pages/tour/full-day-tours.astro
+++ b/next/src/pages/tour/full-day-tours.astro
@@ -36,7 +36,8 @@ export const prerender = true;
     heroImage="/images/sourced/explore-arthurs-seat-lookout-01.webp"
     imageAlt="Arthurs Seat lookout over Port Phillip Bay — full-day Peninsula tours"
     imageCaption="Mornington Peninsula"
-  entitySlug="tour-full-day-tours"
+  entitySlug="tour/full-day-tours"
+  entityType="page"
   >
     <div class="prose">
       <p>Full-day tours on the Mornington Peninsula typically run eight to ten hours, departing Melbourne in the morning and returning by early evening. They cover multiple stops — cellar doors, produce destinations, the hot springs, or coastal walks — depending on the operator's product.</p>

--- a/next/src/pages/tour/hot-springs-tours.astro
+++ b/next/src/pages/tour/hot-springs-tours.astro
@@ -40,7 +40,8 @@ export const prerender = true;
     heroImage="/images/sourced/spa-peninsula-hot-springs-hilltop-01.webp"
     imageAlt="Peninsula Hot Springs hilltop pools — guided hot springs tours from Melbourne"
     imageCaption="Mornington Peninsula"
-  entitySlug="tour-hot-springs-tours"
+  entitySlug="tour/hot-springs-tours"
+  entityType="page"
   >
     <div class="prose">
       <p>Peninsula Hot Springs at Fingal is the region's main thermal bathing destination. Most guided tours that include hot springs combine them with a wine component or a beach stop. Pure hot springs tours are less common from Melbourne — the most practical option for visitors who want to focus the day on bathing is to stay on the Peninsula and book directly with the springs.</p>

--- a/next/src/pages/tour/index.astro
+++ b/next/src/pages/tour/index.astro
@@ -70,6 +70,8 @@ export const prerender = true;
     dek="Peninsula Insider covers every guided tour and operator-led experience on the Peninsula. Verified facts, honest comparison, and the editorial call on who each tour actually suits."
     gradient="vineyard"
     heroImage="/images/sourced/wine-hub-hero-01.webp"
+    entitySlug="tour"
+    entityType="page"
   />
 
   {featuredTours.length > 0 && (

--- a/next/src/pages/tour/operators/index.astro
+++ b/next/src/pages/tour/operators/index.astro
@@ -38,7 +38,8 @@ export const prerender = true;
     heroImage="/images/sourced/place-mornington-01.webp"
     imageAlt="Mornington township — Peninsula tour operators guide"
     imageCaption="Sorrento"
-  entitySlug="tour-operators"
+  entitySlug="tour/operators"
+  entityType="page"
   >
     <div class="prose">
       <p>Peninsula Insider vets every operator listed here against a consistent set of criteria: product accuracy, guest experience track record, and affiliate transparency. We note which operator type each one is, what they are genuinely good at, and where they fall short.</p>

--- a/next/src/pages/tour/private-tours.astro
+++ b/next/src/pages/tour/private-tours.astro
@@ -40,7 +40,8 @@ export const prerender = true;
     heroImage="/images/sourced/spa-treatment-room-rose-01.webp"
     imageAlt="Private spa experience on the Mornington Peninsula — bespoke private tours"
     imageCaption="Mornington Peninsula"
-  entitySlug="tour-private-tours"
+  entitySlug="tour/private-tours"
+  entityType="page"
   >
     <div class="prose">
       <p>Private tours give you a dedicated vehicle, a guide working only for your group, and an itinerary that you shape. The cost is higher than a small-group day, but if you fill the vehicle — typically four to eight guests — the per-person difference is often modest.</p>

--- a/next/src/pages/tour/small-group-tours.astro
+++ b/next/src/pages/tour/small-group-tours.astro
@@ -36,7 +36,8 @@ export const prerender = true;
     heroImage="/images/sourced/category-winery-06.webp"
     imageAlt="Small-group cellar door tasting on the Mornington Peninsula"
     imageCaption="Mornington Peninsula"
-  entitySlug="tour-small-group-tours"
+  entitySlug="tour/small-group-tours"
+  entityType="page"
   >
     <div class="prose">
       <p>Small-group tours — typically 8 to 24 guests sharing a vehicle — are the practical middle ground between a private charter and a large coach. You get the logistics removed, a guide, and a structured itinerary, without the premium of a private booking.</p>

--- a/next/src/pages/tour/wine-tours.astro
+++ b/next/src/pages/tour/wine-tours.astro
@@ -36,7 +36,8 @@ export const prerender = true;
     heroImage="/images/sourced/venue-montalto-banner-01.webp"
     imageAlt="Montalto Estate on the Mornington Peninsula — guided wine tours"
     imageCaption="Red Hill Plateau"
-  entitySlug="tour-wine-tours"
+  entitySlug="tour/wine-tours"
+  entityType="page"
   >
     <div class="prose">
       <p>A guided wine tour removes the logistics of driving between cellar doors. You cover more ground, everyone in the group can drink, and a good guide adds the regional context that makes the difference between a pleasant day and a properly illuminating one.</p>

--- a/studio-peninsula-insider/scripts/seed-eat-tour-hub-heroes.ts
+++ b/studio-peninsula-insider/scripts/seed-eat-tour-hub-heroes.ts
@@ -1,0 +1,128 @@
+/**
+ * Seed pageHero singletons for /eat and /tour subpage heroes.
+ *
+ * PR E of the click-to-edit-images series wired up every /eat and /tour
+ * subpage to pass `entitySlug` to SubpageHero / SectionHero so the title
+ * and hero image become CMS-editable. With no pageHero document present
+ * the components fall back to Astro-prop defaults (byte-equivalent public
+ * render). This script creates the pageHero docs so editors can override
+ * from Studio.
+ *
+ *   Usage: SANITY_AUTH_TOKEN=... npx tsx scripts/seed-eat-tour-hub-heroes.ts
+ *          (SANITY_WRITE_TOKEN is also honoured)
+ *
+ * Idempotent: createOrReplace by fixed _id derived from pathSlug.
+ */
+import {createClient} from '@sanity/client'
+import {readFile} from 'node:fs/promises'
+import {join, dirname, basename} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const imagesRoot = join(repoRoot, 'next', 'public')
+
+const token = process.env.SANITY_AUTH_TOKEN || process.env.SANITY_WRITE_TOKEN
+
+const client = createClient({
+  projectId: 'a062b30n',
+  dataset: 'production',
+  apiVersion: '2025-01-01',
+  token,
+  useCdn: false,
+})
+
+interface HubHero {
+  slug: string
+  imagePath: string
+  eyebrow: string
+  category?: string
+  title: string
+}
+
+const HUBS: HubHero[] = [
+  // /eat subpages
+  {slug: 'eat/bakeries', imagePath: '/images/sourced/explore-dromana-beach-01.webp', eyebrow: 'Eat & Drink', category: 'Bakeries', title: 'Best Bakeries on the Mornington Peninsula'},
+  {slug: 'eat/best-restaurants', imagePath: '/images/sourced/article-hatted-restaurants-01.webp', eyebrow: 'Eat & Drink', category: 'Best Restaurants', title: 'The Best Restaurants on the Mornington Peninsula'},
+  {slug: 'eat/brunch', imagePath: '/images/sourced/explore-mount-martha-beach-01.webp', eyebrow: 'Eat & Drink', category: 'Brunch', title: 'Best Brunch on the Mornington Peninsula'},
+  {slug: 'eat/cafes', imagePath: '/images/sourced/explore-mprg-01.webp', eyebrow: 'Eat & Drink', category: 'Cafes', title: 'Best Cafes on the Mornington Peninsula'},
+  {slug: 'eat/cellar-door-lunch', imagePath: '/images/sourced/article-cellar-door-01.webp', eyebrow: 'Eat & Drink', category: 'Cellar Door Lunch', title: 'Cellar Door Lunch on the Mornington Peninsula'},
+  {slug: 'eat/date-night', imagePath: '/images/sourced/article-couples-weekend-01.webp', eyebrow: 'Eat & Drink', category: 'Date Night', title: 'Date Night on the Mornington Peninsula'},
+  {slug: 'eat/dog-friendly', imagePath: '/images/sourced/article-dog-friendly-01.webp', eyebrow: 'Eat & Drink', category: 'Dog-Friendly', title: 'Dog-Friendly Dining on the Mornington Peninsula'},
+  {slug: 'eat/family-friendly', imagePath: '/images/sourced/article-kids-peninsula-01.webp', eyebrow: 'Eat & Drink', category: 'Family-Friendly', title: 'Family-Friendly Dining on the Mornington Peninsula'},
+  {slug: 'eat/fine-dining', imagePath: '/images/sourced/venue-lindenderry-01.webp', eyebrow: 'Eat & Drink', category: 'Fine Dining', title: 'Fine Dining on the Mornington Peninsula'},
+  {slug: 'eat/hatted-restaurants', imagePath: '/images/sourced/venue-pt-leo-sculpture-01.webp', eyebrow: 'Eat & Drink', category: 'Hatted Restaurants', title: 'Hatted Restaurants on the Mornington Peninsula'},
+  {slug: 'eat/long-lunch', imagePath: '/images/sourced/article-long-lunch-01.webp', eyebrow: 'Eat & Drink', category: 'Long Lunch', title: 'The Long Lunch on the Mornington Peninsula'},
+  {slug: 'eat/markets', imagePath: '/images/sourced/article-red-hill-saturday-01.webp', eyebrow: 'Eat & Drink', category: 'Markets', title: 'Best Markets on the Mornington Peninsula'},
+  {slug: 'eat/no-booking', imagePath: '/images/sourced/explore-mornington-foreshore-01.webp', eyebrow: 'Eat & Drink', category: 'Walk-In', title: 'Walk-In Restaurants on the Mornington Peninsula'},
+  {slug: 'eat/paddock-to-plate', imagePath: '/images/sourced/article-producer-trail-01.webp', eyebrow: 'Eat & Drink', category: 'Paddock to Plate', title: 'Paddock to Plate on the Mornington Peninsula'},
+  {slug: 'eat/pubs', imagePath: '/images/sourced/place-portsea-01.webp', eyebrow: 'Eat & Drink', category: 'Pubs', title: 'Best Pubs on the Mornington Peninsula'},
+  {slug: 'eat/seafood', imagePath: '/images/sourced/article-seafood-01.webp', eyebrow: 'Eat & Drink', category: 'Seafood', title: 'Best Seafood on the Mornington Peninsula'},
+  {slug: 'eat/waterfront', imagePath: '/images/sourced/explore-sorrento-ferry-01.webp', eyebrow: 'Eat & Drink', category: 'Waterfront', title: 'Waterfront Restaurants on the Mornington Peninsula'},
+
+  // /tour hub + subpages
+  {slug: 'tour', imagePath: '/images/sourced/wine-hub-hero-01.webp', eyebrow: 'Tours', title: 'Operator-led experiences on the <em>Mornington Peninsula</em>'},
+  {slug: 'tour/small-group-tours', imagePath: '/images/sourced/category-winery-06.webp', eyebrow: 'Tours', category: 'Small Group', title: 'Small-Group Tours'},
+  {slug: 'tour/wine-tours', imagePath: '/images/sourced/venue-montalto-banner-01.webp', eyebrow: 'Tours', category: 'Wine & Cellar Door', title: 'Peninsula Wine Tours'},
+  {slug: 'tour/private-tours', imagePath: '/images/sourced/spa-treatment-room-rose-01.webp', eyebrow: 'Tours', category: 'Private & Bespoke', title: 'Private Tours — Mornington Peninsula'},
+  {slug: 'tour/hot-springs-tours', imagePath: '/images/sourced/spa-peninsula-hot-springs-hilltop-01.webp', eyebrow: 'Tours', category: 'Wellness & Hot Springs', title: 'Hot Springs Tours on the Mornington Peninsula'},
+  {slug: 'tour/for-families', imagePath: '/images/sourced/explore-two-bays-walk-01.webp', eyebrow: 'Tours', category: 'For Families', title: 'Family Tours on the Mornington Peninsula'},
+  {slug: 'tour/full-day-tours', imagePath: '/images/sourced/explore-arthurs-seat-lookout-01.webp', eyebrow: 'Tours', category: 'Full Day', title: 'Full Day Tours'},
+  {slug: 'tour/fishing-tours', imagePath: '/images/sourced/explore-portsea-front-beach-01.webp', eyebrow: 'Tours · Fishing', title: '<em>Fishing tours</em> on the Mornington Peninsula'},
+  {slug: 'tour/for-couples', imagePath: '/images/sourced/article-picnic-01.webp', eyebrow: 'Tours', category: 'For Couples', title: 'Couples Tours on the Mornington Peninsula'},
+  {slug: 'tour/operators', imagePath: '/images/sourced/place-mornington-01.webp', eyebrow: 'Tours', category: 'Operators', title: 'Mornington Peninsula Tour Operators'},
+]
+
+async function uploadImage(src: string): Promise<string | null> {
+  try {
+    const buf = await readFile(join(imagesRoot, src.replace(/^\/+/, '')))
+    const filename = basename(src)
+    const a = await client.assets.upload('image', buf, {filename})
+    return a._id
+  } catch (err) {
+    console.error(`  ! upload failed ${src}: ${(err as Error).message}`)
+    return null
+  }
+}
+
+// Sanity _id allows alphanumerics, hyphens, underscores and dots — not "/".
+// Replace path separators with double-dash so the id stays unique per slug.
+function idForSlug(slug: string): string {
+  return `pageHero-${slug.replace(/\//g, '--')}`
+}
+
+async function seed() {
+  if (!token) {
+    console.error('SANITY_AUTH_TOKEN (or SANITY_WRITE_TOKEN) not set.')
+    process.exit(1)
+  }
+
+  for (const h of HUBS) {
+    console.log(`→ ${h.slug}`)
+    const assetId = await uploadImage(h.imagePath)
+    const image = assetId
+      ? {
+          _type: 'imageRef',
+          asset: {_type: 'reference', _ref: assetId},
+          alt: h.title.replace(/<[^>]+>/g, ''),
+          credit: 'venue-media-kit',
+          license: 'venue-media-kit',
+        }
+      : undefined
+
+    await client.createOrReplace({
+      _id: idForSlug(h.slug),
+      _type: 'pageHero',
+      pathSlug: h.slug,
+      eyebrow: h.eyebrow,
+      ...(h.category ? {category: h.category} : {}),
+      title: h.title,
+      image,
+    })
+    console.log(`  ✓ ${idForSlug(h.slug)}`)
+  }
+
+  console.log('\nDone.')
+}
+
+void seed()


### PR DESCRIPTION
## Summary
- Every /eat and /tour subpage now passes `entitySlug` (path-style, e.g. `eat/bakeries`, `tour/wine-tours`) and `entityType="page"` to SubpageHero / SectionHero, so the title and hero image become CMS-editable.
- `/tour/index` and `/tour/fishing-tours` previously passed no slug; both now point at `tour` and `tour/fishing-tours` respectively.
- Adds `studio-peninsula-insider/scripts/seed-eat-tour-hub-heroes.ts` (modelled on `seed-section-hub-heroes.ts`) to upload the current hardcoded hero image and createOrReplace a `pageHero` doc per slug.

## Behaviour
SubpageHero / SectionHero already dual-read the `pageHero` singleton. If no doc exists for a given slug, both components fall back to the Astro-prop defaults, so public HTML for unauthenticated visitors stays byte-identical until docs are seeded and the page-level flag is on (or preview cookie is set).

## Seed once locally
```
SANITY_AUTH_TOKEN=... npx tsx scripts/seed-eat-tour-hub-heroes.ts
```
(falls back to `SANITY_WRITE_TOKEN` if `SANITY_AUTH_TOKEN` is unset)

## Test plan
- [ ] Public render unchanged on `/eat/bakeries`, `/eat/best-restaurants`, `/tour/wine-tours`, `/tour/fishing-tours`, `/tour/`, `/tour/operators/` before seeding
- [ ] After seeding, Studio shows a `pageHero` doc for each path slug, and signed-in editors can right-click hero title/image to edit
- [ ] `node scripts/lint-no-pricing.mjs` clean (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)