### PR TITLE
Fix broken access gate password and subscribe buttons

### DIFF
--- a/access/index.html
+++ b/access/index.html
@@ -47,7 +47,7 @@
             body: JSON.stringify({ email: email, source: 'access-gate' })
           });
           if (res.ok) {
-            setStatus('You're on the list. We'll be in touch.', 'success');
+            setStatus("You're on the list. We'll be in touch.", 'success');
             subEmail.value = '';
           } else {
             setStatus('Something went wrong — try again.', 'error');

--- a/next/src/pages/access/index.astro
+++ b/next/src/pages/access/index.astro
@@ -295,7 +295,7 @@
             body: JSON.stringify({ email: email, source: 'access-gate' })
           });
           if (res.ok) {
-            setStatus('You're on the list. We'll be in touch.', 'success');
+            setStatus("You're on the list. We'll be in touch.", 'success');
             subEmail.value = '';
           } else {
             setStatus('Something went wrong — try again.', 'error');


### PR DESCRIPTION
## Summary
- The access gate (`/access/`) had a JavaScript syntax error caused by unescaped apostrophes in the subscribe success message (`'You're on the list. We'll be in touch.'`).
- The apostrophes terminated the single-quoted string literal early, breaking the entire inline IIFE that wires up **both** buttons.
- As a result, neither the password **Enter** button nor the **Notify me** subscribe button responded to clicks.

## Fix
- Switched the success message to a double-quoted string so the apostrophes are valid: `"You're on the list. We'll be in touch."`
- Verified the inline script now parses cleanly with `node --check`.

## Test plan
- [ ] Load `/access/`, enter the password, confirm Enter redirects.
- [ ] Enter an email and click Notify me, confirm the success message shows.

https://claude.ai/code/session_01MJ2kEGCwDEyM4oUnzt2P3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJ2kEGCwDEyM4oUnzt2P3A)_