### PR TITLE
feat(cms): polish admin media-library overlay (drag-drop, undo, keyboard, a11y)

### DIFF
--- a/next/src/lib/inline-edit/sanity-image-overlay.ts
+++ b/next/src/lib/inline-edit/sanity-image-overlay.ts
@@ -203,43 +203,75 @@ interface SanityAssetSummary {
 }
 
 let activeModal: HTMLDivElement | null = null;
+let activeModalCleanup: (() => void) | null = null;
+
+type Sort = 'recent' | 'name';
+type Orientation = 'any' | 'landscape' | 'portrait' | 'square';
 
 export function openMediaLibraryModal(opts: ModalOpts): void {
   closeMediaLibraryModal();
+
+  const headerSub = opts.source.resolvedVia === 'stega'
+    ? `Source: stega — doc ${escapeHtml(opts.source.docId ?? '')}, field ${escapeHtml(opts.source.fieldPath)}`
+    : `Source: ${escapeHtml(opts.source.entityType ?? '')}/${escapeHtml(opts.source.entitySlug ?? '')}, field ${escapeHtml(opts.source.fieldPath)}`;
+
+  // Snapshot the currently-visible src for the preview thumbnail and so
+  // Undo can restore it.
+  let currentVisibleSrc = '';
+  if (opts.el instanceof HTMLImageElement) {
+    currentVisibleSrc = opts.el.getAttribute('src') || opts.el.src || '';
+  } else {
+    const bg = opts.el.style.backgroundImage || window.getComputedStyle(opts.el).backgroundImage;
+    const m = bg.match(/url\((['"]?)([^)]+?)\1\)/);
+    currentVisibleSrc = m?.[2] ?? '';
+  }
+  const currentClean = stripStega(currentVisibleSrc);
 
   const wrap = document.createElement('div');
   wrap.className = 'pi-sanity-modal';
   wrap.setAttribute('role', 'dialog');
   wrap.setAttribute('aria-modal', 'true');
-  wrap.setAttribute('aria-label', 'Replace from Sanity media library');
+  wrap.setAttribute('aria-labelledby', 'pi-sanity-modal-title');
   wrap.innerHTML = `
     <div class="pi-sanity-modal__backdrop" data-close="1"></div>
-    <div class="pi-sanity-modal__panel">
+    <div class="pi-sanity-modal__panel" tabindex="-1">
       <div class="pi-sanity-modal__head">
-        <div>
-          <div class="pi-sanity-modal__title">Replace from media library</div>
-          <div class="pi-sanity-modal__sub">${
-            opts.source.resolvedVia === 'stega'
-              ? `Source: stega — doc ${escapeHtml(opts.source.docId ?? '')}, field ${escapeHtml(opts.source.fieldPath)}`
-              : `Source: ${escapeHtml(opts.source.entityType ?? '')}/${escapeHtml(opts.source.entitySlug ?? '')}, field ${escapeHtml(opts.source.fieldPath)}`
-          }</div>
+        <div class="pi-sanity-modal__head-main">
+          ${currentClean ? `<span class="pi-sanity-modal__current" aria-hidden="true" style="background-image: url('${cssUrl(currentClean)}')"></span>` : ''}
+          <div>
+            <div class="pi-sanity-modal__title" id="pi-sanity-modal-title">Replace from media library</div>
+            <div class="pi-sanity-modal__sub">${headerSub}</div>
+          </div>
         </div>
         <button type="button" class="pi-sanity-modal__close" data-close="1" aria-label="Close">×</button>
       </div>
       <div class="pi-sanity-modal__toolbar">
-        <input type="search" class="pi-sanity-modal__search" placeholder="Search assets by filename…" />
+        <input type="search" class="pi-sanity-modal__search" placeholder="Search assets by filename…" aria-label="Search assets" />
+        <div class="pi-sanity-modal__chips" role="group" aria-label="Filter by orientation">
+          <button type="button" class="pi-sanity-modal__chip" data-orient="any" aria-pressed="true">Any</button>
+          <button type="button" class="pi-sanity-modal__chip" data-orient="landscape" aria-pressed="false">Landscape</button>
+          <button type="button" class="pi-sanity-modal__chip" data-orient="portrait" aria-pressed="false">Portrait</button>
+          <button type="button" class="pi-sanity-modal__chip" data-orient="square" aria-pressed="false">Square</button>
+        </div>
+        <div class="pi-sanity-modal__sort" role="group" aria-label="Sort">
+          <button type="button" class="pi-sanity-modal__chip" data-sort="recent" aria-pressed="true">Recent</button>
+          <button type="button" class="pi-sanity-modal__chip" data-sort="name" aria-pressed="false">Name</button>
+        </div>
         <label class="pi-sanity-modal__upload">
           <span>Upload new…</span>
           <input type="file" accept="image/jpeg,image/png,image/webp,image/avif" hidden />
         </label>
       </div>
-      <div class="pi-sanity-modal__grid" role="listbox" aria-label="Assets">
+      <div class="pi-sanity-modal__grid" role="listbox" aria-label="Assets" tabindex="0">
         <div class="pi-sanity-modal__status">Loading…</div>
       </div>
       <div class="pi-sanity-modal__foot">
         <button type="button" class="pi-sanity-modal__btn" data-action="prev">‹ Prev</button>
         <span class="pi-sanity-modal__page">Page 1</span>
         <button type="button" class="pi-sanity-modal__btn" data-action="next">Next ›</button>
+      </div>
+      <div class="pi-sanity-modal__drop" aria-hidden="true">
+        <div class="pi-sanity-modal__drop-inner">Drop to upload</div>
       </div>
     </div>
   `;
@@ -248,82 +280,140 @@ export function openMediaLibraryModal(opts: ModalOpts): void {
 
   let page = 0;
   let q = '';
+  let sort: Sort = 'recent';
+  let orientation: Orientation = 'any';
+  let assets: SanityAssetSummary[] = [];
+  let focusedIdx = -1;
+  let uploadInFlight = false;
+  let lastLoadReq = 0;
 
+  const panel = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__panel')!;
   const grid = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__grid')!;
   const search = wrap.querySelector<HTMLInputElement>('.pi-sanity-modal__search')!;
   const fileInput = wrap.querySelector<HTMLInputElement>('.pi-sanity-modal__upload input')!;
   const pageEl = wrap.querySelector<HTMLSpanElement>('.pi-sanity-modal__page')!;
 
+  const setChipState = (group: 'orient' | 'sort', value: string) => {
+    const attr = group === 'orient' ? 'data-orient' : 'data-sort';
+    wrap.querySelectorAll<HTMLButtonElement>(`[${attr}]`).forEach((b) => {
+      b.setAttribute('aria-pressed', b.getAttribute(attr) === value ? 'true' : 'false');
+    });
+  };
+
+  const orientLabel = (a: SanityAssetSummary): string =>
+    a.dimensions ? `${a.dimensions.width}×${a.dimensions.height}` : '';
+
+  const renderAssets = () => {
+    if (assets.length === 0) {
+      grid.innerHTML = '<div class="pi-sanity-modal__status">No assets found.</div>';
+      return;
+    }
+    grid.innerHTML = assets
+      .map(
+        (a, i) => `
+      <button type="button" role="option" class="pi-sanity-modal__asset" data-asset-id="${escapeHtml(a._id)}" data-idx="${i}" aria-label="Replace with ${escapeHtml(a.originalFilename || a._id)}" title="${escapeHtml(a.originalFilename || a._id)}">
+        <span class="pi-sanity-modal__thumb" style="background-image: url('${cssUrl(a.url)}?w=360&h=225&fit=crop&auto=format')"></span>
+        <span class="pi-sanity-modal__meta">
+          <span class="pi-sanity-modal__name">${escapeHtml(a.originalFilename || a._id)}</span>
+          <span class="pi-sanity-modal__dims">${escapeHtml(orientLabel(a))}</span>
+        </span>
+      </button>`,
+      )
+      .join('');
+  };
+
   const loadAssets = async () => {
+    const reqId = ++lastLoadReq;
     grid.innerHTML = '<div class="pi-sanity-modal__status">Loading…</div>';
     pageEl.textContent = `Page ${page + 1}`;
+    focusedIdx = -1;
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    if (q) params.set('q', q);
+    if (sort !== 'recent') params.set('sort', sort);
+    if (orientation !== 'any') params.set('orientation', orientation);
     try {
-      const url = `/api/admin/sanity-assets?page=${page}${q ? `&q=${encodeURIComponent(q)}` : ''}`;
-      const res = await fetch(url, { credentials: 'same-origin' });
+      const res = await fetch(`/api/admin/sanity-assets?${params.toString()}`, {
+        credentials: 'same-origin',
+      });
+      if (reqId !== lastLoadReq) return;
       const body = await res.json();
       if (!res.ok || !body.ok) {
-        grid.innerHTML = `<div class="pi-sanity-modal__status pi-sanity-modal__status--err">${escapeHtml(body.error || 'Failed to load')}</div>`;
+        renderError(grid, res.status, body?.error || 'Failed to load', () => void loadAssets());
         return;
       }
-      const assets: SanityAssetSummary[] = body.data?.assets ?? [];
-      if (assets.length === 0) {
-        grid.innerHTML = '<div class="pi-sanity-modal__status">No assets found.</div>';
-        return;
-      }
-      grid.innerHTML = assets
-        .map(
-          (a) => `
-        <button type="button" class="pi-sanity-modal__asset" data-asset-id="${escapeHtml(a._id)}" title="${escapeHtml(a.originalFilename || a._id)}">
-          <span class="pi-sanity-modal__thumb" style="background-image: url('${cssUrl(a.url)}?w=320&h=200&fit=crop&auto=format')"></span>
-          <span class="pi-sanity-modal__name">${escapeHtml(a.originalFilename || a._id)}</span>
-        </button>`,
-        )
-        .join('');
+      assets = (body.data?.assets ?? []) as SanityAssetSummary[];
+      renderAssets();
     } catch (err) {
-      grid.innerHTML = `<div class="pi-sanity-modal__status pi-sanity-modal__status--err">${escapeHtml((err as Error).message)}</div>`;
+      if (reqId !== lastLoadReq) return;
+      renderError(grid, 0, (err as Error).message, () => void loadAssets());
     }
+  };
+
+  const doPatch = async (assetId: string): Promise<{ ok: boolean; newUrl?: string; previousAssetRef?: string; status?: number; error?: string }> => {
+    const payload: Record<string, string> = {
+      fieldPath: opts.source.fieldPath,
+      newAssetRef: assetId,
+    };
+    if (opts.source.docId) payload.docId = opts.source.docId;
+    if (opts.source.entityType) payload.entityType = opts.source.entityType;
+    if (opts.source.entitySlug) payload.entitySlug = opts.source.entitySlug;
+    const res = await fetch('/api/admin/sanity-patch', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json();
+    if (!res.ok || !body.ok) return { ok: false, status: res.status, error: body?.error };
+    return {
+      ok: true,
+      newUrl: body.data?.newUrl,
+      previousAssetRef: body.data?.previousAssetRef,
+    };
   };
 
   const onPick = async (assetId: string) => {
     opts.toast('Patching…', 'info');
     try {
-      const payload: Record<string, string> = {
-        fieldPath: opts.source.fieldPath,
-        newAssetRef: assetId,
-      };
-      if (opts.source.docId) payload.docId = opts.source.docId;
-      if (opts.source.entityType) payload.entityType = opts.source.entityType;
-      if (opts.source.entitySlug) payload.entitySlug = opts.source.entitySlug;
-
-      const res = await fetch('/api/admin/sanity-patch', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      const body = await res.json();
-      if (!res.ok || !body.ok) {
-        opts.toast(`Save failed: ${body.error || res.statusText}`, 'err');
+      const result = await doPatch(assetId);
+      if (!result.ok) {
+        handleApiError(result.status ?? 0, result.error, opts.toast, () => void onPick(assetId));
         return;
       }
-      // Cache-bust so the visible swap is immediate even if the asset URL is
-      // already in browser cache. NOTE: this updates `src` only — responsive
-      // `srcset` regeneration is a follow-up; for now the picture element's
-      // other sources stay on the previous asset until next deploy.
-      const newUrl = body.data?.newUrl as string | undefined;
-      if (newUrl) {
-        const bust = newUrl.includes('?') ? `${newUrl}&v=${Date.now()}` : `${newUrl}?v=${Date.now()}`;
+      const previousVisibleSrc = currentVisibleSrc;
+      if (result.newUrl) {
+        const bust = result.newUrl.includes('?')
+          ? `${result.newUrl}&v=${Date.now()}`
+          : `${result.newUrl}?v=${Date.now()}`;
         opts.setImageSrc(opts.el, bust);
+        currentVisibleSrc = bust;
       }
-      opts.toast('Replaced from Sanity.', 'ok');
       closeMediaLibraryModal();
       opts.onClose();
+      if (result.previousAssetRef) {
+        const prevRef = result.previousAssetRef;
+        showUndoToast(async () => {
+          opts.toast('Undoing…', 'info');
+          const undo = await doPatch(prevRef);
+          if (!undo.ok) {
+            opts.toast(`Undo failed: ${undo.error || 'request failed'}`, 'err');
+            return;
+          }
+          if (previousVisibleSrc) opts.setImageSrc(opts.el, previousVisibleSrc);
+          opts.toast('Reverted.', 'ok');
+        });
+      } else {
+        opts.toast('Replaced from Sanity.', 'ok');
+      }
     } catch (err) {
       opts.toast(`Save failed: ${(err as Error).message}`, 'err');
     }
   };
 
   const onUpload = async (file: File) => {
+    if (uploadInFlight) return;
+    uploadInFlight = true;
     opts.toast(`Uploading "${file.name}"…`, 'info');
     try {
       const fd = new FormData();
@@ -335,7 +425,7 @@ export function openMediaLibraryModal(opts: ModalOpts): void {
       });
       const body = await res.json();
       if (!res.ok || !body.ok) {
-        opts.toast(`Upload failed: ${body.error || res.statusText}`, 'err');
+        handleApiError(res.status, body?.error || 'Upload failed', opts.toast, () => void onUpload(file));
         return;
       }
       const assetId = body.data?._id as string | undefined;
@@ -346,10 +436,12 @@ export function openMediaLibraryModal(opts: ModalOpts): void {
       await onPick(assetId);
     } catch (err) {
       opts.toast(`Upload failed: ${(err as Error).message}`, 'err');
+    } finally {
+      uploadInFlight = false;
     }
   };
 
-  // Wire events.
+  // ── Click event delegation ─────────────────────────────────────────────
   wrap.addEventListener('click', (e) => {
     const target = e.target as HTMLElement | null;
     if (!target) return;
@@ -358,10 +450,32 @@ export function openMediaLibraryModal(opts: ModalOpts): void {
       opts.onClose();
       return;
     }
+    const retry = target.closest<HTMLElement>('[data-retry="1"]');
+    if (retry) {
+      const fn = (retry as HTMLElement & { __piRetry?: () => void }).__piRetry;
+      if (fn) fn();
+      return;
+    }
     const asset = target.closest<HTMLElement>('[data-asset-id]');
     if (asset) {
       const id = asset.dataset.assetId;
       if (id) void onPick(id);
+      return;
+    }
+    const orient = target.closest<HTMLElement>('[data-orient]');
+    if (orient) {
+      orientation = (orient.dataset.orient || 'any') as Orientation;
+      setChipState('orient', orientation);
+      page = 0;
+      void loadAssets();
+      return;
+    }
+    const sortBtn = target.closest<HTMLElement>('[data-sort]');
+    if (sortBtn) {
+      sort = (sortBtn.dataset.sort || 'recent') as Sort;
+      setChipState('sort', sort);
+      page = 0;
+      void loadAssets();
       return;
     }
     const action = target.closest<HTMLElement>('[data-action]')?.dataset.action;
@@ -389,21 +503,187 @@ export function openMediaLibraryModal(opts: ModalOpts): void {
     if (f) void onUpload(f);
   });
 
-  document.addEventListener('keydown', onModalKeyDown);
+  // ── Drag-and-drop upload ───────────────────────────────────────────────
+  let dragDepth = 0;
+  const onDragEnter = (e: DragEvent) => {
+    if (!e.dataTransfer?.types?.includes('Files')) return;
+    e.preventDefault();
+    dragDepth += 1;
+    wrap.classList.add('pi-sanity-modal--drag');
+  };
+  const onDragOver = (e: DragEvent) => {
+    if (!e.dataTransfer?.types?.includes('Files')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  };
+  const onDragLeave = () => {
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) wrap.classList.remove('pi-sanity-modal--drag');
+  };
+  const onDrop = (e: DragEvent) => {
+    e.preventDefault();
+    dragDepth = 0;
+    wrap.classList.remove('pi-sanity-modal--drag');
+    const f = e.dataTransfer?.files?.[0];
+    if (f && /^image\//.test(f.type)) void onUpload(f);
+    else if (f) opts.toast('Only image files are accepted.', 'err');
+  };
+  wrap.addEventListener('dragenter', onDragEnter);
+  wrap.addEventListener('dragover', onDragOver);
+  wrap.addEventListener('dragleave', onDragLeave);
+  wrap.addEventListener('drop', onDrop);
+
+  // ── Keyboard nav, Esc, focus trap, arrow keys ──────────────────────────
+  const focusableSel =
+    'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const onKey = (e: KeyboardEvent) => {
+    if (!activeModal) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeMediaLibraryModal();
+      opts.onClose();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSel)).filter(
+        (n) => n.offsetParent !== null,
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+      return;
+    }
+    const inGrid = grid.contains(document.activeElement) || document.activeElement === grid;
+    if (!inGrid || assets.length === 0) return;
+    const cols = Math.max(1, Math.floor(grid.clientWidth / 200));
+    let next = focusedIdx;
+    if (e.key === 'ArrowRight') next = Math.min(assets.length - 1, focusedIdx + 1);
+    else if (e.key === 'ArrowLeft') next = Math.max(0, focusedIdx - 1);
+    else if (e.key === 'ArrowDown') next = Math.min(assets.length - 1, focusedIdx + cols);
+    else if (e.key === 'ArrowUp') next = Math.max(0, focusedIdx - cols);
+    else if (e.key === 'Enter' && focusedIdx >= 0) {
+      e.preventDefault();
+      const a = assets[focusedIdx];
+      if (a) void onPick(a._id);
+      return;
+    } else {
+      return;
+    }
+    if (next !== focusedIdx) {
+      e.preventDefault();
+      focusedIdx = next < 0 ? 0 : next;
+      const target = grid.querySelector<HTMLElement>(`[data-idx="${focusedIdx}"]`);
+      target?.focus();
+    }
+  };
+  document.addEventListener('keydown', onKey);
+
+  activeModalCleanup = () => {
+    document.removeEventListener('keydown', onKey);
+  };
 
   void loadAssets();
+  setTimeout(() => search.focus(), 0);
 }
 
 export function closeMediaLibraryModal(): void {
+  if (activeModalCleanup) {
+    activeModalCleanup();
+    activeModalCleanup = null;
+  }
   if (activeModal) {
     activeModal.remove();
     activeModal = null;
   }
-  document.removeEventListener('keydown', onModalKeyDown);
 }
 
-function onModalKeyDown(e: KeyboardEvent) {
-  if (e.key === 'Escape') closeMediaLibraryModal();
+// ── Error handling ───────────────────────────────────────────────────────
+
+function handleApiError(status: number, error: string | undefined, toast: ToastFn, retry: () => void) {
+  if (status === 401) {
+    toast('Session expired — re-login required.', 'err');
+    showStickyBanner('Session expired.', 'Re-login', '/admin/login/');
+    return;
+  }
+  toast(`${error || 'Request failed'}`, 'err');
+  showStickyBanner(`Error: ${error || 'Request failed'}`, 'Try again', null, retry);
+}
+
+function renderError(host: HTMLElement, status: number, msg: string, retry: () => void) {
+  const sessionExpired = status === 401;
+  host.innerHTML = `
+    <div class="pi-sanity-modal__status pi-sanity-modal__status--err">
+      <div>${sessionExpired ? 'Session expired — please re-login.' : escapeHtml(msg)}</div>
+      <div class="pi-sanity-modal__err-actions">
+        ${sessionExpired
+          ? `<a class="pi-sanity-modal__btn" href="/admin/login/">Re-login</a>`
+          : `<button type="button" class="pi-sanity-modal__btn" data-retry="1">Try again</button>`}
+      </div>
+    </div>
+  `;
+  if (!sessionExpired) {
+    const btn = host.querySelector<HTMLElement>('[data-retry="1"]');
+    if (btn) (btn as HTMLElement & { __piRetry?: () => void }).__piRetry = retry;
+  }
+}
+
+// ── Sticky banner (undo + retry) ─────────────────────────────────────────
+
+let stickyBannerEl: HTMLDivElement | null = null;
+let stickyBannerTimer: ReturnType<typeof setTimeout> | null = null;
+
+function showUndoToast(onUndo: () => void) {
+  showStickyBanner('Replaced from Sanity.', 'Undo (5s)', null, onUndo, 5000);
+}
+
+function showStickyBanner(
+  label: string,
+  actionLabel: string,
+  href: string | null,
+  onAction?: () => void,
+  ttlMs = 6000,
+) {
+  if (stickyBannerEl) {
+    stickyBannerEl.remove();
+    stickyBannerEl = null;
+  }
+  if (stickyBannerTimer) {
+    clearTimeout(stickyBannerTimer);
+    stickyBannerTimer = null;
+  }
+  const el = document.createElement('div');
+  el.className = 'pi-sanity-banner';
+  el.innerHTML = `
+    <span class="pi-sanity-banner__msg">${escapeHtml(label)}</span>
+    ${href
+      ? `<a class="pi-sanity-banner__btn" href="${escapeHtml(href)}">${escapeHtml(actionLabel)}</a>`
+      : `<button type="button" class="pi-sanity-banner__btn" data-banner-action="1">${escapeHtml(actionLabel)}</button>`}
+    <button type="button" class="pi-sanity-banner__close" aria-label="Dismiss">×</button>
+  `;
+  document.body.appendChild(el);
+  stickyBannerEl = el;
+  el.addEventListener('click', (e) => {
+    const t = e.target as HTMLElement;
+    if (t.closest('[data-banner-action="1"]')) {
+      onAction?.();
+      el.remove();
+      if (stickyBannerEl === el) stickyBannerEl = null;
+    } else if (t.closest('.pi-sanity-banner__close')) {
+      el.remove();
+      if (stickyBannerEl === el) stickyBannerEl = null;
+    }
+  });
+  stickyBannerTimer = setTimeout(() => {
+    el.remove();
+    if (stickyBannerEl === el) stickyBannerEl = null;
+  }, ttlMs);
 }
 
 // ─── Tiny utils (duplicated here to keep this module self-contained when

--- a/next/src/pages/api/admin/sanity-assets.ts
+++ b/next/src/pages/api/admin/sanity-assets.ts
@@ -36,16 +36,25 @@ export const GET: APIRoute = async ({ request, url }) => {
 
   const page = Math.max(0, parseInt(url.searchParams.get('page') || '0', 10) || 0);
   const q = (url.searchParams.get('q') || '').trim().toLowerCase();
+  const sort = (url.searchParams.get('sort') || 'recent').trim();
+  const orientation = (url.searchParams.get('orientation') || 'any').trim();
   const start = page * PAGE_SIZE;
   const end = start + PAGE_SIZE;
 
   // Filter assets by filename when a query is provided. Use `lower(...)` so
   // the match is case-insensitive — Sanity assets carry the originalFilename
   // exactly as uploaded, which is often Mixed Case.
-  const filter = q
-    ? `*[_type=="sanity.imageAsset" && lower(originalFilename) match $q]`
-    : `*[_type=="sanity.imageAsset"]`;
-  const query = `${filter} | order(_createdAt desc)[$start...$end]{
+  const conds: string[] = [`_type=="sanity.imageAsset"`];
+  if (q) conds.push(`lower(originalFilename) match $q`);
+  // Aspect ratio bands: landscape > 1.15, portrait < 0.85, square between.
+  if (orientation === 'landscape') conds.push(`metadata.dimensions.aspectRatio > 1.15`);
+  else if (orientation === 'portrait') conds.push(`metadata.dimensions.aspectRatio < 0.85`);
+  else if (orientation === 'square')
+    conds.push(`metadata.dimensions.aspectRatio >= 0.85 && metadata.dimensions.aspectRatio <= 1.15`);
+
+  const filter = `*[${conds.join(' && ')}]`;
+  const orderBy = sort === 'name' ? 'lower(originalFilename) asc' : '_createdAt desc';
+  const query = `${filter} | order(${orderBy})[$start...$end]{
     _id,
     url,
     originalFilename,

--- a/next/src/pages/api/admin/sanity-patch.ts
+++ b/next/src/pages/api/admin/sanity-patch.ts
@@ -100,6 +100,20 @@ export const POST: APIRoute = async ({ request }) => {
   // want to patch the published doc.
   if (targetDocId.startsWith('drafts.')) targetDocId = targetDocId.slice('drafts.'.length);
 
+  // Fetch the current asset ref at fieldPath BEFORE patching so the client
+  // can offer an Undo. Non-fatal if it fails — Undo simply won't appear.
+  // The fieldPath has already been validated as a safe identifier above.
+  let previousAssetRef: string | null = null;
+  try {
+    const prev = await client.fetch<{ ref: string | null } | null>(
+      `*[_id == $id][0]{ "ref": ${fieldPath}.asset._ref }`,
+      { id: targetDocId },
+    );
+    if (prev && typeof prev.ref === 'string') previousAssetRef = prev.ref;
+  } catch {
+    /* non-fatal */
+  }
+
   try {
     await client
       .patch(targetDocId)
@@ -122,7 +136,7 @@ export const POST: APIRoute = async ({ request }) => {
 
     return jsonResponse({
       ok: true,
-      data: { docId: targetDocId, fieldPath, newAssetRef, newUrl },
+      data: { docId: targetDocId, fieldPath, newAssetRef, newUrl, previousAssetRef },
     });
   } catch (err) {
     return internalError(`Patch failed: ${(err as Error).message}`);

--- a/next/src/styles/inline-edit.css
+++ b/next/src/styles/inline-edit.css
@@ -643,6 +643,21 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
   justify-content: space-between;
   gap: 12px;
 }
+.pi-sanity-modal__head-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.pi-sanity-modal__current {
+  display: block;
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  background: #e8eaef center / cover no-repeat;
+  flex: 0 0 48px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
 .pi-sanity-modal__title {
   font-weight: 600;
   font-size: 16px;
@@ -690,15 +705,47 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
   cursor: pointer;
 }
 .pi-sanity-modal__upload:hover { background: #1e40af; }
+.pi-sanity-modal__toolbar {
+  flex-wrap: wrap;
+}
+.pi-sanity-modal__chips,
+.pi-sanity-modal__sort {
+  display: inline-flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.pi-sanity-modal__chip {
+  appearance: none;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: #fff;
+  color: #1a1d24;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.pi-sanity-modal__chip:hover { background: #f3f4f7; }
+.pi-sanity-modal__chip[aria-pressed="true"] {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  color: #fff;
+}
+.pi-sanity-modal__chip:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
 .pi-sanity-modal__grid {
   flex: 1 1 auto;
   overflow-y: auto;
   padding: 14px 18px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 14px;
   align-content: start;
 }
+.pi-sanity-modal__grid:focus { outline: none; }
 .pi-sanity-modal__asset {
   border: 1px solid rgba(0, 0, 0, 0.08);
   background: #fff;
@@ -712,6 +759,21 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
   transition: border-color 0.12s, transform 0.12s;
 }
 .pi-sanity-modal__asset:hover { border-color: #1d4ed8; transform: translateY(-1px); }
+.pi-sanity-modal__asset:focus-visible {
+  outline: none;
+  border-color: #1d4ed8;
+  box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.25);
+}
+.pi-sanity-modal__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.pi-sanity-modal__dims {
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.45);
+}
 .pi-sanity-modal__thumb {
   display: block;
   width: 100%;
@@ -720,11 +782,12 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
   border-radius: 6px;
 }
 .pi-sanity-modal__name {
-  font-size: 11px;
-  color: rgba(0, 0, 0, 0.65);
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.78);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 500;
 }
 .pi-sanity-modal__status {
   grid-column: 1 / -1;
@@ -760,3 +823,87 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
   opacity: 0.55;
   cursor: not-allowed;
 }
+
+
+/* Drag-and-drop overlay — sits on top of the modal panel when a file is
+   being dragged over the modal. */
+.pi-sanity-modal__drop {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(29, 78, 216, 0.86);
+  color: #fff;
+  z-index: 5;
+  pointer-events: none;
+}
+.pi-sanity-modal--drag .pi-sanity-modal__drop { display: flex; }
+.pi-sanity-modal__drop-inner {
+  font-size: 22px;
+  font-weight: 600;
+  padding: 18px 28px;
+  border: 2px dashed rgba(255, 255, 255, 0.7);
+  border-radius: 12px;
+  letter-spacing: 0.02em;
+}
+
+/* Error state action row inside the grid. */
+.pi-sanity-modal__err-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+.pi-sanity-modal__err-actions a.pi-sanity-modal__btn {
+  text-decoration: none;
+  color: inherit;
+  display: inline-block;
+}
+
+/* Sticky banner — used for Undo and "Try again" prompts. */
+.pi-sanity-banner {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2147483700;
+  background: #1a1a1a;
+  color: #faf7f0;
+  border-radius: 999px;
+  padding: 0.5rem 0.75rem 0.5rem 1.1rem;
+  font: 500 0.82rem/1 'Outfit', system-ui, sans-serif;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  animation: piSanityBannerIn 0.2s ease-out both;
+}
+@keyframes piSanityBannerIn {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+.pi-sanity-banner__btn {
+  appearance: none;
+  border: 0;
+  background: #8b4e3b;
+  color: #faf7f0;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+.pi-sanity-banner__btn:hover { background: #6f3d2e; }
+.pi-sanity-banner__close {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: rgba(250, 247, 240, 0.55);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.3rem;
+}
+.pi-sanity-banner__close:hover { color: #fff; }


### PR DESCRIPTION
## Summary

Round D polish over the functional MVP from PR #193. Makes the right-click "Replace from media library" modal pleasant to use repeatedly.

### P1 — instant feedback + recovery
- **Drag-and-drop upload** anywhere onto the modal, with a clear blue "Drop to upload" overlay during drag.
- **Undo (5s)** sticky banner after every successful patch. The patch endpoint now returns the previous asset ref so the client can re-patch on undo and restore the previously-visible src locally.
- **Actionable errors.** 401 -> "Session expired" banner with `/admin/login/` link. Other failures -> "Try again" button that re-fires the request.

### P2 — find the right asset faster
- Wider asset tiles (180px min) with filename + WxH dimensions below.
- **Sort toggle**: Recent (default) | Name. Pipes through to the GROQ order.
- **Orientation chips**: Any | Landscape | Portrait | Square. Maps to `metadata.dimensions.aspectRatio` bands in `/api/admin/sanity-assets`.
- Stale-fetch guard via reqId counter, plus the existing 250ms debounce.

### P3 — keyboard + accessibility
- Esc closes (confirmed). Tab cycles within the modal (focus trap).
- Arrow keys move focus across the grid; Enter picks.
- ARIA: `role="dialog"` + `aria-modal` + `aria-labelledby` on the panel, `aria-label="Replace with <filename>"` on each asset button, `aria-pressed` on the chip toggles, `role="group"` on the chip rows.
- Search input auto-focuses on open.

### Current image preview
Shipped as a bonus — the modal header shows a 48px thumbnail of the image being replaced.

### Deferred (P4)
- Click-outside-to-close (backdrop already closes; mid-upload confirm is unnecessary because uploads are guarded by `uploadInFlight`).
- Tag filter — Sanity doesn't reliably populate `opt.media.tags` across the current asset set; defer until we tag-curate the library.

## Files

- `next/src/lib/inline-edit/sanity-image-overlay.ts` — modal logic, drag-drop, undo, keyboard nav, focus trap
- `next/src/styles/inline-edit.css` — chip styles, drop overlay, sticky banner, larger thumbs
- `next/src/pages/api/admin/sanity-patch.ts` — returns `previousAssetRef` for the undo path
- `next/src/pages/api/admin/sanity-assets.ts` — honours `sort=recent|name` and `orientation=any|landscape|portrait|square`

## Test plan
- [ ] Right-click any editable image, modal opens with current-image preview, search autofocus, recent-first grid
- [ ] Type a query — list debounces (250ms) and reloads
- [ ] Toggle Landscape/Portrait/Square chips — grid filters by aspect ratio
- [ ] Pick an asset — Undo banner appears, click Undo within 5s, original image restored
- [ ] Drag a JPEG onto the modal — blue overlay appears, upload completes, image swaps
- [ ] Arrow keys move focus through the grid; Enter picks
- [ ] Tab cycles; Esc closes
- [ ] Force a 401 by clearing the admin cookie — banner shows "Session expired" with Re-login link