### PR TITLE
Add landingPage schema (Sanity migration: hardcoded editorial pages)

### DIFF
--- a/studio-peninsula-insider/schemaTypes/documents/landingPage.ts
+++ b/studio-peninsula-insider/schemaTypes/documents/landingPage.ts
@@ -1,0 +1,210 @@
+import {defineType, defineField} from 'sanity'
+
+/**
+ * Landing / guide page — the editorial pages that currently live as
+ * hardcoded markup inside `.astro` files (SEO category pages, hub guides,
+ * long-form guides, corporate/about pages). One document per route.
+ *
+ * Migration target for the ~120 standalone pages identified in the
+ * 2026-05 content audit (e.g. /eat/cafes/, /wine/red-hill/,
+ * /explore/hot-springs/, /guides/winter/, /about/). The `path` field is
+ * the canonical key (full route path) because slugs are not unique across
+ * sections. Document id convention: `landingPage-<slugified-path>`.
+ *
+ * Astro reads this via a fetchLandingPageFromSanity(path) adapter and
+ * falls back to the existing hardcoded page if the doc doesn't exist —
+ * same dual-read pattern as every other entity.
+ */
+const sectionOptions = [
+  'eat', 'wine', 'stay', 'explore', 'tour', 'guides', 'walks',
+  'journal', 'fishing', 'boating', 'weddings', 'corporate-events',
+  'corporate', 'other',
+]
+
+const jsonLdOptions = [
+  'WebPage', 'CollectionPage', 'FAQPage', 'Article', 'TouristAttraction',
+]
+
+const statusOptions = ['draft', 'review', 'published']
+
+export const landingPage = defineType({
+  name: 'landingPage',
+  title: 'Landing / guide page',
+  type: 'document',
+  groups: [
+    {name: 'editorial', title: 'Editorial', default: true},
+    {name: 'body', title: 'Body'},
+    {name: 'curated', title: 'Curated lists'},
+    {name: 'related', title: 'Related'},
+    {name: 'seo', title: 'SEO & FAQ'},
+    {name: 'admin', title: 'Admin'},
+  ],
+  fields: [
+    // ── Editorial ──────────────────────────────────────────────────────
+    defineField({
+      name: 'title', title: 'Title', type: 'string', group: 'editorial',
+      validation: (R) => R.required(),
+    }),
+    defineField({
+      name: 'path', title: 'Route path', type: 'string', group: 'editorial',
+      description: 'Full URL path this page renders at, with leading and trailing slash. e.g. "/eat/cafes/".',
+      validation: (R) =>
+        R.required().regex(/^\/.*\/$/, {name: 'path with leading and trailing slash'}),
+    }),
+    defineField({
+      name: 'slug', title: 'Slug', type: 'slug', group: 'editorial',
+      options: {source: 'title', maxLength: 96},
+      description: 'Convenience slug, derived from the title. The route path above is the canonical key.',
+    }),
+    defineField({
+      name: 'section', title: 'Section', type: 'string', group: 'editorial',
+      options: {list: sectionOptions.map((v) => ({title: v, value: v}))},
+      description: 'Which part of the site this page belongs to — controls template and grouping.',
+      validation: (R) => R.required(),
+    }),
+    defineField({
+      name: 'eyebrow', title: 'Eyebrow label', type: 'string', group: 'editorial',
+      description: 'Small label above the title (optional).',
+    }),
+    defineField({
+      name: 'dek', title: 'Dek / intro', type: 'text', rows: 3, group: 'editorial',
+      description: 'Short standfirst shown under the title.',
+    }),
+    defineField({
+      name: 'heroImage', title: 'Hero image', type: 'imageRef', group: 'editorial',
+    }),
+
+    // ── Body ───────────────────────────────────────────────────────────
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      group: 'body',
+      description: 'Main editorial prose. Supports the same rich embeds as articles.',
+      of: [
+        {
+          type: 'block',
+          styles: [
+            {title: 'Normal', value: 'normal'},
+            {title: 'H2', value: 'h2'},
+            {title: 'H3', value: 'h3'},
+            {title: 'Quote', value: 'blockquote'},
+          ],
+          lists: [
+            {title: 'Bullet', value: 'bullet'},
+            {title: 'Number', value: 'number'},
+          ],
+          marks: {
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'},
+            ],
+            annotations: [
+              {
+                name: 'link', title: 'Link', type: 'object',
+                fields: [defineField({name: 'href', title: 'URL', type: 'string'})],
+              },
+            ],
+          },
+        },
+        {type: 'alertBlock'},
+        {type: 'practicalCallout'},
+        {type: 'cellarDoorList'},
+        {type: 'dogPolicyTable'},
+        {type: 'subregionGrid'},
+        {type: 'varietyGuide'},
+      ],
+    }),
+
+    // ── Curated lists ──────────────────────────────────────────────────
+    // Replaces the hardcoded venue-slug arrays (fineDiningSlugs, cafeSlugs,
+    // etc.). Each block is a headed, ordered list of references an editor
+    // can reorder, add to, or remove in Studio.
+    defineField({
+      name: 'curatedCollections',
+      title: 'Curated collections',
+      type: 'array',
+      group: 'curated',
+      of: [{
+        type: 'object',
+        name: 'curatedCollection',
+        fields: [
+          defineField({name: 'heading', title: 'Heading', type: 'string'}),
+          defineField({name: 'intro', title: 'Intro', type: 'text', rows: 2}),
+          defineField({
+            name: 'items', title: 'Items', type: 'array',
+            of: [{
+              type: 'reference',
+              weak: true,
+              to: [
+                {type: 'venue'}, {type: 'place'}, {type: 'experience'},
+                {type: 'tour'}, {type: 'tourOperator'}, {type: 'tourPackage'},
+                {type: 'article'}, {type: 'itinerary'},
+              ],
+            }],
+          }),
+        ],
+        preview: {select: {title: 'heading'}},
+      }],
+    }),
+
+    // ── Related ────────────────────────────────────────────────────────
+    defineField({
+      name: 'relatedLinks', title: 'Related guides', type: 'array', group: 'related',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({name: 'label', title: 'Label', type: 'string'}),
+          defineField({name: 'href', title: 'URL', type: 'string'}),
+        ],
+        preview: {select: {title: 'label', subtitle: 'href'}},
+      }],
+    }),
+
+    // ── SEO + FAQ ──────────────────────────────────────────────────────
+    defineField({
+      name: 'seoTitle', title: 'SEO title', type: 'string', group: 'seo',
+      description: 'Overrides the <title> tag if set; otherwise the page title is used.',
+    }),
+    defineField({
+      name: 'seoDescription', title: 'SEO description', type: 'text', rows: 3, group: 'seo',
+    }),
+    defineField({
+      name: 'jsonLdType', title: 'Structured data type', type: 'string', group: 'seo',
+      options: {list: jsonLdOptions.map((v) => ({title: v, value: v}))},
+      initialValue: 'WebPage',
+    }),
+    defineField({
+      name: 'faq', title: 'FAQ', type: 'array', of: [{type: 'faqItem'}], group: 'seo',
+    }),
+
+    // ── Admin ──────────────────────────────────────────────────────────
+    defineField({
+      name: 'status', title: 'Status', type: 'string', group: 'admin',
+      options: {list: statusOptions.map((v) => ({title: v, value: v}))},
+      initialValue: 'draft', validation: (R) => R.required(),
+    }),
+    defineField({name: 'publishedAt', title: 'Published at', type: 'datetime', group: 'admin'}),
+    defineField({name: 'updatedAt', title: 'Updated at', type: 'datetime', group: 'admin'}),
+    defineField({
+      name: 'noindex', title: 'Hide from search engines', type: 'boolean', group: 'admin',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'sitemapExclude', title: 'Exclude from sitemap', type: 'boolean', group: 'admin',
+      initialValue: false,
+    }),
+  ],
+  preview: {
+    select: {title: 'title', subtitle: 'path', media: 'heroImage'},
+    prepare: ({title, subtitle, media}) => ({
+      title: title ?? 'Untitled page',
+      subtitle: subtitle ?? undefined,
+      media,
+    }),
+  },
+  orderings: [
+    {title: 'Section', name: 'section', by: [{field: 'section', direction: 'asc'}, {field: 'title', direction: 'asc'}]},
+    {title: 'Title A→Z', name: 'titleAsc', by: [{field: 'title', direction: 'asc'}]},
+  ],
+})

--- a/studio-peninsula-insider/schemaTypes/index.ts
+++ b/studio-peninsula-insider/schemaTypes/index.ts
@@ -28,6 +28,7 @@ import {homepageCover} from './documents/homepageCover'
 import {megaRail} from './documents/megaRail'
 import {pageHero} from './documents/pageHero'
 import {legalPage} from './documents/legalPage'
+import {landingPage} from './documents/landingPage'
 
 export const schemaTypes = [
   // Reusable object types — registered first so documents can reference them.
@@ -65,4 +66,5 @@ export const schemaTypes = [
   megaRail,
   pageHero,
   legalPage,
+  landingPage,
 ]


### PR DESCRIPTION
## Goal
Complete the Sanity migration so **all pages and images are editable in one place** with near-instant live updates, and simplify the stack. This is the first PR of that effort.

## This PR
Adds a `landingPage` Sanity document type — the migration target for the **~120 standalone editorial pages** whose content is currently hardcoded in `.astro` files (SEO category pages like `/eat/cafes/`, hub guides, long-form guides like `/explore/hot-springs/`, and corporate/about pages). The 2026-05 content audit found these are the largest body of editor-facing content **not** in any CMS.

The schema follows existing studio conventions:
- Reuses `imageRef`, `faqItem`, and the Portable Text embed blocks (`alertBlock`, `cellarDoorList`, etc.).
- **Curated collections** — editor-reorderable reference lists that replace the hardcoded `cafeSlugs` / `fineDiningSlugs` arrays buried in page code.
- Rich `body`, related links, FAQ, and SEO / JSON-LD fields.
- Keyed by full route `path` (slugs aren't unique across sections); doc id convention `landingPage-<slugified-path>`.

## Not in this PR (next steps, need owner input / access)
- Migration script that extracts each hardcoded page into this schema.
- Image migration to Sanity assets.
- Flipping the `SANITY_*_ENABLED` flags + runtime reads (near-instant updates).
- These need Sanity API access (token / MCP) — I can't reach `sanity.io` from the build sandbox.

## Test plan
- [ ] `landingPage` appears in the deployed Studio with all field groups.
- [ ] Schema deploys cleanly (`sanity deploy` / typecheck) alongside existing types.

https://claude.ai/code/session_01MJ2kEGCwDEyM4oUnzt2P3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJ2kEGCwDEyM4oUnzt2P3A)_