### PR TITLE
fix(autofix): safe-stash wrapper to prevent silent work loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 
 # Approvals / workspace tooling (not part of the public repo)
 .approvals/
+.pi-autofix/
 
 .claude/worktrees/
 

--- a/docs/peninsula-insider-daily-accuracy-scan-spec-2026-04-14.md
+++ b/docs/peninsula-insider-daily-accuracy-scan-spec-2026-04-14.md
@@ -377,3 +377,32 @@ The Friday Performance Council cron should additionally surface:
 - all articles published in the past 7 days that did not pass governance gates at time of publish
 - any outstanding correction or removal requests logged in `docs/site-changelog.md`
 - count of `needs-verification` articles still unpublished (from the 84-winery batch and others)
+
+---
+
+## Working tree safety (MANDATORY)
+
+The autofix run touches files in the repo and commits them. It MUST NOT
+silently shelve unrelated working-tree changes belonging to a human session
+or another agent. On 2026-05-28 an autofix run did exactly that: it created
+`stash@{0}: pi-autofix-temp-stash 2026-05-28` containing a 117-file Kids
+Grade taxonomy removal, then the stash was lost. Recovery was impossible.
+
+**Rule:** the autofix MUST gate its run through
+`ops/scripts/pi-autofix-safe-stash.sh`. The script has three subcommands:
+
+1. `pi-autofix-safe-stash.sh check` — call this first. Exit 0 means safe to
+   proceed. Exit 2 means the working tree has changes outside the autofix
+   allowlist (see the script for the current list). On exit 2 the autofix
+   MUST abort the run entirely and write a deferral note. It will retry on
+   the next hourly tick.
+2. `pi-autofix-safe-stash.sh stash` — only call if a stash is genuinely
+   needed (autofix-owned files were already dirty before the run). Creates
+   a labelled stash and records its ref so `restore` can verify.
+3. `pi-autofix-safe-stash.sh restore` — pops the stash. If the pop fails
+   for ANY reason (conflict, ref mismatch), the stash is left in place and
+   a conflict sentinel is written under `.pi-autofix/`. The autofix MUST
+   NOT call `git stash drop` under any circumstances.
+
+The autofix is FORBIDDEN from calling `git stash` directly. All stash
+handling goes through this script.

--- a/ops/scripts/pi-autofix-safe-stash.sh
+++ b/ops/scripts/pi-autofix-safe-stash.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Safe working-tree handling for the PI autofix automation.
+#
+# Replaces the ad-hoc `git stash push -m pi-autofix-temp-stash ... && git stash pop`
+# pattern that lost a 117-file Kids Grade taxonomy removal on 2026-05-28: the
+# autofix run stashed unrelated working-tree changes, then either dropped the
+# stash or hit a silent pop failure, leaving no recoverable copy of the work.
+#
+# Usage:
+#   pi-autofix-safe-stash.sh check     # exit 0 if safe to start autofix run
+#   pi-autofix-safe-stash.sh stash     # stash autofix-owned changes only
+#   pi-autofix-safe-stash.sh restore   # pop stash; on conflict, leave it
+#
+# Semantics:
+#   - If the working tree is clean: all three subcommands are no-ops.
+#   - If the working tree has changes ONLY inside the autofix allowlist:
+#     check passes; stash creates a labelled stash; restore pops it and on
+#     ANY non-zero pop exit code leaves the stash in place and writes a
+#     conflict sentinel. NEVER `git stash drop`.
+#   - If the working tree has ANY changes outside the autofix allowlist:
+#     check fails with a defer sentinel and exit 2. The caller MUST abort the
+#     autofix run; do NOT stash, do NOT touch the working tree. The deferred
+#     run will resume on the next hourly tick once the user commits or
+#     discards their changes.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+STASH_LABEL="pi-autofix-temp-stash $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+SENTINEL_DIR="$REPO_ROOT/.pi-autofix"
+DEFER_SENTINEL="$SENTINEL_DIR/deferred.log"
+CONFLICT_SENTINEL="$SENTINEL_DIR/stash-conflict.log"
+STASH_REF_FILE="$SENTINEL_DIR/active-stash-ref"
+
+# Files the autofix is allowed to own. Anything outside this list belongs to
+# a human (or another agent) and must NOT be stashed away. Keep this list
+# narrow: every entry is an implicit promise that autofix can clobber it.
+ALLOWLIST_PATTERNS=(
+  'next/src/content/events/'
+  'next/src/content/dispatches/'
+  'next/src/content/weekend-picks/'
+  'ops/run-log/entries/'
+  'ops/run-log/index.csv'
+  'docs/reports/peninsula-accuracy-'
+  'docs/reports/peninsula-image-'
+)
+
+mkdir -p "$SENTINEL_DIR"
+
+is_allowlisted() {
+  local path="$1"
+  for prefix in "${ALLOWLIST_PATTERNS[@]}"; do
+    case "$path" in
+      "$prefix"*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Print every changed path (staged, unstaged, untracked) one per line.
+changed_paths() {
+  git status --porcelain=v1 -z | tr '\0' '\n' | awk 'NF>=2 {print substr($0,4)}'
+}
+
+classify() {
+  local foreign=()
+  local owned=()
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    if is_allowlisted "$path"; then
+      owned+=("$path")
+    else
+      foreign+=("$path")
+    fi
+  done < <(changed_paths)
+  printf 'FOREIGN_COUNT=%d\n' "${#foreign[@]}"
+  printf 'OWNED_COUNT=%d\n'   "${#owned[@]}"
+  printf 'FOREIGN:\n'
+  printf '  %s\n' "${foreign[@]:-}"
+  printf 'OWNED:\n'
+  printf '  %s\n' "${owned[@]:-}"
+}
+
+cmd_check() {
+  local report; report="$(classify)"
+  local foreign_count
+  foreign_count="$(printf '%s\n' "$report" | awk -F= '/^FOREIGN_COUNT=/{print $2}')"
+  if [ "${foreign_count:-0}" -gt 0 ]; then
+    {
+      printf '[%s] PI autofix deferred — working tree has non-autofix changes.\n' "$(date -u +%FT%TZ)"
+      printf '%s\n' "$report"
+      printf 'Action: the user must commit or discard these changes before autofix can run.\n\n'
+    } >> "$DEFER_SENTINEL"
+    echo "pi-autofix: DEFERRED. See $DEFER_SENTINEL." >&2
+    return 2
+  fi
+  return 0
+}
+
+cmd_stash() {
+  cmd_check
+  if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+    : > "$STASH_REF_FILE"  # nothing to stash
+    return 0
+  fi
+  # Only allowlisted paths reach here, so it's safe to stash everything.
+  git stash push --include-untracked -m "$STASH_LABEL"
+  # Record the exact stash ref so restore can verify it.
+  git rev-parse stash@{0} > "$STASH_REF_FILE"
+}
+
+cmd_restore() {
+  if [ ! -s "$STASH_REF_FILE" ]; then
+    return 0  # nothing was stashed
+  fi
+  local expected actual
+  expected="$(cat "$STASH_REF_FILE")"
+  actual="$(git rev-parse stash@{0} 2>/dev/null || true)"
+  if [ "$expected" != "$actual" ]; then
+    {
+      printf '[%s] PI autofix stash ref mismatch — refusing to pop.\n' "$(date -u +%FT%TZ)"
+      printf '  expected: %s\n' "$expected"
+      printf '  actual  : %s\n' "$actual"
+      printf 'The stash has been left intact. Inspect with `git stash list`.\n\n'
+    } >> "$CONFLICT_SENTINEL"
+    echo "pi-autofix: stash ref mismatch. See $CONFLICT_SENTINEL." >&2
+    return 3
+  fi
+  if ! git stash pop; then
+    {
+      printf '[%s] PI autofix `git stash pop` failed (likely conflicts).\n' "$(date -u +%FT%TZ)"
+      printf '  stash ref: %s\n' "$expected"
+      printf 'The stash entry has been LEFT IN PLACE. NEVER run `git stash drop` here.\n'
+      printf 'Resolve manually: `git stash show -p stash@{0}` then `git stash apply`.\n\n'
+    } >> "$CONFLICT_SENTINEL"
+    echo "pi-autofix: stash pop failed; stash preserved. See $CONFLICT_SENTINEL." >&2
+    return 4
+  fi
+  : > "$STASH_REF_FILE"
+}
+
+case "${1:-}" in
+  check)   cmd_check ;;
+  stash)   cmd_stash ;;
+  restore) cmd_restore ;;
+  *)
+    echo "usage: $0 {check|stash|restore}" >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
## What was broken

The hourly PI autofix Claude session (`pi-daily-accuracy-autofix` / `pi-daily-image-relevance-autofix` cron jobs in `C:/Users/James/.openclaw/cron/jobs.json`) found a dirty working tree on 2026-05-28 and ran `git stash push -m \"pi-autofix-temp-stash 2026-05-27\"` to clear it. The stash was then either dropped or hit a silent pop failure. A 117-file Kids Grade taxonomy rip-out (schema, content data, components, scripts) was lost and had to be redone from scratch in the same session.

Spec (`docs/peninsula-insider-daily-accuracy-scan-spec-2026-04-14.md`) and SKILL.md had no working-tree safety rules, so the autofix improvised the dangerous behaviour.

## What's changed

- New `ops/scripts/pi-autofix-safe-stash.sh` with three subcommands:
  - `check` — exit 0 if tree is clean or only contains autofix-owned files (allowlist: events, dispatches, weekend-picks, run-log, accuracy/image reports). Exit 2 with a deferral note in `.pi-autofix/deferred.log` if foreign changes are present.
  - `stash` — labels the stash with an ISO timestamp and records its ref to `.pi-autofix/active-stash-ref`.
  - `restore` — verifies the stash ref before popping. On ref mismatch or pop failure (conflict, etc.) leaves the stash in place and writes `.pi-autofix/stash-conflict.log`. NEVER `git stash drop`.
- Spec doc gains a mandatory \"Working tree safety\" section requiring the wrapper and forbidding direct `git stash`.
- `.pi-autofix/` sentinel dir added to `.gitignore`.

## How to verify

Tested against a throwaway repo (results inline in the PR investigation):

| Scenario | Expected | Result |
|---|---|---|
| Clean tree | `check` exit 0 | exit 0 |
| Only allowlisted dirty paths | `stash` saves, `restore` pops cleanly | stash created, restore returned 0, working tree intact |
| Foreign dirty paths present | `check` exit 2 + deferral sentinel | exit 2, `.pi-autofix/deferred.log` written |
| Pop conflict (overlapping commit between stash and restore) | exit 4, stash preserved, conflict sentinel | exit 4, `stash@{0}` still in list, `.pi-autofix/stash-conflict.log` written |

Manual repro of the original failure on this branch's HEAD: with the current dirty tree (`promote-auto-detected-images.mjs` modified plus 5 untracked items), `bash ops/scripts/pi-autofix-safe-stash.sh check` exits 2 — the autofix would defer rather than swallow the work.

Memory note: `feedback_pi_autofix_stash_safety.md` records the incident and the safeguard for future sessions.