### PR TITLE
feat(cms): wire mega rail, pageHero, siteSettings to admin overlay

### DIFF
--- a/next/src/components/AskPICTA.astro
+++ b/next/src/components/AskPICTA.astro
@@ -28,11 +28,21 @@ const {
 // Concierge icon resolves via siteSettings Sanity singleton with a hard
 // fallback to /images/pi-concierge.svg so pre-seed render is unchanged.
 import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+import {editableImage} from '../lib/inline-edit/attrs';
 let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
 try {
   const s = await fetchSiteSettingsFromSanity();
   if (s?.conciergeAvatar?.src) conciergeIcon = s.conciergeAvatar.src;
 } catch {}
+const conciergeAvatarAttrs = editableImage({
+  entityType: 'page',
+  entitySlug: '_global',
+  fieldPath: 'site-settings.conciergeAvatar',
+  label: 'Concierge avatar',
+  purpose: 'inline',
+  sanitySingletonId: 'siteSettings',
+  sanitySingletonPath: 'conciergeAvatar',
+});
 ---
 
 <aside
@@ -45,7 +55,7 @@ try {
   <button class="pi-cta__btn" type="button" aria-label={label}>
     <span class="pi-cta__avatar" aria-hidden="true">
       <span class="pi-cta__fallback">PI</span>
-      <img src={conciergeIcon} alt="" width="36" height="36" onerror="this.remove()" />
+      <img src={conciergeIcon} alt="" width="36" height="36" onerror="this.remove()" {...conciergeAvatarAttrs} />
     </span>
     <span class="pi-cta__text">
       <span class="pi-cta__eyebrow">Ask The Insider <span aria-hidden="true">✦</span></span>

--- a/next/src/components/ConciergeDrawer.astro
+++ b/next/src/components/ConciergeDrawer.astro
@@ -16,6 +16,17 @@
  * if the singleton hasn't been seeded or the fetch fails.
  */
 import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+import {editableImage} from '../lib/inline-edit/attrs';
+
+const conciergeAvatarAttrs = editableImage({
+  entityType: 'page',
+  entitySlug: '_global',
+  fieldPath: 'site-settings.conciergeAvatar',
+  label: 'Concierge avatar',
+  purpose: 'inline',
+  sanitySingletonId: 'siteSettings',
+  sanitySingletonPath: 'conciergeAvatar',
+});
 
 let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
 try {
@@ -49,7 +60,7 @@ try {
   >
     <span class="pi-drawer__bubble-avatar" aria-hidden="true">
       <span class="pi-drawer__bubble-fallback">PI</span>
-      <img src={conciergeIcon} alt="" width="40" height="40" onerror="this.remove()" />
+      <img src={conciergeIcon} alt="" width="40" height="40" onerror="this.remove()" {...conciergeAvatarAttrs} />
     </span>
     <span class="pi-drawer__bubble-label">Ask <em>The Insider</em></span>
     <span class="pi-drawer__bubble-pulse" aria-hidden="true"></span>
@@ -71,7 +82,7 @@ try {
       <div class="pi-drawer__id">
         <span class="pi-avatar pi-avatar--md" aria-hidden="true">
           <span class="pi-avatar__fallback">PI</span>
-          <img src={conciergeIcon} alt="" width="42" height="42" onerror="this.remove()" />
+          <img src={conciergeIcon} alt="" width="42" height="42" onerror="this.remove()" {...conciergeAvatarAttrs} />
         </span>
         <div>
           <p class="pi-drawer__name">The Insider <span class="pi-drawer__name-mark" aria-hidden="true">✦</span></p>
@@ -120,7 +131,7 @@ try {
         <div class="ask-msg__byline">
           <span class="pi-avatar pi-avatar--sm" aria-hidden="true">
             <span class="pi-avatar__fallback">PI</span>
-            <img src={conciergeIcon} alt="" width="22" height="22" onerror="this.remove()" />
+            <img src={conciergeIcon} alt="" width="22" height="22" onerror="this.remove()" {...conciergeAvatarAttrs} />
           </span>
           <span class="ask-msg__byline-name">The Insider</span>
           <span class="ask-msg__byline-rule" aria-hidden="true"></span>

--- a/next/src/components/GuideHero.astro
+++ b/next/src/components/GuideHero.astro
@@ -81,7 +81,21 @@ const dekAttrs = editable
   ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.dek', label: `${entitySlug} hero dek` })
   : {};
 const imageAttrs = editable
-  ? editableImage({ entityType, entitySlug: entitySlug!, fieldPath: 'hero', label: `${entitySlug} hero image`, purpose: 'hero' })
+  ? editableImage({
+      entityType,
+      entitySlug: entitySlug!,
+      fieldPath: 'hero',
+      label: `${entitySlug} hero image`,
+      purpose: 'hero',
+      // When the page-level singleton is in play, point the admin overlay
+      // at the pageHero doc keyed by slug (slashes → double-dash).
+      ...(isPageEntity
+        ? {
+            sanitySingletonId: `pageHero-${entitySlug!.replace(/\//g, '--')}`,
+            sanitySingletonPath: 'image',
+          }
+        : {}),
+    })
   : {};
 ---
 

--- a/next/src/components/InsiderAsk.astro
+++ b/next/src/components/InsiderAsk.astro
@@ -39,11 +39,21 @@ const {
 // Concierge icon resolves via siteSettings Sanity singleton with a hard
 // fallback to /images/pi-concierge.svg so pre-seed render is unchanged.
 import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+import {editableImage} from '../lib/inline-edit/attrs';
 let conciergeIcon = SITE_SETTINGS_IMAGE_FALLBACKS.conciergeAvatar.src;
 try {
   const s = await fetchSiteSettingsFromSanity();
   if (s?.conciergeAvatar?.src) conciergeIcon = s.conciergeAvatar.src;
 } catch {}
+const conciergeAvatarAttrs = editableImage({
+  entityType: 'page',
+  entitySlug: '_global',
+  fieldPath: 'site-settings.conciergeAvatar',
+  label: 'Concierge avatar',
+  purpose: 'inline',
+  sanitySingletonId: 'siteSettings',
+  sanitySingletonPath: 'conciergeAvatar',
+});
 ---
 
 <section class="insider-ask" aria-label="Ask The Insider">
@@ -51,7 +61,7 @@ try {
     <div class="insider-ask__inner">
       <div class="insider-ask__head">
         <span class="insider-ask__avatar" aria-hidden="true">
-          <img src={conciergeIcon} alt="" width="56" height="56" onerror="this.remove()" />
+          <img src={conciergeIcon} alt="" width="56" height="56" onerror="this.remove()" {...conciergeAvatarAttrs} />
           <span class="insider-ask__avatar-fallback">PI</span>
         </span>
         <div class="insider-ask__heading-block">

--- a/next/src/components/SectionHero.astro
+++ b/next/src/components/SectionHero.astro
@@ -76,7 +76,19 @@ const dekAttrs = editable
   ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.dek', label: `${entitySlug} hero dek` })
   : {};
 const imageAttrs = editable
-  ? editableImage({ entityType, entitySlug: entitySlug!, fieldPath: 'hero', label: `${entitySlug} hero`, purpose: 'hero' })
+  ? editableImage({
+      entityType,
+      entitySlug: entitySlug!,
+      fieldPath: 'hero',
+      label: `${entitySlug} hero`,
+      purpose: 'hero',
+      ...(isPageEntity
+        ? {
+            sanitySingletonId: `pageHero-${entitySlug!.replace(/\//g, '--')}`,
+            sanitySingletonPath: 'image',
+          }
+        : {}),
+    })
   : {};
 ---
 

--- a/next/src/components/SubpageHero.astro
+++ b/next/src/components/SubpageHero.astro
@@ -84,7 +84,19 @@ const titleAttrs = editable
   ? editableText({ entityType, entitySlug: entitySlug!, fieldPath: 'hero.title', label: `${entitySlug} hero title` })
   : {};
 const imageAttrs = editable
-  ? editableImage({ entityType, entitySlug: entitySlug!, fieldPath: 'hero', label: `${entitySlug} hero image`, purpose: 'hero' })
+  ? editableImage({
+      entityType,
+      entitySlug: entitySlug!,
+      fieldPath: 'hero',
+      label: `${entitySlug} hero image`,
+      purpose: 'hero',
+      ...(isPageEntity
+        ? {
+            sanitySingletonId: `pageHero-${entitySlug!.replace(/\//g, '--')}`,
+            sanitySingletonPath: 'image',
+          }
+        : {}),
+    })
   : {};
 ---
 

--- a/next/src/components/v4/V4MegaRail.astro
+++ b/next/src/components/v4/V4MegaRail.astro
@@ -28,15 +28,31 @@ const { rail, pillarKey } = Astro.props;
 let imageSrc = rail.image;
 let imageAlt = rail.imageAlt;
 
+// Canonical entry order matches the megaRail schema's `key` enum. We use
+// this as the fallback index when the Sanity dual-read hasn't fired, so
+// the admin overlay's patch path (entries[idx].image) still resolves.
+const canonicalOrder = ['whats-on', 'escape', 'eat', 'wine', 'stay'];
+let sanityEntryIndex: number | null = null;
+
 const isPreview = (Astro.locals as Record<string, unknown>).sanityPreview === true;
 if (isPreview || sanityReadEnabled('page-level')) {
   const entries = await fetchMegaRailFromSanity({preview: isPreview});
-  const entry = entries?.find((e) => e.key === pillarKey);
-  if (entry?.imageSrc) {
-    imageSrc = entry.imageSrc;
-    imageAlt = entry.imageAlt ?? rail.imageAlt;
+  const idx = entries?.findIndex((e) => e.key === pillarKey) ?? -1;
+  if (entries && idx >= 0) {
+    sanityEntryIndex = idx;
+    const entry = entries[idx];
+    if (entry?.imageSrc) {
+      imageSrc = entry.imageSrc;
+      imageAlt = entry.imageAlt ?? rail.imageAlt;
+    }
   }
-} else {
+}
+if (sanityEntryIndex === null) {
+  const fallbackIdx = canonicalOrder.indexOf(pillarKey);
+  if (fallbackIdx >= 0) sanityEntryIndex = fallbackIdx;
+}
+
+if (!isPreview && !sanityReadEnabled('page-level')) {
   const globalOverrides = await loadOverrides('page', '_global');
   const overrideImage = globalOverrides.image[`mega-rail.${pillarKey}`];
   if (overrideImage?.src) {
@@ -56,8 +72,14 @@ if (isPreview || sanityReadEnabled('page-level')) {
         entityType: 'page',
         entitySlug: '_global',
         fieldPath: `mega-rail.${pillarKey}`,
-        label: `Mega menu — ${pillarKey} rail image`,
+        label: `Mega rail: ${rail.title ?? pillarKey}`,
         purpose: 'inline',
+        ...(sanityEntryIndex !== null
+          ? {
+              sanitySingletonId: 'megaRail',
+              sanitySingletonPath: `entries[${sanityEntryIndex}].image`,
+            }
+          : {}),
       })}
     />
   </div>

--- a/next/src/pages/404.astro
+++ b/next/src/pages/404.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
 import AskPICTA from '../components/AskPICTA.astro';
 import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+import {editableImage} from '../lib/inline-edit/attrs';
 export const prerender = true;
 
 // 404 graphic comes from siteSettings.notFoundImage (Sanity). Hard fallback
@@ -12,6 +13,16 @@ try {
   const s = await fetchSiteSettingsFromSanity();
   if (s?.notFoundImage?.src) notFoundImage = s.notFoundImage.src;
 } catch {}
+
+const notFoundImageAttrs = editableImage({
+  entityType: 'page',
+  entitySlug: '_global',
+  fieldPath: 'site-settings.notFoundImage',
+  label: '404 page graphic',
+  purpose: 'hero',
+  sanitySingletonId: 'siteSettings',
+  sanitySingletonPath: 'notFoundImage',
+});
 ---
 
 <BaseLayout
@@ -28,7 +39,7 @@ try {
         <div class="not-found__pi" aria-hidden="true">
           <span class="not-found__avatar">
             <span class="not-found__avatar-fallback">PI</span>
-            <img src={notFoundImage} alt="" width="72" height="72" onerror="this.remove()" />
+            <img src={notFoundImage} alt="" width="72" height="72" onerror="this.remove()" {...notFoundImageAttrs} />
           </span>
         </div>
 

--- a/next/src/pages/ask.astro
+++ b/next/src/pages/ask.astro
@@ -6,6 +6,17 @@
  */
 import BaseLayout from '../layouts/BaseLayout.astro';
 import {fetchSiteSettingsFromSanity, SITE_SETTINGS_IMAGE_FALLBACKS} from '../lib/sanity/singletons-adapter';
+import {editableImage} from '../lib/inline-edit/attrs';
+
+const conciergeAvatarAttrs = editableImage({
+  entityType: 'page',
+  entitySlug: '_global',
+  fieldPath: 'site-settings.conciergeAvatar',
+  label: 'Concierge avatar',
+  purpose: 'inline',
+  sanitySingletonId: 'siteSettings',
+  sanitySingletonPath: 'conciergeAvatar',
+});
 
 const API_URL = import.meta.env.PUBLIC_CONCIERGE_API_URL || 'http://localhost:8787';
 export const prerender = true;
@@ -36,7 +47,7 @@ try {
         <div class="ask-hero__avatar" aria-hidden="true">
           <span class="pi-avatar pi-avatar--xl">
             <span class="pi-avatar__fallback">PI</span>
-            <img src={conciergeIcon} alt="" onerror="this.remove()" />
+            <img src={conciergeIcon} alt="" onerror="this.remove()" {...conciergeAvatarAttrs} />
           </span>
         </div>
         <p class="ask-hero__eyebrow">Peninsula Insider · Field notes</p>
@@ -56,7 +67,7 @@ try {
           <div class="ask-dialog__id">
             <span class="pi-avatar pi-avatar--md" aria-hidden="true">
               <span class="pi-avatar__fallback">PI</span>
-              <img src={conciergeIcon} alt="" onerror="this.remove()" />
+              <img src={conciergeIcon} alt="" onerror="this.remove()" {...conciergeAvatarAttrs} />
             </span>
             <div class="ask-dialog__id-text">
               <p class="ask-dialog__name">The Insider <span class="ask-dialog__name-mark" aria-hidden="true">✦</span></p>
@@ -80,7 +91,7 @@ try {
             <div class="ask-msg__byline">
               <span class="pi-avatar pi-avatar--sm" aria-hidden="true">
                 <span class="pi-avatar__fallback">PI</span>
-                <img src={conciergeIcon} alt="" onerror="this.remove()" />
+                <img src={conciergeIcon} alt="" onerror="this.remove()" {...conciergeAvatarAttrs} />
               </span>
               <span class="ask-msg__byline-name">The Insider</span>
               <span class="ask-msg__byline-rule" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

Extends the singleton-binding pattern from #194 (homepage cover) to every remaining singleton-backed image surface so the admin right-click overlay can patch the right Sanity doc.

- **V4MegaRail**: each entry now carries \`sanitySingletonId='megaRail'\` with \`entries[idx].image\` path. Index resolves via the Sanity dual-read first, then falls back to the canonical key order so the overlay still works when the page-level flag is off.
- **SectionHero / SubpageHero / GuideHero**: when \`entitySlug\` is set on a \`page\` entity, the hero image points the overlay at \`pageHero-<slug-with-double-dash>\` doc with path \`image\`.
- **siteSettings.conciergeAvatar**: wired in ConciergeDrawer (3 imgs), AskPICTA, InsiderAsk, ask.astro (3 imgs).
- **siteSettings.notFoundImage**: wired on 404.astro.

## Reach

- 5 mega rail images on every page that renders the mega menu
- 3 hero components covering ~70 pages indirectly (hubs + subpages + guides)
- ~8 siteSettings-bound image elements

## Test plan

- [ ] npx astro check  no new TS errors in touched files
- [ ] node next/scripts/lint-no-pricing.mjs passes
- [ ] Public render byte-identical for unauthenticated visitors (attrs are inert)
- [ ] Right-click on a mega rail image in admin mode opens the overlay against the megaRail singleton
- [ ] Right-click on a hub/subpage hero opens against pageHero-<slug>
- [ ] Right-click on the concierge avatar/404 opens against siteSettings

Generated with [Claude Code](https://claude.com/claude-code)