### PR TITLE
feat(cms): brand & utility imagery via siteSettings singleton

### DIFF
--- a/next/src/components/AskPICTA.astro
+++ b/next/src/components/AskPICTA.astro
@@ -24,6 +24,15 @@ const {
   hint = "She knows the staff, the table, and what to actually order.",
   variant = 'rule',
 } = Astro.props;
+
+// Concierge icon resolves via siteSettings Sanity singleton with a hard
+// fallback to /images/pi-concierge.svg so pre-seed render is unchanged.
+import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
+try {
+  const s = await fetchSiteSettingsFromSanity();
+  if (s?.conciergeAvatar?.src) conciergeIcon = s.conciergeAvatar.src;
+} catch {}
 ---
 
 <aside
@@ -36,7 +45,7 @@ const {
   <button class="pi-cta__btn" type="button" aria-label={label}>
     <span class="pi-cta__avatar" aria-hidden="true">
       <span class="pi-cta__fallback">PI</span>
-      <img src="/images/pi-concierge.svg" alt="" width="36" height="36" onerror="this.remove()" />
+      <img src={conciergeIcon} alt="" width="36" height="36" onerror="this.remove()" />
     </span>
     <span class="pi-cta__text">
       <span class="pi-cta__eyebrow">Ask The Insider <span aria-hidden="true">✦</span></span>

--- a/next/src/components/ConciergeDrawer.astro
+++ b/next/src/components/ConciergeDrawer.astro
@@ -10,8 +10,25 @@
  *   pi-drawer-history  : array of {role, data} — conversation
  *
  * Trigger from anywhere: window.openConcierge() / window.openConcierge(prefill)
+ *
+ * The concierge avatar src is editable via the siteSettings Sanity
+ * singleton (conciergeAvatar field). Falls back to /images/pi-concierge.svg
+ * if the singleton hasn't been seeded or the fetch fails.
  */
+import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+
+let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
+try {
+  const s = await fetchSiteSettingsFromSanity();
+  if (s?.conciergeAvatar?.src) conciergeIcon = s.conciergeAvatar.src;
+} catch {
+  // soft-fail to the hardcoded fallback
+}
 ---
+
+<script is:inline define:vars={{ conciergeIcon }}>
+  window.__PI_CONCIERGE_ICON = conciergeIcon;
+</script>
 
 <aside
   class="pi-drawer"
@@ -32,7 +49,7 @@
   >
     <span class="pi-drawer__bubble-avatar" aria-hidden="true">
       <span class="pi-drawer__bubble-fallback">PI</span>
-      <img src="/images/pi-concierge.svg" alt="" width="40" height="40" onerror="this.remove()" />
+      <img src={conciergeIcon} alt="" width="40" height="40" onerror="this.remove()" />
     </span>
     <span class="pi-drawer__bubble-label">Ask <em>The Insider</em></span>
     <span class="pi-drawer__bubble-pulse" aria-hidden="true"></span>
@@ -54,7 +71,7 @@
       <div class="pi-drawer__id">
         <span class="pi-avatar pi-avatar--md" aria-hidden="true">
           <span class="pi-avatar__fallback">PI</span>
-          <img src="/images/pi-concierge.svg" alt="" width="42" height="42" onerror="this.remove()" />
+          <img src={conciergeIcon} alt="" width="42" height="42" onerror="this.remove()" />
         </span>
         <div>
           <p class="pi-drawer__name">The Insider <span class="pi-drawer__name-mark" aria-hidden="true">✦</span></p>
@@ -103,7 +120,7 @@
         <div class="ask-msg__byline">
           <span class="pi-avatar pi-avatar--sm" aria-hidden="true">
             <span class="pi-avatar__fallback">PI</span>
-            <img src="/images/pi-concierge.svg" alt="" width="22" height="22" onerror="this.remove()" />
+            <img src={conciergeIcon} alt="" width="22" height="22" onerror="this.remove()" />
           </span>
           <span class="ask-msg__byline-name">The Insider</span>
           <span class="ask-msg__byline-rule" aria-hidden="true"></span>
@@ -804,7 +821,7 @@
       return ''
         + '<span class="pi-avatar pi-avatar--' + size + '" aria-hidden="true">'
         +   '<span class="pi-avatar__fallback">PI</span>'
-        +   '<img src="/images/pi-concierge.svg" alt="" width="' + px + '" height="' + px + '" onerror="this.remove()" />'
+        +   '<img src="' + (window.__PI_CONCIERGE_ICON || '/images/pi-concierge.svg') + '" alt="" width="' + px + '" height="' + px + '" onerror="this.remove()" />'
         + '</span>';
     }
 

--- a/next/src/components/InsiderAsk.astro
+++ b/next/src/components/InsiderAsk.astro
@@ -35,6 +35,15 @@ const {
     "What's open on a wet Sunday",
   ],
 } = Astro.props;
+
+// Concierge icon resolves via siteSettings Sanity singleton with a hard
+// fallback to /images/pi-concierge.svg so pre-seed render is unchanged.
+import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
+try {
+  const s = await fetchSiteSettingsFromSanity();
+  if (s?.conciergeAvatar?.src) conciergeIcon = s.conciergeAvatar.src;
+} catch {}
 ---
 
 <section class="insider-ask" aria-label="Ask The Insider">
@@ -42,7 +51,7 @@ const {
     <div class="insider-ask__inner">
       <div class="insider-ask__head">
         <span class="insider-ask__avatar" aria-hidden="true">
-          <img src="/images/pi-concierge.svg" alt="" width="56" height="56" onerror="this.remove()" />
+          <img src={conciergeIcon} alt="" width="56" height="56" onerror="this.remove()" />
           <span class="insider-ask__avatar-fallback">PI</span>
         </span>
         <div class="insider-ask__heading-block">

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -28,6 +28,7 @@ import SaveSiteController from '../components/SaveSiteController.astro';
 import CloudSync from '../components/CloudSync.astro';
 import InlineEditor from '../components/admin/InlineEditor.astro';
 import SanityVisualEditing from '../components/admin/SanityVisualEditing.astro';
+import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
 
 export interface Props {
   title: string;
@@ -54,7 +55,7 @@ const {
   section = 'home',
   preview = false,
   canonical,
-  ogImage = '/images/sourced/home-cover.webp',
+  ogImage,
   ogType = 'website',
   noindex = false,
   publishedTime,
@@ -86,10 +87,23 @@ const normalizedPath = rawPathname === '/' ? '/' : rawPathname.replace(/\/?$/, '
 const rawCanonical = canonical ?? `${SITE_URL}${normalizedPath}`;
 const canonicalUrl = rawCanonical.endsWith('/') ? rawCanonical : rawCanonical + '/';
 
+// OG image fallback: if no per-page ogImage prop was supplied, resolve from
+// the siteSettings.ogFallback Sanity field; that in turn falls back to the
+// previous hardcoded path, so render is byte-equivalent pre-seed.
+let resolvedOgImage = ogImage;
+if (!resolvedOgImage) {
+  try {
+    const s = await fetchSiteSettingsFromSanity();
+    resolvedOgImage = s?.ogFallback?.src ?? SITE_SETTINGS_IMAGE_FALLBACKS.ogFallback.src;
+  } catch {
+    resolvedOgImage = SITE_SETTINGS_IMAGE_FALLBACKS.ogFallback.src;
+  }
+}
+
 // OG image must be an absolute URL.
-const ogImageAbsolute = ogImage.startsWith('http')
-  ? ogImage
-  : `${SITE_URL}${ogImage.startsWith('/') ? ogImage : '/' + ogImage}`;
+const ogImageAbsolute = resolvedOgImage.startsWith('http')
+  ? resolvedOgImage
+  : `${SITE_URL}${resolvedOgImage.startsWith('/') ? resolvedOgImage : '/' + resolvedOgImage}`;
 
 // Don't render the floating drawer when the visitor is on /ask itself.
 // /ask IS the full-screen chat, the drawer would be a duplicate.
@@ -241,8 +255,8 @@ const isAskPage = rawPathname.startsWith('/ask');
         display:none elements as invisible and skips them during indexing,
         which means `data-pagefind-meta` attributes on hidden elements are
         ignored. Empty <span> has zero visual impact regardless. */}
-    {!searchExclude && ogImage && (
-      <span data-pagefind-meta={`image:${ogImage}`}></span>
+    {!searchExclude && resolvedOgImage && (
+      <span data-pagefind-meta={`image:${resolvedOgImage}`}></span>
     )}
     <slot />
   </main>

--- a/next/src/lib/sanity/singletons-adapter.ts
+++ b/next/src/lib/sanity/singletons-adapter.ts
@@ -1,10 +1,10 @@
 /**
  * Sanity adapters for page-level singletons.
  *
- *   - homepageCover  → drives index.astro's <section class="cover">
- *   - megaRail       → drives V4MegaRail.astro
- *   - siteSettings   → drives masthead label, edition, footer links
- *   - pageHero(slug) → drives the SubpageHero override for a given hub
+ *   - homepageCover  -> drives index.astro's <section class="cover">
+ *   - megaRail       -> drives V4MegaRail.astro
+ *   - siteSettings   -> drives masthead label, edition, footer links, brand imagery
+ *   - pageHero(slug) -> drives the SubpageHero override for a given hub
  */
 import {getSanityReadClient} from './client'
 import {intentUrl} from './image'
@@ -26,7 +26,19 @@ function imageOrFallback(image: SanityImageRef, fallback: string, fallbackAlt: s
   return {src: intentUrl(image, 'hero'), alt: image.alt ?? fallbackAlt}
 }
 
-// ── Homepage cover ───────────────────────────────────────────────────────
+/** Small-icon variant: thumb-intent URL (320w), suits logos / avatars. */
+function iconOrFallback(image: SanityImageRef, fallback: string, fallbackAlt: string) {
+  if (!image?.asset) return {src: fallback, alt: fallbackAlt}
+  return {src: intentUrl(image, 'thumb'), alt: image.alt ?? fallbackAlt}
+}
+
+/** OG-intent (1200x630) variant for share-card fallback imagery. */
+function ogOrFallback(image: SanityImageRef, fallback: string, fallbackAlt: string) {
+  if (!image?.asset) return {src: fallback, alt: fallbackAlt}
+  return {src: intentUrl(image, 'og'), alt: image.alt ?? fallbackAlt}
+}
+
+// Homepage cover ----------------------------------------------------------
 
 const homepageCoverQuery = `*[_id == "homepageCover"][0]{
   activeSceneIndex,
@@ -78,7 +90,7 @@ export async function fetchHomepageCoverFromSanity(opts: FetchOpts = {}): Promis
   }
 }
 
-// ── Mega-rail ────────────────────────────────────────────────────────────
+// Mega-rail ---------------------------------------------------------------
 
 const megaRailQuery = `*[_id == "megaRail"][0]{
   entries[]{
@@ -113,12 +125,28 @@ export async function fetchMegaRailFromSanity(opts: FetchOpts = {}): Promise<Meg
   })
 }
 
-// ── Site settings ────────────────────────────────────────────────────────
+// Site settings -----------------------------------------------------------
 
 const siteSettingsQuery = `*[_id == "siteSettings"][0]{
   mastheadLabel, tagline, editionLabel, edition, editionYear, social,
-  footerLinks[]{label, href}
+  footerLinks[]{label, href},
+  "logo": logo ${img},
+  "conciergeAvatar": conciergeAvatar ${img},
+  "ogFallback": ogFallback ${img},
+  "notFoundImage": notFoundImage ${img}
 }`
+
+// Hardcoded paths preserved so any consumer that lands before the doc is
+// seeded renders byte-identically to the current static markup.
+const LOGO_FALLBACK = '/images/pi-logo-new.svg'
+const CONCIERGE_FALLBACK = '/images/pi-concierge.svg'
+const OG_FALLBACK = '/images/sourced/home-cover.webp'
+const NOT_FOUND_FALLBACK = '/images/pi-concierge.svg'
+
+export interface SiteSettingsImage {
+  src: string
+  alt: string
+}
 
 export interface SiteSettings {
   mastheadLabel: string
@@ -128,6 +156,10 @@ export interface SiteSettings {
   editionYear?: number
   footerLinks: Array<{label: string; href: string}>
   social: {instagram?: string; facebook?: string; twitter?: string}
+  logo: SiteSettingsImage
+  conciergeAvatar: SiteSettingsImage
+  ogFallback: SiteSettingsImage
+  notFoundImage: SiteSettingsImage
 }
 
 export async function fetchSiteSettingsFromSanity(opts: FetchOpts = {}): Promise<SiteSettings | null> {
@@ -141,10 +173,23 @@ export async function fetchSiteSettingsFromSanity(opts: FetchOpts = {}): Promise
     editionYear: d.editionYear ?? undefined,
     footerLinks: d.footerLinks ?? [],
     social: d.social ?? {},
+    logo: iconOrFallback(d.logo, LOGO_FALLBACK, 'Peninsula Insider'),
+    conciergeAvatar: iconOrFallback(d.conciergeAvatar, CONCIERGE_FALLBACK, ''),
+    ogFallback: ogOrFallback(d.ogFallback, OG_FALLBACK, 'Peninsula Insider'),
+    notFoundImage: iconOrFallback(d.notFoundImage, NOT_FOUND_FALLBACK, ''),
   }
 }
 
-// ── Page hero ────────────────────────────────────────────────────────────
+/** Default values used when the singleton doc hasn't been seeded yet -
+ *  exposed for consumers that want to render without a network round-trip. */
+export const SITE_SETTINGS_IMAGE_FALLBACKS = {
+  logo: {src: LOGO_FALLBACK, alt: 'Peninsula Insider'} as SiteSettingsImage,
+  conciergeAvatar: {src: CONCIERGE_FALLBACK, alt: ''} as SiteSettingsImage,
+  ogFallback: {src: OG_FALLBACK, alt: 'Peninsula Insider'} as SiteSettingsImage,
+  notFoundImage: {src: NOT_FOUND_FALLBACK, alt: ''} as SiteSettingsImage,
+}
+
+// Page hero ---------------------------------------------------------------
 
 const pageHeroQuery = `*[_type == "pageHero" && pathSlug == $slug][0]{
   pathSlug, title, eyebrow, category, dek,

--- a/next/src/pages/404.astro
+++ b/next/src/pages/404.astro
@@ -2,7 +2,16 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
 import AskPICTA from '../components/AskPICTA.astro';
+import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
 export const prerender = true;
+
+// 404 graphic comes from siteSettings.notFoundImage (Sanity). Hard fallback
+// to the concierge avatar so pre-seed render is identical.
+let notFoundImage = SITE_SETTINGS_IMAGE_FALLBACKS.notFoundImage.src;
+try {
+  const s = await fetchSiteSettingsFromSanity();
+  if (s?.notFoundImage?.src) notFoundImage = s.notFoundImage.src;
+} catch {}
 ---
 
 <BaseLayout
@@ -19,7 +28,7 @@ export const prerender = true;
         <div class="not-found__pi" aria-hidden="true">
           <span class="not-found__avatar">
             <span class="not-found__avatar-fallback">PI</span>
-            <img src="/images/pi-concierge.svg" alt="" width="72" height="72" onerror="this.remove()" />
+            <img src={notFoundImage} alt="" width="72" height="72" onerror="this.remove()" />
           </span>
         </div>
 

--- a/next/src/pages/ask.astro
+++ b/next/src/pages/ask.astro
@@ -5,15 +5,28 @@
  * filed-under tags. Designed as a magazine column, not a chatbot.
  */
 import BaseLayout from '../layouts/BaseLayout.astro';
+import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
 
 const API_URL = import.meta.env.PUBLIC_CONCIERGE_API_URL || 'http://localhost:8787';
 export const prerender = true;
+
+// Concierge icon comes from siteSettings (Sanity). Hard fallback to the
+// previous hardcoded /images/pi-concierge.svg so pre-seed render is identical.
+let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
+try {
+  const s = await fetchSiteSettingsFromSanity();
+  if (s?.conciergeAvatar?.src) conciergeIcon = s.conciergeAvatar.src;
+} catch {}
 ---
 
 <BaseLayout
   title="Ask The Insider — Your Peninsula Concierge"
   description="Ask Peninsula Insider anything about the Mornington Peninsula. Cellar doors, dining, stays, rainy days, dog-friendly spots. Local knowledge, editorial taste."
 >
+
+  <script is:inline define:vars={{ conciergeIcon }}>
+    window.__PI_CONCIERGE_ICON = conciergeIcon;
+  </script>
 
   <main class="ask-page">
 
@@ -23,7 +36,7 @@ export const prerender = true;
         <div class="ask-hero__avatar" aria-hidden="true">
           <span class="pi-avatar pi-avatar--xl">
             <span class="pi-avatar__fallback">PI</span>
-            <img src="/images/pi-concierge.svg" alt="" onerror="this.remove()" />
+            <img src={conciergeIcon} alt="" onerror="this.remove()" />
           </span>
         </div>
         <p class="ask-hero__eyebrow">Peninsula Insider · Field notes</p>
@@ -43,7 +56,7 @@ export const prerender = true;
           <div class="ask-dialog__id">
             <span class="pi-avatar pi-avatar--md" aria-hidden="true">
               <span class="pi-avatar__fallback">PI</span>
-              <img src="/images/pi-concierge.svg" alt="" onerror="this.remove()" />
+              <img src={conciergeIcon} alt="" onerror="this.remove()" />
             </span>
             <div class="ask-dialog__id-text">
               <p class="ask-dialog__name">The Insider <span class="ask-dialog__name-mark" aria-hidden="true">✦</span></p>
@@ -67,7 +80,7 @@ export const prerender = true;
             <div class="ask-msg__byline">
               <span class="pi-avatar pi-avatar--sm" aria-hidden="true">
                 <span class="pi-avatar__fallback">PI</span>
-                <img src="/images/pi-concierge.svg" alt="" onerror="this.remove()" />
+                <img src={conciergeIcon} alt="" onerror="this.remove()" />
               </span>
               <span class="ask-msg__byline-name">The Insider</span>
               <span class="ask-msg__byline-rule" aria-hidden="true"></span>
@@ -187,7 +200,7 @@ export const prerender = true;
     return `
       <span class="pi-avatar pi-avatar--${size}" aria-hidden="true">
         <span class="pi-avatar__fallback">PI</span>
-        <img src="/images/pi-concierge.svg" alt="" width="${px}" height="${px}" onerror="this.remove()" />
+        <img src="${window.__PI_CONCIERGE_ICON || '/images/pi-concierge.svg'}" alt="" width="${px}" height="${px}" onerror="this.remove()" />
       </span>
     `;
   }

--- a/studio-peninsula-insider/schemaTypes/documents/siteSettings.ts
+++ b/studio-peninsula-insider/schemaTypes/documents/siteSettings.ts
@@ -4,7 +4,7 @@ import {defineType, defineField} from 'sanity'
  * Site settings — singleton. One document, _id = 'siteSettings'.
  * Holds the small set of cross-page values that today live as inline
  * constants in the masthead, footer, and BaseLayout: edition date,
- * social handles, footer links.
+ * social handles, footer links, and brand / utility imagery.
  */
 export const siteSettings = defineType({
   name: 'siteSettings',
@@ -34,6 +34,33 @@ export const siteSettings = defineType({
         defineField({name: 'facebook', title: 'Facebook', type: 'url'}),
         defineField({name: 'twitter', title: 'Twitter / X', type: 'url'}),
       ],
+    }),
+
+    // Brand & utility imagery. Each falls back to its current hardcoded
+    // /images/* path in the adapter, so pre-seed render is byte-equivalent.
+    defineField({
+      name: 'logo',
+      title: 'Site logo',
+      type: 'imageRef',
+      description: 'Primary brand logo. Falls back to /images/pi-logo-new.svg if unset.',
+    }),
+    defineField({
+      name: 'conciergeAvatar',
+      title: 'Concierge avatar',
+      type: 'imageRef',
+      description: 'Avatar for "The Insider" concierge across the drawer, /ask, AskPICTA, InsiderAsk, and 404. Falls back to /images/pi-concierge.svg.',
+    }),
+    defineField({
+      name: 'ogFallback',
+      title: 'Open Graph fallback image',
+      type: 'imageRef',
+      description: 'Default share-card image when a page has no per-page hero. Falls back to /images/sourced/home-cover.webp.',
+    }),
+    defineField({
+      name: 'notFoundImage',
+      title: '404 page graphic',
+      type: 'imageRef',
+      description: 'Image shown on the 404 page. Defaults to the concierge avatar; override for a dedicated 404 illustration.',
     }),
   ],
   preview: {prepare: () => ({title: 'Site settings'})},

--- a/studio-peninsula-insider/scripts/seed-site-settings-imagery.ts
+++ b/studio-peninsula-insider/scripts/seed-site-settings-imagery.ts
@@ -1,0 +1,94 @@
+/**
+ * Seed brand & utility imagery into the existing siteSettings singleton.
+ *
+ * Uploads the current hardcoded images (logo, concierge avatar, OG fallback,
+ * 404 graphic) to Sanity's Asset Pipeline and patches the existing
+ * `siteSettings` document with imageRef references for each. Uses
+ * `client.patch(...).set(...).commit()` (not createOrReplace) so existing
+ * fields on the singleton — masthead label, footer links, social — are
+ * preserved.
+ *
+ *   Usage: SANITY_WRITE_TOKEN=... npx tsx scripts/seed-site-settings-imagery.ts
+ *
+ * Idempotent: the patch overwrites only the four imagery fields. Re-running
+ * uploads the same source files again (Sanity dedupes by content hash for
+ * identical bytes, so no orphan assets pile up).
+ */
+import {createClient} from '@sanity/client'
+import {readFile} from 'node:fs/promises'
+import {join, dirname, basename} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const imagesRoot = join(repoRoot, 'next', 'public')
+
+const client = createClient({
+  projectId: 'a062b30n',
+  dataset: 'production',
+  apiVersion: '2025-01-01',
+  token: process.env.SANITY_WRITE_TOKEN,
+  useCdn: false,
+})
+
+interface ImageSeed {
+  field: 'logo' | 'conciergeAvatar' | 'ogFallback' | 'notFoundImage'
+  path: string
+  alt: string
+}
+
+const SEEDS: ImageSeed[] = [
+  {field: 'logo', path: '/images/pi-logo-new.svg', alt: 'Peninsula Insider'},
+  {field: 'conciergeAvatar', path: '/images/pi-concierge.svg', alt: 'The Insider, Peninsula Insider concierge'},
+  {field: 'ogFallback', path: '/images/sourced/home-cover.webp', alt: 'Peninsula Insider'},
+  {field: 'notFoundImage', path: '/images/pi-concierge.svg', alt: ''},
+]
+
+async function uploadImage(src: string): Promise<string | null> {
+  try {
+    const buf = await readFile(join(imagesRoot, src.replace(/^\/+/, '')))
+    const filename = basename(src)
+    const a = await client.assets.upload('image', buf, {filename})
+    return a._id
+  } catch (err) {
+    console.error(`  ! upload failed ${src}: ${(err as Error).message}`)
+    return null
+  }
+}
+
+async function seed() {
+  if (!process.env.SANITY_WRITE_TOKEN) {
+    console.error('SANITY_WRITE_TOKEN not set.')
+    process.exit(1)
+  }
+
+  const patchSet: Record<string, unknown> = {}
+
+  for (const s of SEEDS) {
+    console.log(`-> ${s.field}  (${s.path})`)
+    const assetId = await uploadImage(s.path)
+    if (!assetId) {
+      console.warn(`  skipping ${s.field} (upload failed)`)
+      continue
+    }
+    patchSet[s.field] = {
+      _type: 'imageRef',
+      asset: {_type: 'reference', _ref: assetId},
+      alt: s.alt,
+      credit: 'original-commissioned',
+      license: 'original-commissioned',
+    }
+    console.log(`  ok ${assetId}`)
+  }
+
+  if (Object.keys(patchSet).length === 0) {
+    console.error('No images uploaded — aborting patch.')
+    process.exit(1)
+  }
+
+  console.log('\nPatching siteSettings document...')
+  await client.patch('siteSettings').set(patchSet).commit()
+  console.log('Done.')
+}
+
+void seed()


### PR DESCRIPTION
## Summary

- Extend the `siteSettings` Sanity singleton with four new image fields: `logo`, `conciergeAvatar`, `ogFallback`, `notFoundImage`.
- Adapter (`singletons-adapter.ts`) resolves each to `{src, alt}` with hardcoded fallbacks that match today's static markup, so pre-seed render is byte-equivalent.
- Wire consumers: `ConciergeDrawer`, `AskPICTA`, `InsiderAsk`, `pages/ask.astro`, `pages/404.astro`, and `BaseLayout` (OG fallback). All render unchanged until the singleton is seeded.
- Add `studio-peninsula-insider/scripts/seed-site-settings-imagery.ts` to upload the four current hardcoded images and patch the existing siteSettings doc (preserves other fields via `client.patch().set().commit()`).

## Notes

- The `logo` field is staged for future use; the live V4 masthead uses a text logo (`Peninsula <span>Insider</span>`), so no logo consumer wiring was needed — `/images/pi-logo-new.svg` only appears in the `v2-staging/logo-preview` design surface.
- Studio Presentation routing for the siteSettings singleton already points at `/preview/home/` and is unchanged — editors will reach the concierge icon and OG fallback via the homepage chrome / meta tags.
- For the JS-templated concierge avatar markup inside `ConciergeDrawer` and `ask.astro` script blocks, the resolved icon is bridged to client JS through `window.__PI_CONCIERGE_ICON` via a small `define:vars` inline script. Falls back to the hardcoded path if unset.

## Test plan

- [ ] `npm run build` in `next/` succeeds.
- [ ] Studio shows the four new imagery fields under Site settings.
- [ ] With the singleton un-seeded, `/`, `/ask/`, `/404/` and any page using `AskPICTA` / `InsiderAsk` render with the original hardcoded images.
- [ ] After running `SANITY_WRITE_TOKEN=... npx tsx scripts/seed-site-settings-imagery.ts`, the concierge avatar, 404 graphic and og:image meta on a heroless page swap to the Sanity-hosted URLs.
- [ ] `lint-no-pricing` passes.

Seed command:
```
SANITY_WRITE_TOKEN=... npx tsx studio-peninsula-insider/scripts/seed-site-settings-imagery.ts
```