### PR TITLE
fix(admin): scroll-lock background page while modal open

### DIFF
--- a/next/src/lib/inline-edit/sanity-bind-modal.ts
+++ b/next/src/lib/inline-edit/sanity-bind-modal.ts
@@ -108,6 +108,16 @@ export function openBindModal(opts: BindModalOpts): void {
   document.body.appendChild(wrap);
   activeWrap = wrap;
 
+  // Scroll lock — match the media library modal's behaviour.
+  const prevHtmlOverflow = document.documentElement.style.overflow;
+  const prevBodyOverflow = document.body.style.overflow;
+  document.documentElement.style.overflow = 'hidden';
+  document.body.style.overflow = 'hidden';
+  (wrap as HTMLElement & { __piScrollRestore?: () => void }).__piScrollRestore = () => {
+    document.documentElement.style.overflow = prevHtmlOverflow;
+    document.body.style.overflow = prevBodyOverflow;
+  };
+
   const panel = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__panel')!;
   const search = wrap.querySelector<HTMLInputElement>('.pi-sanity-modal__search')!;
   const resultsBox = wrap.querySelector<HTMLDivElement>('.pi-sanity-modal__bind-results')!;
@@ -312,7 +322,12 @@ export function openBindModal(opts: BindModalOpts): void {
 
 export function closeBindModal(): void {
   if (activeCleanup) { activeCleanup(); activeCleanup = null; }
-  if (activeWrap) { activeWrap.remove(); activeWrap = null; }
+  if (activeWrap) {
+    const restore = (activeWrap as HTMLElement & { __piScrollRestore?: () => void }).__piScrollRestore;
+    if (restore) restore();
+    activeWrap.remove();
+    activeWrap = null;
+  }
 }
 
 function esc(s: string | null | undefined): string {

--- a/next/src/lib/inline-edit/sanity-image-overlay.ts
+++ b/next/src/lib/inline-edit/sanity-image-overlay.ts
@@ -377,6 +377,18 @@ export function openMediaLibraryModal(opts: ModalOpts): void {
   document.body.appendChild(wrap);
   activeModal = wrap;
 
+  // Scroll lock — keep the underlying page still while the editor wheels
+  // inside the modal. Record the previous overflow values so close can
+  // restore them exactly (some other component may already have set them).
+  const prevHtmlOverflow = document.documentElement.style.overflow;
+  const prevBodyOverflow = document.body.style.overflow;
+  document.documentElement.style.overflow = 'hidden';
+  document.body.style.overflow = 'hidden';
+  (wrap as HTMLElement & { __piScrollRestore?: () => void }).__piScrollRestore = () => {
+    document.documentElement.style.overflow = prevHtmlOverflow;
+    document.body.style.overflow = prevBodyOverflow;
+  };
+
   let page = 0;
   let q = '';
   let sort: Sort = 'recent';
@@ -698,6 +710,8 @@ export function closeMediaLibraryModal(): void {
     activeModalCleanup = null;
   }
   if (activeModal) {
+    const restore = (activeModal as HTMLElement & { __piScrollRestore?: () => void }).__piScrollRestore;
+    if (restore) restore();
     activeModal.remove();
     activeModal = null;
   }


### PR DESCRIPTION
Background page no longer scrolls when wheeling inside the media library / bind modal.