### PR TITLE
feat(cms): dual-read homepage cards through Sanity adapters

### DIFF
--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -32,6 +32,8 @@ import { routeSlug, currentSeason, seasonBlurb, dispatchWeekend } from '../lib/e
 import { loadPublishedHomepageOverrides } from '../lib/content/homepage';
 import { sanityReadEnabled } from '../lib/sanity/client';
 import { fetchHomepageCoverFromSanity } from '../lib/sanity/singletons-adapter';
+import { fetchPlaceFromSanity } from '../lib/sanity/place-adapter';
+import { fetchItineraryFromSanity } from '../lib/sanity/itinerary-adapter';
 import { editableText, editableImage } from '../lib/inline-edit/attrs';
 
 // CMS-driven overrides for editor-controlled fields on the homepage. Empty
@@ -117,6 +119,44 @@ const placesTitleRaw = cmsText['places.title'];
 const placesTitle = placesTitleRaw === 'The Peninsula, place by place'
   ? 'Explore the Peninsula'
   : placesTitleRaw ?? 'Explore the Peninsula';
+
+// Dual-read: when the per-entity Sanity flag is on, overwrite the heroImage
+// src on featured places + plan cards with the Sanity CDN URL. Sanity's
+// production client has stega enabled and the adapters thread ctx through
+// intentUrl(), so the rendered URL carries an invisible marker pointing
+// back at the source doc/field. That marker is what lets the admin
+// right-click overlay auto-detect the binding for "Replace from media
+// library…". Card visuals are unchanged — only the URL string differs.
+async function applySanityHero<T extends { data: any }>(
+  entity: T,
+  slug: string,
+  fetcher: (s: string) => Promise<any | null>,
+): Promise<T> {
+  const doc = await fetcher(slug);
+  const sanitySrc = doc?.data?.heroImage?.src;
+  if (!sanitySrc) return entity;
+  return {
+    ...entity,
+    data: {
+      ...entity.data,
+      heroImage: { ...entity.data.heroImage, src: sanitySrc },
+    },
+  };
+}
+const placeReadOn      = sanityReadEnabled('places');
+const itineraryReadOn  = sanityReadEnabled('itineraries');
+const [hydratedFeaturedPlaces, hydratedPlanCards] = await Promise.all([
+  Promise.all(
+    featuredPlaces.map((p) =>
+      placeReadOn ? applySanityHero(p, routeSlug(p), fetchPlaceFromSanity) : p,
+    ),
+  ),
+  Promise.all(
+    planCards.map((it) =>
+      itineraryReadOn ? applySanityHero(it, routeSlug(it), fetchItineraryFromSanity) : it,
+    ),
+  ),
+]);
 
 const season         = currentSeason();
 const seasonBlurbData = seasonBlurb[season];
@@ -474,7 +514,7 @@ export const prerender = true;
           >{cmsText['places.sub'] ?? 'Start with the Peninsula destinations people search for first, the towns, villages and landmarks that anchor most trips.'}</p>
         </div>
         <div class="places__grid">
-          {featuredPlaces.map((place, index) => (
+          {hydratedFeaturedPlaces.map((place, index) => (
             <PlaceCard
               place={place}
               variant={index % 3 === 1 ? 'bay' : index % 3 === 2 ? 'sand' : 'vineyard'}
@@ -509,7 +549,7 @@ export const prerender = true;
           >{cmsText['plans.sub'] ?? 'Three editorial itineraries, built around a single anchor stay, paced for the way the Peninsula actually works.'}</p>
         </div>
         <div class="hp-plans__grid">
-          {planCards.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
+          {hydratedPlanCards.map((itinerary) => <ItineraryCard itinerary={itinerary} />)}
         </div>
         <div class="hp-plans__footer">
           <a href="/plans/" class="venues__link">View Plans →</a>


### PR DESCRIPTION
## Summary

- Dual-reads the homepage's featured **places** rail and **plan cards** through the Sanity adapters when the per-entity flags are on
- Overwrites `data.heroImage.src` with the stega-encoded Sanity CDN URL so the admin right-click overlay can auto-detect the binding for "Replace from media library…"
- Falls through to the existing local heroImage when the flag is off or the doc has no hero set
- Fetches run in parallel via `Promise.all` to keep build time flat

## Scope

Scope is `next/src/pages/index.astro` only — does not touch the cover scene (PR #194), the mega rail (PR #199), detail pages, or hub pages.

The brief also called for dual-reading articles on the homepage, but inspection shows no article hero `<img>` or background-image is rendered on the homepage (weekend dispatch uses `WeekendPickerBlock` which has no image, editor picks use `Shortlist` which has no images, and "Also in this issue" reads from the inline `scenes` array, not articles). So articles dual-read is a no-op here and was skipped.

## Test plan

- [x] `npm run build` (hybrid mode) passes — build completed in 84.67s vs 80.97s baseline (~4s delta for ~13 Sanity fetches added)
- [x] `lint:no-pricing` clean
- [x] Card visuals unchanged — only the URL string differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)