### PR TITLE
PR-6: Regions Collection & Template (/explore/regions)

### DIFF
--- a/next/src/components/RegionDetailTemplate.astro
+++ b/next/src/components/RegionDetailTemplate.astro
@@ -1,0 +1,195 @@
+---
+/**
+ * RegionDetailTemplate: the /explore/regions/[slug] page body.
+ *
+ * Regions are the second tier of the geographic hierarchy (above places,
+ * below the Peninsula). Surfaces editorial intro, the region's places, a
+ * tab-filtered venue + experience grid, journal picks, adjacent regions,
+ * and TouristDestination JSON-LD.
+ */
+import type { CollectionEntry } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from './Breadcrumbs.astro';
+import PlaceCard from './PlaceCard.astro';
+import VenueCard from './VenueCard.astro';
+import ExperienceCard from './ExperienceCard.astro';
+import ArticleCard from './ArticleCard.astro';
+import NewsletterBlock from './NewsletterBlock.astro';
+import { venueHrefPrefix, routeSlug } from '../lib/editorial';
+
+interface Props {
+  region: CollectionEntry<'regions'>;
+  places: any[];
+  venues: any[];
+  experiences: any[];
+  articles: any[];
+  adjacentRegionData: any[];
+}
+const { region, places, venues, experiences, articles, adjacentRegionData } = Astro.props;
+const d = region.data;
+const SITE = 'https://peninsulainsider.com.au';
+const url = `${SITE}/explore/regions/${d.slug}/`;
+const heroAbs = d.heroImage.src.startsWith('http') ? d.heroImage.src : `${SITE}${d.heroImage.src}`;
+
+const pillarOf = (type: string) => venueHrefPrefix(type).replace(/\//g, '');
+
+const touristDestination = {
+  '@context': 'https://schema.org',
+  '@type': 'TouristDestination',
+  name: d.name,
+  description: d.tagline ?? (d.intro.split('. ')[0] + '.'),
+  url,
+  image: heroAbs,
+  ...(d.coordinates
+    ? { geo: { '@type': 'GeoCoordinates', latitude: String(d.coordinates.lat), longitude: String(d.coordinates.lng) } }
+    : {}),
+  containsPlace: places.map((p) => ({
+    '@type': 'Place',
+    name: p.data.name,
+    url: `${SITE}/explore/places/${routeSlug(p)}/`,
+  })),
+  touristType: ['Couples', 'Families', 'Food and wine lovers', 'Weekend travellers'],
+  isLocatedIn: {
+    '@type': 'AdministrativeArea',
+    name: 'Mornington Peninsula',
+    addressRegion: 'VIC',
+    addressCountry: 'AU',
+  },
+};
+---
+
+<BaseLayout
+  title={`${d.name} · Peninsula Insider`}
+  description={d.tagline ?? d.intro.slice(0, 155)}
+  section="explore"
+  canonical={url}
+  ogImage={d.heroImage.src}
+>
+  <script type="application/ld+json" set:html={JSON.stringify(touristDestination)} />
+
+  <section class="region-hero" style={`background-image:linear-gradient(rgba(20,18,16,0.25),rgba(20,18,16,0.6)),url('${d.heroImage.src}')`}>
+    <div class="container">
+      <p class="region-hero__eyebrow">Explore · Regions</p>
+      <h1 class="region-hero__title">{d.name}</h1>
+      {d.tagline && <p class="region-hero__tagline">{d.tagline}</p>}
+    </div>
+  </section>
+
+  <div class="container">
+    <Breadcrumbs
+      items={[
+        { label: 'Home', href: '/' },
+        { label: 'Explore', href: '/explore/' },
+        { label: 'Regions', href: '/explore/regions/' },
+        { label: d.name },
+      ]}
+    />
+
+    <section class="region-intro prose">
+      <p>{d.intro}</p>
+    </section>
+
+    {places.length > 0 && (
+      <section class="region-places">
+        <h2 class="region-section__title">Places in {d.name}</h2>
+        <div class="region-places__rail">
+          {places.map((p) => <PlaceCard place={p} />)}
+        </div>
+      </section>
+    )}
+
+    {(venues.length > 0 || experiences.length > 0) && (
+      <section class="region-venues">
+        <h2 class="region-section__title">Where to eat, drink, stay and explore</h2>
+        <div class="region-tabs" role="tablist">
+          <button data-tab="all" class="region-tab is-active" type="button">All</button>
+          <button data-tab="eat" class="region-tab" type="button">Eat &amp; Drink</button>
+          <button data-tab="stay" class="region-tab" type="button">Stay</button>
+          <button data-tab="wine" class="region-tab" type="button">Wine</button>
+          {experiences.length > 0 && <button data-tab="experiences" class="region-tab" type="button">Experiences</button>}
+        </div>
+        <div class="venues__grid" id="regionGrid">
+          {venues.map((v) => (
+            <div class="region-grid__item" data-pillar={pillarOf(v.data.type)}>
+              <VenueCard venue={v} hrefPrefix={venueHrefPrefix(v.data.type)} />
+            </div>
+          ))}
+          {experiences.map((e) => (
+            <div class="region-grid__item" data-pillar="experiences">
+              <ExperienceCard experience={e} />
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {articles.length > 0 && (
+      <section class="region-journal">
+        <h2 class="region-section__title">From the Journal</h2>
+        <div class="venues__grid">
+          {articles.map((a) => <ArticleCard article={a} />)}
+        </div>
+      </section>
+    )}
+
+    {adjacentRegionData.length > 0 && (
+      <section class="region-adjacent">
+        <h2 class="region-section__title">Nearby regions</h2>
+        <div class="region-adjacent__grid">
+          {adjacentRegionData.map((r) => (
+            <a class="region-adjacent__card" href={`/explore/regions/${r.data.slug}/`}>
+              <span class="region-adjacent__name">{r.data.name}</span>
+              {r.data.tagline && <span class="region-adjacent__tagline">{r.data.tagline}</span>}
+            </a>
+          ))}
+        </div>
+      </section>
+    )}
+  </div>
+
+  <NewsletterBlock />
+
+  <script is:inline>
+    (function () {
+      function initRegionTabs() {
+        var tabs = document.querySelectorAll('.region-tab');
+        var items = document.querySelectorAll('#regionGrid .region-grid__item');
+        if (!tabs.length) return;
+        tabs.forEach(function (btn) {
+          if (btn._bound) return;
+          btn._bound = true;
+          btn.addEventListener('click', function () {
+            var tab = btn.getAttribute('data-tab');
+            items.forEach(function (card) {
+              card.hidden = tab !== 'all' && card.getAttribute('data-pillar') !== tab;
+            });
+            tabs.forEach(function (b) { b.classList.toggle('is-active', b === btn); });
+          });
+        });
+      }
+      if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initRegionTabs, { once: true });
+      else initRegionTabs();
+      document.addEventListener('astro:page-load', initRegionTabs);
+    })();
+  </script>
+
+  <style>
+    .region-hero { background-size: cover; background-position: center; color: #fff; padding: clamp(64px, 12vw, 160px) 0 clamp(40px, 7vw, 90px); }
+    .region-hero__eyebrow { font-family: 'Outfit', sans-serif; text-transform: uppercase; letter-spacing: 0.16em; font-size: 11px; opacity: 0.92; margin: 0 0 12px; }
+    .region-hero__title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: clamp(36px, 6vw, 72px); line-height: 1.02; margin: 0; }
+    .region-hero__tagline { font-family: 'Cormorant Garamond', Georgia, serif; font-style: italic; font-size: clamp(17px, 2.4vw, 24px); max-width: 60ch; margin: 14px 0 0; }
+    .region-intro { margin: 36px 0; max-width: 70ch; font-size: 1.05rem; line-height: 1.6; }
+    .region-section__title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: clamp(24px, 3.5vw, 34px); margin: 40px 0 18px; }
+    .region-places__rail { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(260px, 1fr); gap: 20px; overflow-x: auto; padding-bottom: 8px; }
+    @media (max-width: 760px) { .region-places__rail { grid-auto-columns: minmax(220px, 80%); } }
+    .region-tabs { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 22px; }
+    .region-tab { font-family: 'Outfit', sans-serif; font-size: 13px; padding: 7px 16px; border: 1px solid var(--border); border-radius: 999px; background: transparent; color: var(--text); cursor: pointer; transition: background 0.15s, border-color 0.15s, color 0.15s; }
+    .region-tab.is-active, .region-tab:hover { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .region-grid__item[hidden] { display: none; }
+    .region-adjacent__grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-bottom: 44px; }
+    .region-adjacent__card { display: flex; flex-direction: column; gap: 6px; padding: 18px 20px; border: 1px solid var(--border); border-radius: 6px; text-decoration: none; color: var(--text); transition: border-color 0.15s; }
+    .region-adjacent__card:hover { border-color: var(--accent); }
+    .region-adjacent__name { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.3rem; }
+    .region-adjacent__tagline { font-size: 0.85rem; color: var(--soft); }
+  </style>
+</BaseLayout>

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -376,6 +376,29 @@ const places = defineCollection({
   }),
 });
 
+const regions = defineCollection({
+  loader: glob({ pattern: '**/*.json', base: './src/content/regions' }),
+  schema: z.object({
+    slug: z.string(),
+    name: z.string(),
+    /** One-line editorial tagline. Used as SEO meta description. */
+    tagline: z.string().optional(),
+    /** Editorial introduction paragraph. 80 to 120 words. */
+    intro: z.string(),
+    heroImage: imageRef,
+    /** The zone enum values that fall within this region. */
+    zones: z.array(zone),
+    /** Place slugs within this region. */
+    places: z.array(reference('places')),
+    /** Slugs of adjacent regions for cross-linking in the template footer. */
+    adjacentRegions: z.array(z.string()).default([]),
+    /** Geographic centroid for map rendering and JSON-LD. */
+    coordinates: coordinates.optional(),
+    publishedAt: z.coerce.date(),
+    sitemapExclude: z.boolean().default(false),
+  }),
+});
+
 const articles = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/articles' }),
   schema: z.object({
@@ -1387,6 +1410,7 @@ export const collections = {
   venues,
   experiences,
   places,
+  regions,
   articles,
   itineraries,
   events,

--- a/next/src/content/regions/mornington-bay-coast.json
+++ b/next/src/content/regions/mornington-bay-coast.json
@@ -1,0 +1,18 @@
+{
+  "slug": "mornington-bay-coast",
+  "name": "Mornington & the Bay",
+  "tagline": "The Peninsula's urban edge: the main street dining strip, the bay beaches, and the easy weekend gateway.",
+  "intro": "Mornington is the Peninsula's largest town and its most accessible gateway. The main street dining strip punches above its weight, the bay beaches stretch from Mount Eliza to Dromana, and the Saturday morning market is a Peninsula institution. This is where the Peninsula starts, the transition from Melbourne's suburbs to something genuinely different. Mount Martha's elevated bay views and the Dromana hillside are the scenic punctuation marks. For first-timers, this is the entry point. For regulars, it is often overlooked in favour of the tip or the ridge, which is a mistake.",
+  "heroImage": {
+    "src": "/images/sourced/region-mornington-01.webp",
+    "alt": "Mornington main street on a clear autumn morning",
+    "credit": "Peninsula Insider",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["mornington", "bay-coast"],
+  "places": ["mornington", "mount-martha", "safety-beach", "mccrae", "dromana", "rosebud", "capel-sound", "mount-eliza"],
+  "adjacentRegions": ["red-hill-wine-country", "western-port"],
+  "coordinates": { "lat": -38.22, "lng": 145.04 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}

--- a/next/src/content/regions/ocean-coast.json
+++ b/next/src/content/regions/ocean-coast.json
@@ -1,0 +1,18 @@
+{
+  "slug": "ocean-coast",
+  "name": "Flinders & the Ocean Coast",
+  "tagline": "Wild surf beaches, the best pub on the Peninsula, and a rural quiet that feels hard-won.",
+  "intro": "The ocean coast runs along the Peninsula's south-facing edge, where Bass Strait swells arrive unimpeded and the light has a particular quality in the afternoon. Flinders is the anchor, an extraordinary village that manages to be a serious food-and-wine destination while remaining genuinely unspoiled. Cape Schanck marks the south-west corner with its lighthouse and coastal boardwalk. The ocean beach walking here is among the best in Victoria. Fewer people come this way, which remains one of the coast's distinguishing features.",
+  "heroImage": {
+    "src": "/images/sourced/region-ocean-coast-01.webp",
+    "alt": "Surf breaking on the ocean beach near Flinders, Mornington Peninsula",
+    "credit": "Peninsula Insider",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["ocean-coast"],
+  "places": ["flinders", "cape-schanck", "rye", "fingal"],
+  "adjacentRegions": ["red-hill-wine-country", "peninsula-tip"],
+  "coordinates": { "lat": -38.49, "lng": 144.97 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}

--- a/next/src/content/regions/peninsula-tip.json
+++ b/next/src/content/regions/peninsula-tip.json
@@ -1,0 +1,18 @@
+{
+  "slug": "peninsula-tip",
+  "name": "Sorrento & Portsea",
+  "tagline": "Limestone cliffs, ocean baths, the Heads ferry, the Peninsula's most iconic edge.",
+  "intro": "The tip of the Mornington Peninsula is where the land narrows to a point and the social temperature rises. Sorrento and Portsea have been Melbourne's summer escape for generations: limestone cliffs above the bay, ocean baths carved into back-beach rock, the ferry to Queenscliff cutting across the Heads. The dining scene has quietly become something worth driving for year-round. Come in the off-season and the towns reveal their best selves: quieter, more local, more honest. The back beach at dusk is one of the best things on the Peninsula.",
+  "heroImage": {
+    "src": "/images/sourced/region-peninsula-tip-01.webp",
+    "alt": "Limestone cliffs and calm bay water at Sorrento, Mornington Peninsula",
+    "credit": "Peninsula Insider",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["peninsula-tip"],
+  "places": ["sorrento", "portsea", "blairgowrie", "rye", "fingal"],
+  "adjacentRegions": ["ocean-coast", "mornington-bay-coast"],
+  "coordinates": { "lat": -38.34, "lng": 144.74 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}

--- a/next/src/content/regions/red-hill-wine-country.json
+++ b/next/src/content/regions/red-hill-wine-country.json
@@ -1,0 +1,18 @@
+{
+  "slug": "red-hill-wine-country",
+  "name": "Red Hill & Merricks",
+  "tagline": "The Peninsula's wine heartland: cool-climate pinot, long lunches, and unhurried cellar doors.",
+  "intro": "Red Hill and Merricks form the Peninsula's most celebrated wine corridor. The ridge sits 300 metres above sea level, catching the cool Bass Strait air that defines the region's pinot noir and chardonnay. This is not a drive-through wine region; it rewards slow movement. Cellar doors range from the architecturally ambitious (Point Leo, Jackalope) to the quietly exceptional (Stonier, Ten Minutes by Tractor). Between tastings, the farmers markets, providores, and destination restaurants make Red Hill one of the most coherent food-and-wine precincts in Victoria.",
+  "heroImage": {
+    "src": "/images/sourced/region-red-hill-01.webp",
+    "alt": "Morning light across Red Hill's vineyard rows, Mornington Peninsula",
+    "credit": "Peninsula Insider",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["red-hill", "hinterland"],
+  "places": ["red-hill", "main-ridge", "merricks", "merricks-beach", "merricks-north", "balnarring"],
+  "adjacentRegions": ["mornington-bay-coast", "ocean-coast"],
+  "coordinates": { "lat": -38.385, "lng": 145.015 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}

--- a/next/src/content/regions/western-port.json
+++ b/next/src/content/regions/western-port.json
@@ -1,0 +1,18 @@
+{
+  "slug": "western-port",
+  "name": "Western Port",
+  "tagline": "The quieter side: mangroves, French Island ferries, and a genuinely local pace of life.",
+  "intro": "Western Port is the Peninsula's other shore, the protected bay side where the water is calmer, the towns are more working than weekending, and the landscape shifts to mangrove and tidal flat. Hastings is the hub, with French Island ferry access and a working harbour that feels a world away from Sorrento. This is the Peninsula for locals and those who have graduated beyond the obvious. The birding is exceptional, the fishing is serious, and the absence of tourists is, for many, the entire point.",
+  "heroImage": {
+    "src": "/images/sourced/region-western-port-01.webp",
+    "alt": "Calm tidal waters at Western Port Bay, Mornington Peninsula",
+    "credit": "Peninsula Insider",
+    "license": "tmp-unsplash"
+  },
+  "zones": ["western-port"],
+  "places": ["hastings", "bittern", "crib-point", "boneo"],
+  "adjacentRegions": ["mornington-bay-coast"],
+  "coordinates": { "lat": -38.30, "lng": 145.20 },
+  "publishedAt": "2026-06-01",
+  "sitemapExclude": false
+}

--- a/next/src/pages/explore/regions/[slug].astro
+++ b/next/src/pages/explore/regions/[slug].astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from 'astro:content';
+import RegionDetailTemplate from '../../../components/RegionDetailTemplate.astro';
+
+export async function getStaticPaths() {
+  const regions = await getCollection('regions', (r) => !r.data.sitemapExclude);
+  return regions.map((region) => ({ params: { slug: region.data.slug }, props: { region } }));
+}
+
+const { region } = Astro.props;
+
+const allPlaces = await getCollection('places');
+const placeIds = new Set(region.data.places.map((ref) => ref.id));
+const regionPlaces = allPlaces.filter((p) => placeIds.has(p.id));
+const placeSlugSet = new Set(regionPlaces.map((p) => p.id));
+
+const allVenues = await getCollection('venues', (v) => v.data.status !== 'permanently_closed');
+const regionVenues = allVenues.filter((v) => placeSlugSet.has(String(v.data.place?.id ?? '')));
+
+const allExperiences = await getCollection('experiences');
+const regionExperiences = allExperiences.filter((e) => placeSlugSet.has(String(e.data.place?.id ?? '')));
+
+const allRegions = await getCollection('regions');
+const adjacentRegionData = allRegions.filter((r) => region.data.adjacentRegions.includes(r.data.slug));
+
+const allArticles = await getCollection('articles', (a) => a.data.status === 'published');
+const regionArticles = allArticles
+  .filter((a) => (a.data as any).relatedPlaces?.some((ref: any) => placeSlugSet.has(String(ref.id ?? ''))))
+  .slice(0, 3);
+
+export const prerender = true;
+---
+
+<RegionDetailTemplate
+  region={region}
+  places={regionPlaces}
+  venues={regionVenues}
+  experiences={regionExperiences}
+  articles={regionArticles}
+  adjacentRegionData={adjacentRegionData}
+/>

--- a/next/src/pages/explore/regions/index.astro
+++ b/next/src/pages/explore/regions/index.astro
@@ -1,0 +1,56 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs.astro';
+import NewsletterBlock from '../../../components/NewsletterBlock.astro';
+
+const regions = (await getCollection('regions', (r) => !r.data.sitemapExclude))
+  .sort((a, b) => a.data.name.localeCompare(b.data.name));
+const SITE = 'https://peninsulainsider.com.au';
+export const prerender = true;
+---
+
+<BaseLayout
+  title="Explore by Region · Peninsula Insider"
+  description="The Mornington Peninsula's five regions: Red Hill & Merricks, Sorrento & Portsea, Mornington & the Bay, Western Port, and Flinders & the Ocean Coast."
+  section="explore"
+  canonical={`${SITE}/explore/regions/`}
+>
+  <div class="container">
+    <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Explore', href: '/explore/' }, { label: 'Regions' }]} />
+
+    <header class="regions-index__header">
+      <p class="regions-index__eyebrow">Explore</p>
+      <h1 class="regions-index__title">The Peninsula by region</h1>
+      <p class="regions-index__lead">Five distinct regions, each with its own character. Start here to find the part of the Peninsula that fits the trip.</p>
+    </header>
+
+    <div class="regions-index__grid">
+      {regions.map((r) => (
+        <a class="region-card" href={`/explore/regions/${r.data.slug}/`}>
+          <div class="region-card__image" style={`background-image:url('${r.data.heroImage.src}')`}></div>
+          <div class="region-card__body">
+            <h2 class="region-card__name">{r.data.name}</h2>
+            {r.data.tagline && <p class="region-card__tagline">{r.data.tagline}</p>}
+          </div>
+        </a>
+      ))}
+    </div>
+  </div>
+
+  <NewsletterBlock />
+
+  <style>
+    .regions-index__header { margin: 32px 0 28px; }
+    .regions-index__eyebrow { font-family: 'Outfit', sans-serif; text-transform: uppercase; letter-spacing: 0.16em; font-size: 11px; color: var(--accent); margin: 0 0 8px; }
+    .regions-index__title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: clamp(32px, 5vw, 56px); margin: 0 0 10px; }
+    .regions-index__lead { max-width: 60ch; color: var(--soft); font-size: 1.05rem; }
+    .regions-index__grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 22px; margin: 0 0 48px; }
+    .region-card { display: flex; flex-direction: column; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; text-decoration: none; color: var(--text); transition: transform 0.15s, border-color 0.15s; }
+    .region-card:hover { transform: translateY(-2px); border-color: var(--accent); }
+    .region-card__image { aspect-ratio: 16 / 10; background-size: cover; background-position: center; background-color: var(--bg-alt); }
+    .region-card__body { padding: 18px 20px 22px; }
+    .region-card__name { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.6rem; margin: 0 0 6px; }
+    .region-card__tagline { font-size: 0.92rem; color: var(--soft); margin: 0; }
+  </style>
+</BaseLayout>

--- a/ops/migrations/2026-06-01-pi-regions.sql
+++ b/ops/migrations/2026-06-01-pi-regions.sql
@@ -1,0 +1,44 @@
+-- PI Regions Table
+-- PR-6: regions collection backing table + content_registry entries
+-- Run after: 2026-06-01-pi-explore-url-migration.sql
+-- Spec: docs/specs/pr-6-regions.md
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS pi.regions (
+  slug          TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  tagline       TEXT,
+  intro         TEXT,
+  hero_image    JSONB,
+  zones         TEXT[] NOT NULL DEFAULT '{}',
+  place_slugs   TEXT[] NOT NULL DEFAULT '{}',
+  coordinates   JSONB,
+  published_at  TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Content registry entries for regions (pillar = explore)
+INSERT INTO pi.content_registry (slug, entity_type, pillar, href, title, priority)
+  VALUES
+    ('red-hill-wine-country', 'region', 'explore', '/explore/regions/red-hill-wine-country/', 'Red Hill & Merricks', 90),
+    ('peninsula-tip',         'region', 'explore', '/explore/regions/peninsula-tip/',         'Sorrento & Portsea',  90),
+    ('mornington-bay-coast',  'region', 'explore', '/explore/regions/mornington-bay-coast/',  'Mornington & the Bay',90),
+    ('western-port',          'region', 'explore', '/explore/regions/western-port/',          'Western Port',        90),
+    ('ocean-coast',           'region', 'explore', '/explore/regions/ocean-coast/',           'Flinders & the Ocean Coast', 90)
+  ON CONFLICT (slug) DO UPDATE SET
+    href = EXCLUDED.href,
+    title = EXCLUDED.title,
+    priority = EXCLUDED.priority;
+
+-- Seed initial region rows
+INSERT INTO pi.regions (slug, name, tagline, zones, place_slugs, published_at) VALUES
+  ('red-hill-wine-country', 'Red Hill & Merricks', 'The Peninsula''s wine heartland', ARRAY['red-hill','hinterland'], ARRAY['red-hill','main-ridge','merricks','merricks-beach','merricks-north','balnarring'], NOW()),
+  ('peninsula-tip', 'Sorrento & Portsea', 'Limestone cliffs, ocean baths, the Heads ferry', ARRAY['peninsula-tip'], ARRAY['sorrento','portsea','blairgowrie','rye','fingal'], NOW()),
+  ('mornington-bay-coast', 'Mornington & the Bay', 'The Peninsula''s urban edge', ARRAY['mornington','bay-coast'], ARRAY['mornington','mount-martha','safety-beach','mccrae','dromana','rosebud','capel-sound','mount-eliza'], NOW()),
+  ('western-port', 'Western Port', 'The quieter side', ARRAY['western-port'], ARRAY['hastings','bittern','crib-point','boneo'], NOW()),
+  ('ocean-coast', 'Flinders & the Ocean Coast', 'Wild surf beaches, the best pub on the Peninsula', ARRAY['ocean-coast'], ARRAY['flinders','cape-schanck','rye','fingal'], NOW())
+ON CONFLICT (slug) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
Implements `docs/specs/pr-6-regions.md`. Depends on PR-5 (merged). **Completes the IA loop** — the mega-nav's Regions links now resolve (places + plans + regions all live).

## What changed
- **Schema**: new `regions` collection in `content.config.ts` (slug, name, tagline, intro, heroImage, zones, place refs, adjacentRegions, coordinates).
- **5 region JSON files**: Red Hill & Merricks, Sorrento & Portsea, Mornington & the Bay, Western Port, Flinders & the Ocean Coast.
- **`RegionDetailTemplate.astro`**: hero, breadcrumb, intro, places strip, **client-side category tabs** (All / Eat & Drink / Stay / Wine / Experiences), venue+experience grid, journal picks, adjacent-regions strip, **`TouristDestination` JSON-LD**.
- **Routes**: `/explore/regions/[slug]` (loads region places, venues, experiences, adjacent regions, related articles) + `/explore/regions/` index grid.
- **Migration** `2026-06-01-pi-regions.sql`: `pi.regions` table + 5 `content_registry` rows + seed (not applied).

## Deviations from spec
- The spec's region `heroImage` blocks omitted the **required `credit` field** — added ("Peninsula Insider").
- The spec's taglines/intros were **full of em-dashes** — replaced with colons/commas per the house rule (content otherwise verbatim).
- v4-nav Regions column was already added in PR-1, so no nav change here.
- Hero images point at `/images/sourced/region-*.webp` placeholders (license `tmp-unsplash`) that don't exist yet — flag for editor to source real imagery.

## Acceptance
- `astro check`: 202 (= baseline, no new). `astro build`: green. All 5 region pages + index render; TouristDestination JSON-LD verified; nav Regions links resolve.