### PR TITLE
Apply published image overrides on every page load (live, no redeploy)

### DIFF
--- a/next/src/components/admin/InlineEditor.astro
+++ b/next/src/components/admin/InlineEditor.astro
@@ -14,19 +14,28 @@
 ---
 
 <script>
-  import { bootInlineEditor } from '../../lib/inline-edit/client';
+  import { bootInlineEditor, applyOverridesOnLoad } from '../../lib/inline-edit/client';
 
-  // Initial boot — fires on cold page loads.
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => void bootInlineEditor());
-  } else {
+  // Always-on image sync (ALL visitors): pull the latest published image
+  // overrides from Supabase on every page load and swap them in, so inline
+  // edits go live immediately without waiting for a redeploy. The static HTML
+  // still carries the last-baked image for an instant first paint; this only
+  // swaps images whose URL actually changed, so unchanged images don't
+  // flicker. Reads via the published-read RLS policy (anon-safe).
+  function init() {
+    void applyOverridesOnLoad();
     void bootInlineEditor();
   }
 
-  // Re-boot after every Astro <ClientRouter /> navigation. Soft transitions
-  // swap <body> and any DOM we appended (the floating toggle) gets wiped, so
-  // we need to re-mount it. `bootInlineEditor()` is idempotent.
-  document.addEventListener('astro:page-load', () => {
-    void bootInlineEditor();
-  });
+  // Initial boot — fires on cold page loads.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  // Re-run after every Astro <ClientRouter /> navigation. Soft transitions
+  // swap <body>, so both the override sync and the admin chrome must re-run.
+  // Both functions are idempotent.
+  document.addEventListener('astro:page-load', init);
 </script>

--- a/next/src/lib/inline-edit/client.ts
+++ b/next/src/lib/inline-edit/client.ts
@@ -829,7 +829,7 @@ async function replaceImage(el: HTMLElement, desc: ImageDescriptor, file: File) 
  * source of post-paint flicker for anon visitors and is no longer needed
  * now that SSR owns override resolution.
  */
-async function applyOverridesOnLoad() {
+export async function applyOverridesOnLoad() {
   const supa = getSupabase();
   if (!supa) return;
 


### PR DESCRIPTION
## What this does
Makes inline **image edits go live immediately** — no redeploy needed.

Previously the runtime image-sync (`applyOverridesOnLoad`) only ran when an admin clicked the "Edit mode" toggle, so a normal refresh showed the image baked into the static HTML at the last deploy (edits appeared to "vanish on refresh" until a rebuild). This runs the sync on **every page load for all visitors**, pulling the latest published `cms_image_slots` overrides from Supabase and swapping them in.

## How
- Export `applyOverridesOnLoad()` from `lib/inline-edit/client.ts`.
- Call it on cold load + every `astro:page-load` in `components/admin/InlineEditor.astro` (which already mounts on every page), alongside the admin `bootInlineEditor()`.

## Behaviour / tradeoffs
- **Freshness:** an inline image edit shows on the next refresh, for everyone, without a deploy.
- **First paint unchanged:** the build still bakes published overrides into the static HTML, so the correct image paints instantly; the runtime pass only swaps images whose URL actually changed → no flicker on unchanged images.
- **Cost:** every page load now makes 1–N Supabase reads (grouped by entity) via the anon-safe `cms_*_public_read_published` RLS policy. Acceptable for this site; worth knowing.
- Scope: applies to pages using `BaseLayout` (where `<InlineEditor />` mounts). If some pages use other layouts and need it too, we can extend.

## Verify after deploy
Edit an image inline → refresh (no redeploy) → it persists. Confirm unchanged images don't flicker on load.

https://claude.ai/code/session_01MJ2kEGCwDEyM4oUnzt2P3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJ2kEGCwDEyM4oUnzt2P3A)_