### PR TITLE
feat(cms): preserve stega marker on Sanity image URLs

### DIFF
--- a/next/src/lib/sanity/article-adapter.ts
+++ b/next/src/lib/sanity/article-adapter.ts
@@ -37,12 +37,16 @@ type SanityImageRef = {
   license?: string | null
 } | null
 
-function imageOrFallback(image: SanityImageRef, fallbackAlt: string) {
+function imageOrFallback(
+  image: SanityImageRef,
+  fallbackAlt: string,
+  ctx?: {docId: string; docType: string; path: string},
+) {
   if (!image?.asset) {
     return {src: '/images/sourced/home-cover.webp', alt: fallbackAlt, credit: '', license: 'venue-media-kit'}
   }
   return {
-    src: intentUrl(image, 'hero'),
+    src: intentUrl(image, 'hero', ctx),
     alt: image.alt ?? fallbackAlt,
     credit: image.credit ?? '',
     license: image.license ?? 'venue-media-kit',
@@ -103,7 +107,11 @@ export async function fetchArticleFromSanity(slug: string): Promise<AdaptedArtic
       houseByline: !!d.houseByline,
       publishedAt: new Date(d.publishedAt),
       updatedAt: d.updatedAt ? new Date(d.updatedAt) : undefined,
-      heroImage: imageOrFallback(d.heroImage ?? null, d.title),
+      heroImage: imageOrFallback(d.heroImage ?? null, d.title, {
+        docId: d._id,
+        docType: 'article',
+        path: 'heroImage',
+      }),
       format: d.format,
       tags: d.tags ?? [],
       relatedVenues: refs(d.relatedVenueSlugs, 'venues'),

--- a/next/src/lib/sanity/event-adapter.ts
+++ b/next/src/lib/sanity/event-adapter.ts
@@ -41,12 +41,16 @@ type SanityImageRef = {
   license?: string | null
 } | null
 
-function imageOrFallback(image: SanityImageRef, fallbackAlt: string) {
+function imageOrFallback(
+  image: SanityImageRef,
+  fallbackAlt: string,
+  ctx?: {docId: string; docType: string; path: string},
+) {
   if (!image?.asset) {
     return undefined // events allow missing hero
   }
   return {
-    src: intentUrl(image, 'hero'),
+    src: intentUrl(image, 'hero', ctx),
     alt: image.alt ?? fallbackAlt,
     credit: image.credit ?? '',
     license: image.license ?? 'venue-media-kit',
@@ -127,7 +131,11 @@ export async function fetchEventFromSanity(slug: string) {
       relatedArticles: [],
       lens: d.lens ?? [],
       editorNote: d.editorNoteText ?? '',
-      heroImage: imageOrFallback(d.heroImage ?? null, d.title),
+      heroImage: imageOrFallback(d.heroImage ?? null, d.title, {
+        docId: d._id,
+        docType: 'event',
+        path: 'heroImage',
+      }),
       internalNotes: d.internalNotes ?? undefined,
       manualFollowUpRequired: !!d.manualFollowUpRequired,
       status: d.status ?? 'published',

--- a/next/src/lib/sanity/image.ts
+++ b/next/src/lib/sanity/image.ts
@@ -16,11 +16,34 @@
  */
 import imageUrlBuilder from '@sanity/image-url'
 import type {SanityImageSource} from '@sanity/image-url/lib/types/types'
+import {vercelStegaCombine} from '@vercel/stega'
 import {sanityClient} from './client'
 
 const builder = imageUrlBuilder(sanityClient)
 
+const STUDIO_URL = 'https://peninsula-insider.sanity.studio'
+
 export type ImageIntent = 'hero' | 'card' | 'thumb' | 'gallery' | 'og'
+
+/**
+ * Optional source-document context for stega-encoding the generated image
+ * URL. When provided, intentUrl appends an invisible stega payload pointing
+ * at the Studio intent URL for the underlying field, so the admin overlay's
+ * stega-fallback resolver can decode docId + fieldPath off the rendered
+ * <img src> even when the element lacks explicit `data-pi-edit` attrs.
+ *
+ * The encoded payload is whitespace-zero-width chars appended to the URL;
+ * browsers, the Sanity CDN, and any consumer that trims/normalises the
+ * string all ignore it.
+ */
+export interface SanitySourceContext {
+  /** Sanity document `_id` */
+  docId: string
+  /** Sanity document `_type` (used to populate the Studio intent URL) */
+  docType: string
+  /** Dot/bracket-notation path to the image field (e.g. `heroImage`, `gallery[0]`) */
+  path: string
+}
 
 const intentDefaults: Record<
   ImageIntent,
@@ -37,12 +60,38 @@ export function urlFor(source: SanityImageSource) {
   return builder.image(source)
 }
 
+/**
+ * Build a Sanity Studio intent URL for an `edit` action on the given doc + path.
+ * Shape mirrors what @sanity/client's stega encoder emits, so the admin
+ * overlay's `parseStudioIntentHref()` decodes it identically.
+ */
+function buildStudioIntentHref(ctx: SanitySourceContext): string {
+  const segment = `id=${ctx.docId};type=${ctx.docType};path=${ctx.path}`
+  return `${STUDIO_URL}/intent/edit/${encodeURIComponent(segment)}`
+}
+
+/**
+ * Wrap a URL with a stega-encoded Sanity source marker, when context is
+ * provided. Safe no-op when ctx is undefined.
+ */
+function withStega(url: string, ctx?: SanitySourceContext): string {
+  if (!ctx) return url
+  const payload = {origin: 'sanity.io', href: buildStudioIntentHref(ctx)}
+  // `skip: false` forces encoding even outside Vercel edge runtimes — we
+  // want the marker present on every server-rendered URL.
+  return vercelStegaCombine(url, payload, false)
+}
+
 /** Convenience: build the canonical URL for a given intent. */
-export function intentUrl(source: SanityImageSource, intent: ImageIntent): string {
+export function intentUrl(
+  source: SanityImageSource,
+  intent: ImageIntent,
+  ctx?: SanitySourceContext,
+): string {
   const cfg = intentDefaults[intent]
   let b = builder.image(source).width(cfg.width).auto('format').fit('max')
   if (cfg.height) b = b.height(cfg.height).fit('crop')
-  return b.quality(cfg.quality).url()
+  return withStega(b.quality(cfg.quality).url(), ctx)
 }
 
 /**

--- a/next/src/lib/sanity/itinerary-adapter.ts
+++ b/next/src/lib/sanity/itinerary-adapter.ts
@@ -85,7 +85,11 @@ interface SanityItinerary {
   }>
 }
 
-function imageRefToAstroShape(img: SanityImageRef, fallbackAlt: string) {
+function imageRefToAstroShape(
+  img: SanityImageRef,
+  fallbackAlt: string,
+  ctx?: {docId: string; docType: string; path: string},
+) {
   if (!img?.asset) {
     return {
       src: '/images/sourced/home-cover.webp',
@@ -95,7 +99,7 @@ function imageRefToAstroShape(img: SanityImageRef, fallbackAlt: string) {
     }
   }
   return {
-    src: intentUrl(img, 'hero'),
+    src: intentUrl(img, 'hero', ctx),
     alt: img.alt ?? fallbackAlt,
     credit: img.credit ?? '',
     license: img.license ?? 'venue-media-kit',
@@ -143,7 +147,11 @@ export async function fetchItineraryFromSanity(slug: string) {
       publishedAt: new Date(doc.publishedAt),
       lastVerified: doc.lastVerified ? new Date(doc.lastVerified) : undefined,
       sitemapExclude: !!doc.sitemapExclude,
-      heroImage: imageRefToAstroShape(doc.heroImage ?? null, doc.title),
+      heroImage: imageRefToAstroShape(doc.heroImage ?? null, doc.title, {
+        docId: doc._id,
+        docType: 'itinerary',
+        path: 'heroImage',
+      }),
       anchorStay: doc.anchorStaySlug
         ? {id: doc.anchorStaySlug, collection: 'venues' as const}
         : undefined,

--- a/next/src/lib/sanity/phase5-adapters.ts
+++ b/next/src/lib/sanity/phase5-adapters.ts
@@ -20,12 +20,16 @@ type SanityImageRef = {
   license?: string | null
 } | null
 
-function imageOrFallback(image: SanityImageRef, fallbackAlt: string) {
+function imageOrFallback(
+  image: SanityImageRef,
+  fallbackAlt: string,
+  ctx?: {docId: string; docType: string; path: string},
+) {
   if (!image?.asset) {
     return {src: '/images/sourced/home-cover.webp', alt: fallbackAlt, credit: '', license: 'venue-media-kit'}
   }
   return {
-    src: intentUrl(image, 'hero'),
+    src: intentUrl(image, 'hero', ctx),
     alt: image.alt ?? fallbackAlt,
     credit: image.credit ?? '',
     license: image.license ?? 'venue-media-kit',
@@ -85,7 +89,9 @@ export async function fetchExperienceFromSanity(slug: string) {
       offLeashNearby: d.offLeashNearby ?? undefined,
       waterAccessNearby: d.waterAccessNearby ?? undefined,
       rainyDayDogSuitability: d.rainyDayDogSuitability ?? undefined,
-      heroImage: imageOrFallback(d.heroImage ?? null, d.name),
+      heroImage: imageOrFallback(d.heroImage ?? null, d.name, {
+        docId: d._id, docType: 'experience', path: 'heroImage',
+      }),
       gallery: [],
       golf: d.golf ?? undefined,
       lastVerified: new Date(d.lastVerified),
@@ -124,7 +130,9 @@ export async function fetchTourOperatorFromSanity(slug: string) {
       affiliateProgram: d.affiliateProgram ?? 'unknown',
       affiliateUrl: d.affiliateUrl ?? undefined,
       vetted: !!d.vetted,
-      heroImage: imageOrFallback(d.heroImage ?? null, d.name),
+      heroImage: imageOrFallback(d.heroImage ?? null, d.name, {
+        docId: d._id, docType: 'tourOperator', path: 'heroImage',
+      }),
       lastVerified: new Date(d.lastVerified),
       publishedAt: new Date(d.publishedAt),
     },
@@ -179,7 +187,9 @@ export async function fetchTourFromSanity(slug: string) {
       bookingIntelligence: d.bookingIntelligence ?? undefined,
       cancellationPolicy: d.cancellationPolicy ?? undefined,
       faq: d.faq ?? [],
-      heroImage: imageOrFallback(d.heroImage ?? null, d.name),
+      heroImage: imageOrFallback(d.heroImage ?? null, d.name, {
+        docId: d._id, docType: 'tour', path: 'heroImage',
+      }),
       lastVerified: new Date(d.lastVerified),
       publishedAt: new Date(d.publishedAt),
     },
@@ -222,7 +232,9 @@ export async function fetchTourPackageFromSanity(slug: string) {
       whyThisCombination: d.whyThisCombination,
       bookingSequence: d.bookingSequence ?? undefined,
       faq: d.faq ?? [],
-      heroImage: imageOrFallback(d.heroImage ?? null, d.name),
+      heroImage: imageOrFallback(d.heroImage ?? null, d.name, {
+        docId: d._id, docType: 'tourPackage', path: 'heroImage',
+      }),
       lastVerified: new Date(d.lastVerified),
       publishedAt: new Date(d.publishedAt),
     },

--- a/next/src/lib/sanity/place-adapter.ts
+++ b/next/src/lib/sanity/place-adapter.ts
@@ -86,6 +86,7 @@ export interface AdaptedPlace {
 function imageRefToAstroShape(
   img: SanityImageRef,
   fallbackAlt: string,
+  ctx?: {docId: string; docType: string; path: string},
 ): {src: string; alt: string; credit: string; license: string; caption?: string} {
   if (!img?.asset) {
     return {
@@ -96,7 +97,7 @@ function imageRefToAstroShape(
     }
   }
   return {
-    src: intentUrl(img, 'hero'),
+    src: intentUrl(img, 'hero', ctx),
     alt: img.alt ?? fallbackAlt,
     credit: img.credit ?? '',
     license: img.license ?? 'venue-media-kit',
@@ -130,7 +131,11 @@ function adapt(doc: SanityPlace): AdaptedPlace {
       featured: !!doc.featured,
       publishedAt: new Date(doc.publishedAt),
       sitemapExclude: !!doc.sitemapExclude,
-      heroImage: imageRefToAstroShape(doc.heroImage ?? null, doc.name),
+      heroImage: imageRefToAstroShape(doc.heroImage ?? null, doc.name, {
+        docId: doc._id,
+        docType: 'place',
+        path: 'heroImage',
+      }),
       relatedPlaces: (doc.relatedPlaces ?? []).map((r) => ({
         id: r.slug,
         collection: 'places' as const,

--- a/next/src/lib/sanity/singletons-adapter.ts
+++ b/next/src/lib/sanity/singletons-adapter.ts
@@ -21,21 +21,42 @@ type SanityImageRef = {
   license?: string | null
 } | null
 
-function imageOrFallback(image: SanityImageRef, fallback: string, fallbackAlt: string) {
+interface StegaCtx {
+  docId: string
+  docType: string
+  path: string
+}
+
+function imageOrFallback(
+  image: SanityImageRef,
+  fallback: string,
+  fallbackAlt: string,
+  ctx?: StegaCtx,
+) {
   if (!image?.asset) return {src: fallback, alt: fallbackAlt}
-  return {src: intentUrl(image, 'hero'), alt: image.alt ?? fallbackAlt}
+  return {src: intentUrl(image, 'hero', ctx), alt: image.alt ?? fallbackAlt}
 }
 
 /** Small-icon variant: thumb-intent URL (320w), suits logos / avatars. */
-function iconOrFallback(image: SanityImageRef, fallback: string, fallbackAlt: string) {
+function iconOrFallback(
+  image: SanityImageRef,
+  fallback: string,
+  fallbackAlt: string,
+  ctx?: StegaCtx,
+) {
   if (!image?.asset) return {src: fallback, alt: fallbackAlt}
-  return {src: intentUrl(image, 'thumb'), alt: image.alt ?? fallbackAlt}
+  return {src: intentUrl(image, 'thumb', ctx), alt: image.alt ?? fallbackAlt}
 }
 
 /** OG-intent (1200x630) variant for share-card fallback imagery. */
-function ogOrFallback(image: SanityImageRef, fallback: string, fallbackAlt: string) {
+function ogOrFallback(
+  image: SanityImageRef,
+  fallback: string,
+  fallbackAlt: string,
+  ctx?: StegaCtx,
+) {
   if (!image?.asset) return {src: fallback, alt: fallbackAlt}
-  return {src: intentUrl(image, 'og'), alt: image.alt ?? fallbackAlt}
+  return {src: intentUrl(image, 'og', ctx), alt: image.alt ?? fallbackAlt}
 }
 
 // Homepage cover ----------------------------------------------------------
@@ -70,8 +91,12 @@ export async function fetchHomepageCoverFromSanity(opts: FetchOpts = {}): Promis
   const d: any = await getSanityReadClient(opts.preview).fetch(homepageCoverQuery)
   if (!d?.scenes?.length) return null
   return {
-    scenes: d.scenes.map((s: any) => {
-      const i = imageOrFallback(s.image, '/images/sourced/home-cover.webp', s.label ?? '')
+    scenes: d.scenes.map((s: any, idx: number) => {
+      const i = imageOrFallback(s.image, '/images/sourced/home-cover.webp', s.label ?? '', {
+        docId: 'homepageCover',
+        docType: 'homepageCover',
+        path: `scenes[${idx}].image`,
+      })
       return {
         id: s.id ?? '',
         label: s.label ?? '',
@@ -111,9 +136,13 @@ export interface MegaRailEntry {
 export async function fetchMegaRailFromSanity(opts: FetchOpts = {}): Promise<MegaRailEntry[] | null> {
   const d: any = await getSanityReadClient(opts.preview).fetch(megaRailQuery)
   if (!d?.entries?.length) return null
-  return d.entries.map((e: any) => {
+  return d.entries.map((e: any, idx: number) => {
     if (!e.image?.asset) return {key: e.key, label: e.label, href: e.href, eyebrow: e.eyebrow}
-    const i = imageOrFallback(e.image, '', e.label ?? '')
+    const i = imageOrFallback(e.image, '', e.label ?? '', {
+      docId: 'megaRail',
+      docType: 'megaRail',
+      path: `entries[${idx}].image`,
+    })
     return {
       key: e.key,
       label: e.label,
@@ -173,10 +202,18 @@ export async function fetchSiteSettingsFromSanity(opts: FetchOpts = {}): Promise
     editionYear: d.editionYear ?? undefined,
     footerLinks: d.footerLinks ?? [],
     social: d.social ?? {},
-    logo: iconOrFallback(d.logo, LOGO_FALLBACK, 'Peninsula Insider'),
-    conciergeAvatar: iconOrFallback(d.conciergeAvatar, CONCIERGE_FALLBACK, ''),
-    ogFallback: ogOrFallback(d.ogFallback, OG_FALLBACK, 'Peninsula Insider'),
-    notFoundImage: iconOrFallback(d.notFoundImage, NOT_FOUND_FALLBACK, ''),
+    logo: iconOrFallback(d.logo, LOGO_FALLBACK, 'Peninsula Insider', {
+      docId: 'siteSettings', docType: 'siteSettings', path: 'logo',
+    }),
+    conciergeAvatar: iconOrFallback(d.conciergeAvatar, CONCIERGE_FALLBACK, '', {
+      docId: 'siteSettings', docType: 'siteSettings', path: 'conciergeAvatar',
+    }),
+    ogFallback: ogOrFallback(d.ogFallback, OG_FALLBACK, 'Peninsula Insider', {
+      docId: 'siteSettings', docType: 'siteSettings', path: 'ogFallback',
+    }),
+    notFoundImage: iconOrFallback(d.notFoundImage, NOT_FOUND_FALLBACK, '', {
+      docId: 'siteSettings', docType: 'siteSettings', path: 'notFoundImage',
+    }),
   }
 }
 
@@ -192,7 +229,7 @@ export const SITE_SETTINGS_IMAGE_FALLBACKS = {
 // Page hero ---------------------------------------------------------------
 
 const pageHeroQuery = `*[_type == "pageHero" && pathSlug == $slug][0]{
-  pathSlug, title, eyebrow, category, dek,
+  _id, pathSlug, title, eyebrow, category, dek,
   "image": image ${img}
 }`
 
@@ -209,7 +246,11 @@ export async function fetchPageHeroFromSanity(slug: string, opts: FetchOpts = {}
   let imageSrc: string | undefined
   let imageAlt: string | undefined
   if (d.image?.asset) {
-    const i = imageOrFallback(d.image, '', d.title ?? slug)
+    const i = imageOrFallback(d.image, '', d.title ?? slug, {
+      docId: d._id,
+      docType: 'pageHero',
+      path: 'image',
+    })
     imageSrc = i.src
     imageAlt = i.alt
   }

--- a/next/src/lib/sanity/venue-adapter.ts
+++ b/next/src/lib/sanity/venue-adapter.ts
@@ -150,6 +150,7 @@ function blocksToText(blocks: Array<Record<string, unknown>> | null | undefined)
 function imageRefToAstroShape(
   img: SanityImageRef,
   fallbackAlt: string,
+  ctx?: {docId: string; docType: string; path: string},
 ): {src: string; alt: string; credit: string; license: string; caption?: string} {
   if (!img?.asset) {
     return {
@@ -160,7 +161,7 @@ function imageRefToAstroShape(
     }
   }
   return {
-    src: intentUrl(img, 'hero'),
+    src: intentUrl(img, 'hero', ctx),
     alt: img.alt ?? fallbackAlt,
     credit: img.credit ?? '',
     license: img.license ?? 'venue-media-kit',
@@ -169,10 +170,20 @@ function imageRefToAstroShape(
 }
 
 function adapt(doc: SanityVenue): AdaptedVenue {
-  const heroImage = imageRefToAstroShape(doc.heroImage ?? null, doc.name)
+  const heroImage = imageRefToAstroShape(doc.heroImage ?? null, doc.name, {
+    docId: doc._id,
+    docType: 'venue',
+    path: 'heroImage',
+  })
   const gallery = (doc.gallery ?? [])
     .filter((g): g is NonNullable<SanityImageRef> => g != null)
-    .map((g) => imageRefToAstroShape(g, doc.name))
+    .map((g, idx) =>
+      imageRefToAstroShape(g, doc.name, {
+        docId: doc._id,
+        docType: 'venue',
+        path: `gallery[${idx}]`,
+      }),
+    )
 
   return {
     id: doc.slug,


### PR DESCRIPTION
## Summary

- Extends `intentUrl()` in `next/src/lib/sanity/image.ts` with an optional `SanitySourceContext` (docId, docType, path). When supplied, the generated CDN URL is wrapped with `vercelStegaCombine` so the URL string carries an invisible Studio-intent marker.
- Wires that context through every adapter that builds image URLs from a Sanity asset ref: article, event, place, itinerary, venue (hero + gallery indices), phase5 (experience/tour/tourOperator/tourPackage), and the singletons (homepageCover scenes, megaRail entries, pageHero, siteSettings logo/conciergeAvatar/ogFallback/notFoundImage).
- This makes the admin overlay's `resolveSanitySource()` stega-fallback path live for every Sanity-bound image, not just those carrying explicit `data-pi-edit` attrs.

## Why

PR #191 turned on stega on the public Sanity client, but `@sanity/image-url`'s `imageUrlBuilder` reads only `asset._id` and emits a fresh CDN URL — losing any stega marker that might have been on a sibling field. The admin overlay's stega decode path was therefore dead code on production. This PR re-injects the marker at URL build time using the same `{origin: 'sanity.io', href: studio-intent-url}` shape the overlay's `parseStudioIntentHref()` already decodes.

## Sample URL with stega

Base URL:
`https://cdn.sanity.io/images/a062b30n/production/abc-1200x800.webp?w=1920&q=82`

After `intentUrl(img, 'hero', {docId: 'venue-foo', docType: 'venue', path: 'heroImage'})`:
- visible portion identical to base URL (browsers strip/ignore the zero-width chars)
- `vercelStegaSplit().cleaned` round-trips back to the base URL
- `vercelStegaDecode()` returns `{origin: 'sanity.io', href: 'https://peninsula-insider.sanity.studio/intent/edit/id%3Dvenue-foo%3Btype%3Dvenue%3Bpath%3DheroImage'}`

Verified locally with `node -e ...` round-trip.

## Adapter coverage

7 files touched, 14 call-site bindings:
- `article-adapter.ts` — heroImage
- `event-adapter.ts` — heroImage
- `place-adapter.ts` — heroImage
- `itinerary-adapter.ts` — heroImage
- `venue-adapter.ts` — heroImage + `gallery[idx]`
- `phase5-adapters.ts` — experience.heroImage, tour.heroImage, tourOperator.heroImage, tourPackage.heroImage
- `singletons-adapter.ts` — homepageCover.scenes[i].image, megaRail.entries[i].image, siteSettings.{logo,conciergeAvatar,ogFallback,notFoundImage}, pageHero.image (added `_id` to pageHero projection)

## Notes for the next pass

- `responsiveSrc()` and `lqipUrl()` in `image.ts` aren't wired through yet (only `intentUrl` is — and that's what every adapter currently uses). If/when consumers start using `responsiveSrc` for SSR-rendered `<img>` tags we should thread ctx through there too. Not blocking — every Sanity image on the public site currently flows through `intentUrl`.
- No new deps. `@vercel/stega` already an explicit dep since PR #193.

## Test plan

- [ ] `npm run build` locally with `PI_ADMIN_HYBRID=1` to confirm no TS errors.
- [ ] After deploy, inspect a page (e.g. a venue detail) — view-source the `<img src>` and confirm zero-width chars are present after the URL.
- [ ] Right-click a Sanity-backed image in the admin overlay that does NOT carry `data-pi-edit` — confirm the "Replace from media library" modal shows `Source: stega — doc <_id>, field heroImage` (or similar).
- [ ] Smoke-test that production image URLs still resolve through the Sanity CDN (browsers ignore the trailing zero-width chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)