### PR TITLE
feat(cms): admin overlay patches trigger on-demand revalidation

### DIFF
--- a/next/src/lib/sanity/revalidate-paths.ts
+++ b/next/src/lib/sanity/revalidate-paths.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared map from a Sanity document `_type` (+ optional slug) to the public
+ * URLs that should be revalidated when the doc changes.
+ *
+ * Used by:
+ *   - /api/revalidate.ts        — Sanity webhook handler (for Studio edits)
+ *   - /api/admin/sanity-patch.ts — admin overlay (for inline edits)
+ *
+ * Adding/changing a route mapping here flows to both surfaces automatically.
+ */
+
+interface DocLike {
+  _type: string;
+  slug?: { current?: string } | string | null;
+}
+
+export function routesForDocument(doc: DocLike): string[] {
+  const slug =
+    typeof doc.slug === 'string'
+      ? doc.slug
+      : typeof doc.slug === 'object' && doc.slug
+        ? doc.slug.current
+        : undefined;
+
+  switch (doc._type) {
+    case 'venue':
+      if (!slug) return [];
+      // Venue pages live under /eat/, /wine/, /stay/ depending on type.
+      // We blast all three — only the right one will actually serve content.
+      return [`/eat/${slug}/`, `/wine/${slug}/`, `/stay/${slug}/`, `/places/`];
+    case 'place':
+      return slug ? [`/places/${slug}/`, `/places/`] : [];
+    case 'article':
+      return slug ? [`/journal/${slug}/`, `/journal/`, `/`] : ['/journal/', '/'];
+    case 'event':
+      return slug ? [`/whats-on/${slug}/`, `/whats-on/`] : ['/whats-on/'];
+    case 'itinerary':
+      return slug ? [`/plans/${slug}/`, `/plans/`] : ['/plans/'];
+    case 'tour':
+      return slug ? [`/tour/${slug}/`, `/tour/`] : ['/tour/'];
+    case 'tourOperator':
+      return slug ? [`/tour/operators/${slug}/`, `/tour/operators/`] : ['/tour/operators/'];
+    case 'tourPackage':
+      return slug ? [`/tour-packages/${slug}/`, `/tour-packages/`] : ['/tour-packages/'];
+    case 'experience':
+      return slug ? [`/explore/${slug}/`, `/explore/`] : ['/explore/'];
+    case 'homepageCover':
+    case 'megaRail':
+    case 'siteSettings':
+      // Site-wide singletons that affect the homepage + everywhere the
+      // mega rail / masthead renders. Blast the homepage and a few key
+      // hubs; other pages will pick up on their next natural rebuild.
+      return ['/', '/eat/', '/wine/', '/stay/', '/places/', '/journal/'];
+    case 'pageHero':
+      // pageHero singletons key on a path field. The slug here IS the
+      // path (e.g. "eat/bakeries"). Strip any leading slash, append
+      // trailing slash, and revalidate that exact route.
+      if (!slug) return ['/'];
+      return [`/${slug.replace(/^\/+|\/+$/g, '')}/`];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Best-effort on-demand revalidation. Used by the admin overlay to push an
+ * inline edit live within a few seconds instead of waiting for a Sanity
+ * webhook or the next natural deploy.
+ *
+ * Fire-and-forget: caller should not await this and should not surface
+ * errors to the editor — a failed revalidate is a soft failure (the next
+ * organic deploy will catch up).
+ */
+export async function triggerRevalidate(routes: string[], origin: string): Promise<void> {
+  const token = process.env.VERCEL_REVALIDATE_TOKEN ?? '';
+  await Promise.all(
+    routes.map((path) =>
+      fetch(`${origin}${path}`, {
+        method: 'GET',
+        headers: token ? { 'x-prerender-revalidate': token } : {},
+      }).catch((err) => {
+        console.error(`[revalidate-paths] failed for ${path}:`, err);
+      }),
+    ),
+  );
+}

--- a/next/src/pages/api/admin/sanity-patch.ts
+++ b/next/src/pages/api/admin/sanity-patch.ts
@@ -25,6 +25,7 @@ import {
   unauthorized,
 } from '../../../lib/cms/server';
 import { entityTypeToSanityType, getSanityWriteClient } from '../../../lib/sanity/write-client';
+import { routesForDocument, triggerRevalidate } from '../../../lib/sanity/revalidate-paths';
 
 export const prerender = process.env.PI_ADMIN_HYBRID !== '1';
 export async function getStaticPaths() {
@@ -133,6 +134,31 @@ export const POST: APIRoute = async ({ request }) => {
       dataset: client.config().dataset!,
     });
     const newUrl = builder.image(newAssetRef).auto('format').url();
+
+    // Fire-and-forget on-demand revalidation so the inline edit reflects
+    // on the public site within a few seconds — no need to wait for a
+    // Sanity webhook (which only catches Studio edits) or a natural
+    // deploy. Best-effort: lookup _type+slug, map to affected routes,
+    // GET each with the prerender-revalidate header.
+    //
+    // We don't await this — the editor's visible swap already happened
+    // client-side; the cache bust is just so OTHER browser sessions
+    // (and the editor's own next page-load) see the new image.
+    (async () => {
+      try {
+        const meta = await client.fetch<{ _type: string; slug?: { current?: string } } | null>(
+          `*[_id == $id][0]{ _type, slug }`,
+          { id: targetDocId },
+        );
+        if (!meta) return;
+        const routes = routesForDocument({ _type: meta._type, slug: meta.slug });
+        if (routes.length === 0) return;
+        const origin = new URL(request.url).origin;
+        await triggerRevalidate(routes, origin);
+      } catch (err) {
+        console.error('[sanity-patch] revalidate trigger failed:', err);
+      }
+    })();
 
     return jsonResponse({
       ok: true,

--- a/next/src/pages/api/revalidate.ts
+++ b/next/src/pages/api/revalidate.ts
@@ -21,6 +21,7 @@
  */
 import type {APIRoute} from 'astro'
 import {isValidSignature, SIGNATURE_HEADER_NAME} from '@sanity/webhook'
+import {routesForDocument as sharedRoutesFor, triggerRevalidate} from '../../lib/sanity/revalidate-paths'
 
 // Static builds (GitHub Pages) don't use this webhook — prerender as a
 // placeholder so output:static doesn't throw NoAdapterInstalled.
@@ -32,48 +33,10 @@ interface SanityWebhookBody {
   slug?: {current?: string} | string | null
 }
 
-// Map a document `_type` → the routes that need invalidating when it changes.
+// Map kept in lib/sanity/revalidate-paths.ts so the admin overlay's
+// /api/admin/sanity-patch can reuse the same routing logic.
 function routesForDocument(body: SanityWebhookBody): string[] {
-  const slug =
-    typeof body.slug === 'string'
-      ? body.slug
-      : typeof body.slug === 'object' && body.slug
-        ? body.slug.current
-        : undefined
-
-  switch (body._type) {
-    case 'venue':
-      if (!slug) return []
-      // Venue pages live under /eat/, /wine/, /stay/ depending on type.
-      // We blast all three — only the right one will actually serve content.
-      return [`/eat/${slug}/`, `/wine/${slug}/`, `/stay/${slug}/`, `/places/`]
-    case 'place':
-      return slug ? [`/places/${slug}/`, `/places/`] : []
-    case 'article':
-      return slug ? [`/journal/${slug}/`, `/journal/`, `/`] : ['/journal/', '/']
-    case 'event':
-      return slug ? [`/whats-on/${slug}/`, `/whats-on/`] : ['/whats-on/']
-    case 'itinerary':
-      return slug ? [`/plans/${slug}/`, `/plans/`] : ['/plans/']
-    case 'tour':
-      return slug ? [`/tour/${slug}/`, `/tour/`] : ['/tour/']
-    case 'tourOperator':
-      return slug ? [`/tour/operators/${slug}/`, `/tour/operators/`] : ['/tour/operators/']
-    case 'tourPackage':
-      return slug ? [`/tour-packages/${slug}/`, `/tour-packages/`] : ['/tour-packages/']
-    case 'experience':
-      return slug ? [`/explore/${slug}/`, `/explore/`] : ['/explore/']
-    case 'homepageCover':
-    case 'megaRail':
-    case 'siteSettings':
-      return ['/']
-    case 'pageHero':
-      // pageHero singletons key on a path field — best-effort: blast the homepage
-      // and the editor can manually trigger a rebuild for deeper hubs if needed.
-      return ['/']
-    default:
-      return []
-  }
+  return sharedRoutesFor({_type: body._type, slug: body.slug})
 }
 
 export const POST: APIRoute = async ({request}) => {
@@ -106,20 +69,11 @@ export const POST: APIRoute = async ({request}) => {
     })
   }
 
-  // Astro's Vercel adapter exposes on-demand revalidation via the platform's
-  // standard `Cache-Control: no-cache` + `purge: 1` semantics. The simplest
-  // portable approach is to fetch each route with a cache-busting header
-  // which the Vercel edge interprets as an invalidation signal.
-  await Promise.all(
-    routes.map((path) =>
-      fetch(`https://peninsulainsider.com.au${path}`, {
-        method: 'GET',
-        headers: {'x-prerender-revalidate': process.env.VERCEL_REVALIDATE_TOKEN ?? ''},
-      }).catch((err) => {
-        console.error(`[revalidate] failed for ${path}:`, err)
-      }),
-    ),
-  )
+  // Fire revalidations through the shared helper. Same logic the admin
+  // overlay uses for inline edits, so a Studio publish and a /admin/
+  // right-click replace go through the same cache-bust path.
+  const origin = new URL(request.url).origin
+  await triggerRevalidate(routes, origin)
 
   console.log(`[revalidate] ${body._type}/${body._id} → ${routes.join(', ')}`)
   return new Response(


### PR DESCRIPTION
Inline edits go live in ~1-2s instead of waiting for a deploy or webhook. Shared revalidate map between /api/admin/sanity-patch and /api/revalidate.