### PR TITLE
feat(cms): bind any image to a Sanity doc on the spot

### DIFF
--- a/next/src/lib/inline-edit/client.ts
+++ b/next/src/lib/inline-edit/client.ts
@@ -91,6 +91,21 @@ export async function bootInlineEditor(): Promise<void> {
   }
   if (!isAdmin) return;
 
+  // Warm the editor-supplied bindings cache for this page so the right-
+  // click handler can resolve "Bind to a Sanity doc…" results synchronously.
+  // Once loaded, patch matching <img> / bg-image elements with data-pi-edit
+  // attrs so the existing tagged-image flow lights up for previously-bound
+  // images on this URL. Admin-gated — anon visitors never reach this code.
+  void (async () => {
+    try {
+      const mod = await import('./sanity-image-overlay');
+      await mod.loadBindingsForPage();
+      applyBindingsToDom();
+    } catch (err) {
+      console.warn('[pi-edit] failed to warm bindings cache', err);
+    }
+  })();
+
   // Mount/restore the floating toggle. Astro's <ClientRouter /> swaps
   // <body> on soft navigations, so any DOM we appended is gone — we
   // re-render on every page-load event. Delegation is installed at module
@@ -612,6 +627,9 @@ function openImagePanel(el: HTMLElement, x: number, y: number) {
     <button type="button" class="pi-edit-panel__replace" data-action="replace">
       <span aria-hidden="true">⇪</span> Replace image (upload)…
     </button>
+    <button type="button" class="pi-edit-panel__replace" data-action="bind-sanity" style="margin-top:6px" hidden>
+      <span aria-hidden="true">🔗</span> Bind to a Sanity doc…
+    </button>
     <button type="button" class="pi-edit-panel__replace" data-action="replace-sanity" style="margin-top:6px">
       <span aria-hidden="true">⬚</span> Replace from media library…
     </button>
@@ -645,10 +663,34 @@ function openImagePanel(el: HTMLElement, x: number, y: number) {
     if (!action) return;
     if (action === 'replace') triggerImageReplace(el, desc);
     if (action === 'replace-sanity') void triggerSanityReplace(el, desc);
+    if (action === 'bind-sanity') void triggerSanityBind(el, desc);
     if (action === 'cancel')  closeMenu();
     if (action === 'save')    void savePanelMeta(menuEl!, el, desc);
   });
   menuEl.querySelector('.pi-edit-panel__close')?.addEventListener('click', closeMenu);
+
+  // Async probe: figure out whether this image already has a Sanity binding
+  // (stega marker, data-pi-edit, or pi.image_bindings row). If NOT, surface
+  // the "Bind to a Sanity doc…" button and hide the Replace button until
+  // the editor has bound something.
+  void (async () => {
+    try {
+      const mod = await import('./sanity-image-overlay');
+      const source = mod.resolveSanitySource(el, desc);
+      if (!menuEl) return;
+      const bindBtn = menuEl.querySelector<HTMLButtonElement>('[data-action="bind-sanity"]');
+      const replaceBtn = menuEl.querySelector<HTMLButtonElement>('[data-action="replace-sanity"]');
+      if (!source) {
+        if (bindBtn) bindBtn.hidden = false;
+        if (replaceBtn) replaceBtn.hidden = true;
+      } else {
+        if (bindBtn) bindBtn.hidden = true;
+        if (replaceBtn) replaceBtn.hidden = false;
+      }
+    } catch {
+      /* leave defaults — Replace visible, Bind hidden */
+    }
+  })();
 }
 
 function cssUrl(src: string): string {
@@ -778,6 +820,77 @@ function triggerImageReplace(el: HTMLElement, desc?: ImageDescriptor) {
  *   2. stega payload decoded from the rendered image src
  *   3. neither → toast a hint and bail
  */
+/**
+ * Open the "Bind to a Sanity doc…" modal for an image that has no existing
+ * Sanity binding. On save, the new pi.image_bindings row is cached, the
+ * data-pi-edit attrs are injected onto matching elements, and a toast
+ * prompts the editor to right-click again.
+ */
+async function triggerSanityBind(el: HTMLElement, _desc: ImageDescriptor) {
+  try {
+    const overlay = await import('./sanity-image-overlay');
+    const bindMod = await import('./sanity-bind-modal');
+    const src = currentImageSrc(el);
+    const basename = overlay.srcBasenameFor(src);
+    const pattern = overlay.currentPageUrlPattern();
+    closeMenu();
+    bindMod.openBindModal({
+      imageBasename: basename,
+      pageUrlPattern: pattern,
+      toast,
+      onClose: () => { /* nothing extra */ },
+      onBound: (binding) => {
+        overlay.invalidateBindingsCache();
+        void (async () => {
+          await overlay.loadBindingsForPage();
+          applyBindingsToDom();
+        })();
+        // Tag this specific element immediately so an instant right-click
+        // works without waiting for the cache reload.
+        el.setAttribute('data-pi-edit', 'image');
+        el.setAttribute('data-pi-entity-type', binding.sanity_doc_type);
+        el.setAttribute('data-pi-entity-slug', binding.sanity_doc_id);
+        el.setAttribute('data-pi-field-path', binding.sanity_field_path);
+        el.setAttribute('data-pi-sanity-singleton-id', binding.sanity_doc_id);
+        el.setAttribute('data-pi-sanity-singleton-path', binding.sanity_field_path);
+      },
+    });
+  } catch (err) {
+    console.error('[pi-edit] bind modal failed to load', err);
+    toast(`Couldn't open bind modal: ${(err as Error).message}`, 'err');
+  }
+}
+
+/**
+ * Walk the DOM and add `data-pi-edit="image"` + sanity-binding attrs to
+ * every `<img>` / background-image element whose filename basename matches
+ * a row in pi.image_bindings for the current page. Idempotent — re-runs
+ * after each bind save. Admin-gated.
+ */
+function applyBindingsToDom(): void {
+  void import('./sanity-image-overlay').then((mod) => {
+    const rows = mod.getCachedBindings();
+    if (!rows.length) return;
+    const byBasename = new Map<string, typeof rows[number]>();
+    for (const r of rows) byBasename.set(r.image_basename, r);
+
+    const candidates = document.querySelectorAll<HTMLElement>('img, [style*="background-image"], [data-pi-edit="image"]');
+    for (const el of candidates) {
+      if (el.dataset.piEdit === 'image' && el.dataset.piEntityType) continue;
+      const src = currentImageSrc(el);
+      const basename = mod.srcBasenameFor(src);
+      const row = byBasename.get(basename);
+      if (!row) continue;
+      el.setAttribute('data-pi-edit', 'image');
+      if (!el.dataset.piEntityType) el.setAttribute('data-pi-entity-type', row.sanity_doc_type);
+      if (!el.dataset.piEntitySlug) el.setAttribute('data-pi-entity-slug', row.sanity_doc_id);
+      if (!el.dataset.piFieldPath)  el.setAttribute('data-pi-field-path', row.sanity_field_path);
+      el.setAttribute('data-pi-sanity-singleton-id', row.sanity_doc_id);
+      el.setAttribute('data-pi-sanity-singleton-path', row.sanity_field_path);
+    }
+  }).catch(() => { /* ignore */ });
+}
+
 async function triggerSanityReplace(el: HTMLElement, desc: ImageDescriptor) {
   try {
     const mod = await import('./sanity-image-overlay');

--- a/next/src/lib/inline-edit/sanity-bind-modal.ts
+++ b/next/src/lib/inline-edit/sanity-bind-modal.ts
@@ -1,0 +1,322 @@
+/**
+ * Sanity "Bind on the spot" modal.
+ *
+ * Lazy-loaded from the inline editor when an admin right-clicks an image
+ * that has no existing Sanity binding. Lets the editor:
+ *
+ *   1. Search Sanity docs by title/name/slug.
+ *   2. Pick one of the doc's image-typed fields.
+ *   3. Save a binding row in pi.image_bindings, keyed by URL path +
+ *      image filename basename.
+ *
+ * On success, the inline editor re-fetches bindings so the next
+ * right-click on the same image goes straight to Replace-from-media.
+ *
+ * Reuses .pi-sanity-modal class skeleton (sanity-image-overlay) for
+ * consistent chrome. Bind-specific styles namespaced under
+ * .pi-sanity-modal--bind.
+ */
+
+export interface BindModalOpts {
+  imageBasename: string;
+  pageUrlPattern: string;
+  toast: (msg: string, tone?: 'ok' | 'err' | 'info') => void;
+  onBound: (binding: BindingRow) => void;
+  onClose: () => void;
+}
+
+export interface BindingRow {
+  id: string;
+  page_url_pattern: string;
+  image_basename: string;
+  sanity_doc_id: string;
+  sanity_doc_type: string;
+  sanity_field_path: string;
+}
+
+interface DocHit {
+  _id: string;
+  _type: string;
+  title: string;
+  slug?: string | null;
+}
+
+interface FieldOption {
+  path: string;
+  label: string;
+}
+
+let activeWrap: HTMLDivElement | null = null;
+let activeCleanup: (() => void) | null = null;
+
+export function openBindModal(opts: BindModalOpts): void {
+  closeBindModal();
+
+  const wrap = document.createElement('div');
+  wrap.className = 'pi-sanity-modal pi-sanity-modal--bind';
+  wrap.setAttribute('role', 'dialog');
+  wrap.setAttribute('aria-modal', 'true');
+  wrap.setAttribute('aria-labelledby', 'pi-bind-modal-title');
+  wrap.innerHTML = `
+    <div class="pi-sanity-modal__backdrop" data-close="1"></div>
+    <div class="pi-sanity-modal__panel" tabindex="-1">
+      <div class="pi-sanity-modal__head">
+        <div class="pi-sanity-modal__head-main">
+          <div>
+            <div class="pi-sanity-modal__title" id="pi-bind-modal-title">Bind this image to a Sanity doc</div>
+            <div class="pi-sanity-modal__sub">
+              <strong>${esc(opts.imageBasename)}</strong> on <code>${esc(opts.pageUrlPattern)}</code>
+            </div>
+          </div>
+        </div>
+        <button type="button" class="pi-sanity-modal__close" data-close="1" aria-label="Close">&times;</button>
+      </div>
+
+      <div class="pi-sanity-modal__bind-body">
+        <section class="pi-sanity-modal__bind-step" data-step="1">
+          <label class="pi-sanity-modal__bind-label">1. Pick the Sanity doc</label>
+          <input
+            type="search"
+            class="pi-sanity-modal__search"
+            placeholder="Search by title, name, or slug…"
+            aria-label="Search Sanity docs"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <div class="pi-sanity-modal__bind-results" role="listbox" aria-label="Sanity docs">
+            <div class="pi-sanity-modal__status">Type to search.</div>
+          </div>
+        </section>
+
+        <section class="pi-sanity-modal__bind-step" data-step="2" hidden>
+          <label class="pi-sanity-modal__bind-label">2. Pick the field</label>
+          <div class="pi-sanity-modal__bind-picked"></div>
+          <div class="pi-sanity-modal__bind-fields">
+            <div class="pi-sanity-modal__status">Loading fields&hellip;</div>
+          </div>
+        </section>
+      </div>
+
+      <div class="pi-sanity-modal__foot">
+        <button type="button" class="pi-sanity-modal__btn" data-action="back" hidden>&lsaquo; Back</button>
+        <span class="pi-sanity-modal__page" data-role="status"></span>
+        <button type="button" class="pi-sanity-modal__btn" data-close="1">Cancel</button>
+        <button type="button" class="pi-sanity-modal__btn pi-sanity-modal__btn--primary" data-action="save" disabled>Save binding</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(wrap);
+  activeWrap = wrap;
+
+  const panel = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__panel')!;
+  const search = wrap.querySelector<HTMLInputElement>('.pi-sanity-modal__search')!;
+  const resultsBox = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__bind-results')!;
+  const step1 = wrap.querySelector<HTMLElement>('[data-step="1"]')!;
+  const step2 = wrap.querySelector<HTMLElement>('[data-step="2"]')!;
+  const fieldsBox = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__bind-fields')!;
+  const pickedBox = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__bind-picked')!;
+  const saveBtn = wrap.querySelector<HTMLButtonElement>('[data-action="save"]')!;
+  const backBtn = wrap.querySelector<HTMLButtonElement>('[data-action="back"]')!;
+  const statusEl = wrap.querySelector<HTMLSpanElement>('[data-role="status"]')!;
+
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  let searchReq = 0;
+  let pickedDoc: DocHit | null = null;
+  let pickedField: FieldOption | null = null;
+
+  const setStatus = (msg: string) => { statusEl.textContent = msg; };
+
+  const renderDocs = (docs: DocHit[]) => {
+    if (docs.length === 0) {
+      resultsBox.innerHTML = '<div class="pi-sanity-modal__status">No matches.</div>';
+      return;
+    }
+    resultsBox.innerHTML = docs
+      .map(
+        (d) => `
+        <button type="button" role="option" class="pi-sanity-modal__bind-doc" data-doc-id="${esc(d._id)}" data-doc-type="${esc(d._type)}" data-doc-title="${esc(d.title)}">
+          <span class="pi-sanity-modal__bind-doc-title">${esc(d.title)}</span>
+          <span class="pi-sanity-modal__bind-doc-meta">${esc(d._type)}${d.slug ? ` &middot; /${esc(d.slug)}/` : ''}</span>
+        </button>`,
+      )
+      .join('');
+  };
+
+  const runSearch = async (q: string) => {
+    const reqId = ++searchReq;
+    if (!q) {
+      resultsBox.innerHTML = '<div class="pi-sanity-modal__status">Type to search.</div>';
+      return;
+    }
+    resultsBox.innerHTML = '<div class="pi-sanity-modal__status">Searching&hellip;</div>';
+    try {
+      const res = await fetch(`/api/admin/sanity-docs-search?q=${encodeURIComponent(q)}`, {
+        credentials: 'same-origin',
+      });
+      if (reqId !== searchReq) return;
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        resultsBox.innerHTML = `<div class="pi-sanity-modal__status">Search failed: ${esc(body?.error || res.statusText)}</div>`;
+        return;
+      }
+      renderDocs((body.data?.docs ?? []) as DocHit[]);
+    } catch (err) {
+      if (reqId !== searchReq) return;
+      resultsBox.innerHTML = `<div class="pi-sanity-modal__status">Search failed: ${esc((err as Error).message)}</div>`;
+    }
+  };
+
+  const renderFields = (fields: FieldOption[]) => {
+    if (fields.length === 0) {
+      fieldsBox.innerHTML =
+        '<div class="pi-sanity-modal__status">This doc has no image-typed fields yet. Pick another doc, or add an image field in Sanity first.</div>';
+      return;
+    }
+    fieldsBox.innerHTML = fields
+      .map(
+        (f) => `
+        <label class="pi-sanity-modal__bind-field">
+          <input type="radio" name="pi-bind-field" value="${esc(f.path)}" data-label="${esc(f.label)}" />
+          <span class="pi-sanity-modal__bind-field-label">${esc(f.label)}</span>
+          <code class="pi-sanity-modal__bind-field-path">${esc(f.path)}</code>
+        </label>`,
+      )
+      .join('');
+  };
+
+  const loadFields = async (doc: DocHit) => {
+    pickedBox.innerHTML = `<strong>${esc(doc.title)}</strong> <span class="pi-sanity-modal__bind-doc-meta">${esc(doc._type)}</span>`;
+    fieldsBox.innerHTML = '<div class="pi-sanity-modal__status">Loading fields&hellip;</div>';
+    try {
+      const res = await fetch(`/api/admin/sanity-doc-fields?docId=${encodeURIComponent(doc._id)}`, {
+        credentials: 'same-origin',
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        fieldsBox.innerHTML = `<div class="pi-sanity-modal__status">Failed to load fields: ${esc(body?.error || res.statusText)}</div>`;
+        return;
+      }
+      renderFields((body.data?.fields ?? []) as FieldOption[]);
+    } catch (err) {
+      fieldsBox.innerHTML = `<div class="pi-sanity-modal__status">Failed to load fields: ${esc((err as Error).message)}</div>`;
+    }
+  };
+
+  const goToStep2 = (doc: DocHit) => {
+    pickedDoc = doc;
+    pickedField = null;
+    saveBtn.disabled = true;
+    step1.hidden = true;
+    step2.hidden = false;
+    backBtn.hidden = false;
+    setStatus('Step 2 of 2 — pick a field.');
+    void loadFields(doc);
+  };
+
+  const goToStep1 = () => {
+    pickedDoc = null;
+    pickedField = null;
+    saveBtn.disabled = true;
+    step1.hidden = false;
+    step2.hidden = true;
+    backBtn.hidden = true;
+    setStatus('');
+    setTimeout(() => search.focus(), 0);
+  };
+
+  const doSave = async () => {
+    if (!pickedDoc || !pickedField) return;
+    saveBtn.disabled = true;
+    setStatus('Saving binding&hellip;');
+    try {
+      const res = await fetch('/api/admin/image-binding', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          pageUrlPattern: opts.pageUrlPattern,
+          imageBasename: opts.imageBasename,
+          sanityDocId: pickedDoc._id,
+          sanityDocType: pickedDoc._type,
+          sanityFieldPath: pickedField.path,
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        setStatus(`Save failed: ${body?.error || res.statusText}`);
+        opts.toast(`Bind failed: ${body?.error || res.statusText}`, 'err');
+        saveBtn.disabled = false;
+        return;
+      }
+      const binding = body.data?.binding as BindingRow | undefined;
+      opts.toast('Bound. Right-click again to replace.', 'ok');
+      closeBindModal();
+      opts.onClose();
+      if (binding) opts.onBound(binding);
+    } catch (err) {
+      setStatus(`Save failed: ${(err as Error).message}`);
+      opts.toast(`Bind failed: ${(err as Error).message}`, 'err');
+      saveBtn.disabled = false;
+    }
+  };
+
+  wrap.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    if (target.closest('[data-close="1"]')) {
+      closeBindModal();
+      opts.onClose();
+      return;
+    }
+    if (target.closest('[data-action="back"]')) { goToStep1(); return; }
+    if (target.closest('[data-action="save"]')) { void doSave(); return; }
+    const doc = target.closest<HTMLElement>('[data-doc-id]');
+    if (doc) {
+      goToStep2({
+        _id: doc.dataset.docId!,
+        _type: doc.dataset.docType!,
+        title: doc.dataset.docTitle!,
+      });
+    }
+  });
+
+  fieldsBox.addEventListener('change', (e) => {
+    const t = e.target as HTMLInputElement | null;
+    if (!t || t.name !== 'pi-bind-field') return;
+    pickedField = { path: t.value, label: t.dataset.label || t.value };
+    saveBtn.disabled = !(pickedDoc && pickedField);
+  });
+
+  search.addEventListener('input', () => {
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => void runSearch(search.value.trim()), 200);
+  });
+
+  const onKey = (e: KeyboardEvent) => {
+    if (!activeWrap) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeBindModal();
+      opts.onClose();
+    }
+  };
+  document.addEventListener('keydown', onKey);
+  activeCleanup = () => document.removeEventListener('keydown', onKey);
+
+  setStatus('Step 1 of 2 — search for a doc.');
+  setTimeout(() => {
+    panel.focus();
+    search.focus();
+  }, 0);
+}
+
+export function closeBindModal(): void {
+  if (activeCleanup) { activeCleanup(); activeCleanup = null; }
+  if (activeWrap) { activeWrap.remove(); activeWrap = null; }
+}
+
+function esc(s: string | null | undefined): string {
+  return String(s ?? '').replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>)[c],
+  );
+}

--- a/next/src/lib/inline-edit/sanity-image-overlay.ts
+++ b/next/src/lib/inline-edit/sanity-image-overlay.ts
@@ -108,6 +108,94 @@ function normaliseFieldPath(raw: string): string {
   return p;
 }
 
+// ─── Editor-supplied bindings cache (pi.image_bindings) ─────────────────
+//
+// When an admin uses "Bind to a Sanity doc…" the row is written to
+// pi.image_bindings. We cache the result of GET /api/admin/image-binding
+// per (pageUrlPattern) for the lifetime of the page so subsequent
+// right-clicks resolve synchronously. The cache is cleared after a fresh
+// bind so the new row is picked up immediately on the next right-click.
+
+export interface BindingRow {
+  id: string;
+  page_url_pattern: string;
+  image_basename: string;
+  sanity_doc_id: string;
+  sanity_doc_type: string;
+  sanity_field_path: string;
+}
+
+let bindingsCache: { pattern: string; rows: BindingRow[] } | null = null;
+let bindingsInFlight: Promise<BindingRow[]> | null = null;
+
+export function currentPageUrlPattern(): string {
+  if (typeof location === 'undefined') return '/';
+  let p = location.pathname || '/';
+  if (!p.startsWith('/')) p = `/${p}`;
+  if (p.length > 1 && !p.endsWith('/') && !/\.[a-z0-9]{2,5}$/i.test(p)) p = `${p}/`;
+  return p;
+}
+
+export async function loadBindingsForPage(pattern = currentPageUrlPattern()): Promise<BindingRow[]> {
+  if (bindingsCache && bindingsCache.pattern === pattern) return bindingsCache.rows;
+  if (bindingsInFlight) return bindingsInFlight;
+  bindingsInFlight = (async () => {
+    try {
+      const res = await fetch(
+        `/api/admin/image-binding?pageUrlPattern=${encodeURIComponent(pattern)}`,
+        { credentials: 'same-origin' },
+      );
+      if (!res.ok) return [];
+      const body = await res.json();
+      const rows = ((body?.data?.bindings as BindingRow[]) ?? []) as BindingRow[];
+      bindingsCache = { pattern, rows };
+      return rows;
+    } catch {
+      return [];
+    } finally {
+      bindingsInFlight = null;
+    }
+  })();
+  return bindingsInFlight;
+}
+
+export function invalidateBindingsCache(): void {
+  bindingsCache = null;
+}
+
+export function getCachedBindings(): BindingRow[] {
+  return bindingsCache?.rows ?? [];
+}
+
+export function srcBasenameFor(src: string | null | undefined): string {
+  if (!src) return 'unknown';
+  let s = src.split('?')[0];
+  try { s = decodeURIComponent(s); } catch { /* ignore */ }
+  const file = s.split('/').filter(Boolean).pop() || 'unknown';
+  return file.toLowerCase().replace(/[^a-z0-9._-]/g, '-');
+}
+
+/**
+ * Synchronous binding lookup against the cache. Returns null when no
+ * matching binding exists for the element's image filename basename.
+ */
+export function lookupBinding(el: HTMLElement): BindingRow | null {
+  if (!bindingsCache) return null;
+  let src = '';
+  if (el instanceof HTMLImageElement) {
+    src = el.getAttribute('src') || el.src;
+  } else {
+    const bg = el.style.backgroundImage || window.getComputedStyle(el).backgroundImage;
+    const m = bg.match(/url\((['"]?)([^)]+?)\1\)/);
+    src = m?.[2] ?? '';
+  }
+  const basename = srcBasenameFor(src);
+  for (const row of bindingsCache.rows) {
+    if (row.image_basename === basename) return row;
+  }
+  return null;
+}
+
 export function resolveSanitySource(
   el: HTMLElement,
   desc: EditableDescriptor,
@@ -161,6 +249,17 @@ export function resolveSanitySource(
       docId: stega.docId,
       fieldPath: stega.fieldPath,
       resolvedVia: 'stega',
+    };
+  }
+
+  // c) Editor-supplied binding (pi.image_bindings). Synchronous lookup
+  //    against the cache populated by `loadBindingsForPage()` on boot.
+  const binding = lookupBinding(el);
+  if (binding) {
+    return {
+      docId: binding.sanity_doc_id,
+      fieldPath: normaliseFieldPath(binding.sanity_field_path),
+      resolvedVia: 'data-pi-edit',
     };
   }
 

--- a/next/src/pages/api/admin/image-binding.ts
+++ b/next/src/pages/api/admin/image-binding.ts
@@ -1,0 +1,107 @@
+/**
+ * /api/admin/image-binding
+ *
+ * Editor-supplied bindings from "unmarked" page images (URL pattern +
+ * filename basename) to a Sanity doc + field path. The admin overlay
+ * uses these to inject `data-pi-edit` attrs on the fly so the existing
+ * Replace-from-media-library flow lights up for any visible image —
+ * no code change required.
+ *
+ *   GET    ?pageUrlPattern=...    list bindings for a URL pattern
+ *   POST   { ... }                upsert a binding (admin-only)
+ *
+ * DELETE lives at /api/admin/image-binding/[id].
+ */
+import type { APIRoute } from 'astro';
+import {
+  badRequest,
+  forbidden,
+  internalError,
+  jsonResponse,
+  resolveCmsAccess,
+  unauthorized,
+} from '../../../lib/cms/server';
+
+export const prerender = process.env.PI_ADMIN_HYBRID !== '1';
+export async function getStaticPaths() {
+  return [];
+}
+
+interface UpsertBody {
+  pageUrlPattern?: string;
+  imageBasename?: string;
+  sanityDocId?: string;
+  sanityDocType?: string;
+  sanityFieldPath?: string;
+}
+
+const BASENAME_RE = /^[a-z0-9._-]{1,200}$/i;
+const DOC_ID_RE = /^[a-zA-Z0-9._-]{1,128}$/;
+const FIELD_PATH_RE = /^[a-zA-Z_][a-zA-Z0-9_.[\]]*$/;
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok || !access.client) {
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
+  }
+
+  const pattern = (url.searchParams.get('pageUrlPattern') || '').trim();
+  if (!pattern) return badRequest('Missing pageUrlPattern');
+
+  const { data, error } = await access.client
+    .from('image_bindings')
+    .select('id, page_url_pattern, image_basename, sanity_doc_id, sanity_doc_type, sanity_field_path, created_at, updated_at')
+    .eq('page_url_pattern', pattern);
+  if (error) return internalError(`List failed: ${error.message}`);
+
+  return jsonResponse({ ok: true, data: { bindings: data ?? [] } });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok || !access.client || !access.access) {
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
+  }
+
+  let body: UpsertBody;
+  try {
+    body = (await request.json()) as UpsertBody;
+  } catch {
+    return badRequest('Body must be JSON');
+  }
+
+  const pageUrlPattern = (body.pageUrlPattern || '').trim();
+  const imageBasename = (body.imageBasename || '').trim().toLowerCase();
+  const sanityDocId = (body.sanityDocId || '').trim();
+  const sanityDocType = (body.sanityDocType || '').trim();
+  const sanityFieldPath = (body.sanityFieldPath || '').trim();
+
+  if (!pageUrlPattern) return badRequest('Missing pageUrlPattern');
+  if (!imageBasename || !BASENAME_RE.test(imageBasename)) return badRequest('Invalid imageBasename');
+  if (!sanityDocId || !DOC_ID_RE.test(sanityDocId)) return badRequest('Invalid sanityDocId');
+  if (!sanityDocType) return badRequest('Missing sanityDocType');
+  if (!sanityFieldPath || !FIELD_PATH_RE.test(sanityFieldPath)) return badRequest('Invalid sanityFieldPath');
+
+  const userId = access.access.identity.userId;
+
+  const { data, error } = await access.client
+    .from('image_bindings')
+    .upsert(
+      {
+        page_url_pattern: pageUrlPattern,
+        image_basename: imageBasename,
+        sanity_doc_id: sanityDocId,
+        sanity_doc_type: sanityDocType,
+        sanity_field_path: sanityFieldPath,
+        created_by: userId,
+      },
+      { onConflict: 'page_url_pattern,image_basename' },
+    )
+    .select()
+    .single();
+
+  if (error) return internalError(`Upsert failed: ${error.message}`);
+  return jsonResponse({ ok: true, data: { binding: data } });
+};

--- a/next/src/pages/api/admin/image-binding/[id].ts
+++ b/next/src/pages/api/admin/image-binding/[id].ts
@@ -1,0 +1,37 @@
+/**
+ * DELETE /api/admin/image-binding/[id]
+ *
+ * Remove a single image binding. Admin-only. RLS also enforces editor-
+ * gating on delete; this is the belt to that suspenders.
+ */
+import type { APIRoute } from 'astro';
+import {
+  badRequest,
+  forbidden,
+  internalError,
+  jsonResponse,
+  resolveCmsAccess,
+  unauthorized,
+} from '../../../../lib/cms/server';
+
+export const prerender = process.env.PI_ADMIN_HYBRID !== '1';
+export async function getStaticPaths() {
+  return [];
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE: APIRoute = async ({ request, params }) => {
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok || !access.client) {
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
+  }
+
+  const id = String(params.id ?? '');
+  if (!UUID_RE.test(id)) return badRequest('Invalid binding id');
+
+  const { error } = await access.client.from('image_bindings').delete().eq('id', id);
+  if (error) return internalError(`Delete failed: ${error.message}`);
+  return jsonResponse({ ok: true });
+};

--- a/next/src/pages/api/admin/sanity-doc-fields.ts
+++ b/next/src/pages/api/admin/sanity-doc-fields.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/admin/sanity-doc-fields?docId=…
+ *
+ * Inspects a Sanity document and returns image-typed field paths the
+ * editor can bind against. Detection runs on the *fetched document* so
+ * we pick up the actual shape — including arrays of images. A field
+ * counts as image-typed when its value is:
+ *
+ *   - object with `_type == 'image'` + `asset._ref`
+ *   - object with `_type == 'imageRef'` (the PI wrapper type)
+ *   - array of either of the above (we emit one slot per populated index)
+ *
+ * Top-level + one-deep nested fields are walked.
+ */
+import type { APIRoute } from 'astro';
+import {
+  badRequest,
+  forbidden,
+  internalError,
+  jsonResponse,
+  resolveCmsAccess,
+  unauthorized,
+} from '../../../lib/cms/server';
+import { getSanityWriteClient } from '../../../lib/sanity/write-client';
+
+export const prerender = process.env.PI_ADMIN_HYBRID !== '1';
+export async function getStaticPaths() {
+  return [];
+}
+
+const DOC_ID_RE = /^[a-zA-Z0-9._-]{1,128}$/;
+
+interface ImageFieldOption {
+  path: string;
+  label: string;
+}
+
+function isImageValue(v: unknown): boolean {
+  if (!v || typeof v !== 'object') return false;
+  const obj = v as Record<string, unknown>;
+  const t = obj._type;
+  if (t === 'image' || t === 'imageRef') return true;
+  const asset = obj.asset as Record<string, unknown> | undefined;
+  if (asset && typeof asset === 'object' && typeof asset._ref === 'string' && asset._ref.startsWith('image-')) return true;
+  return false;
+}
+
+function humanise(key: string): string {
+  return key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim();
+}
+
+function collectImageFields(doc: Record<string, unknown>, prefix = '', maxDepth = 2): ImageFieldOption[] {
+  const out: ImageFieldOption[] = [];
+  if (!doc || typeof doc !== 'object') return out;
+  for (const [key, value] of Object.entries(doc)) {
+    if (key.startsWith('_')) continue;
+    const path = prefix ? `${prefix}.${key}` : key;
+    const label = humanise(key);
+    if (isImageValue(value)) {
+      out.push({ path, label });
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const indexedImages = value
+        .map((v, i) => ({ v, i }))
+        .filter(({ v }) => isImageValue(v));
+      if (indexedImages.length > 0) {
+        for (const { i } of indexedImages) {
+          out.push({ path: `${path}[${i}]`, label: `${label} #${i + 1}` });
+        }
+      } else if (maxDepth > 0) {
+        for (let i = 0; i < value.length; i++) {
+          const v = value[i];
+          if (v && typeof v === 'object' && !Array.isArray(v)) {
+            out.push(
+              ...collectImageFields(v as Record<string, unknown>, `${path}[${i}]`, maxDepth - 1),
+            );
+          }
+        }
+      }
+      continue;
+    }
+    if (value && typeof value === 'object' && maxDepth > 0) {
+      out.push(...collectImageFields(value as Record<string, unknown>, path, maxDepth - 1));
+    }
+  }
+  return out;
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok) {
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
+  }
+
+  const client = getSanityWriteClient();
+  if (!client) return internalError('SANITY_ADMIN_WRITE_TOKEN not configured');
+
+  const docId = (url.searchParams.get('docId') || '').trim();
+  if (!docId || !DOC_ID_RE.test(docId)) return badRequest('Invalid docId');
+
+  try {
+    const id = docId.startsWith('drafts.') ? docId.slice('drafts.'.length) : docId;
+    const doc = await client.fetch<Record<string, unknown> | null>(`*[_id == $id][0]`, { id });
+    if (!doc) return badRequest(`No document with _id "${id}"`);
+    const fields = collectImageFields(doc);
+    const seen = new Set<string>();
+    const unique = fields.filter((f) => (seen.has(f.path) ? false : (seen.add(f.path), true)));
+    return jsonResponse({ ok: true, data: { fields: unique, docType: doc._type ?? null } });
+  } catch (err) {
+    return internalError((err as Error).message || 'Field introspection failed');
+  }
+};

--- a/next/src/pages/api/admin/sanity-docs-search.ts
+++ b/next/src/pages/api/admin/sanity-docs-search.ts
@@ -1,0 +1,84 @@
+/**
+ * GET /api/admin/sanity-docs-search?q=…&type=…
+ *
+ * Lightweight Sanity doc search for the "Bind to a Sanity doc…" modal.
+ * Matches `title` / `name` / `slug.current` (case-insensitive contains).
+ * Optional `?type=<sanity _type>` filter. Returns up to 20 hits.
+ *
+ * Admin-only.
+ */
+import type { APIRoute } from 'astro';
+import {
+  badRequest,
+  forbidden,
+  internalError,
+  jsonResponse,
+  resolveCmsAccess,
+  unauthorized,
+} from '../../../lib/cms/server';
+import { getSanityWriteClient } from '../../../lib/sanity/write-client';
+
+export const prerender = process.env.PI_ADMIN_HYBRID !== '1';
+export async function getStaticPaths() {
+  return [];
+}
+
+// Known PI document types the bind flow can target. Mirrors the registered
+// schema in studio-peninsula-insider/schemaTypes/index.ts.
+const SEARCHABLE_TYPES = [
+  'article',
+  'venue',
+  'place',
+  'event',
+  'itinerary',
+  'tour',
+  'tourOperator',
+  'tourPackage',
+  'experience',
+  'author',
+  'homepageCover',
+  'pageHero',
+  'megaRail',
+  'siteSettings',
+];
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const access = await resolveCmsAccess(request.headers.get('cookie'));
+  if (!access.ok) {
+    if (access.reason === 'not-editor') return forbidden(`Not an editor (${access.reason})`);
+    return unauthorized(`Unauthorized (${access.reason ?? 'unknown'})`);
+  }
+
+  const client = getSanityWriteClient();
+  if (!client) return internalError('SANITY_ADMIN_WRITE_TOKEN not configured');
+
+  const q = (url.searchParams.get('q') || '').trim();
+  const type = (url.searchParams.get('type') || '').trim();
+
+  if (type && !SEARCHABLE_TYPES.includes(type)) {
+    return badRequest(`Unknown type "${type}"`);
+  }
+
+  const typeFilter = type ? `_type == $type` : `_type in $types`;
+  const groq = `
+    *[${typeFilter} && !(_id in path("drafts.**")) && (
+      lower(coalesce(title, name, slug.current, _id)) match $q
+      || _id match $q
+    )] | order(_updatedAt desc)[0...20]{
+      _id,
+      _type,
+      "title": coalesce(title, name, slug.current, _id),
+      "slug": slug.current
+    }
+  `;
+  try {
+    const docs = await client.fetch(groq, {
+      type,
+      types: SEARCHABLE_TYPES,
+      q: q ? `*${q.toLowerCase()}*` : '*',
+    });
+    return jsonResponse({ ok: true, data: { docs } });
+  } catch (err) {
+    return internalError((err as Error).message || 'Search failed');
+  }
+};

--- a/ops/migrations/2026-05-19-pi-image-bindings.sql
+++ b/ops/migrations/2026-05-19-pi-image-bindings.sql
@@ -1,0 +1,80 @@
+-- Migration: pi.image_bindings
+-- Date: 2026-05-19
+-- Purpose: Editor-supplied binding from an unmarked page image
+--          (URL pattern + image basename) to a Sanity doc + field path.
+--          Powers the "Bind to a Sanity doc…" right-click flow in the
+--          admin overlay so editors can wire any visible image into the
+--          existing Replace-from-media-library pipeline without a code
+--          change.
+
+create table if not exists pi.image_bindings (
+  id uuid primary key default gen_random_uuid(),
+  page_url_pattern text not null,
+  image_basename text not null,
+  sanity_doc_id text not null,
+  sanity_doc_type text not null,
+  sanity_field_path text not null,
+  created_at timestamptz not null default now(),
+  created_by uuid references auth.users(id) on delete set null,
+  updated_at timestamptz not null default now(),
+  unique (page_url_pattern, image_basename)
+);
+
+comment on table pi.image_bindings is
+  'Editor-supplied binding from an unmarked page image (URL pattern + basename) to a Sanity doc/field. Used by the admin overlay to inject data-pi-edit on the fly.';
+
+create index if not exists image_bindings_pattern_idx on pi.image_bindings (page_url_pattern);
+
+create or replace function pi.image_bindings_set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists image_bindings_set_updated_at on pi.image_bindings;
+create trigger image_bindings_set_updated_at
+  before update on pi.image_bindings
+  for each row execute function pi.image_bindings_set_updated_at();
+
+alter table pi.image_bindings enable row level security;
+
+-- Public SELECT: bindings are essentially page-config (no secrets).
+drop policy if exists image_bindings_public_read on pi.image_bindings;
+create policy image_bindings_public_read on pi.image_bindings
+  for select using (true);
+
+-- Editor write: insert/update/delete restricted to allowlisted editors.
+drop policy if exists image_bindings_editor_insert on pi.image_bindings;
+create policy image_bindings_editor_insert on pi.image_bindings
+  for insert with check (
+    exists (
+      select 1 from pi.admin_user_allowlist a
+      where a.user_id = auth.uid()
+        and a.role in ('editor','publisher','admin')
+    )
+  );
+
+drop policy if exists image_bindings_editor_update on pi.image_bindings;
+create policy image_bindings_editor_update on pi.image_bindings
+  for update using (
+    exists (
+      select 1 from pi.admin_user_allowlist a
+      where a.user_id = auth.uid()
+        and a.role in ('editor','publisher','admin')
+    )
+  );
+
+drop policy if exists image_bindings_editor_delete on pi.image_bindings;
+create policy image_bindings_editor_delete on pi.image_bindings
+  for delete using (
+    exists (
+      select 1 from pi.admin_user_allowlist a
+      where a.user_id = auth.uid()
+        and a.role in ('editor','publisher','admin')
+    )
+  );
+
+grant select on pi.image_bindings to anon, authenticated;
+grant insert, update, delete on pi.image_bindings to authenticated;


### PR DESCRIPTION
## Summary
- Add a "Bind to a Sanity doc…" right-click flow that lets editors wire any visible image to a Sanity doc/field without code changes. After binding, the existing "Replace from media library…" flow lights up for that image on the next right-click.
- New `pi.image_bindings` table (editor-gated writes, public SELECT) stores the URL-pattern + image-basename → Sanity doc/field mapping. A boot-time client patcher injects `data-pi-edit` attrs onto matching `<img>` / bg-image elements for admins, so the existing tagged-image flow picks bound images up automatically.
- Anon visitors: zero new code downloaded. Bindings fetch + bind modal only fire for authenticated admin sessions; the modal module is dynamically imported.

## What landed
- Migration `2026-05-19-pi-image-bindings.sql` (applied via Supabase MCP to `tjjhpvslpysfklwpqmgz`).
- Four endpoints, all `resolveCmsAccess`-gated:
  - `GET / POST  /api/admin/image-binding`
  - `DELETE      /api/admin/image-binding/[id]`
  - `GET         /api/admin/sanity-docs-search?q=&type=`
  - `GET         /api/admin/sanity-doc-fields?docId=`
- New module `next/src/lib/inline-edit/sanity-bind-modal.ts` — two-step modal (search doc → pick image field → save).
- `sanity-image-overlay.ts` gains `loadBindingsForPage` / `lookupBinding` / `invalidateBindingsCache` / `getCachedBindings`, and `resolveSanitySource` consults the cache as a 3rd-tier fallback after stega.
- `client.ts` warms the cache + runs `applyBindingsToDom()` on admin boot, surfaces the Bind menu item when the image is unbound, and hides Replace until something's bound.

## Test plan
- [ ] Sign in as an editor. Right-click an image with no Sanity binding → see "Bind to a Sanity doc…" (Replace hidden).
- [ ] Search for an article, pick `heroImage`, save → toast "Bound. Right-click again to replace."
- [ ] Right-click the same image again → Bind hidden, Replace visible → media library opens → pick another asset → image swaps in place.
- [ ] Anon visitor on the same page sees no extra network traffic and no `data-pi-edit` injection.
- [ ] Verify RLS: signed-out user attempting `POST /api/admin/image-binding` gets 401; signed-in non-editor gets 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)