### PR TITLE
hotfix(cms): gate visual-editing overlay to Studio iframe context

### DIFF
--- a/next/src/components/admin/SanityVisualEditing.astro
+++ b/next/src/components/admin/SanityVisualEditing.astro
@@ -1,32 +1,51 @@
 ---
 /**
- * Sanity Visual Editing overlay — mounts on every page so click-to-edit
- * works on the public site when loaded inside Studio's Presentation
- * iframe.
+ * Sanity Visual Editing overlay.
  *
- * The overlay script:
- *   - Reads stega-encoded markers attached to every string field by the
- *     Sanity client (lib/sanity/client.ts — stega is now enabled on the
- *     production client too)
- *   - Listens for postMessage from the parent Studio frame
- *   - Renders clickable hotspots over each stega-marked element
- *   - When the editor clicks one, opens the corresponding field in
- *     Sanity Studio's Presentation panel
+ * Only mounts when we're loaded inside a Sanity Studio Presentation
+ * iframe. PR #191 dropped the gate hoping enableVisualEditing() would
+ * self-detect — it doesn't, the overlay was leaking onto public traffic
+ * (boxes around headlines + "Open in Studio" buttons). This component
+ * now gates the mount explicitly on:
+ *   1. Being in a child frame (window !== top), AND
+ *   2. The parent referrer being the Studio origin
  *
- * The script self-detects whether it's in an iframe and goes inert if
- * there's no parent frame to message — so public visitors loading the
- * site outside of Studio pay only the bundle download cost (~25 KB
- * gzipped) and the overlay produces no UI.
- *
- * The bundle is only requested when the script tag fires, so it's
- * download-once-cache-forever after the first load.
+ * Outside Studio the import never fires, so the visual-editing bundle
+ * (~25 KB gzipped) isn't downloaded by public visitors either.
  */
 ---
 
 <script>
-  // Mount on every page. @sanity/visual-editing internally checks for
-  // parent frame and stays inert when loaded outside Studio.
-  import('@sanity/visual-editing').then(({ enableVisualEditing }) => {
-    enableVisualEditing({ zIndex: 9999 });
-  });
+  (function () {
+    // Skip mount entirely outside browser (SSR build).
+    if (typeof window === 'undefined') return;
+
+    // Skip if we're the top-level window. Studio's Presentation loads the
+    // site in an iframe, so window.top !== window when in Presentation.
+    let inIframe = false;
+    try {
+      inIframe = window.top !== window.self;
+    } catch (_) {
+      // Cross-origin throws on .top access — treat as iframed (we ARE in
+      // a frame we can't introspect, which is exactly the Studio case).
+      inIframe = true;
+    }
+    if (!inIframe) return;
+
+    // Belt-and-braces: only mount if the parent is Sanity Studio. The
+    // referrer is the URL of the page that loaded us, which for a Studio
+    // iframe is the Studio's own URL. Cross-origin iframe restrictions
+    // can blank document.referrer; in that case skip rather than
+    // attaching the overlay to arbitrary embeds.
+    const ref = document.referrer || '';
+    const isStudioParent =
+      ref.startsWith('https://peninsula-insider.sanity.studio') ||
+      ref.startsWith('https://sanity.io') ||
+      ref.includes('.sanity.studio');
+    if (!isStudioParent) return;
+
+    import('@sanity/visual-editing').then(({ enableVisualEditing }) => {
+      enableVisualEditing({ zIndex: 9999 });
+    });
+  })();
 </script>


### PR DESCRIPTION
PR #191 leaked the overlay onto public traffic. This explicit-gates the mount on (window.top !== window.self) + Studio referrer. Public visitors see no overlay UI and don't download the visual-editing bundle.