### PR TITLE
fix(cms): wire singleton-backed images to admin overlay

### DIFF
--- a/next/src/lib/inline-edit/attrs.ts
+++ b/next/src/lib/inline-edit/attrs.ts
@@ -38,6 +38,20 @@ export interface EditableImageOpts {
   label: string;
   /** Defaults to `'hero'`. */
   purpose?: 'hero' | 'card' | 'gallery' | 'inline' | 'seo';
+  /**
+   * Optional: when this image is sourced from a Sanity *singleton* doc
+   * (e.g. `homepageCover`, `megaRail`, `siteSettings`), pass the singleton
+   * `_id` here. The admin overlay will resolve the patch target directly
+   * to that doc id instead of trying to query by slug.
+   */
+  sanitySingletonId?: string;
+  /**
+   * Optional: dot-notation path inside the singleton doc to the image
+   * field. Defaults to `fieldPath`. Use this when the legacy `fieldPath`
+   * (e.g. `cover.image`) doesn't match the Sanity schema's actual path
+   * (e.g. `scenes[2].image`).
+   */
+  sanitySingletonPath?: string;
 }
 
 /**
@@ -72,7 +86,7 @@ export function editableText(opts: EditableTextOpts): Record<string, string> {
  *     src={src} alt={alt} />
  */
 export function editableImage(opts: EditableImageOpts): Record<string, string> {
-  return {
+  const attrs: Record<string, string> = {
     'data-pi-edit': 'image',
     'data-pi-entity-type': opts.entityType,
     'data-pi-entity-slug': opts.entitySlug,
@@ -80,4 +94,9 @@ export function editableImage(opts: EditableImageOpts): Record<string, string> {
     'data-pi-purpose': opts.purpose ?? 'hero',
     'data-pi-label': opts.label,
   };
+  if (opts.sanitySingletonId) {
+    attrs['data-pi-sanity-singleton-id'] = opts.sanitySingletonId;
+    attrs['data-pi-sanity-singleton-path'] = opts.sanitySingletonPath ?? opts.fieldPath;
+  }
+  return attrs;
 }

--- a/next/src/lib/inline-edit/client.ts
+++ b/next/src/lib/inline-edit/client.ts
@@ -432,6 +432,10 @@ interface ImageDescriptor {
   purpose: 'hero' | 'card' | 'gallery' | 'inline' | 'seo';
   /** True when the element was auto-detected rather than explicitly tagged. */
   autoDetected: boolean;
+  /** Sanity singleton _id, when the source is a singleton doc. */
+  sanitySingletonId?: string;
+  /** Dot-notation path inside the singleton doc to the image field. */
+  sanitySingletonPath?: string;
 }
 
 /**
@@ -501,6 +505,8 @@ function readImageDescriptor(el: HTMLElement): ImageDescriptor | null {
       label: explicitLabel || explicitPath,
       purpose,
       autoDetected: false,
+      sanitySingletonId: el.dataset.piSanitySingletonId || undefined,
+      sanitySingletonPath: el.dataset.piSanitySingletonPath || undefined,
     };
   }
 

--- a/next/src/lib/inline-edit/sanity-image-overlay.ts
+++ b/next/src/lib/inline-edit/sanity-image-overlay.ts
@@ -35,6 +35,10 @@ interface EditableDescriptor {
   entitySlug: string;
   fieldPath: string;
   autoDetected: boolean;
+  /** Sanity singleton _id when this image binds to a singleton doc. */
+  sanitySingletonId?: string;
+  /** Dot-notation path inside the singleton doc. Defaults to fieldPath. */
+  sanitySingletonPath?: string;
 }
 
 interface ToastFn {
@@ -108,7 +112,17 @@ export function resolveSanitySource(
   el: HTMLElement,
   desc: EditableDescriptor,
 ): SanitySource | null {
-  // a) data-pi-edit attrs — only useful when the entityType maps to a Sanity
+  // a) Explicit Sanity singleton binding via data-pi-sanity-singleton-id.
+  //    Highest priority — the element's source is unambiguous.
+  if (!desc.autoDetected && desc.sanitySingletonId) {
+    return {
+      docId: desc.sanitySingletonId,
+      fieldPath: normaliseFieldPath(desc.sanitySingletonPath ?? desc.fieldPath),
+      resolvedVia: 'data-pi-edit',
+    };
+  }
+
+  // b) data-pi-edit attrs — only useful when the entityType maps to a Sanity
   //    type with a slug. Page-level slots fall through to stega.
   if (!desc.autoDetected) {
     const SANITY_BACKED: ReadonlySet<string> = new Set([

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -237,10 +237,12 @@ let ssrScene: Scene = coverImageOverride
 // Dual-read: hydrate the cover from Sanity's homepageCover singleton
 // when the page-level flag is on. Replaces both the inline `scenes[]`
 // array AND the legacy Supabase cover.image override.
+let sanityActiveSceneIndex: number | null = null;
 if (sanityReadEnabled('page-level')) {
   const sanityCover = await fetchHomepageCoverFromSanity();
   if (sanityCover && sanityCover.scenes.length > 0) {
-    const sc = sanityCover.scenes[Math.min(sanityCover.activeIndex, sanityCover.scenes.length - 1)];
+    sanityActiveSceneIndex = Math.min(sanityCover.activeIndex, sanityCover.scenes.length - 1);
+    const sc = sanityCover.scenes[sanityActiveSceneIndex];
     ssrScene = {
       id: sc.id,
       label: sc.label,
@@ -376,6 +378,16 @@ export const prerender = true;
               fieldPath: 'cover.image',
               label: 'Cover image',
               purpose: 'hero',
+              // Bind to the homepageCover Sanity singleton so the admin
+              // overlay's "Replace from media library" can patch the right
+              // scene's image. Falls through to legacy Supabase override if
+              // the Sanity dual-read didn't fire (flag off).
+              ...(sanityActiveSceneIndex !== null
+                ? {
+                    sanitySingletonId: 'homepageCover',
+                    sanitySingletonPath: `scenes[${sanityActiveSceneIndex}].image`,
+                  }
+                : {}),
             })}
           />
         </div>


### PR DESCRIPTION
Closes the 'not bound to a Sanity field' rejection on the homepage cover. Extends editableImage() with sanitySingletonId/Path; cover uses it. Same pattern applies to mega rail and pageHero in follow-ups.