### PR TITLE
diag(cms): surface access reason in admin API 401/403 responses

### DIFF
--- a/next/src/pages/api/admin/sanity-asset-upload.ts
+++ b/next/src/pages/api/admin/sanity-asset-upload.ts
@@ -30,8 +30,8 @@ const MAX_BYTES = 25 * 1024 * 1024; // 25MB
 export const POST: APIRoute = async ({ request }) => {
   const access = await resolveCmsAccess(request.headers.get('cookie'));
   if (!access.ok) {
-    if (access.reason === 'not-editor') return forbidden('Not an editor');
-    return unauthorized();
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
   }
 
   const client = getSanityWriteClient();

--- a/next/src/pages/api/admin/sanity-assets.ts
+++ b/next/src/pages/api/admin/sanity-assets.ts
@@ -27,8 +27,8 @@ const PAGE_SIZE = 24;
 export const GET: APIRoute = async ({ request, url }) => {
   const access = await resolveCmsAccess(request.headers.get('cookie'));
   if (!access.ok) {
-    if (access.reason === 'not-editor') return forbidden('Not an editor');
-    return unauthorized();
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
   }
 
   const client = getSanityWriteClient();

--- a/next/src/pages/api/admin/sanity-patch.ts
+++ b/next/src/pages/api/admin/sanity-patch.ts
@@ -42,8 +42,8 @@ interface PatchBody {
 export const POST: APIRoute = async ({ request }) => {
   const access = await resolveCmsAccess(request.headers.get('cookie'));
   if (!access.ok) {
-    if (access.reason === 'not-editor') return forbidden('Not an editor');
-    return unauthorized();
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
   }
 
   const client = getSanityWriteClient();


### PR DESCRIPTION
One-line diagnostic improvement so 'Unauthorized' on the admin overlay tells us which check failed.