### PR TITLE
feat: mega menu V5 typographic refactor + full IA implementation specs (PR-1)

### DIFF
--- a/docs/specs/mega-menu-refactor-v5.md
+++ b/docs/specs/mega-menu-refactor-v5.md
@@ -1,0 +1,656 @@
+# Mega Menu Refactor — V5 Typographic Edition
+
+**Spec version:** 1.0  
+**Status:** Ready for implementation  
+**Branch target:** `feat/mega-menu-v5-typographic`  
+**Estimated effort:** 2–3 days (1 developer)  
+**Depends on:** None — standalone PR, no schema or routing changes required  
+**Followed by:** Phase 5 nav restructure (Places + Plans → Explore)
+
+---
+
+## Overview
+
+This PR removes the image rail from the V4 mega menu and replaces it with a pure-typographic editorial pin block. The motivation is editorial and brand clarity: the mega menu is a navigation surface, not a magazine spread. Images in navigation compete with content, slow perceived performance, and require editorial overhead (seasonal rotation, override management) that belongs on content pages, not chrome.
+
+The reference aesthetic is the Tate Modern digital identity: compressed grotesque at commanding scale, whitespace as layout device, weight and proportion doing the full visual argument without imagery.
+
+No routing changes, no schema changes, no Supabase work. This is a self-contained component and CSS change that ships ahead of the Phase 5 IA restructure.
+
+---
+
+## Pillar Structure Changes
+
+The current `v4-nav.ts` has 8 pillars. This PR also implements the approved navigation restructure: Plans and Places are absorbed into Explore, reducing the nav to 6 pillars.
+
+### Before (8 pillars)
+```
+What's On · Plans · Eat & Drink · Wine · Stay · Places · Explore · Journal
+```
+
+### After (6 pillars)
+```
+Eat & Drink · Stay · Wine · Explore · What's On · Journal
+```
+
+**Rationale for ordering:** Category pillars (intent-driven discovery) lead. Explore handles Places, Plans, and experiences as the umbrella. What's On and Journal trail as editorial/temporal surfaces.
+
+### Pillar removals
+
+**Delete the `escape` (Plans) pillar object** from `v4Pillars`. Its content migrates into the Explore pillar columns.
+
+**Delete the `places` pillar object** from `v4Pillars`. Its content migrates into the Explore pillar columns.
+
+### `v4-nav.ts` — Explore pillar replacement
+
+Replace the current Explore pillar with the following. This is the complete new object:
+
+```ts
+{
+  key: 'explore',
+  label: 'Explore',
+  href: '/explore/',
+  intro: "Every move on the Peninsula that isn't a meal or a bed.",
+  topBanner: {
+    text: "The whole Peninsula, on one screen.",
+    ctaLabel: 'Open the map',
+    ctaHref: '/map/',
+    icon: 'peninsula-map',
+  },
+  rail: {
+    eyebrow: "Editor's pick · Autumn '26",
+    title: 'Bushrangers Bay walk',
+    verdict: 'Two hours, almost nobody on it after lunch, and the wildflowers come out late April. Park at Cape Schanck, not Boneo.',
+    href: '/explore/bushrangers-bay-walk/',
+    cta: 'Plan the walk',
+    // image field removed — not rendered in V5
+  },
+  columns: [
+    {
+      eyebrow: 'Places',
+      items: [
+        { key: 'sorrento',    label: 'Sorrento',          href: '/explore/places/sorrento/' },
+        { key: 'red-hill',    label: 'Red Hill',           href: '/explore/places/red-hill/' },
+        { key: 'flinders',    label: 'Flinders',           href: '/explore/places/flinders/' },
+        { key: 'mornington',  label: 'Mornington',         href: '/explore/places/mornington/' },
+        { key: 'all-places',  label: 'All places →',       href: '/explore/places/' },
+      ],
+    },
+    {
+      eyebrow: 'Regions',
+      items: [
+        { key: 'wine-country',  label: 'Red Hill & Merricks',     href: '/explore/regions/red-hill-wine-country/' },
+        { key: 'peninsula-tip', label: 'Sorrento & Portsea',      href: '/explore/regions/peninsula-tip/' },
+        { key: 'mornington-bay','label': 'Mornington & the Bay',  href: '/explore/regions/mornington-bay-coast/' },
+        { key: 'ocean-coast',   label: 'Flinders & Ocean Coast',  href: '/explore/regions/ocean-coast/' },
+        { key: 'all-regions',   label: 'All regions →',           href: '/explore/regions/' },
+      ],
+    },
+    {
+      eyebrow: 'Plans & moves',
+      items: [
+        { key: 'one-night',   label: 'One night',          href: '/explore/plans/one-night-escape/' },
+        { key: 'weekend',     label: 'Two-day weekend',    href: '/explore/plans/' },
+        { key: 'wellness',    label: 'Wellness weekend',   href: '/explore/plans/wellness-weekend/' },
+        { key: 'walks',       label: 'Walks & trails',     href: '/explore/walks/' },
+        { key: 'beaches',     label: 'Beaches',            href: '/explore/beaches/' },
+        { key: 'map',         label: 'Open the map →',     href: '/map/' },
+      ],
+    },
+  ],
+  askLine: 'Not sure which part of the Peninsula fits? Ask PI →',
+},
+```
+
+### `v4-nav.ts` — Eat & Drink pillar: update place hrefs
+
+The "Where to eat" column currently points to `/places/[slug]/`. Update to `/explore/places/[slug]/`:
+
+```ts
+// Old                              // New
+href: '/places/red-hill/'       →   href: '/explore/places/red-hill/'
+href: '/places/sorrento/'       →   href: '/explore/places/sorrento/'
+href: '/places/flinders/'       →   href: '/explore/places/flinders/'
+href: '/places/mornington/'     →   href: '/explore/places/mornington/'
+href: '/places/merricks/'       →   href: '/explore/places/merricks/'
+```
+
+### `v4-nav.ts` — Wine pillar: update place hrefs
+
+The "By the place" column currently points to `/wine/[place]/`. These are category+place intersection pages — leave hrefs unchanged. No updates needed.
+
+### `v4-nav.ts` — Re-order `v4Pillars` array
+
+After deletions and updates, reorder the array to:
+```
+[eat, stay, wine, explore, whats-on, journal]
+```
+
+### `v4-nav.ts` — Remove `image` + `imageAlt` fields from `V4MegaRail` interface
+
+```ts
+// Before
+export interface V4MegaRail {
+  eyebrow: string;
+  title: string;
+  verdict: string;
+  image: string;      // ← remove
+  imageAlt: string;   // ← remove
+  href: string;
+  cta?: string;
+}
+
+// After
+export interface V4MegaRail {
+  eyebrow: string;
+  title: string;
+  verdict: string;
+  href: string;
+  cta?: string;
+}
+```
+
+Also remove `image` and `imageAlt` fields from all remaining pillar `rail:` objects in `v4Pillars`.
+
+---
+
+## New Component: `V4MegaPin.astro`
+
+Create `/next/src/components/v4/V4MegaPin.astro`.
+
+This replaces `V4MegaRail.astro` in the panel grid. It carries the same editorial function — "the one thing PI is sending you to in this pillar right now" — through pure typography: no image, no card border, no hover transform.
+
+```astro
+---
+/**
+ * V4 MegaPin — typographic editorial pin inside a mega panel.
+ *
+ * Replaces V4MegaRail (image card) with a pure-type block.
+ * Carries the editor's pick verdict in Space Grotesk + Instrument Serif.
+ * No image. No card border. Weight and scale carry the argument.
+ *
+ * The pin occupies the leftmost column of the mega grid, same position
+ * as the old rail — 200px wide on desktop, hidden at ≤920px where the
+ * grid falls to 2 columns and the columns carry the panel alone.
+ */
+import type { V4MegaRail } from '../../lib/v4-nav';
+
+export interface Props {
+  rail: V4MegaRail;
+}
+const { rail } = Astro.props;
+---
+
+<a class="v4-pin" href={rail.href}>
+  <p class="v4-pin__eyebrow">{rail.eyebrow}</p>
+  <h3 class="v4-pin__title">{rail.title}</h3>
+  <p class="v4-pin__verdict">{rail.verdict}</p>
+  <span class="v4-pin__cta">{rail.cta ?? 'Read the verdict'}</span>
+</a>
+```
+
+**Note:** No `editableImage` call. No `loadOverrides` call. No `pillarKey` prop. The pin has no image override surface — editorial updates are made by editing the `rail.title` and `rail.verdict` fields in `v4-nav.ts` directly.
+
+---
+
+## Modified Component: `V4MegaPanel.astro`
+
+Replace the `V4MegaRail` import with `V4MegaPin`. The grid logic simplifies because the pin has no "wide rail" variant.
+
+```astro
+---
+import type { V4Pillar } from '../../lib/v4-nav';
+import V4MegaColumn from './V4MegaColumn.astro';
+import V4MegaPin from './V4MegaPin.astro';  // ← replaces V4MegaRail
+
+export interface Props {
+  pillar: V4Pillar;
+  triggerId: string;
+}
+
+const { pillar, triggerId } = Astro.props;
+const cols = pillar.columns.length;  // 2 or 3
+const panelClass = [
+  'v4-mega',
+  cols === 2 ? 'v4-mega--cols-2' : 'v4-mega--cols-3',
+].filter(Boolean).join(' ');
+// Note: v4-mega--rail-wide class removed — no longer needed
+---
+
+{pillar.columns?.length > 0 && (
+<div
+  class={panelClass}
+  role="menu"
+  aria-labelledby={triggerId}
+  data-v4-mega
+>
+  <div class="v4-mega__container">
+    {pillar.topBanner && <V4PillarTopBanner banner={pillar.topBanner} />}
+    <div class="v4-mega__grid">
+      <V4MegaPin rail={pillar.rail} />
+      {pillar.columns.map((col) => <V4MegaColumn column={col} />)}
+    </div>
+  </div>
+</div>
+)}
+```
+
+**Also add:** `import V4PillarTopBanner from './V4PillarTopBanner.astro';` — the topBanner render was previously missing from the panel template and needs to be wired in.
+
+---
+
+## Modified Component: `V4MegaColumn.astro`
+
+No structural changes. One type-system update: item font-family changes from Cormorant Garamond to Space Grotesk (handled in CSS — no template change needed).
+
+---
+
+## CSS Changes: `v4.css`
+
+### 1. Update CSS custom properties
+
+```css
+:root {
+  --v4-mega-w:           1240px;
+  --v4-mega-pin-w:       200px;      /* replaces --v4-mega-rail-w: 280px */
+  --v4-mega-col-gap:     48px;       /* increased from 40px — more air with pin replacing image */
+  --v4-mega-row-h:       56px;
+  --v4-mega-pad-y:       44px;       /* slightly increased from 40px */
+  --v4-mega-open-delay:  70ms;
+  --v4-mega-close-delay: 220ms;
+
+  --v4-shadow-mega:      0 16px 40px -16px rgba(30, 27, 24, 0.18);
+  --v4-shadow-mega-soft: 0 8px 24px -12px rgba(30, 27, 24, 0.12);
+  --v4-focus-ring:       0 0 0 3px rgba(139, 78, 59, 0.22);
+  --v4-hairline-mega:    rgba(30, 27, 24, 0.10);
+  --v4-ease:             cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+```
+
+Remove `--v4-mega-rail-w` entirely.
+
+### 2. Update mega grid
+
+```css
+/* Remove the rail-wide modifier (no longer needed): */
+/* DELETE: .v4-mega--rail-wide { ... } */
+/* DELETE: .v4-mega--rail-wide .v4-mega__grid { ... } */
+
+.v4-mega__grid {
+  display: grid;
+  grid-template-columns: var(--v4-mega-pin-w) repeat(var(--v4-cols, 3), 1fr);
+  gap: var(--v4-mega-col-gap);
+  align-items: start;
+}
+.v4-mega--cols-2 { --v4-cols: 2; }
+.v4-mega--cols-3 { --v4-cols: 3; }
+
+@media (max-width: 1080px) {
+  .v4-mega__grid {
+    grid-template-columns: 180px repeat(var(--v4-cols, 3), 1fr);
+    gap: 28px;
+  }
+}
+
+/* At ≤920px: drop the pin, show columns only in a 2-up grid */
+@media (max-width: 920px) {
+  .v4-mega__grid { grid-template-columns: 1fr 1fr; }
+  .v4-pin { display: none; }
+}
+```
+
+### 3. Remove all `.v4-mega__rail` CSS
+
+Delete the entire "MEGA RAIL" block (lines 370–434 in the current file):
+
+```css
+/* DELETE this entire block: */
+.v4-mega__rail { ... }
+.v4-mega__rail:hover { ... }
+.v4-mega__rail-image { ... }
+.v4-mega__rail-image img { ... }
+.v4-mega__rail:hover .v4-mega__rail-image img { ... }
+.v4-mega__rail-body { ... }
+.v4-mega__rail-eyebrow { ... }
+.v4-mega__rail-title { ... }
+.v4-mega__rail-verdict { ... }
+.v4-mega__rail-cta { ... }
+```
+
+### 4. Add `.v4-pin` CSS (new block — insert where rail block was removed)
+
+```css
+/* =========================================================
+   MEGA PIN (typographic editorial block — replaces image rail)
+   ---------------------------------------------------------
+   Tate Modern reference: compressed grotesque at hierarchy-
+   defining scale. No card. No border. No image. Weight and
+   proportion carry the full visual argument.
+   ========================================================= */
+
+.v4-pin {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  text-decoration: none;
+  color: var(--text);
+  padding: 0;
+  /* Vertical alignment: pin top aligns with first column eyebrow */
+  padding-top: 0;
+}
+
+.v4-pin__eyebrow {
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 10px 0;
+  /* Match the eyebrow baseline of adjacent columns */
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--v4-hairline-mega);
+}
+
+.v4-pin__title {
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-size: clamp(22px, 2vw, 28px);
+  font-weight: 700;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin: 14px 0 12px 0;
+  /* No text-transform. The title carries the weight through mass, not case. */
+}
+
+.v4-pin__verdict {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--soft);
+  margin: 0 0 16px 0;
+  /* Max 2 lines at pin width. Title must be ≤3 words for this to hold. */
+}
+
+.v4-pin__cta {
+  font-family: 'Space Mono', 'Courier New', monospace;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  /* No arrow. No uppercase. The underline is the whole signal. */
+  margin-top: auto;
+}
+
+/* Hover state: title colour only — no transform, no shadow, no border */
+.v4-pin:hover .v4-pin__title { color: var(--accent); }
+.v4-pin:hover .v4-pin__cta {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+
+/* Focus state */
+.v4-pin:focus-visible {
+  outline: none;
+  box-shadow: var(--v4-focus-ring);
+  border-radius: 2px;
+}
+
+/* Reduced motion: no transition needed — there are no animated properties on pin */
+```
+
+### 5. Update `.v4-mega__col-list a` font-family
+
+The column item links currently use Cormorant Garamond at 19px. For the Tate Modern treatment, shift to Space Grotesk at a slightly reduced size for better scan readability at this scale:
+
+```css
+.v4-mega__col-list a {
+  font-family: 'Space Grotesk', system-ui, sans-serif;  /* was Cormorant Garamond */
+  font-size: 16px;                                        /* was 19px */
+  font-weight: 400;
+  line-height: 1.3;
+  color: var(--text);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  border-bottom: 1px solid transparent;
+  transition: color var(--v4-mega-open-delay) var(--v4-ease),
+              border-color var(--v4-mega-open-delay) var(--v4-ease);
+}
+.v4-mega__col-list a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 500;                 /* weight shift replaces colour change as primary signal */
+}
+```
+
+**Rationale:** Cormorant Garamond at 19px reads as decorative in a navigation context. Space Grotesk at 16px is more legible at speed and signals "navigation" rather than "editorial prose." The column eyebrows (Outfit, uppercase) remain unchanged — the typographic contrast between eyebrow and item is preserved.
+
+### 6. Remove `.v4-mega__intro` CSS
+
+The intro field was previously removed from the template (2026-05-13). Clean up the orphaned CSS:
+
+```css
+/* DELETE: */
+.v4-mega__intro { ... }
+```
+
+---
+
+## Breakpoint Behaviour Summary
+
+| Viewport | Pin | Columns | Grid layout |
+|---|---|---|---|
+| ≥1081px | 200px fixed | 2 or 3 × `1fr` | `200px repeat(N, 1fr)`, gap 48px |
+| 921px–1080px | 180px fixed | 2 or 3 × `1fr` | `180px repeat(N, 1fr)`, gap 28px |
+| 761px–920px | Hidden | 2 × `1fr` | `1fr 1fr`, gap 28px |
+| ≤760px | — | — | Desktop mega hidden; mobile drawer active |
+| ≤380px | — | — | Drawer tightened (existing behaviour, no change) |
+
+---
+
+## Hover States — Complete Reference
+
+| Element | Default | Hover |
+|---|---|---|
+| Pillar trigger link | `color: var(--text)`, `border-bottom: 2px transparent` | `color: var(--accent)`, `border-bottom: 2px var(--accent)` |
+| Chevron | Neutral rotation | `rotate(180deg)` on `.is-open` |
+| Pin block (`.v4-pin`) | — | `.v4-pin__title` → `color: var(--accent)` |
+| Pin CTA | `color: var(--text)`, underline | `color: var(--accent)`, `text-decoration-color: var(--accent)` |
+| Column item link | `color: var(--text)`, `border-bottom: 1px transparent` | `color: var(--accent)`, `border-bottom: 1px var(--accent)`, `font-weight: 500` |
+| Live indicator dot | Sage, pulsing | No change |
+| Top banner CTA | `color: var(--accent)`, no underline | `text-decoration: underline` |
+
+**No hover transforms anywhere in the menu panel.** The image rail's `translateY(-2px)` on hover is removed with the rail. Navigation elements do not animate vertically — that was a card interaction pattern, not a nav one.
+
+---
+
+## Accessibility Requirements
+
+### Keyboard navigation
+
+No changes to the existing keyboard handling in the V4 BaseLayout inline script. The existing behaviour — `Escape` closes the open panel, `Tab` navigates through items, arrow keys not required for WCAG AA — is preserved.
+
+Verify:
+- Every pillar trigger (`V4PillarLink`) retains `aria-haspopup="true"` and `aria-expanded`
+- Every mega panel retains `role="menu"` and `aria-labelledby={triggerId}`
+- Every column item retains `role="menuitem"`
+- `V4MegaPin` anchor has no `role` — it is a standard link within the menu container, not a menuitem
+
+### Focus ring
+
+All interactive elements use `var(--v4-focus-ring)` on `:focus-visible`. The pin block adds this:
+
+```css
+.v4-pin:focus-visible {
+  outline: none;
+  box-shadow: var(--v4-focus-ring);
+  border-radius: 2px;
+}
+```
+
+### Reduced motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .v4-mega { transition: none; transform: none; }
+  /* Pin has no animated properties — no additional rule needed */
+  /* Live dot pulse already handled by existing rule */
+}
+```
+
+### Contrast
+
+- `var(--text)` on `var(--bg)` (cream): passes WCAG AA at all sizes used in the pin
+- `var(--soft)` on `var(--bg)` for the verdict line: verify passes 4.5:1 — if not, bump to `var(--text)` on the verdict specifically
+- `var(--accent)` (ochre) on `var(--bg)`: eyebrow uses uppercase + letter-spacing which reduces minimum contrast threshold — acceptable at 10–11px uppercase per existing brand system
+
+### Screen reader experience
+
+The typographic pin renders as a standard `<a>` containing four text nodes. No `aria-label` needed — the link text (eyebrow + title + verdict + CTA) is fully descriptive in sequence. Verify with VoiceOver: the link should announce as "[title], [verdict], Read the verdict, link."
+
+---
+
+## Mobile Drawer: No Changes
+
+`V4MobileDrawer.astro` is already typographic. The `Editor's pick: {title} →` line inside each expanded pillar body is a plain text link — no image, no card. It is already the Tate Modern approach.
+
+The drawer `rail` field access (`pillar.rail.title`) continues to work after the `V4MegaRail` interface update because `title`, `verdict`, and `href` are all retained.
+
+---
+
+## Files Changed
+
+| File | Action |
+|---|---|
+| `src/lib/v4-nav.ts` | Remove `image`/`imageAlt` from `V4MegaRail` interface; remove from all `rail:` objects; delete `escape` pillar; delete `places` pillar; add new `explore` pillar; reorder array; update Eat & Drink place hrefs |
+| `src/components/v4/V4MegaPanel.astro` | Replace `V4MegaRail` import with `V4MegaPin`; remove `wideRail` logic; add `V4PillarTopBanner` wiring; remove `v4-mega--rail-wide` class |
+| `src/components/v4/V4MegaPin.astro` | **New file** — typographic pin component |
+| `src/components/v4/V4MegaRail.astro` | **Delete** — replaced by V4MegaPin |
+| `src/styles/v4.css` | Update `--v4-mega-rail-w` → `--v4-mega-pin-w`; remove rail CSS block; add pin CSS block; update column item font-family and size; remove `.v4-mega__intro` orphan; remove `--rail-wide` modifier rules |
+| `src/components/v4/V4MobileDrawer.astro` | No change |
+| `src/components/v4/V4MegaColumn.astro` | No change |
+| `src/components/v4/V4PillarLink.astro` | No change |
+| `src/components/v4/V4PillarTopBanner.astro` | No change |
+| `src/components/v4/V4Masthead.astro` | No change |
+
+---
+
+## Font Loading
+
+`Space Grotesk` is used by the pin title and the updated column item links. Confirm it is already loaded in `V4BaseLayout.astro` (or equivalent font loading). If `Space Grotesk` is not in the current font stack, add to the font loading link:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap"
+>
+```
+
+`Space Mono` is used for the pin CTA. Confirm it is loaded. The font is already used in the broader PI design system; this is a new usage site for it in the nav layer.
+
+If either font is served locally (in `/public/fonts/`), no change needed.
+
+---
+
+## Testing Checklist
+
+### Desktop (≥1081px)
+- [ ] All 6 pillars render in correct order: Eat & Drink · Stay · Wine · Explore · What's On · Journal
+- [ ] Explore panel shows 3 columns: Places / Regions / Plans & moves
+- [ ] Pin renders in leftmost position: eyebrow → title → verdict → CTA
+- [ ] Pin title is at least 22px, bold, tight tracking
+- [ ] Verdict line is italic Cormorant Garamond, max 2 lines at pin width
+- [ ] CTA is Space Mono, underlined, no arrow
+- [ ] No images anywhere in the mega panel
+- [ ] Column items render in Space Grotesk 16px (not Cormorant Garamond 19px)
+- [ ] Column eyebrows remain Outfit uppercase ochre
+- [ ] Hover on pin: title and CTA shift to `var(--accent)`, no translateY
+- [ ] Hover on column item: accent colour + weight 500 + underline
+- [ ] No card border or shadow on pin
+- [ ] Panel border-top: 1px `var(--border)` (unchanged)
+- [ ] Panel box-shadow intact
+
+### Breakpoint 921px–1080px
+- [ ] Pin narrows to 180px, remains visible
+- [ ] Gap reduces to 28px
+- [ ] No layout overflow
+
+### Breakpoint 761px–920px
+- [ ] Pin hidden (`.v4-pin { display: none }`)
+- [ ] Grid falls to 2-column: `1fr 1fr`
+- [ ] Both columns visible and readable
+- [ ] No orphaned rail image placeholder
+
+### Mobile (≤760px)
+- [ ] Desktop mega panel not rendered
+- [ ] Mobile drawer opens correctly
+- [ ] Drawer Explore pillar expands to show Places / Regions / Plans & moves columns
+- [ ] `Editor's pick: Bushrangers Bay walk →` link renders in expanded Explore body
+- [ ] Plans and Places pillars no longer appear as standalone drawer items
+
+### Accessibility
+- [ ] Tab through all pillar triggers — focus ring visible on each
+- [ ] Escape closes open panel and returns focus to trigger
+- [ ] VoiceOver: pin announces as link with title + verdict + CTA text
+- [ ] Column items announce as `role="menuitem"` links
+- [ ] Verify `prefers-reduced-motion`: no animation on panel open/close when set
+
+### Regression
+- [ ] Journal pillar still renders as `v4-pillars__link--journal` (italic, no chevron)
+- [ ] What's On pillar topBanner renders (the live conditions banner)
+- [ ] Explore pillar topBanner (Peninsula map CTA) renders
+- [ ] Live indicator dots on What's On column items still pulse
+- [ ] Subscribe CTA in masthead action cluster unchanged
+- [ ] Footer nav (`v4FooterDepartments`) still lists all pillars — update if Places or Plans rows appear
+
+### Footer update
+
+`v4FooterDepartments` in `v4-nav.ts` currently lists Places and Plans (escape) as separate entries. After this PR:
+
+```ts
+export const v4FooterDepartments: V4NavItem[] = [
+  { key: 'eat',      label: 'Eat & Drink', href: '/eat/' },
+  { key: 'stay',     label: 'Stay',        href: '/stay/' },
+  { key: 'wine',     label: 'Wine',        href: '/wine/' },
+  { key: 'explore',  label: 'Explore',     href: '/explore/' },
+  { key: 'whats-on', label: "What's On",   href: '/whats-on/' },
+  { key: 'journal',  label: 'Journal',     href: '/journal/' },
+];
+```
+
+Remove the `places` and `escape` entries. Explore covers both.
+
+---
+
+## What This PR Does Not Do
+
+To be explicit — the following are out of scope for this PR and belong to later phases:
+
+- **URL changes.** `/places/[slug]` and `/plans/[slug]` still resolve. This PR only removes them from the navigation surface. The 301 redirects and content migration belong to Phase 5.
+- **Region pages.** `/explore/regions/` links in the new Explore column will return 404 until Phase 6. This is acceptable — the nav links can be added now; the pages follow.
+- **VenueDetailTemplate or PlaceDetailTemplate changes.** Those are Phase 5–6 work.
+- **Article breadcrumb updates.** Phase 5.
+- **Supabase or search index changes.** None required.
+
+---
+
+## Visual Reference: The Tate Modern Principle
+
+The Tate Modern nav strips imagery from navigation entirely. Type at commanding scale — often just a section name at 28–32px compressed grotesque — carries the full wayfinding argument. Whitespace is generous and intentional. Colour is monochrome or near-monochrome in the chrome layer, with accent colour used only for active states and calls to action.
+
+Applied to PI: the mega panel becomes a table of contents, not a magazine layout. The pin title at 28px bold does the work the image used to do. The italic verdict line is PI voice in one sentence. The monospace CTA is functional, not decorative. The column items are readable nouns, not small-text links buried under imagery.
+
+The result: a faster-scanning, lower-maintenance, more editorially authoritative navigation layer.
+
+---
+
+*Spec authored: Sunday 31 May 2026. Author: James Richmond / Peninsula Insider editorial.*  
+*For questions during implementation, refer to `BRAND-PI.md` for voice rules and `v4.css` for existing token values.*

--- a/docs/specs/pr-2-schema-foundations.md
+++ b/docs/specs/pr-2-schema-foundations.md
@@ -1,0 +1,344 @@
+# PR-2 · Schema Foundations
+
+**Branch:** `feat/schema-foundations`  
+**Depends on:** Nothing (parallel with PR-1)  
+**Effort:** 2–3 days  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Lay the complete data foundation for the IA refactor: correct the zone enum, introduce `providore` as a first-class venue type, add estate/tier/region relational fields to the content schemas, and migrate Supabase columns to match. All downstream PRs (3–9) depend on this landing cleanly.
+
+---
+
+## 1 · Zone Enum Correction
+
+**File:** `next/src/content.config.ts`
+
+Replace the current 7-value zone enum (which uses legacy names) with the corrected set:
+
+```ts
+// BEFORE
+const zone = z.enum([
+  'bayside',
+  'hinterland',
+  'red-hill-plateau',
+  'ocean-coast',
+  'back-beaches',
+  'tip',
+  'western-port',
+]);
+
+// AFTER
+const zone = z.enum([
+  'mornington',      // was 'bayside'
+  'bay-coast',       // new — covers Dromana–Rye coastal strip
+  'red-hill',        // was 'red-hill-plateau'
+  'hinterland',      // unchanged
+  'peninsula-tip',   // was 'tip' and 'back-beaches' (consolidated)
+  'ocean-coast',     // unchanged
+  'western-port',    // unchanged
+]);
+```
+
+**Migration notes:**
+- `bayside` → `mornington` in all venue/place/experience JSON files
+- `red-hill-plateau` → `red-hill`
+- `back-beaches` → `peninsula-tip`
+- `tip` → `peninsula-tip`
+- New `bay-coast` zone covers Dromana, Rye, Rosebud, Safety Beach, McCrae, Capel Sound — update those venue/place JSONs accordingly
+
+**Search for all affected JSON files:**
+```bash
+grep -rl '"zone": "bayside"\|"zone": "red-hill-plateau"\|"zone": "back-beaches"\|"zone": "tip"' next/src/content/
+```
+
+---
+
+## 2 · Venue Type Enum — Add `providore`
+
+**File:** `next/src/content.config.ts`
+
+Add `providore` to the venue type enum. Keep `producer` in the enum during migration (PR-3 handles reclassification and eventual deprecation):
+
+```ts
+// In the venues defineCollection schema, type field:
+type: z.enum([
+  'restaurant',
+  'winery',
+  'cafe',
+  'bakery',
+  'pub',
+  'brewery',
+  'distillery',
+  'producer',      // deprecated — keep during migration, remove after PR-3
+  'providore',     // NEW — farmgate, cheesemonger, fishmonger, produce store
+  'market',
+  'hotel',
+  'villa',
+  'cottage',
+  'glamping',
+  'farm-stay',
+  'spa',
+  'walk',
+  'beach',
+  'activity',
+]),
+```
+
+---
+
+## 3 · New Venue Fields
+
+**File:** `next/src/content.config.ts` — venues `defineCollection` schema
+
+Add the following optional fields to the venues schema block:
+
+```ts
+/**
+ * Optional free-text sub-classification within a type.
+ * Examples: type=cafe + subtype=roaster | type=providore + subtype=fishmonger
+ * Surfaced as a secondary chip on venue cards and detail pages.
+ */
+subtype: z.string().optional(),
+
+/**
+ * Estate grouping — links this venue to a parent multi-venue estate.
+ * When set, VenueDetailTemplate renders an EstateCluster block showing
+ * sibling venues. Value must match an estateSlug from the confirmed
+ * multi-venue estate list (see PR-7 spec).
+ */
+estateSlug: z.string().optional(),
+estateLabel: z.string().optional(),
+
+/**
+ * Editorial tier — drives verdict block visibility and listing sort order.
+ *   destination  → full editorial treatment, verdict block shown
+ *   recommended  → listed and linked, no verdict block
+ *   directory    → directory-only entry, minimal page
+ */
+venueTier: z.enum(['destination', 'recommended', 'directory']).default('destination'),
+```
+
+---
+
+## 4 · New Experience Field
+
+**File:** `next/src/content.config.ts` — experiences `defineCollection` schema
+
+```ts
+/**
+ * Optional link to a parent venue when the experience is venue-owned
+ * (e.g. a winery tour, a restaurant garden experience).
+ * Used by VenueDetailTemplate to surface owned experiences inline.
+ */
+venueSlug: z.string().optional(),
+```
+
+---
+
+## 5 · New Places Fields
+
+**File:** `next/src/content.config.ts` — places `defineCollection` schema
+
+```ts
+/**
+ * Region this place belongs to. Set on all 37 place JSONs post PR-2.
+ * Used by RegionDetailTemplate (PR-6) to build the places strip.
+ */
+regionSlug: z.string().optional(),
+regionLabel: z.string().optional(),
+```
+
+---
+
+## 6 · `lib/editorial.ts` Updates
+
+**File:** `next/src/lib/editorial.ts`
+
+### 6a — Correct routing arrays
+
+```ts
+// BEFORE
+export const wineTypes = ['winery', 'producer', 'brewery', 'distillery'];
+export const eatTypes = ['restaurant', 'cafe', 'bakery', 'pub', 'market', 'winery'];
+export const stayTypes = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'];
+
+// AFTER
+export const wineTypes = ['winery'];
+export const eatTypes = [
+  'restaurant', 'cafe', 'bakery', 'pub', 'market',
+  'brewery', 'distillery', 'providore',
+];
+export const stayTypes = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'];
+// Note: 'producer' removed from all arrays — handled as deprecated in PR-3
+```
+
+### 6b — Update `typeLabel` map
+
+```ts
+export const typeLabel: Record<string, string> = {
+  restaurant: 'Restaurant',
+  winery: 'Winery',
+  cafe: 'Café',
+  bakery: 'Bakery',
+  pub: 'Pub',
+  brewery: 'Brewery',
+  distillery: 'Distillery',
+  producer: 'Producer',    // keep during migration
+  providore: 'Providore',  // NEW
+  market: 'Market',
+  hotel: 'Hotel',
+  villa: 'Villa',
+  cottage: 'Cottage',
+  glamping: 'Glamping',
+  'farm-stay': 'Farm Stay',
+  spa: 'Spa',
+};
+```
+
+### 6c — Update zone label map (add if not present)
+
+```ts
+export const zoneLabel: Record<string, string> = {
+  mornington: 'Mornington',
+  'bay-coast': 'Bay Coast',
+  'red-hill': 'Red Hill',
+  hinterland: 'Hinterland',
+  'peninsula-tip': 'Peninsula Tip',
+  'ocean-coast': 'Ocean Coast',
+  'western-port': 'Western Port',
+};
+```
+
+---
+
+## 7 · Supabase Migration
+
+**File:** `ops/migrations/2026-06-XX-pi-schema-foundations.sql`
+
+Create this migration file:
+
+```sql
+-- PI Schema Foundations Migration
+-- PR-2: zone enum correction, providore type, estate/tier/region fields
+-- Run after: 2026-05-19-pi-image-bindings.sql
+
+BEGIN;
+
+-- ── 1. Zone enum ─────────────────────────────────────────────────────────────
+-- Rename legacy zone values to new canonical names
+-- Note: Supabase enums cannot be renamed in-place; use a column migration approach
+
+-- Add new zone enum if pi.zone_enum exists as a type
+DO $$
+BEGIN
+  -- Update any zone columns using text-based approach
+  -- (adjust table/column names to match actual Supabase schema)
+  UPDATE pi.venues SET zone = 'mornington'    WHERE zone = 'bayside';
+  UPDATE pi.venues SET zone = 'red-hill'      WHERE zone = 'red-hill-plateau';
+  UPDATE pi.venues SET zone = 'peninsula-tip' WHERE zone = 'back-beaches';
+  UPDATE pi.venues SET zone = 'peninsula-tip' WHERE zone = 'tip';
+  
+  UPDATE pi.places SET zone = 'mornington'    WHERE zone = 'bayside';
+  UPDATE pi.places SET zone = 'red-hill'      WHERE zone = 'red-hill-plateau';
+  UPDATE pi.places SET zone = 'peninsula-tip' WHERE zone = 'back-beaches';
+  UPDATE pi.places SET zone = 'peninsula-tip' WHERE zone = 'tip';
+  
+  UPDATE pi.experiences SET zone = 'mornington'    WHERE zone = 'bayside';
+  UPDATE pi.experiences SET zone = 'red-hill'      WHERE zone = 'red-hill-plateau';
+  UPDATE pi.experiences SET zone = 'peninsula-tip' WHERE zone = 'back-beaches';
+  UPDATE pi.experiences SET zone = 'peninsula-tip' WHERE zone = 'tip';
+END $$;
+
+-- ── 2. Venues — new columns ───────────────────────────────────────────────────
+ALTER TABLE pi.venues
+  ADD COLUMN IF NOT EXISTS subtype       TEXT,
+  ADD COLUMN IF NOT EXISTS estate_slug   TEXT,
+  ADD COLUMN IF NOT EXISTS estate_label  TEXT,
+  ADD COLUMN IF NOT EXISTS venue_tier    TEXT NOT NULL DEFAULT 'destination'
+    CHECK (venue_tier IN ('destination', 'recommended', 'directory'));
+
+-- ── 3. Experiences — new column ───────────────────────────────────────────────
+ALTER TABLE pi.experiences
+  ADD COLUMN IF NOT EXISTS venue_slug TEXT;
+
+-- ── 4. Places — new columns ───────────────────────────────────────────────────
+ALTER TABLE pi.places
+  ADD COLUMN IF NOT EXISTS region_slug  TEXT,
+  ADD COLUMN IF NOT EXISTS region_label TEXT;
+
+-- ── 5. Content registry — add providore type ─────────────────────────────────
+-- content_registry.entity_type check constraint may need updating
+-- Check existing constraint name:
+-- SELECT conname FROM pg_constraint WHERE conrelid = 'pi.content_registry'::regclass;
+-- Then drop and recreate with updated list including 'providore'
+
+-- ── 6. Indexes ────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS venues_estate_slug_idx  ON pi.venues (estate_slug);
+CREATE INDEX IF NOT EXISTS venues_venue_tier_idx   ON pi.venues (venue_tier);
+CREATE INDEX IF NOT EXISTS venues_zone_idx         ON pi.venues (zone);
+CREATE INDEX IF NOT EXISTS places_region_slug_idx  ON pi.places (region_slug);
+
+COMMIT;
+```
+
+---
+
+## 8 · JSON File Updates Required
+
+### Zone renames — run bulk update script
+After schema change, update all venue/place/experience JSON files:
+
+```bash
+# Dry run first
+find next/src/content -name "*.json" | xargs grep -l '"zone": "bayside"' 
+find next/src/content -name "*.json" | xargs grep -l '"zone": "tip"'
+find next/src/content -name "*.json" | xargs grep -l '"zone": "back-beaches"'
+find next/src/content -name "*.json" | xargs grep -l '"zone": "red-hill-plateau"'
+
+# Then sed replace (macOS: sed -i '')
+sed -i 's/"zone": "bayside"/"zone": "mornington"/g' $(find next/src/content -name "*.json")
+sed -i 's/"zone": "tip"/"zone": "peninsula-tip"/g' $(find next/src/content -name "*.json")
+sed -i 's/"zone": "back-beaches"/"zone": "peninsula-tip"/g' $(find next/src/content -name "*.json")
+sed -i 's/"zone": "red-hill-plateau"/"zone": "red-hill"/g' $(find next/src/content -name "*.json")
+```
+
+### Region assignments — manual, after zone migration
+Set `regionSlug` + `regionLabel` on all 37 place JSONs per the confirmed region map:
+
+| regionSlug | regionLabel | Places |
+|---|---|---|
+| `red-hill-wine-country` | Red Hill & Merricks | red-hill, main-ridge, merricks, merricks-beach, merricks-north, balnarring |
+| `peninsula-tip` | Sorrento & Portsea | sorrento, portsea, blairgowrie, rye (partially) |
+| `mornington-bay-coast` | Mornington & the Bay | mornington, mount-martha, safety-beach, mccrae, dromana, rosebud, capel-sound, mount-eliza |
+| `western-port` | Western Port | hastings, bittern, crib-point, boneo |
+| `ocean-coast` | Flinders & the Ocean Coast | flinders, cape-schanck, fingal, rye (partially) |
+
+---
+
+## 9 · Acceptance Criteria
+
+- [ ] `npx astro check` passes with no type errors after schema changes
+- [ ] Zone enum values match exactly: `mornington · bay-coast · red-hill · hinterland · peninsula-tip · ocean-coast · western-port`
+- [ ] `providore` present in venue type enum; `producer` still present (deprecated marker in comment)
+- [ ] `subtype`, `estateSlug`, `estateLabel`, `venueTier` fields present in venues schema — all optional or default-bearing
+- [ ] `venueSlug` present in experiences schema
+- [ ] `regionSlug`, `regionLabel` present in places schema
+- [ ] `editorial.ts` routing arrays correct: `wineTypes = ['winery']`, `eatTypes` includes brewery/distillery/providore
+- [ ] Supabase migration runs clean with no FK violations
+- [ ] All 37 place JSON files pass `astro check` — no zone enum errors
+- [ ] All 140 venue JSON files pass — no zone enum errors
+
+---
+
+## Dependencies
+
+- **Blocks:** PR-3, PR-5, PR-7 (all need the new fields live)
+- **Parallel with:** PR-1 (mega menu — no schema overlap)
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-3-type-routing.md
+++ b/docs/specs/pr-3-type-routing.md
@@ -1,0 +1,195 @@
+# PR-3 · Type Rationalisation & Routing
+
+**Branch:** `feat/type-routing`  
+**Depends on:** PR-2 merged  
+**Effort:** 2–3 days  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Reclassify all `producer` venues to their correct new types (`providore`, `cafe`, or experience-side), fix brewery/distillery routing from Wine → Eat & Drink, and clean up any residual routing mismatches. After this PR, `producer` is dead as an active type — no venue JSON should carry it forward.
+
+---
+
+## 1 · `producer` Type Reclassification
+
+There are ~20 venues currently typed as `producer`. Each needs reassignment to one of:
+
+| New type | Criteria |
+|---|---|
+| `providore` | Farmgate store, cheesemonger, fishmonger, produce retailer — sells product directly to consumers |
+| `cafe` | Has a café / dining component that is the primary offering |
+| Experience (move to `/experiences/`) | Primarily an attraction — truffle hunting, berry picking, maze — not a food-retail venue |
+
+### Confirmed reclassifications (from session analysis)
+
+| Venue slug | Current type | New type | Notes |
+|---|---|---|---|
+| red-hill-truffles | producer | experience | Seasonal truffle hunt — move to experiences collection |
+| sunny-ridge-strawberry-farm | producer | experience | Pick-your-own attraction |
+| ashcombe-maze | producer | experience | Attraction, not a food retailer |
+| any cheesemonger/fishmonger/farmgate | producer | providore | Retail produce model |
+| any with café seating as primary | producer | cafe | Subtype = 'roaster' or similar if warranted |
+
+**Developer task:** Run the full audit:
+
+```bash
+# List all producer-typed venues
+grep -rl '"type": "producer"' next/src/content/venues/ | sort
+```
+
+For each file, determine correct new type and update. Add `subtype` field where useful (e.g. `"subtype": "cheesemonger"`).
+
+### Three venues moving to experiences
+Create new experience JSON files (or move existing venue JSONs):
+- `next/src/content/experiences/red-hill-truffles.json`
+- `next/src/content/experiences/sunny-ridge-strawberry-farm.json`  
+- `next/src/content/experiences/ashcombe-maze.json`
+
+Add `type: 'attraction'` to each (already in experiences type enum). Add `venueSlug` if applicable.
+
+Delete the corresponding venue JSON files after experience files are created.
+
+---
+
+## 2 · Brewery / Distillery Routing Fix
+
+In the current `editorial.ts`, brewery and distillery are under `wineTypes` (route to `/wine/`). Under the confirmed IA, they belong under `eatTypes` (route to `/eat/`).
+
+PR-2 already corrects the arrays in `editorial.ts`. This PR validates that all brewery/distillery venues now resolve to `/eat/[slug]` URLs and that no `/wine/brewery/` or `/wine/distillery/` collection URLs are referenced anywhere.
+
+**Audit:**
+
+```bash
+# Check for any hardcoded wine/brewery or wine/distillery paths
+grep -r '/wine/brewery\|/wine/distillery\|wine.*brewery\|wine.*distillery' next/src/ --include="*.astro" --include="*.ts" --include="*.tsx"
+```
+
+Add 301 redirects for any legacy URLs that may have been indexed:
+- `/wine/brewery/` → `/eat/brewery/`
+- `/wine/distillery/` → `/eat/distillery/`
+- Individual venue pages (e.g. `/wine/[brewery-slug]`) → `/eat/[brewery-slug]/`
+
+**File:** `next/astro.config.mjs` (or wherever redirects are configured)
+
+---
+
+## 3 · Wine Mega Menu — Remove Brewery/Distillery Links
+
+**File:** `next/src/lib/v4-nav.ts`
+
+The current Wine pillar in v4-nav.ts contains links to breweries and distilleries:
+
+```ts
+// REMOVE these from the Wine pillar columns:
+{ key: 'brewery',    label: 'Breweries',    href: '/wine/#breweries' },
+{ key: 'distillery', label: 'Distilleries', href: '/wine/#distilleries' },
+```
+
+Move them to the Eat & Drink pillar column under "More":
+
+```ts
+// ADD to Eat & Drink pillar:
+{ key: 'brewery',    label: 'Breweries',    href: '/eat/breweries/' },
+{ key: 'distillery', label: 'Distilleries', href: '/eat/distilleries/' },
+{ key: 'providore',  label: 'Providores',   href: '/eat/providores/' },
+```
+
+---
+
+## 4 · Hub Page Type Filtering
+
+Any hub page that currently filters by `wineTypes` to include breweries/distilleries needs updating.
+
+**Audit:**
+
+```bash
+grep -rn "wineTypes\|wine.*brewery\|wine.*distillery" next/src/pages/ --include="*.astro"
+```
+
+For each occurrence, ensure the filter now uses the updated `editorial.ts` arrays (which will be correct after PR-2). No hardcoded type lists should remain in page files — all routing logic flows through `editorial.ts`.
+
+---
+
+## 5 · `venueHrefPrefix` Function Verification
+
+**File:** `next/src/lib/editorial.ts`
+
+After PR-2's changes, verify the function resolves correctly:
+
+```ts
+// Expected resolution after PR-2 + PR-3:
+venueHrefPrefix('restaurant')   // → /eat/
+venueHrefPrefix('cafe')         // → /eat/
+venueHrefPrefix('brewery')      // → /eat/
+venueHrefPrefix('distillery')   // → /eat/
+venueHrefPrefix('providore')    // → /eat/
+venueHrefPrefix('winery')       // → /wine/
+venueHrefPrefix('hotel')        // → /stay/
+venueHrefPrefix('spa')          // → /stay/
+```
+
+Write a simple test or add assertions in a dev script to verify all 15 venue types resolve to the correct pillar.
+
+---
+
+## 6 · Content Registry Updates (Supabase)
+
+Update `entity_type` values in `pi.content_registry` for reclassified venues:
+
+```sql
+-- Update brewery/distillery routing in content_registry
+UPDATE pi.content_registry
+  SET pillar = 'eat'
+  WHERE entity_type IN ('brewery', 'distillery')
+    AND pillar = 'wine';
+
+-- Update producer → providore for reclassified venues
+-- (run after venue JSONs are updated and re-synced)
+UPDATE pi.content_registry
+  SET entity_type = 'providore'
+  WHERE entity_type = 'producer'
+    AND slug IN (
+      -- list of slugs confirmed as providore type
+      -- populate after audit in step 1
+    );
+
+-- Remove producer entries for venues moving to experiences
+DELETE FROM pi.content_registry
+  WHERE entity_type = 'producer'
+    AND slug IN ('red-hill-truffles', 'sunny-ridge-strawberry-farm', 'ashcombe-maze');
+
+-- Insert experience entries for moved venues
+INSERT INTO pi.content_registry (slug, entity_type, pillar, href, ...)
+  VALUES
+    ('red-hill-truffles', 'experience', 'explore', '/explore/places/red-hill/', ...),
+    ('sunny-ridge-strawberry-farm', 'experience', 'explore', '/explore/places/...', ...),
+    ('ashcombe-maze', 'experience', 'explore', '/explore/places/...', ...);
+```
+
+---
+
+## 7 · Acceptance Criteria
+
+- [ ] Zero venue JSON files carry `"type": "producer"` after this PR
+- [ ] `red-hill-truffles`, `sunny-ridge-strawberry-farm`, `ashcombe-maze` exist in `experiences/` collection
+- [ ] `venueHrefPrefix('brewery')` → `/eat/`, `venueHrefPrefix('distillery')` → `/eat/`
+- [ ] `venueHrefPrefix('winery')` → `/wine/` only
+- [ ] No `wineTypes` array includes brewery or distillery after PR-2
+- [ ] 301 redirects added for `/wine/brewery/` and `/wine/distillery/`
+- [ ] v4-nav.ts Wine pillar contains no brewery/distillery links
+- [ ] `npx astro check` passes — no type errors on reclassified venue JSONs
+- [ ] Supabase content_registry rows reflect updated types and pillars
+
+---
+
+## Dependencies
+
+- **Requires:** PR-2 merged (providore type in enum, updated routing arrays)
+- **Blocks:** PR-4, PR-5
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-4-market-consolidation.md
+++ b/docs/specs/pr-4-market-consolidation.md
@@ -1,0 +1,174 @@
+# PR-4 · Market Consolidation
+
+**Branch:** `feat/market-consolidation`  
+**Depends on:** PR-3 merged  
+**Effort:** 1 day  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Collapse the dual market collection structure (experience-markets and venue-markets) into a single, coherent venue-market model. Delete the five experience-collection market files, enrich the three retained venue-market files, add two new venue-market files, and add 301 redirects for the deleted experience-market URLs. Markets become a consistently venue-type content node — not a hybrid experience/venue collection.
+
+---
+
+## Background
+
+The current content structure has markets split across two collections:
+- **Experience-side markets** (`/experiences/`) — thin files, minimal editorial
+- **Venue-side markets** (`/venues/`) — richer files with venue-type routing to `/eat/`
+
+Under the confirmed IA, markets are a venue type (`"type": "market"`) routed to `/eat/`. Experience-side market files are an artefact of the old taxonomy and must be removed.
+
+---
+
+## 1 · Files to Delete (Experience-Side Markets)
+
+Audit experience JSONs for market-type entries:
+
+```bash
+grep -rl '"type": "market"' next/src/content/experiences/
+```
+
+Expected deletions (confirm via audit):
+
+| File | Redirect target |
+|---|---|
+| `next/src/content/experiences/[market-slug-1].json` | `/eat/[market-slug]/` |
+| `next/src/content/experiences/[market-slug-2].json` | `/eat/[market-slug]/` |
+| `next/src/content/experiences/[market-slug-3].json` | `/eat/[market-slug]/` |
+| `next/src/content/experiences/[market-slug-4].json` | `/eat/[market-slug]/` |
+| `next/src/content/experiences/[market-slug-5].json` | `/eat/[market-slug]/` |
+
+**Do not delete** the event-side market entries (e.g. community markets in `/events/`). Those are event records for specific dates, not venue pages.
+
+---
+
+## 2 · Venue-Market Files to Retain and Enrich
+
+Three existing venue-market files are retained. Each should be reviewed and enriched with:
+- `editorNote` — minimum 2 sentences, editorial voice
+- `whyWeGo` — one-line insider positioning
+- `bestFor` — 2–4 audience tags
+- `venueTier` — set to `'recommended'` or `'destination'` as appropriate
+- `heroImage` — confirm non-placeholder image is set
+- `lastVerified` — update to current date
+
+Audit command:
+
+```bash
+grep -rl '"type": "market"' next/src/content/venues/
+```
+
+---
+
+## 3 · New Venue-Market Files to Create
+
+Add two new venue-market JSON files for markets that have editorial value but are currently unrepresented as venue pages.
+
+**Template for new market venue JSON:**
+
+```json
+{
+  "slug": "[market-slug]",
+  "name": "[Market Name]",
+  "type": "market",
+  "place": "[place-slug]",
+  "zone": "[corrected-zone]",
+  "coordinates": { "lat": 0.0, "lng": 0.0 },
+  "address": "[address]",
+  "website": "[url]",
+  "priceBand": "$",
+  "venueTier": "recommended",
+  "authority": null,
+  "signature": "[one-line tagline]",
+  "editorNote": "[editorial paragraph]",
+  "whyWeGo": "[insider positioning line]",
+  "bestFor": ["families", "local produce"],
+  "tags": { "mood": [], "audience": [], "season": [] },
+  "heroImage": {
+    "src": "/images/placeholder.webp",
+    "alt": "[description]",
+    "license": "tmp-unsplash"
+  },
+  "lastVerified": "2026-06-01",
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}
+```
+
+Developer to confirm the two market slugs with editorial before creating files.
+
+---
+
+## 4 · 301 Redirects
+
+**File:** `next/astro.config.mjs` (or `next/src/pages/[...404].astro` redirect config — check existing pattern)
+
+Add 301 redirects for all five deleted experience-market URLs:
+
+```js
+// In astro.config.mjs redirects block:
+redirects: {
+  // Market consolidation PR-4
+  '/experiences/[market-slug-1]/': { status: 301, destination: '/eat/[market-slug-1]/' },
+  '/experiences/[market-slug-2]/': { status: 301, destination: '/eat/[market-slug-2]/' },
+  '/experiences/[market-slug-3]/': { status: 301, destination: '/eat/[market-slug-3]/' },
+  '/experiences/[market-slug-4]/': { status: 301, destination: '/eat/[market-slug-4]/' },
+  '/experiences/[market-slug-5]/': { status: 301, destination: '/eat/[market-slug-5]/' },
+  
+  // Also redirect the experience-side market collection URL if it existed
+  '/explore/markets/': { status: 301, destination: '/eat/markets/' },
+}
+```
+
+Populate actual slugs after the audit in Step 1.
+
+---
+
+## 5 · Content Registry Cleanup (Supabase)
+
+```sql
+-- Remove experience-side market entries
+DELETE FROM pi.content_registry
+  WHERE entity_type = 'market'
+    AND pillar = 'explore'  -- or however experience markets were registered
+    AND slug IN (
+      '[market-slug-1]',
+      '[market-slug-2]',
+      '[market-slug-3]',
+      '[market-slug-4]',
+      '[market-slug-5]'
+    );
+
+-- Ensure venue-side markets are registered correctly
+UPDATE pi.content_registry
+  SET pillar = 'eat',
+      href = '/eat/' || slug || '/'
+  WHERE entity_type = 'market'
+    AND pillar != 'eat';
+```
+
+---
+
+## 6 · Acceptance Criteria
+
+- [ ] Zero market-type JSON files remain in `next/src/content/experiences/`
+- [ ] Three existing venue-market files enriched (editorNote, whyWeGo, venueTier set)
+- [ ] Two new venue-market JSON files created and pass `astro check`
+- [ ] Five 301 redirects added and tested in local dev (verify with `curl -I`)
+- [ ] `npx astro build` completes without referencing deleted experience market files
+- [ ] Supabase content_registry: no `entity_type = 'market'` rows with `pillar = 'explore'`
+- [ ] No broken internal links to deleted experience-market slugs (run `astro check` or link checker)
+
+---
+
+## Dependencies
+
+- **Requires:** PR-3 merged (type rationalisation complete — markets confirmed as venue type only)
+- **Blocks:** Nothing directly (but clean data here helps PR-8 Plans Browse and PR-9 Search Sync)
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-5-explore-url-migration.md
+++ b/docs/specs/pr-5-explore-url-migration.md
@@ -1,0 +1,268 @@
+# PR-5 · Explore URL Migration
+
+**Branch:** `feat/explore-url-migration`  
+**Depends on:** PR-3 merged  
+**Effort:** 3–4 days  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Move Places and Plans under the `/explore/` URL umbrella. Migrate all `/places/` routes to `/explore/places/`, all `/plans/` and `/escape/` routes to `/explore/plans/`, add ~50 redirects, update the BaseLayout section enum, and update all Supabase `content_registry` hrefs to match the new URL structure.
+
+---
+
+## 1 · URL Structure Change
+
+### Before → After
+
+| Content type | Old URL pattern | New URL pattern |
+|---|---|---|
+| Places index | `/places/` | `/explore/places/` |
+| Place detail | `/places/[slug]/` | `/explore/places/[slug]/` |
+| Plans index | `/plans/` | `/explore/plans/` |
+| Plan/escape detail | `/plans/[slug]/` | `/explore/plans/[slug]/` |
+| Escape (legacy) | `/escape/` | `/explore/plans/` |
+| Explore hub | `/explore/` | `/explore/` (unchanged — now a hub) |
+
+---
+
+## 2 · File Structure Changes
+
+### 2a — Places pages
+
+Move/rename Astro page files:
+
+```
+# From:
+next/src/pages/places/index.astro
+next/src/pages/places/[slug].astro
+
+# To:
+next/src/pages/explore/places/index.astro
+next/src/pages/explore/places/[slug].astro
+```
+
+If the `next/src/pages/explore/` directory doesn't exist yet, create it. The `explore/` directory will also house `regions/` (PR-6) and `plans/` (this PR).
+
+### 2b — Plans pages
+
+```
+# From:
+next/src/pages/plans/index.astro
+next/src/pages/plans/[slug].astro
+next/src/pages/escape/[slug].astro  (if it exists)
+
+# To:
+next/src/pages/explore/plans/index.astro
+next/src/pages/explore/plans/[slug].astro
+```
+
+### 2c — Explore hub index
+
+Create or update `next/src/pages/explore/index.astro` as the Explore umbrella hub. This page surfaces:
+- Places grid (featured places, filtered by `featured: true`)
+- Plans rail (latest plans articles)
+- Regions grid (after PR-6 — feature-flag until then)
+- Free experiences highlights
+
+For this PR, the index is a lightweight hub — a full explore hub design is part of PR-8.
+
+---
+
+## 3 · 301 Redirects
+
+**File:** `next/astro.config.mjs`
+
+Add all place and plan redirects to the `redirects` block:
+
+```js
+// ── PR-5 · Explore URL Migration ─────────────────────────────────────────────
+// Places: /places/ → /explore/places/
+'/places/': { status: 301, destination: '/explore/places/' },
+
+// Place detail pages (~37 slugs)
+// Generate this list from: ls next/src/content/places/ | sed 's/.json//'
+'/places/arthurs-seat/':      { status: 301, destination: '/explore/places/arthurs-seat/' },
+'/places/balnarring/':        { status: 301, destination: '/explore/places/balnarring/' },
+'/places/bittern/':           { status: 301, destination: '/explore/places/bittern/' },
+'/places/blairgowrie/':       { status: 301, destination: '/explore/places/blairgowrie/' },
+'/places/boneo/':             { status: 301, destination: '/explore/places/boneo/' },
+'/places/cape-schanck/':      { status: 301, destination: '/explore/places/cape-schanck/' },
+'/places/capel-sound/':       { status: 301, destination: '/explore/places/capel-sound/' },
+'/places/crib-point/':        { status: 301, destination: '/explore/places/crib-point/' },
+'/places/dromana/':           { status: 301, destination: '/explore/places/dromana/' },
+'/places/fingal/':            { status: 301, destination: '/explore/places/fingal/' },
+'/places/flinders/':          { status: 301, destination: '/explore/places/flinders/' },
+'/places/hastings/':          { status: 301, destination: '/explore/places/hastings/' },
+'/places/main-ridge/':        { status: 301, destination: '/explore/places/main-ridge/' },
+'/places/mccrae/':            { status: 301, destination: '/explore/places/mccrae/' },
+'/places/merricks-beach/':    { status: 301, destination: '/explore/places/merricks-beach/' },
+'/places/merricks-north/':    { status: 301, destination: '/explore/places/merricks-north/' },
+'/places/merricks/':          { status: 301, destination: '/explore/places/merricks/' },
+'/places/moorooduc/':         { status: 301, destination: '/explore/places/moorooduc/' },
+'/places/mornington/':        { status: 301, destination: '/explore/places/mornington/' },
+'/places/mount-eliza/':       { status: 301, destination: '/explore/places/mount-eliza/' },
+// ... (complete the full list from ls next/src/content/places/)
+
+// Plans: /plans/ → /explore/plans/
+'/plans/': { status: 301, destination: '/explore/plans/' },
+'/escape/': { status: 301, destination: '/explore/plans/' },
+
+// Individual plan slugs — generate from content/articles where section=plans
+// '/plans/[slug]/': { status: 301, destination: '/explore/plans/[slug]/' },
+```
+
+**Generate the complete redirect list:**
+
+```bash
+# Get all place slugs
+ls next/src/content/places/ | sed 's/\.json//' | \
+  awk '{print "'"'"'/places/" $0 "/'"'"': { status: 301, destination: '"'"'/explore/places/" $0 "/'"'"' },"}'
+
+# Get all plans article slugs  
+grep -rl '"section": "plans"' next/src/content/articles/ | \
+  sed 's/.*\///' | sed 's/\.md//' | sed 's/\.mdx//'
+```
+
+---
+
+## 4 · BaseLayout Section Enum
+
+**File:** `next/src/layouts/BaseLayout.astro`
+
+```ts
+// BEFORE
+section?: 'home' | 'eat' | 'stay' | 'wine' | 'explore' | 'journal' | 'places' | 'escape' | 'whats-on';
+
+// AFTER
+section?: 'home' | 'eat' | 'stay' | 'wine' | 'explore' | 'journal' | 'whats-on';
+// 'places' and 'escape' removed — both now map to 'explore'
+```
+
+Update the `SECTION_TO_SEARCH_KIND` map:
+
+```ts
+// Remove or remap:
+// places: 'Places',  → remove (use explore)
+// escape: 'Plans',   → remove (use explore)
+
+// Ensure:
+explore: 'Explore',
+```
+
+Update all page files that pass `section="places"` or `section="escape"` to instead pass `section="explore"`.
+
+**Audit:**
+
+```bash
+grep -rn 'section="places"\|section="escape"\|section=.places.\|section=.escape.' next/src/pages/ next/src/layouts/ --include="*.astro"
+```
+
+---
+
+## 5 · Internal Link Updates
+
+All internal links to `/places/` and `/plans/` must be updated to the new paths.
+
+**Audit commands:**
+
+```bash
+# Find all hardcoded /places/ links
+grep -rn '"/places/\|href="/places/' next/src/ --include="*.astro" --include="*.ts" --include="*.tsx" --include="*.json"
+
+# Find all hardcoded /plans/ links
+grep -rn '"/plans/\|href="/plans/' next/src/ --include="*.astro" --include="*.ts" --include="*.tsx" --include="*.json"
+
+# Find /escape/ links
+grep -rn '"/escape/\|href="/escape/' next/src/ --include="*.astro" --include="*.ts" --include="*.tsx"
+```
+
+Key locations to update:
+- `next/src/lib/v4-nav.ts` — Places and Plans pillar hrefs
+- `next/src/lib/editorial.ts` — any place/plan href helpers
+- Hub pages (`/eat/`, `/wine/`, `/stay/` index pages) — place links in sidebars
+- Article body content — inline links to places (search markdown content too)
+- Venue JSON `pairWith` arrays that reference place URLs
+
+---
+
+## 6 · v4-nav.ts Updates
+
+**File:** `next/src/lib/v4-nav.ts`
+
+Update the Explore pillar to reflect the new URL structure:
+
+```ts
+// Explore pillar top-level
+href: '/explore/',
+
+// Column links:
+{ key: 'places',  label: 'Places',  href: '/explore/places/' },
+{ key: 'plans',   label: 'Plans',   href: '/explore/plans/'  },
+{ key: 'regions', label: 'Regions', href: '/explore/regions/' }, // live after PR-6
+```
+
+Remove the standalone Plans pillar if it exists, or remap its href to `/explore/plans/`.
+
+---
+
+## 7 · Supabase `content_registry` Updates
+
+Update all `href` values for places and plans entries:
+
+```sql
+-- Update place href patterns
+UPDATE pi.content_registry
+  SET href = REPLACE(href, '/places/', '/explore/places/')
+  WHERE href LIKE '/places/%';
+
+-- Update plan/escape href patterns  
+UPDATE pi.content_registry
+  SET href = REPLACE(href, '/plans/', '/explore/plans/')
+  WHERE href LIKE '/plans/%';
+
+UPDATE pi.content_registry
+  SET href = REPLACE(href, '/escape/', '/explore/plans/')
+  WHERE href LIKE '/escape/%';
+
+-- Verify no legacy paths remain
+SELECT slug, href FROM pi.content_registry
+  WHERE href LIKE '/places/%' OR href LIKE '/plans/%' OR href LIKE '/escape/%';
+```
+
+---
+
+## 8 · Sitemap
+
+After the URL migration, regenerate the sitemap. Ensure:
+- Old `/places/` and `/plans/` URLs are **not** in the sitemap (they 301 to new URLs)
+- New `/explore/places/` and `/explore/plans/` URLs are in the sitemap
+- `sitemapExclude: false` on all active place and plan files
+
+---
+
+## 9 · Acceptance Criteria
+
+- [ ] All 37 place detail pages render at `/explore/places/[slug]/`
+- [ ] `/places/` and `/places/[slug]/` return 301 to new URLs (test with `curl -I`)
+- [ ] Plans index renders at `/explore/plans/`
+- [ ] `/plans/` and `/escape/` return 301 to `/explore/plans/`
+- [ ] BaseLayout section enum no longer includes `'places'` or `'escape'`
+- [ ] No page file passes `section="places"` or `section="escape"` to BaseLayout
+- [ ] `npx astro build` completes without 404s or broken routes
+- [ ] Supabase content_registry: zero rows with `href LIKE '/places/%'`
+- [ ] v4-nav.ts Explore pillar href = `/explore/`, Places link = `/explore/places/`
+- [ ] Pagefind index rebuild queued (PR-9 handles full rebuild)
+
+---
+
+## Dependencies
+
+- **Requires:** PR-3 merged
+- **Blocks:** PR-6 (regions need places at new URLs), PR-8 (plans browse hub)
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-6-regions.md
+++ b/docs/specs/pr-6-regions.md
@@ -1,0 +1,436 @@
+# PR-6 · Regions Collection & Template
+
+**Branch:** `feat/regions`  
+**Depends on:** PR-5 merged  
+**Effort:** 1 week  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Introduce `regions` as a new Astro content collection with 5 JSON files, build the `RegionDetailTemplate` component, create the `/explore/regions/[slug]` route, implement `TouristDestination` JSON-LD, and seed the Supabase `regions` table. Regions are the second tier of the geographic hierarchy — above places, below the Peninsula itself — and are the primary surface for editorial depth, AI discoverability, and cross-pillar content aggregation.
+
+---
+
+## 1 · Content Schema
+
+**File:** `next/src/content.config.ts`
+
+Add a new `regions` collection after the `places` collection:
+
+```ts
+const regions = defineCollection({
+  loader: glob({ pattern: '**/*.json', base: './src/content/regions' }),
+  schema: z.object({
+    slug: z.string(),
+    name: z.string(),
+    
+    /** One-line editorial tagline. Used as SEO meta description. */
+    tagline: z.string().optional(),
+    
+    /** Editorial introduction paragraph. 80–120 words. */
+    intro: z.string(),
+    
+    heroImage: imageRef,
+    
+    /** The 7-value zone enum values that fall within this region. */
+    zones: z.array(zone),
+    
+    /** Place slugs within this region — references to places collection. */
+    places: z.array(reference('places')),
+    
+    /** Slugs of adjacent regions for cross-linking in the template footer. */
+    adjacentRegions: z.array(z.string()).default([]),
+    
+    /** Geographic centroid for map rendering and JSON-LD. Optional. */
+    coordinates: coordinates.optional(),
+    
+    publishedAt: z.coerce.date(),
+    sitemapExclude: z.boolean().default(false),
+  }),
+});
+```
+
+Add `regions` to the `export const collections` object at the bottom of `content.config.ts`.
+
+---
+
+## 2 · Region JSON Files
+
+**Directory:** `next/src/content/regions/` (create this directory)
+
+Create 5 JSON files, one per confirmed region:
+
+### `red-hill-wine-country.json`
+```json
+{
+  "slug": "red-hill-wine-country",
+  "name": "Red Hill & Merricks",
+  "tagline": "The Peninsula's wine heartland — cool-climate pinot, long lunches, and unhurried cellar doors.",
+  "intro": "Red Hill and Merricks form the Peninsula's most celebrated wine corridor. The ridge sits 300 metres above sea level, catching the cool Bass Strait air that defines the region's pinot noir and chardonnay. This is not a drive-through wine region — it rewards slow movement. Cellar doors range from the architecturally ambitious (Point Leo, Jackalope) to the quietly exceptional (Stonier, Ten Minutes by Tractor). Between tastings, the farmers markets, providores, and destination restaurants make Red Hill one of the most coherent food-and-wine precincts in Victoria.",
+  "heroImage": {
+    "src": "/images/sourced/region-red-hill-01.webp",
+    "alt": "Morning light across Red Hill's vineyard rows, Mornington Peninsula",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["red-hill", "hinterland"],
+  "places": ["red-hill", "main-ridge", "merricks", "merricks-beach", "merricks-north", "balnarring"],
+  "adjacentRegions": ["mornington-bay-coast", "ocean-coast"],
+  "coordinates": { "lat": -38.385, "lng": 145.015 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}
+```
+
+### `peninsula-tip.json`
+```json
+{
+  "slug": "peninsula-tip",
+  "name": "Sorrento & Portsea",
+  "tagline": "Limestone cliffs, ocean baths, the Heads ferry — the Peninsula's most iconic edge.",
+  "intro": "The tip of the Mornington Peninsula is where the land narrows to a point and the social temperature rises. Sorrento and Portsea have been Melbourne's summer escape for generations — limestone cliffs above the bay, ocean baths carved into back-beach rock, the ferry to Queenscliff cutting across the Heads. The dining scene has quietly become something worth driving for year-round. Come in the off-season and the towns reveal their best selves: quieter, more local, more honest. The back beach at dusk is one of the best things on the Peninsula.",
+  "heroImage": {
+    "src": "/images/sourced/region-peninsula-tip-01.webp",
+    "alt": "Limestone cliffs and calm bay water at Sorrento, Mornington Peninsula",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["peninsula-tip"],
+  "places": ["sorrento", "portsea", "blairgowrie", "rye", "fingal"],
+  "adjacentRegions": ["ocean-coast", "mornington-bay-coast"],
+  "coordinates": { "lat": -38.34, "lng": 144.74 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}
+```
+
+### `mornington-bay-coast.json`
+```json
+{
+  "slug": "mornington-bay-coast",
+  "name": "Mornington & the Bay",
+  "tagline": "The Peninsula's urban edge — the main street dining strip, the bay beaches, and the easy weekend gateway.",
+  "intro": "Mornington is the Peninsula's largest town and its most accessible gateway. The main street dining strip punches above its weight, the bay beaches stretch from Mount Eliza to Dromana, and the Saturday morning market is a Peninsula institution. This is where the Peninsula starts — the transition from Melbourne's suburbs to something genuinely different. Mount Martha's elevated bay views and the Dromana hillside are the scenic punctuation marks. For first-timers, this is the entry point. For regulars, it's often overlooked in favour of the tip or the ridge — a mistake.",
+  "heroImage": {
+    "src": "/images/sourced/region-mornington-01.webp",
+    "alt": "Mornington main street on a clear autumn morning",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["mornington", "bay-coast"],
+  "places": ["mornington", "mount-martha", "safety-beach", "mccrae", "dromana", "rosebud", "capel-sound", "mount-eliza"],
+  "adjacentRegions": ["red-hill-wine-country", "western-port"],
+  "coordinates": { "lat": -38.22, "lng": 145.04 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}
+```
+
+### `western-port.json`
+```json
+{
+  "slug": "western-port",
+  "name": "Western Port",
+  "tagline": "The quieter side — mangroves, French Island ferries, and a genuinely local pace of life.",
+  "intro": "Western Port is the Peninsula's other shore — the protected bay side where the water is calmer, the towns are more working than weekending, and the landscape shifts to mangrove and tidal flat. Hastings is the hub, with French Island ferry access and a working harbour that feels a world away from Sorrento. This is the Peninsula for locals and those who have graduated beyond the obvious. The birding is exceptional, the fishing is serious, and the absence of tourists is, for many, the entire point.",
+  "heroImage": {
+    "src": "/images/sourced/region-western-port-01.webp",
+    "alt": "Calm tidal waters at Western Port Bay, Mornington Peninsula",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["western-port"],
+  "places": ["hastings", "bittern", "crib-point", "boneo"],
+  "adjacentRegions": ["mornington-bay-coast"],
+  "coordinates": { "lat": -38.30, "lng": 145.20 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}
+```
+
+### `ocean-coast.json`
+```json
+{
+  "slug": "ocean-coast",
+  "name": "Flinders & the Ocean Coast",
+  "tagline": "Wild surf beaches, the best pub on the Peninsula, and a rural quiet that feels hard-won.",
+  "intro": "The ocean coast runs along the Peninsula's south-facing edge, where Bass Strait swells arrive unimpeded and the light has a particular quality in the afternoon. Flinders is the anchor — an extraordinary village that manages to be a serious food-and-wine destination while remaining genuinely unspoiled. Cape Schanck marks the south-west corner with its lighthouse and coastal boardwalk. The ocean beach walking here is among the best in Victoria. Fewer people come this way, which remains one of the coast's distinguishing features.",
+  "heroImage": {
+    "src": "/images/sourced/region-ocean-coast-01.webp",
+    "alt": "Surf breaking on the ocean beach near Flinders, Mornington Peninsula",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["ocean-coast"],
+  "places": ["flinders", "cape-schanck", "rye", "fingal"],
+  "adjacentRegions": ["red-hill-wine-country", "peninsula-tip"],
+  "coordinates": { "lat": -38.49, "lng": 144.97 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}
+```
+
+---
+
+## 3 · Region Detail Template
+
+**File:** `next/src/components/RegionDetailTemplate.astro` (create new)
+
+### Component structure
+
+```
+RegionDetailTemplate
+│
+├── Hero
+│   └── Full-bleed heroImage · region name overlay · tagline
+│
+├── Breadcrumb
+│   └── Home → Explore → Regions → [Region Name]
+│
+├── Editorial Header
+│   └── name (h1) · intro paragraph
+│
+├── Places Strip
+│   └── Horizontal scroll rail of place cards (PlaceCard component)
+│       Filtered to places[] from region JSON
+│
+├── Category Tabs (client-side filter, no full-page reload)
+│   └── All · Eat & Drink · Stay · Wine · Experiences
+│       Tab click filters the venue grid below
+│
+├── Venue Grid
+│   └── VenueCard grid, filtered by region → places → venues
+│       Rendered server-side, tab state managed client-side via data attributes
+│
+├── Journal Picks
+│   └── 2–3 articles where relatedPlaces includes any place in this region
+│
+├── Adjacent Regions Strip
+│   └── Small cards: region name + tagline, link to /explore/regions/[slug]
+│
+└── Footer / Schema
+    └── TouristDestination JSON-LD (see section 4)
+```
+
+### Props interface
+
+```ts
+interface Props {
+  region: CollectionEntry<'regions'>;
+  places: CollectionEntry<'places'>[];
+  venues: CollectionEntry<'venues'>[];
+  articles: CollectionEntry<'articles'>[];
+  adjacentRegionData: CollectionEntry<'regions'>[];
+}
+```
+
+### Category tab implementation
+
+Use `data-venue-type` attributes on venue cards and a lightweight `<script>` for tab filtering:
+
+```html
+<!-- Tab buttons -->
+<button data-tab="all" class="tab active">All</button>
+<button data-tab="eat" class="tab">Eat & Drink</button>
+<button data-tab="stay" class="tab">Stay</button>
+<button data-tab="wine" class="tab">Wine</button>
+<button data-tab="experiences" class="tab">Experiences</button>
+
+<!-- Venue cards get data attribute from server-rendered pillar -->
+<div class="venue-card" data-pillar="eat">...</div>
+```
+
+```js
+// Inline <script> in the component
+document.querySelectorAll('[data-tab]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const tab = btn.dataset.tab;
+    document.querySelectorAll('[data-pillar]').forEach(card => {
+      card.hidden = tab !== 'all' && card.dataset.pillar !== tab;
+    });
+    document.querySelectorAll('[data-tab]').forEach(b => b.classList.toggle('active', b === btn));
+  });
+});
+```
+
+---
+
+## 4 · Route Page
+
+**File:** `next/src/pages/explore/regions/[slug].astro` (create new, ensure `explore/regions/` directory exists)
+
+```ts
+---
+import { getCollection, getEntry } from 'astro:content';
+import RegionDetailTemplate from '../../../components/RegionDetailTemplate.astro';
+import { eatTypes, stayTypes, wineTypes } from '../../../lib/editorial';
+
+export async function getStaticPaths() {
+  const regions = await getCollection('regions', r => !r.data.sitemapExclude);
+  return regions.map(region => ({ params: { slug: region.data.slug } }));
+}
+
+const { slug } = Astro.params;
+const region = await getEntry('regions', slug);
+if (!region) return Astro.redirect('/explore/regions/', 302);
+
+// Load all places in this region
+const allPlaces = await getCollection('places');
+const regionPlaces = allPlaces.filter(p => region.data.places.some(ref => ref.id === p.id));
+const placeSlugs = new Set(regionPlaces.map(p => p.data.slug));
+
+// Load all venues in region places
+const allVenues = await getCollection('venues', v => v.data.status !== 'permanently_closed');
+const regionVenues = allVenues.filter(v => placeSlugs.has(String(v.data.place?.id ?? '')));
+
+// Load adjacent regions
+const allRegions = await getCollection('regions');
+const adjacentRegionData = allRegions.filter(r =>
+  region.data.adjacentRegions.includes(r.data.slug)
+);
+
+// Load related articles
+const allArticles = await getCollection('articles', a => a.data.status === 'published');
+const regionArticles = allArticles.filter(a =>
+  a.data.relatedPlaces?.some(ref => placeSlugs.has(String(ref.id ?? '')))
+).slice(0, 3);
+---
+
+<RegionDetailTemplate
+  region={region}
+  places={regionPlaces}
+  venues={regionVenues}
+  articles={regionArticles}
+  adjacentRegionData={adjacentRegionData}
+/>
+```
+
+---
+
+## 5 · Regions Index Page
+
+**File:** `next/src/pages/explore/regions/index.astro` (create new)
+
+A simple grid of 5 region cards. Each card: hero image, region name, tagline, link to detail page.
+
+---
+
+## 6 · TouristDestination JSON-LD
+
+Add in `RegionDetailTemplate.astro` `<head>` or `<script type="application/ld+json">`:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "TouristDestination",
+  "name": "[region.name]",
+  "description": "[region.intro — first sentence or tagline]",
+  "url": "https://peninsulainsider.com.au/explore/regions/[region.slug]/",
+  "image": "[region.heroImage.src — full absolute URL]",
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "[region.coordinates.lat]",
+    "longitude": "[region.coordinates.lng]"
+  },
+  "containsPlace": [
+    // One entry per place in region.places
+    {
+      "@type": "Place",
+      "name": "[place.name]",
+      "url": "https://peninsulainsider.com.au/explore/places/[place.slug]/"
+    }
+  ],
+  "touristType": ["Couples", "Families", "Food and wine lovers", "Weekend travellers"],
+  "isLocatedIn": {
+    "@type": "AdministrativeArea",
+    "name": "Mornington Peninsula",
+    "addressRegion": "VIC",
+    "addressCountry": "AU"
+  }
+}
+```
+
+---
+
+## 7 · Supabase — Regions Table
+
+**Migration file:** `ops/migrations/2026-06-XX-pi-regions.sql`
+
+```sql
+-- PR-6: Regions table
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS pi.regions (
+  slug          TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  tagline       TEXT,
+  intro         TEXT,
+  hero_image    JSONB,
+  zones         TEXT[] NOT NULL DEFAULT '{}',
+  place_slugs   TEXT[] NOT NULL DEFAULT '{}',
+  coordinates   JSONB,
+  published_at  TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Content registry entries for regions
+INSERT INTO pi.content_registry (slug, entity_type, pillar, href, title, priority)
+  VALUES
+    ('red-hill-wine-country', 'region', 'explore', '/explore/regions/red-hill-wine-country/', 'Red Hill & Merricks', 90),
+    ('peninsula-tip',         'region', 'explore', '/explore/regions/peninsula-tip/',         'Sorrento & Portsea',  90),
+    ('mornington-bay-coast',  'region', 'explore', '/explore/regions/mornington-bay-coast/',  'Mornington & the Bay',90),
+    ('western-port',          'region', 'explore', '/explore/regions/western-port/',          'Western Port',        90),
+    ('ocean-coast',           'region', 'explore', '/explore/regions/ocean-coast/',           'Flinders & the Ocean Coast', 90)
+  ON CONFLICT (slug) DO UPDATE SET
+    href = EXCLUDED.href,
+    title = EXCLUDED.title,
+    priority = EXCLUDED.priority;
+
+-- Seed initial region data
+INSERT INTO pi.regions (slug, name, tagline, zones, place_slugs, published_at) VALUES
+  ('red-hill-wine-country', 'Red Hill & Merricks', 'The Peninsula''s wine heartland', ARRAY['red-hill','hinterland'], ARRAY['red-hill','main-ridge','merricks','merricks-beach','merricks-north','balnarring'], NOW()),
+  ('peninsula-tip', 'Sorrento & Portsea', 'Limestone cliffs, ocean baths, the Heads ferry', ARRAY['peninsula-tip'], ARRAY['sorrento','portsea','blairgowrie','rye','fingal'], NOW()),
+  ('mornington-bay-coast', 'Mornington & the Bay', 'The Peninsula''s urban edge', ARRAY['mornington','bay-coast'], ARRAY['mornington','mount-martha','safety-beach','mccrae','dromana','rosebud','capel-sound','mount-eliza'], NOW()),
+  ('western-port', 'Western Port', 'The quieter side', ARRAY['western-port'], ARRAY['hastings','bittern','crib-point','boneo'], NOW()),
+  ('ocean-coast', 'Flinders & the Ocean Coast', 'Wild surf beaches, the best pub on the Peninsula', ARRAY['ocean-coast'], ARRAY['flinders','cape-schanck','rye','fingal'], NOW())
+ON CONFLICT (slug) DO NOTHING;
+
+COMMIT;
+```
+
+---
+
+## 8 · v4-nav.ts Regions Link
+
+**File:** `next/src/lib/v4-nav.ts`
+
+Add Regions link to the Explore pillar mega panel:
+
+```ts
+{ key: 'regions', label: 'Regions', href: '/explore/regions/' },
+```
+
+---
+
+## 9 · Acceptance Criteria
+
+- [ ] `regions` collection defined in `content.config.ts`, `npx astro check` passes
+- [ ] 5 region JSON files exist and pass schema validation
+- [ ] All 5 region detail pages render at `/explore/regions/[slug]/`
+- [ ] Regions index renders at `/explore/regions/`
+- [ ] RegionDetailTemplate shows: hero, intro, places strip, category tabs, venue grid, journal picks, adjacent regions
+- [ ] Category tab filtering works client-side with no full-page reload
+- [ ] TouristDestination JSON-LD present in page source for all 5 region pages
+- [ ] Supabase `pi.regions` table created and seeded with 5 rows
+- [ ] Content registry contains 5 region entries with `entity_type = 'region'`
+- [ ] v4-nav.ts Explore pillar includes Regions link
+
+---
+
+## Dependencies
+
+- **Requires:** PR-5 merged (places at new `/explore/places/` URLs — region template links to them)
+- **Parallel with:** PR-7 (template extensions — no overlap)
+- **Blocks:** PR-8 (Plans Browse needs regions for area filter)
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-7-template-extensions.md
+++ b/docs/specs/pr-7-template-extensions.md
@@ -1,0 +1,331 @@
+# PR-7 · Template Extensions
+
+**Branch:** `feat/template-extensions`  
+**Depends on:** PR-2 merged (parallel with PR-6)  
+**Effort:** 3–4 days  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Extend four existing templates to reflect the new IA: add the EstateCluster block to VenueDetailTemplate, add the region kicker and category sub-nav tabs to PlaceDetailTemplate, add place/estate context to the event template sidebar, and add region-aware breadcrumbs to the article template. No layout redesign — these are targeted additions to existing, well-functioning templates.
+
+---
+
+## 1 · VenueDetailTemplate — EstateCluster Block
+
+**File:** `next/src/components/VenueDetailTemplate.astro`
+
+### 1a — EstateCluster component
+
+**File:** `next/src/components/EstateCluster.astro` (create new)
+
+The EstateCluster block surfaces sibling venues within the same multi-venue estate. It appears below the hero/intro block on venue pages where `estateSlug` is set.
+
+```ts
+---
+interface Props {
+  estateSlug: string;
+  estateLabel: string;
+  currentVenueSlug: string;
+  siblingVenues: CollectionEntry<'venues'>[];
+}
+
+const { estateSlug, estateLabel, currentVenueSlug, siblingVenues } = Astro.props;
+const siblings = siblingVenues.filter(v => v.data.slug !== currentVenueSlug);
+---
+```
+
+**Render structure:**
+
+```
+EstateCluster
+│
+├── Label: "Part of [estateLabel]" (small grey kicker)
+├── Horizontal card strip of sibling venues (2–4 cards)
+│   Each card: venue name · type chip · brief signature line · link
+└── [View all at estateLabel] link → /eat/[estate-hub]/ or /wine/[estate-hub]/
+```
+
+**Design notes:**
+- Use a contained, outlined card style — distinct from full venue cards
+- This is a contextual block, not a hub feature
+- Mobile: horizontal scroll
+- Max display: 4 sibling venues (show "and X more" if > 4)
+
+### 1b — Integration in VenueDetailTemplate
+
+```ts
+---
+// In VenueDetailTemplate.astro, add after the hero block data loading:
+import EstateCluster from './EstateCluster.astro';
+
+// Load sibling venues if estateSlug is present
+const estateSlug = venue.data.estateSlug;
+let estateVenues: CollectionEntry<'venues'>[] = [];
+
+if (estateSlug) {
+  const allVenues = await getCollection('venues');
+  estateVenues = allVenues.filter(v => v.data.estateSlug === estateSlug);
+}
+---
+```
+
+In template body, insert after the hero/intro section:
+
+```astro
+{estateSlug && (
+  <EstateCluster
+    estateSlug={estateSlug}
+    estateLabel={venue.data.estateLabel ?? estateSlug}
+    currentVenueSlug={venue.data.slug}
+    siblingVenues={estateVenues}
+  />
+)}
+```
+
+### 1c — Breadcrumb update
+
+Update breadcrumb in VenueDetailTemplate to reflect pillar routing:
+
+```
+Home → [Pillar] → [Place] → [Venue Name]
+
+Examples:
+Home → Eat & Drink → Sorrento → Laura
+Home → Wine → Red Hill → Ten Minutes by Tractor
+Home → Stay → Portsea → Portsea Hotel
+```
+
+Use `venueHrefPrefix(venue.data.type)` to derive the pillar link.
+
+### 1d — `venueTier` gate on verdict block
+
+The verdict/authority block should only render for venues with `venueTier === 'destination'`.
+
+```astro
+{venue.data.venueTier === 'destination' && venue.data.authority && (
+  <AuthorityBlock authority={venue.data.authority} />
+)}
+```
+
+For `recommended` and `directory` tier venues, the authority block is hidden. This is already handled by `authority` being optional — add the explicit tier gate so it's clear in code, and so future changes to tier don't inadvertently show verdict blocks.
+
+---
+
+## 2 · PlaceDetailTemplate — Region Kicker + Category Sub-Nav
+
+**File:** `next/src/components/PlaceDetailTemplate.astro`
+
+### 2a — Region kicker
+
+Above the place name (h1), add a small region kicker if `regionSlug` is set:
+
+```astro
+{place.data.regionSlug && (
+  <a href={`/explore/regions/${place.data.regionSlug}/`} class="region-kicker">
+    {place.data.regionLabel ?? place.data.regionSlug}
+  </a>
+)}
+<h1>{place.data.name}</h1>
+```
+
+**Style:** Small uppercase text, underline on hover, links to the region page. Establishes the geographic hierarchy visually.
+
+### 2b — Category sub-nav tabs
+
+After the intro paragraph, before the venue grid, add a client-side filter tab row:
+
+```
+[ All ]  [ Eat & Drink ]  [ Stay ]  [ Wine ]  [ Experiences ]
+```
+
+Implementation mirrors the approach in RegionDetailTemplate (PR-6). Use `data-pillar` attributes on venue/experience cards and an inline `<script>` for tab state:
+
+```astro
+<div class="category-tabs" role="tablist">
+  <button data-tab="all" class="tab-btn active" role="tab">All</button>
+  <button data-tab="eat" class="tab-btn" role="tab">Eat & Drink</button>
+  <button data-tab="stay" class="tab-btn" role="tab">Stay</button>
+  <button data-tab="wine" class="tab-btn" role="tab">Wine</button>
+  <button data-tab="experiences" class="tab-btn" role="tab">Experiences</button>
+</div>
+
+<!-- Venue cards rendered with data-pillar attribute -->
+<!-- Experience cards rendered with data-pillar="experiences" -->
+
+<script>
+  // Same pattern as RegionDetailTemplate — tab filter logic
+</script>
+```
+
+### 2c — Breadcrumb update
+
+```
+Home → Explore → Places → [Place Name]
+```
+
+Update the existing breadcrumb component call in PlaceDetailTemplate to use the new URL structure:
+
+```astro
+<Breadcrumb items={[
+  { label: 'Home', href: '/' },
+  { label: 'Explore', href: '/explore/' },
+  { label: 'Places', href: '/explore/places/' },
+  { label: place.data.name },
+]} />
+```
+
+---
+
+## 3 · Event Template — Place & Estate Context in Sidebar
+
+**File:** `next/src/pages/whats-on/[slug].astro`
+
+### 3a — Place link in sidebar
+
+The event template currently surfaces venue information. Add a place link when the event's venue has a `place` reference:
+
+```astro
+{eventVenue?.data.place && (
+  <div class="sidebar-item">
+    <span class="sidebar-label">Location</span>
+    <a href={`/explore/places/${eventVenue.data.place.id}/`}>
+      {placeLabel(eventVenue.data.place.id)}
+    </a>
+  </div>
+)}
+```
+
+### 3b — Estate context in "Hosted at"
+
+When the venue has an `estateSlug`, modify the "Hosted at" sidebar row to include the estate context:
+
+```astro
+<div class="sidebar-item">
+  <span class="sidebar-label">Hosted at</span>
+  <a href={venueHref}>{eventVenue.data.name}</a>
+  {eventVenue.data.estateLabel && (
+    <span class="sidebar-sub">Part of {eventVenue.data.estateLabel}</span>
+  )}
+</div>
+```
+
+---
+
+## 4 · Article Template — Region-Aware Breadcrumbs
+
+**File:** `next/src/pages/journal/[slug].astro`
+
+For articles with format `'hub-guide'` or `'service'` that have `relatedPlaces` set, add a region-aware breadcrumb.
+
+**Logic:**
+1. If `article.data.relatedPlaces` has exactly one place, and that place has a `regionSlug`, show:
+   `Home → [Region Name] → [Place Name] → [Article Title]`
+2. If multiple places from the same region, show:
+   `Home → [Region Name] → [Article Title]`
+3. Otherwise fall back to standard:
+   `Home → Journal → [Article Title]`
+
+```ts
+// In journal/[slug].astro frontmatter
+const breadcrumbItems = (() => {
+  const places = article.data.relatedPlaces ?? [];
+  const base = [{ label: 'Home', href: '/' }];
+  
+  if (places.length === 1) {
+    const place = resolvedPlaces[0]; // pre-fetched
+    if (place?.data.regionSlug) {
+      return [
+        ...base,
+        { label: place.data.regionLabel ?? place.data.regionSlug, href: `/explore/regions/${place.data.regionSlug}/` },
+        { label: place.data.name, href: `/explore/places/${place.data.slug}/` },
+        { label: article.data.title },
+      ];
+    }
+  }
+  // fallback
+  return [...base, { label: 'Journal', href: '/journal/' }, { label: article.data.title }];
+})();
+```
+
+Only apply to formats: `'hub-guide'`, `'service'`, `'venue-guide'`, `'trail-guide'`. Other formats (editors-letter, long-lunch-list etc.) keep their existing breadcrumb.
+
+---
+
+## 5 · Shared Breadcrumb Component
+
+If a `Breadcrumb.astro` component doesn't already exist, create one:
+
+**File:** `next/src/components/Breadcrumb.astro`
+
+```ts
+---
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+interface Props {
+  items: BreadcrumbItem[];
+}
+const { items } = Astro.props;
+---
+
+<nav aria-label="Breadcrumb" class="breadcrumb">
+  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+    {items.map((item, i) => (
+      <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+        {item.href
+          ? <a itemprop="item" href={item.href}><span itemprop="name">{item.label}</span></a>
+          : <span itemprop="name">{item.label}</span>
+        }
+        <meta itemprop="position" content={String(i + 1)} />
+      </li>
+    ))}
+  </ol>
+</nav>
+```
+
+This implements `BreadcrumbList` schema markup — useful for AI overviews and rich results.
+
+---
+
+## 6 · Acceptance Criteria
+
+### VenueDetailTemplate
+- [ ] `EstateCluster.astro` component created
+- [ ] EstateCluster renders on venue pages with `estateSlug` set (test with Point Leo Estate venues)
+- [ ] EstateCluster does **not** render on venues without `estateSlug`
+- [ ] Venue breadcrumb: `Home → [Pillar] → [Place] → [Venue]`
+- [ ] Authority/verdict block hidden for `venueTier === 'recommended'` and `'directory'` venues
+
+### PlaceDetailTemplate
+- [ ] Region kicker renders above h1 when `regionSlug` is set, links to correct region page
+- [ ] Category tabs filter venue grid client-side — no page reload
+- [ ] Tabs: All, Eat & Drink, Stay, Wine, Experiences
+- [ ] Place breadcrumb: `Home → Explore → Places → [Place]` (updated URLs)
+
+### Event Template
+- [ ] Place link present in sidebar when venue has place reference
+- [ ] Estate context line present when venue has `estateLabel`
+
+### Article Template
+- [ ] Region-aware breadcrumb renders for hub-guide, service, venue-guide, trail-guide formats with single-place relatedPlaces
+- [ ] Fallback breadcrumb for other formats unchanged
+
+### Shared
+- [ ] `Breadcrumb.astro` component created with `BreadcrumbList` JSON-LD markup
+- [ ] `npx astro check` passes across all modified templates
+
+---
+
+## Dependencies
+
+- **Requires:** PR-2 merged (`estateSlug`, `venueTier`, `regionSlug` fields in schema)
+- **Parallel with:** PR-6 (no file overlap)
+- **Blocks:** Nothing directly
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-8-plans-browse.md
+++ b/docs/specs/pr-8-plans-browse.md
@@ -1,0 +1,329 @@
+# PR-8 · Plans Browse Hub
+
+**Branch:** `feat/plans-browse`  
+**Depends on:** PR-5 + PR-6 merged  
+**Effort:** 3–4 days  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Build the `/explore/plans/` hub as a fully functional editorial browse experience with a four-axis filter UI. Plans are itinerary-style articles (`section: 'plans'` in the articles schema) surfaced as scannable cards. The four filter axes are: occasion, duration, season, and peninsula area (region). No back-end search required — all filtering is client-side over a pre-rendered dataset.
+
+---
+
+## 1 · URL & Route
+
+**Route:** `/explore/plans/` (created in PR-5 as a basic index — this PR builds the full hub)
+
+**File:** `next/src/pages/explore/plans/index.astro` — replace the stub from PR-5 with the full implementation.
+
+Individual plan articles continue to live at their existing journal slugs (`/journal/[slug]/`) — the plans hub is a filtered browse surface, not a separate URL for plan content.
+
+> **Note:** If PR-7 has introduced `section: 'plans'` routing to `/explore/plans/[slug]/`, coordinate to ensure no double routing. Confirm with lead developer before implementing individual plan URL routing.
+
+---
+
+## 2 · Content Source
+
+Plans are `articles` collection entries where `section === 'plans'`.
+
+```ts
+const plans = await getCollection('articles', a =>
+  a.data.section === 'plans' && a.data.status === 'published'
+);
+```
+
+Each plan card uses:
+- `title` — plan name
+- `dek` — subtitle/sell line
+- `heroImage` — card image
+- `planShape` — `'one-night' | 'two-night' | 'day-trip' | 'seasonal'` (maps to Duration axis)
+- `tags.mood` — maps to Occasion axis
+- `tags.season` — maps to Season axis
+- `relatedPlaces` — derive peninsula area (region) by looking up `regionSlug` on each place
+
+---
+
+## 3 · Four-Axis Filter System
+
+### Axis 1 — Occasion
+
+Source: article `tags.mood` values
+
+| Filter value | Label | Mood tags that match |
+|---|---|---|
+| `romantic` | Romantic | anniversary, romance, first-date, sunset |
+| `family` | Family | family |
+| `long-lunch` | Long Lunch | long-lunch, slow |
+| `wellness` | Wellness | wellness |
+| `adventure` | Adventure + Outdoors | walk, beach, outdoor, surf |
+| `weekend-escape` | Weekend Escape | weekend-escape, cellar-door |
+
+### Axis 2 — Duration
+
+Source: article `planShape` field
+
+| planShape value | Label |
+|---|---|
+| `day-trip` | Day trip |
+| `one-night` | One night |
+| `two-night` | Weekend |
+| `seasonal` | Seasonal |
+
+### Axis 3 — Season
+
+Source: article `tags.season` values (or `dispatch.weather` for weekend-picker formats)
+
+| Value | Label |
+|---|---|
+| `summer` | Summer |
+| `autumn` | Autumn |
+| `winter` | Winter |
+| `spring` | Spring |
+| `all-year` | Any time |
+
+### Axis 4 — Peninsula Area (Region)
+
+Source: derived from `relatedPlaces` → place `regionSlug`
+
+| regionSlug | Label |
+|---|---|
+| `red-hill-wine-country` | Red Hill & Merricks |
+| `peninsula-tip` | Sorrento & Portsea |
+| `mornington-bay-coast` | Mornington & the Bay |
+| `western-port` | Western Port |
+| `ocean-coast` | Flinders & the Ocean Coast |
+
+---
+
+## 4 · Filter UI Implementation
+
+### Architecture: server-side render + client-side filter
+
+Render all plan cards server-side. Attach `data-*` attributes to each card from the four axes. Filter state is managed entirely client-side — no API calls, no route changes.
+
+```astro
+<!-- Plan card markup (simplified) -->
+<article
+  class="plan-card"
+  data-occasion="romantic long-lunch"
+  data-duration="two-night"
+  data-season="autumn winter"
+  data-region="red-hill-wine-country"
+>
+  <!-- card content -->
+</article>
+```
+
+### Filter bar markup
+
+```astro
+<div class="plans-filter" role="search" aria-label="Filter plans">
+  
+  <!-- Occasion -->
+  <fieldset>
+    <legend>Occasion</legend>
+    <label><input type="checkbox" name="occasion" value="romantic"> Romantic</label>
+    <label><input type="checkbox" name="occasion" value="family"> Family</label>
+    <label><input type="checkbox" name="occasion" value="long-lunch"> Long Lunch</label>
+    <label><input type="checkbox" name="occasion" value="wellness"> Wellness</label>
+    <label><input type="checkbox" name="occasion" value="adventure"> Adventure</label>
+    <label><input type="checkbox" name="occasion" value="weekend-escape"> Weekend Escape</label>
+  </fieldset>
+
+  <!-- Duration -->
+  <fieldset>
+    <legend>Duration</legend>
+    <label><input type="checkbox" name="duration" value="day-trip"> Day trip</label>
+    <label><input type="checkbox" name="duration" value="one-night"> One night</label>
+    <label><input type="checkbox" name="duration" value="two-night"> Weekend</label>
+    <label><input type="checkbox" name="duration" value="seasonal"> Seasonal</label>
+  </fieldset>
+
+  <!-- Season -->
+  <fieldset>
+    <legend>Season</legend>
+    <label><input type="checkbox" name="season" value="summer"> Summer</label>
+    <label><input type="checkbox" name="season" value="autumn"> Autumn</label>
+    <label><input type="checkbox" name="season" value="winter"> Winter</label>
+    <label><input type="checkbox" name="season" value="spring"> Spring</label>
+    <label><input type="checkbox" name="season" value="all-year"> Any time</label>
+  </fieldset>
+
+  <!-- Area -->
+  <fieldset>
+    <legend>Peninsula Area</legend>
+    <label><input type="checkbox" name="region" value="red-hill-wine-country"> Red Hill & Merricks</label>
+    <label><input type="checkbox" name="region" value="peninsula-tip"> Sorrento & Portsea</label>
+    <label><input type="checkbox" name="region" value="mornington-bay-coast"> Mornington & the Bay</label>
+    <label><input type="checkbox" name="region" value="western-port"> Western Port</label>
+    <label><input type="checkbox" name="region" value="ocean-coast"> Flinders & the Ocean Coast</label>
+  </fieldset>
+
+  <button type="button" id="clear-filters">Clear all</button>
+</div>
+```
+
+### Filter script
+
+```js
+// Inline <script> in explore/plans/index.astro
+(function () {
+  const cards = Array.from(document.querySelectorAll('.plan-card'));
+  const filterBar = document.querySelector('.plans-filter');
+  const countEl = document.getElementById('plans-count');
+
+  function getActiveFilters() {
+    const checked = Array.from(filterBar.querySelectorAll('input[type=checkbox]:checked'));
+    const filters = { occasion: [], duration: [], season: [], region: [] };
+    checked.forEach(input => {
+      filters[input.name]?.push(input.value);
+    });
+    return filters;
+  }
+
+  function matches(card, filters) {
+    return ['occasion', 'duration', 'season', 'region'].every(axis => {
+      if (!filters[axis].length) return true; // no filter on this axis
+      const cardValues = (card.dataset[axis] ?? '').split(' ');
+      return filters[axis].some(v => cardValues.includes(v));
+    });
+  }
+
+  function applyFilters() {
+    const filters = getActiveFilters();
+    let visible = 0;
+    cards.forEach(card => {
+      const show = matches(card, filters);
+      card.hidden = !show;
+      if (show) visible++;
+    });
+    if (countEl) countEl.textContent = `${visible} plan${visible !== 1 ? 's' : ''}`;
+  }
+
+  filterBar.addEventListener('change', applyFilters);
+  document.getElementById('clear-filters')?.addEventListener('click', () => {
+    filterBar.querySelectorAll('input[type=checkbox]').forEach(i => (i.checked = false));
+    applyFilters();
+  });
+
+  applyFilters(); // initial state
+})();
+```
+
+---
+
+## 5 · Plan Card Component
+
+**File:** `next/src/components/PlanCard.astro` (create new, or extend existing ArticleCard if one exists)
+
+```ts
+---
+interface Props {
+  plan: CollectionEntry<'articles'>;
+  regionLabel?: string;
+}
+---
+```
+
+**Card structure:**
+```
+PlanCard
+├── Hero image (16:9, lazy loaded)
+├── Occasion chip (from tags.mood[0])
+├── Duration chip (from planShape)
+├── Title (h2 or h3)
+├── Dek
+├── Region label (small grey)
+└── "Read the plan →" link
+```
+
+---
+
+## 6 · Itinerary `baseTowns` Enrichment
+
+**File:** `next/src/content.config.ts` — itineraries collection
+
+The existing `itineraries` collection may have a `baseTowns` field. If not, add:
+
+```ts
+// In itineraries schema
+baseTowns: z.array(z.string()).optional(),
+```
+
+For any itinerary JSON files (if they exist), populate `baseTowns` with place slugs that the itinerary covers. This data feeds the region-area filter on the plans hub — itinerary-format plans use `baseTowns` rather than `relatedPlaces` to derive their region.
+
+**Audit:**
+```bash
+ls next/src/content/itineraries/ 2>/dev/null || echo "No itineraries directory"
+```
+
+If the itineraries collection exists and has files, enrich `baseTowns` for each file and update the filter derivation logic accordingly.
+
+---
+
+## 7 · Hub Page Structure
+
+```
+/explore/plans/ — full page layout
+
+├── Masthead (existing, section="explore")
+│
+├── Hub header
+│   ├── Title: "Peninsula Plans"
+│   └── Subtitle: "Every weekend sorted. Browse by occasion, duration, or where you want to be."
+│
+├── Results count: "24 plans" (updates live via JS)
+│
+├── Filter bar (left sidebar on desktop, drawer on mobile)
+│   └── Four-axis filters (see section 4)
+│
+├── Plan card grid (right, main)
+│   └── Responsive 2–3 column grid of PlanCard components
+│
+└── Footer (existing)
+```
+
+**Mobile layout:** Filter bar collapses into a "Filter plans" button that opens a bottom drawer. Filter state persists across open/close. Badge count on button shows number of active filters.
+
+---
+
+## 8 · URL State (Optional Enhancement)
+
+If time allows, persist filter state to URL query params so filtered views are shareable:
+
+```
+/explore/plans/?occasion=romantic&duration=two-night&region=peninsula-tip
+```
+
+On page load, read query params and pre-check corresponding checkboxes before running `applyFilters()`. This is a nice-to-have, not a blocker.
+
+---
+
+## 9 · Acceptance Criteria
+
+- [ ] `/explore/plans/` renders with all published `section: 'plans'` articles as cards
+- [ ] Four filter axes present: Occasion, Duration, Season, Peninsula Area
+- [ ] Selecting a filter hides non-matching cards instantly (no page reload)
+- [ ] Multiple filters on same axis: OR logic (show if matches any)
+- [ ] Filters across different axes: AND logic (must match all active axes)
+- [ ] "Clear all" resets all filters and shows all cards
+- [ ] Results count updates live as filters change
+- [ ] Plan cards show: hero image, occasion chip, duration chip, title, dek, region label
+- [ ] Mobile filter: collapsed behind button, opens as drawer
+- [ ] `npx astro build` completes with no errors
+- [ ] 301 redirect from `/plans/` → `/explore/plans/` confirmed working (PR-5)
+- [ ] Itineraries `baseTowns` field added and populated if itineraries collection exists
+
+---
+
+## Dependencies
+
+- **Requires:** PR-5 merged (`/explore/plans/` route exists), PR-6 merged (regions available for area filter)
+- **Blocks:** Nothing directly (PR-9 search sync is parallel-capable)
+
+---
+
+*Spec version: 1.0 · 31 May 2026*

--- a/docs/specs/pr-9-search-sync.md
+++ b/docs/specs/pr-9-search-sync.md
@@ -1,0 +1,284 @@
+# PR-9 · Search Sync
+
+**Branch:** `feat/search-sync`  
+**Depends on:** All data PRs merged (PR-2 through PR-7)  
+**Effort:** 2–3 days  
+**Owner:** Developer
+
+---
+
+## Objective
+
+Synchronise the search layer with the completed IA refactor. This PR updates the search client to surface `region_slug` as a new facet, extends the `pi.search()` RPC to return region and estate data, creates a `pi.venues_search` view that joins place region data, registers the `region` entity type in the content registry, cleans up `producer` → `providore` in search data, and triggers a full Pagefind index rebuild after all URL changes from PR-5.
+
+---
+
+## 1 · SearchHit Type Extension
+
+**File:** `next/src/lib/search.ts` (or wherever the SearchHit interface is defined — locate with `grep -rn "SearchHit\|searchHit" next/src/`)
+
+Add `region_slug` and `estate_slug` to the SearchHit type:
+
+```ts
+export interface SearchHit {
+  slug: string;
+  entity_type: string;
+  pillar: string;
+  href: string;
+  title: string;
+  // ... existing fields ...
+  
+  // New in PR-9
+  region_slug?: string;    // populated for venues, places, regions
+  estate_slug?: string;    // populated for venues within a multi-venue estate
+  venue_tier?: string;     // 'destination' | 'recommended' | 'directory'
+  zone?: string;           // zone enum value (corrected names from PR-2)
+}
+```
+
+---
+
+## 2 · `pi.search()` RPC Extension
+
+**File:** `ops/migrations/2026-06-XX-pi-search-sync.sql`
+
+The existing `pi.search()` RPC (defined in `2026-05-17-pi-search-rpc.sql`) needs to return `region_slug` and `estate_slug` as additional facet columns.
+
+```sql
+-- First: create the venues_search view (used by updated RPC)
+CREATE OR REPLACE VIEW pi.venues_search AS
+SELECT
+  v.slug,
+  v.name,
+  v.type           AS entity_type,
+  v.zone,
+  v.estate_slug,
+  v.venue_tier,
+  p.slug           AS place_slug,
+  p.name           AS place_name,
+  p.region_slug,
+  p.region_label
+FROM pi.venues v
+LEFT JOIN pi.places p ON p.slug = v.place_slug  -- adjust column name to match actual FK
+WHERE v.status IS NULL OR v.status = 'active';
+
+-- Grant read access
+GRANT SELECT ON pi.venues_search TO anon, authenticated;
+```
+
+Update the `pi.search()` function to include the new fields in its return set. The exact SQL depends on the current RPC definition — read `2026-05-17-pi-search-rpc.sql` before writing the update:
+
+```bash
+cat ops/migrations/2026-05-17-pi-search-rpc.sql
+```
+
+At minimum, add `region_slug`, `estate_slug`, and `venue_tier` to:
+1. The function return type declaration (`RETURNS TABLE(...)`)
+2. The SELECT clause of the function body
+3. The client TypeScript type if auto-generated from Supabase schema
+
+---
+
+## 3 · Content Registry Updates
+
+### 3a — Register `region` entity type
+
+Regions were added to the content registry in PR-6. This PR ensures the search client handles `entity_type = 'region'` correctly:
+
+```ts
+// In search client, entity_type routing for display
+case 'region':
+  return {
+    icon: 'map',
+    label: 'Region',
+    href: `/explore/regions/${hit.slug}/`,
+    pillar: 'explore',
+  };
+```
+
+Verify the content_registry priority for regions is 90 (set in PR-6 migration).
+
+### 3b — `producer` → `providore` cleanup
+
+After PR-3 has reclassified all producer venues, ensure no `entity_type = 'producer'` rows remain in `pi.content_registry`:
+
+```sql
+-- Verify
+SELECT COUNT(*) FROM pi.content_registry WHERE entity_type = 'producer';
+
+-- If any remain (shouldn't after PR-3, but belt-and-braces):
+UPDATE pi.content_registry
+  SET entity_type = 'providore'
+  WHERE entity_type = 'producer';
+```
+
+### 3c — Update `typeLabel` in search results display
+
+The search results UI may have a display label for `producer`. Update to `providore`:
+
+```ts
+// In search display utility
+const entityTypeLabel: Record<string, string> = {
+  // ... existing ...
+  providore: 'Providore',
+  region: 'Region',
+  // Remove or leave as fallback:
+  // producer: 'Producer',
+};
+```
+
+---
+
+## 4 · Zone Filter Update
+
+The search client may expose a zone filter. Update zone values to match the corrected enum from PR-2:
+
+```ts
+// Corrected zone filter options
+const zoneFilterOptions = [
+  { value: 'mornington',    label: 'Mornington' },
+  { value: 'bay-coast',     label: 'Bay Coast' },
+  { value: 'red-hill',      label: 'Red Hill' },
+  { value: 'hinterland',    label: 'Hinterland' },
+  { value: 'peninsula-tip', label: 'Peninsula Tip' },
+  { value: 'ocean-coast',   label: 'Ocean Coast' },
+  { value: 'western-port',  label: 'Western Port' },
+];
+```
+
+Remove legacy zone values: `bayside`, `red-hill-plateau`, `back-beaches`, `tip`.
+
+**Audit:**
+```bash
+grep -rn "bayside\|red-hill-plateau\|back-beaches\|\"tip\"" next/src/ --include="*.ts" --include="*.astro" --include="*.tsx"
+```
+
+---
+
+## 5 · Region Facet in Search UI
+
+Add `region_slug` as a filterable facet in the search interface. This allows users to filter search results by region.
+
+**Implementation approach:**
+
+If the search UI has an existing facet sidebar or filter panel:
+
+```ts
+// Add region filter group
+{
+  key: 'region_slug',
+  label: 'Region',
+  options: [
+    { value: 'red-hill-wine-country', label: 'Red Hill & Merricks' },
+    { value: 'peninsula-tip',         label: 'Sorrento & Portsea' },
+    { value: 'mornington-bay-coast',  label: 'Mornington & the Bay' },
+    { value: 'western-port',          label: 'Western Port' },
+    { value: 'ocean-coast',           label: 'Flinders & the Ocean Coast' },
+  ],
+}
+```
+
+If the search is powered by Pagefind, add `data-pagefind-filter="region_slug"` to venue and place page elements that carry region data:
+
+```astro
+<!-- In VenueDetailTemplate, somewhere in the body -->
+{venue.data.place?.data?.regionSlug && (
+  <meta data-pagefind-filter="region_slug" content={venue.data.place.data.regionSlug} />
+)}
+```
+
+---
+
+## 6 · `pi.search()` RPC — `pi.venues_search` View
+
+**File:** `ops/migrations/2026-06-XX-pi-search-sync.sql` (continued from section 2)
+
+The `pi.venues_search` view should also be surfaced through the search RPC for venue queries that need region context. Specifically, when a search returns venue hits, the client should be able to display the region name as a secondary label.
+
+```sql
+-- Example extension to search RPC return type
+-- (depends on existing RPC structure — read the existing RPC first)
+-- Add to RETURNS TABLE(...):
+  region_slug  TEXT,
+  estate_slug  TEXT,
+  venue_tier   TEXT
+```
+
+---
+
+## 7 · Pagefind Index Rebuild
+
+Pagefind is a static search index that needs to be rebuilt after:
+- All URL changes from PR-5 (places at new `/explore/places/` paths)
+- New region pages from PR-6
+- Any venue pages with updated types/routes
+
+**Rebuild command** (run after final production build):
+
+```bash
+cd next && npx astro build && npx pagefind --site dist
+```
+
+**Important:** Do not run the Pagefind rebuild mid-PR sequence. Run once after PR-5 through PR-9 are all merged and a clean build is done.
+
+**CI/Build note:** Add a comment to the CI config noting that a Pagefind rebuild is required after any URL-structure PR merge:
+
+```yaml
+# .github/workflows/deploy.yml or similar
+# After PR-5 through PR-9: run full Pagefind rebuild
+# npx pagefind --site dist
+```
+
+---
+
+## 8 · Search Client Integration Test
+
+After all changes, run manual search tests to verify:
+
+| Query | Expected top result type | Notes |
+|---|---|---|
+| "red hill wine" | venue (winery) or region | Should surface Red Hill & Merricks region |
+| "sorrento restaurant" | venue (restaurant) | Should be in peninsula-tip region |
+| "providore" | venue (providore) | No producer-type results |
+| "weekend plan" | article (plans section) | Plans section articles surface |
+| "flinders" | place or region | ocean-coast region present |
+| "brewery" | venue (brewery in eat pillar) | NOT wine pillar |
+
+---
+
+## 9 · Acceptance Criteria
+
+- [ ] `SearchHit` interface includes `region_slug`, `estate_slug`, `venue_tier`
+- [ ] `pi.venues_search` view exists and returns region_slug correctly
+- [ ] `pi.search()` RPC returns `region_slug` and `estate_slug` for venue hits
+- [ ] Content registry: zero rows with `entity_type = 'producer'`
+- [ ] Content registry: 5 rows with `entity_type = 'region'`
+- [ ] Search UI zone filter uses corrected zone values (no legacy values)
+- [ ] Search results display shows `Providore` label, not `Producer`
+- [ ] Region facet available in search filter UI
+- [ ] Pagefind rebuild completed — all `/explore/places/` and `/explore/regions/` URLs indexed
+- [ ] Legacy `/places/` URLs return 0 results in Pagefind (they 301 away)
+- [ ] Manual search tests pass (see section 8)
+
+---
+
+## Dependencies
+
+- **Requires:** PR-2 (schema/zones), PR-3 (type routing), PR-4 (market cleanup), PR-5 (URL migration), PR-6 (regions in content registry), PR-7 (template data attributes for Pagefind)
+- **Blocks:** Nothing — this is the final PR
+
+---
+
+## Post-Deploy Checklist
+
+After PR-9 is merged and deployed:
+
+1. Run Pagefind rebuild on production build
+2. Verify Google Search Console has no 404 spikes (301s should be transparent)
+3. Submit updated sitemap to Google Search Console
+4. Check AI Overview presence for key region queries ("what to do in Red Hill", "Sorrento weekend")
+5. Verify `pi.search()` RPC latency is acceptable with new view join
+
+---
+
+*Spec version: 1.0 · 31 May 2026*


### PR DESCRIPTION
## PR-1 · Mega Menu V5 Typographic Refactor

**Branch:** `feat/mega-menu-v5-typographic`  
**Depends on:** Nothing (standalone)  
**Effort:** 2–3 days

---

### What this PR does

Removes the image rail from the mega menu and implements a Tate Modern typographic direction — dense, architectural, no decorative imagery. Restructures the navigation from 8 pillars to 6: **Eat & Drink · Stay · Wine · Explore · What's On · Journal**.

Full spec: [`docs/specs/mega-menu-refactor-v5.md`](docs/specs/mega-menu-refactor-v5.md)

---

### Also included: Full IA implementation specs (PR-2 through PR-9)

This branch also carries developer-ready specs for all remaining IA pull requests. These specs are documentation only — no code changes beyond the mega menu refactor:

| Spec | Branch (to be created) | Summary |
|---|---|---|
| [PR-2](docs/specs/pr-2-schema-foundations.md) | `feat/schema-foundations` | Zone enum correction, providore type, estate/tier/region fields, Supabase migration |
| [PR-3](docs/specs/pr-3-type-routing.md) | `feat/type-routing` | Producer reclassification, brewery/distillery → eat pillar |
| [PR-4](docs/specs/pr-4-market-consolidation.md) | `feat/market-consolidation` | Delete experience-markets, enrich venue-markets, 5× 301 redirects |
| [PR-5](docs/specs/pr-5-explore-url-migration.md) | `feat/explore-url-migration` | /places/ → /explore/places/, /plans/ → /explore/plans/, ~50 redirects |
| [PR-6](docs/specs/pr-6-regions.md) | `feat/regions` | 5 region JSONs, RegionDetailTemplate, /explore/regions/[slug], TouristDestination JSON-LD |
| [PR-7](docs/specs/pr-7-template-extensions.md) | `feat/template-extensions` | EstateCluster, place region kicker + category tabs, event place/estate sidebar, article breadcrumbs |
| [PR-8](docs/specs/pr-8-plans-browse.md) | `feat/plans-browse` | Plans browse hub /explore/plans/ with 4-axis filter UI |
| [PR-9](docs/specs/pr-9-search-sync.md) | `feat/search-sync` | region_slug facet, pi.search() RPC extension, pi.venues_search view, Pagefind rebuild |

---

### Dependency sequence

```
PR-1 (standalone)
PR-2 (parallel with PR-1)
  └── PR-3
       ├── PR-4
       └── PR-5
            └── PR-6
                 └── PR-8
PR-2 also unblocks:
  └── PR-7 (parallel with PR-6)

PR-9 (after all data PRs)
```

---

### Acceptance criteria (PR-1 mega menu)

See [full spec](docs/specs/mega-menu-refactor-v5.md) for complete criteria. Key items:

- [ ] Image rail removed from all 6 pillar mega panels
- [ ] Navigation reduced from 8 pillars to 6: Eat & Drink · Stay · Wine · Explore · What's On · Journal
- [ ] V4MegaRail component deleted or made conditional
- [ ] Typographic panel layout matches Tate Modern direction (dense columns, no imagery)
- [ ] Mobile drawer updated to match new pillar structure
- [ ] `npx astro build` passes with no type errors
- [ ] No visual regression on existing pillar pages