### PR TITLE
fix(cms): editableImage fieldPath should be 'heroImage' not 'hero'

### DIFF
--- a/next/src/components/EventCard.astro
+++ b/next/src/components/EventCard.astro
@@ -106,7 +106,7 @@ const heroImageSrc = event.data.heroImage?.src ?? fallbackHeroByCategory[categor
     {...editableImage({
       entityType: 'event',
       entitySlug: slug,
-      fieldPath: 'hero',
+      fieldPath: 'heroImage',
       label: `${event.data.title} hero`,
       purpose: 'hero',
     })}

--- a/next/src/components/ExperienceCard.astro
+++ b/next/src/components/ExperienceCard.astro
@@ -44,7 +44,7 @@ const imgStyle = heroBackgroundStyle(data);
     {...editableImage({
       entityType: 'experience',
       entitySlug: slug,
-      fieldPath: 'hero',
+      fieldPath: 'heroImage',
       label: `${data.name} hero`,
       purpose: 'hero',
     })}

--- a/next/src/components/ItineraryCard.astro
+++ b/next/src/components/ItineraryCard.astro
@@ -36,7 +36,7 @@ const metaLine = [tripType, `Best for ${audienceLabel}`, regionLabel, driveLabel
       {...editableImage({
         entityType: 'itinerary',
         entitySlug: slug,
-        fieldPath: 'hero',
+        fieldPath: 'heroImage',
         label: `${data.title} hero`,
         purpose: 'hero',
       })}

--- a/next/src/components/PlaceCard.astro
+++ b/next/src/components/PlaceCard.astro
@@ -53,7 +53,7 @@ const heroSrc = heroMatch ? heroMatch[1].replace(/^['"]|['"]$/g, '') : undefined
     {...editableImage({
       entityType: 'place',
       entitySlug: slug,
-      fieldPath: 'hero',
+      fieldPath: 'heroImage',
       label: `${data.name} hero`,
       purpose: 'hero',
     })}

--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -186,7 +186,7 @@ const factual = place.data.factualLede ?? '';
      ═══════════════════════════════════════════════════════════════════════ -->
 <section class="pdv2-hero" style={`background-image: url(${heroSrc});`}
   {...editableImage({
-    entityType: 'place', entitySlug: placeSlug, fieldPath: 'hero',
+    entityType: 'place', entitySlug: placeSlug, fieldPath: 'heroImage',
     label: `${place.data.name} hero`, purpose: 'hero',
   })}>
   <div class="pdv2-hero__scrim"></div>

--- a/next/src/components/TourCard.astro
+++ b/next/src/components/TourCard.astro
@@ -68,7 +68,7 @@ const excerpt = data.intro
           {...editableImage({
             entityType: 'tour',
             entitySlug: slug,
-            fieldPath: 'hero',
+            fieldPath: 'heroImage',
             label: `${data.name} hero`,
             purpose: 'hero',
           })}

--- a/next/src/components/TourOperatorCard.astro
+++ b/next/src/components/TourOperatorCard.astro
@@ -42,7 +42,7 @@ const excerpt = data.intro
           {...editableImage({
             entityType: 'tour-operator',
             entitySlug: slug,
-            fieldPath: 'hero',
+            fieldPath: 'heroImage',
             label: `${data.name} hero`,
             purpose: 'hero',
           })}

--- a/next/src/components/TourPackageCard.astro
+++ b/next/src/components/TourPackageCard.astro
@@ -60,7 +60,7 @@ const excerpt = data.intro
           {...editableImage({
             entityType: 'tour-package',
             entitySlug: slug,
-            fieldPath: 'hero',
+            fieldPath: 'heroImage',
             label: `${data.name} hero`,
             purpose: 'hero',
           })}

--- a/next/src/components/VenueCard.astro
+++ b/next/src/components/VenueCard.astro
@@ -66,7 +66,7 @@ const verifiedTier = verificationFreshness(data.lastVerified);
     {...editableImage({
       entityType: 'venue',
       entitySlug: slug,
-      fieldPath: 'hero',
+      fieldPath: 'heroImage',
       label: `${data.name} hero`,
       purpose: 'hero',
     })}

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -158,7 +158,7 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
       {...editableImage({
         entityType: 'venue',
         entitySlug: venueSlug,
-        fieldPath: 'hero',
+        fieldPath: 'heroImage',
         label: `${data.name} hero`,
         purpose: 'hero',
       })}

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -12,13 +12,36 @@ import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import EventStrip from '../../components/EventStrip.astro';
 import { isUpcoming, routeSlug, currentSeason } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchVenueFromSanity } from '../../lib/sanity/venue-adapter';
 import EditorialSurface from '../../components/EditorialSurface.astro';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 const eatTypes = ['restaurant', 'cafe', 'bakery', 'pub', 'market', 'winery'];
-const venues = (await getCollection('venues'))
+const venuesRaw = (await getCollection('venues'))
   .filter((venue) => eatTypes.includes(venue.data.type))
   .sort((a, b) => Number(b.data.authority?.hats ?? 0) - Number(a.data.authority?.hats ?? 0));
+
+// Dual-read: overwrite heroImage.src on each filtered venue with the Sanity
+// venue doc's heroImage when SANITY_VENUES_ENABLED is on. Same pattern as
+// PR #211 on places — needed so admin overlay image edits persist on the
+// hub page instead of reverting to the content-collection path. Filtered
+// first so we only fan out across the ~50 eat venues, not all 500+.
+const venueReadOn = sanityReadEnabled('venues');
+const venues = venueReadOn
+  ? await Promise.all(
+      venuesRaw.map(async (v) => {
+        try {
+          const doc = await fetchVenueFromSanity(routeSlug(v));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return v;
+          return { ...v, data: { ...v.data, heroImage: { ...v.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return v;
+        }
+      }),
+    )
+  : venuesRaw;
 
 // Filter dimensions for the directory grid (Phase 2, WS2A). Built from the
 // venue corpus so the filter row only ever shows values that actually have

--- a/next/src/pages/explore/[slug].astro
+++ b/next/src/pages/explore/[slug].astro
@@ -191,7 +191,7 @@ export const prerender = true;
       })}>{experience.data.name}</h1>
 
       <div class={`experience-detail__hero feature__image-block ${heroClass}`} aria-hidden="true" style={heroStyle} {...editableImage({
-        entityType: 'experience', entitySlug: slug, fieldPath: 'hero',
+        entityType: 'experience', entitySlug: slug, fieldPath: 'heroImage',
         label: `${experience.data.name} hero`, purpose: 'hero',
       })}>
         <div class="experience-detail__hero-fog"></div>

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -13,6 +13,8 @@ import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import EventStrip from '../../components/EventStrip.astro';
 import { routeSlug, currentSeason, seasonBlurb, experienceInSeason, isUpcoming } from '../../lib/editorial';
 import { buildCollectionPageSchema, buildFaqSchema, buildBreadcrumbSchema } from '../../lib/schema';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchExperienceFromSanity } from '../../lib/sanity/phase5-adapters';
 import EditorialSurface from '../../components/EditorialSurface.astro';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
@@ -22,7 +24,25 @@ const _eNotes = (await getCollection('quickNotes', ({ data }) => data.status ===
   .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
 const notebookNote = _eNotes.find((n) => ['explore', 'weather', 'spa'].includes(n.data.section)) ?? _eNotes[0] ?? null;
 
-const experiences = (await getCollection('experiences')).sort((a, b) => a.data.name.localeCompare(b.data.name));
+const experiencesRaw = (await getCollection('experiences')).sort((a, b) => a.data.name.localeCompare(b.data.name));
+
+// Dual-read experiences through Sanity so admin overlay heroImage edits
+// persist on the hub. Same PR #211 pattern. ~45 experiences in parallel.
+const experienceReadOn = sanityReadEnabled('experiences');
+const experiences = experienceReadOn
+  ? await Promise.all(
+      experiencesRaw.map(async (e) => {
+        try {
+          const doc = await fetchExperienceFromSanity(routeSlug(e));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return e;
+          return { ...e, data: { ...e.data, heroImage: { ...e.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return e;
+        }
+      }),
+    )
+  : experiencesRaw;
 
 // Family + arts + nature events surfacing from /whats-on/.
 const exploreEventCategories = ['nature', 'family-programs', 'arts', 'exhibition', 'community', 'wellness'];

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -295,7 +295,7 @@ export const prerender = true;
           </div>
           <figure class="article-hero__figure">
             <div class="article-hero__image" role="img" aria-label={heroAlt} style={articleHeroStyle} {...editableImage({
-              entityType: 'article', entitySlug: slug, fieldPath: 'hero',
+              entityType: 'article', entitySlug: slug, fieldPath: 'heroImage',
               label: `${article.data.title} hero`, purpose: 'hero',
             })}></div>
             {article.data.heroImage.credit && (

--- a/next/src/pages/journal/index.astro
+++ b/next/src/pages/journal/index.astro
@@ -6,10 +6,31 @@ import SectionHero from '../../components/SectionHero.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { formatLabel, routeSlug, heroBackgroundStyle } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchArticleFromSanity } from '../../lib/sanity/article-adapter';
 
-const articles = (await getCollection('articles', ({ data }) =>
+const articlesRaw = (await getCollection('articles', ({ data }) =>
   data.status === 'published' && (data.section ?? 'journal') !== 'plans'
 )).sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+// Dual-read journal articles through Sanity so admin overlay heroImage
+// edits persist on the hub. Same PR #211 pattern. All ~150 articles run
+// in parallel via Promise.all — build-time impact accepted.
+const articleReadOn = sanityReadEnabled('articles');
+const articles = articleReadOn
+  ? await Promise.all(
+      articlesRaw.map(async (a) => {
+        try {
+          const doc = await fetchArticleFromSanity(routeSlug(a));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return a;
+          return { ...a, data: { ...a.data, heroImage: { ...a.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return a;
+        }
+      }),
+    )
+  : articlesRaw;
 const featured = articles.find((article) => article.data.featured) ?? articles[0];
 const featuredSlug = featured ? routeSlug(featured) : null;
 const latest = articles.filter((article) => routeSlug(article) !== featuredSlug);

--- a/next/src/pages/plans/index.astro
+++ b/next/src/pages/plans/index.astro
@@ -10,12 +10,32 @@ import VenueCard from '../../components/VenueCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { routeSlug, stayTypes } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchItineraryFromSanity } from '../../lib/sanity/itinerary-adapter';
 import EditorialSurface from '../../components/EditorialSurface.astro';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
-const itineraries = (await getCollection('itineraries')).sort(
+const itinerariesRaw = (await getCollection('itineraries')).sort(
   (a, b) => b.data.lengthNights - a.data.lengthNights,
 );
+
+// Dual-read itineraries through Sanity so admin overlay heroImage edits
+// persist on the hub. Same PR #211 pattern. Small set (~6) — trivial cost.
+const itineraryReadOn = sanityReadEnabled('itineraries');
+const itineraries = itineraryReadOn
+  ? await Promise.all(
+      itinerariesRaw.map(async (it) => {
+        try {
+          const doc = await fetchItineraryFromSanity(routeSlug(it));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return it;
+          return { ...it, data: { ...it.data, heroImage: { ...it.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return it;
+        }
+      }),
+    )
+  : itinerariesRaw;
 const allVenues = await getCollection('venues');
 const stays = allVenues.filter((venue) => stayTypes.includes(venue.data.type));
 const places = await getCollection('places');

--- a/next/src/pages/stay/index.astro
+++ b/next/src/pages/stay/index.astro
@@ -12,9 +12,29 @@ import ArticleCard from '../../components/ArticleCard.astro';
 import PlaceCard from '../../components/PlaceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { routeSlug, stayTypes, currentSeason, seasonBlurb } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchVenueFromSanity } from '../../lib/sanity/venue-adapter';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
-const venues = (await getCollection('venues')).filter((v) => stayTypes.includes(v.data.type));
+const venuesRaw = (await getCollection('venues')).filter((v) => stayTypes.includes(v.data.type));
+
+// Dual-read filtered stay venues through Sanity (same PR #211 pattern).
+// Filter first so we only fan out across stay venues, not all 500+.
+const venueReadOn = sanityReadEnabled('venues');
+const venues = venueReadOn
+  ? await Promise.all(
+      venuesRaw.map(async (v) => {
+        try {
+          const doc = await fetchVenueFromSanity(routeSlug(v));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return v;
+          return { ...v, data: { ...v.data, heroImage: { ...v.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return v;
+        }
+      }),
+    )
+  : venuesRaw;
 const itineraries = await getCollection('itineraries');
 const places = await getCollection('places');
 const season = currentSeason();

--- a/next/src/pages/whats-on/index.astro
+++ b/next/src/pages/whats-on/index.astro
@@ -7,10 +7,12 @@ import SectionDivider from '../../components/SectionDivider.astro';
 import EventCard from '../../components/EventCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import { isUpcoming, routeSlug } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchEventFromSanity } from '../../lib/sanity/event-adapter';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 const now = new Date();
-const events = (await getCollection('events', ({ data }) => data.status === 'published'))
+const eventsRaw = (await getCollection('events', ({ data }) => data.status === 'published'))
   .filter((event) => {
     const cancelled = /cancelled/i.test(event.data.verificationStatus ?? '') || /^cancelled:/i.test(event.data.summary ?? '');
     if (cancelled) return false;
@@ -19,6 +21,25 @@ const events = (await getCollection('events', ({ data }) => data.status === 'pub
     return isUpcoming(end, now);
   })
   .sort((a, b) => a.data.startDate.getTime() - b.data.startDate.getTime());
+
+// Dual-read events through Sanity so admin overlay heroImage edits persist.
+// Same PR #211 pattern. Filtered to upcoming/recurring events only, bounded
+// fan-out. No-op when SANITY_EVENTS_ENABLED is off.
+const eventReadOn = sanityReadEnabled('events');
+const events = eventReadOn
+  ? await Promise.all(
+      eventsRaw.map(async (e) => {
+        try {
+          const doc = await fetchEventFromSanity(routeSlug(e));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return e;
+          return { ...e, data: { ...e.data, heroImage: { ...e.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return e;
+        }
+      }),
+    )
+  : eventsRaw;
 
 const dispatches = (await getCollection('articles', ({ data }) => data.status === 'published'))
   .filter((a) => a.data.format === 'weekend-picker')

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -12,6 +12,8 @@ import PlaceCard from '../../components/PlaceCard.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import EventStrip from '../../components/EventStrip.astro';
 import { routeSlug, currentSeason, seasonBlurb, isUpcoming } from '../../lib/editorial';
+import { sanityReadEnabled } from '../../lib/sanity/client';
+import { fetchVenueFromSanity } from '../../lib/sanity/venue-adapter';
 import EditorialSurface from '../../components/EditorialSurface.astro';
 
 // ── Data ──────────────────────────────────────────────────────────────────────
@@ -27,9 +29,27 @@ const wineEvents = (await getCollection('events'))
   })
   .sort((a, b) => (b.data.visitorAppealScore ?? 0) - (a.data.visitorAppealScore ?? 0))
   .slice(0, 3);
-const venues = (await getCollection('venues'))
+const venuesRaw = (await getCollection('venues'))
   .filter((venue) => wineTypes.includes(venue.data.type))
   .sort((a, b) => Number(b.data.authority?.hallidayScore ?? 0) - Number(a.data.authority?.hallidayScore ?? 0));
+
+// Dual-read after the eat-style filter so we only fan out across wine venues
+// (~50), not all 500+ in the corpus. Same shape as PR #211 on places.
+const venueReadOn = sanityReadEnabled('venues');
+const venues = venueReadOn
+  ? await Promise.all(
+      venuesRaw.map(async (v) => {
+        try {
+          const doc = await fetchVenueFromSanity(routeSlug(v));
+          const sanitySrc = doc?.data?.heroImage?.src;
+          if (!sanitySrc) return v;
+          return { ...v, data: { ...v.data, heroImage: { ...v.data.heroImage, src: sanitySrc } } };
+        } catch {
+          return v;
+        }
+      }),
+    )
+  : venuesRaw;
 
 const wineries = venues.filter((v) => v.data.type === 'winery');
 const producers = venues.filter((v) => v.data.type === 'producer');


### PR DESCRIPTION
Every card / detail editableImage call sent fieldPath='hero', a legacy Supabase value. Schema field is heroImage. Patches were landing on a phantom 'hero' field nobody renders, hence Sorrento's apparent revert.