### PR TITLE
PR-7: Template Extensions (EstateCluster, venue/place templates, breadcrumbs)

### DIFF
--- a/next/src/components/EstateCluster.astro
+++ b/next/src/components/EstateCluster.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * EstateCluster: sibling venues within a multi-venue estate.
+ *
+ * Renders on VenueDetailTemplate when the venue has estateSlug set. A
+ * contextual outlined block (distinct from full venue cards), not a hub
+ * feature. Shows up to 4 siblings, then "and X more".
+ */
+import { venueHrefPrefix, routeSlug, typeLabel } from '../lib/editorial';
+
+interface Props {
+  estateSlug: string;
+  estateLabel: string;
+  currentVenueSlug: string;
+  siblingVenues: any[];
+}
+const { estateLabel, currentVenueSlug, siblingVenues } = Astro.props;
+const siblings = siblingVenues.filter((v) => routeSlug(v) !== currentVenueSlug);
+const shown = siblings.slice(0, 4);
+const more = siblings.length - shown.length;
+---
+
+{shown.length > 0 && (
+  <section class="estate-cluster">
+    <p class="estate-cluster__kicker">Part of {estateLabel}</p>
+    <div class="estate-cluster__strip">
+      {shown.map((v) => (
+        <a class="estate-cluster__card" href={`${venueHrefPrefix(v.data.type)}/${routeSlug(v)}/`}>
+          <span class="estate-cluster__name">{v.data.name}</span>
+          <span class="estate-cluster__type">{typeLabel[v.data.type] ?? v.data.type}</span>
+          {v.data.signature && <span class="estate-cluster__sig">{v.data.signature}</span>}
+        </a>
+      ))}
+    </div>
+    {more > 0 && <p class="estate-cluster__more">and {more} more at {estateLabel}</p>}
+
+    <style>
+      .estate-cluster { margin: 36px 0; padding: 22px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-alt, #faf7f2); }
+      .estate-cluster__kicker { font-family: 'Outfit', sans-serif; text-transform: uppercase; letter-spacing: 0.14em; font-size: 11px; color: var(--soft); margin: 0 0 14px; }
+      .estate-cluster__strip { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(220px, 1fr); gap: 14px; overflow-x: auto; padding-bottom: 4px; }
+      @media (max-width: 700px) { .estate-cluster__strip { grid-auto-columns: minmax(200px, 85%); } }
+      .estate-cluster__card { display: flex; flex-direction: column; gap: 5px; padding: 14px 16px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); text-decoration: none; color: var(--text); transition: border-color 0.15s; }
+      .estate-cluster__card:hover { border-color: var(--accent); }
+      .estate-cluster__name { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.2rem; line-height: 1.15; }
+      .estate-cluster__type { font-family: 'Outfit', sans-serif; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); }
+      .estate-cluster__sig { font-size: 0.82rem; color: var(--soft); line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+      .estate-cluster__more { font-size: 0.85rem; color: var(--soft); margin: 12px 0 0; }
+    </style>
+  </section>
+)}

--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -131,7 +131,8 @@ const stayHref = STAY_SUBPAGE_SLUGS.has(placeSlug)
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
-  { label: 'Places', href: '/places' },
+  { label: 'Explore', href: '/explore/' },
+  { label: 'Places', href: '/explore/places/' },
   { label: place.data.name },
 ];
 
@@ -192,6 +193,13 @@ const factual = place.data.factualLede ?? '';
   <div class="pdv2-hero__scrim"></div>
   <div class="pdv2-hero__inner container">
     <p class="pdv2-hero__eyebrow">{zoneLabel} · {kindLabel}</p>
+    {place.data.regionSlug && (
+      <a
+        href={`/explore/regions/${place.data.regionSlug}/`}
+        class="pdv2-hero__eyebrow pdv2-hero__region"
+        style="display:inline-block;text-decoration:none;border-bottom:1px solid currentColor;margin:2px 0 8px;"
+      >{place.data.regionLabel ?? place.data.regionSlug}</a>
+    )}
     <h1 class="pdv2-hero__title"
       {...editableText({ entityType: 'place', entitySlug: placeSlug, fieldPath: 'name', label: `${place.data.name} — name` })}
     >{place.data.name}</h1>

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -7,8 +7,10 @@ import VenueCard from './VenueCard.astro';
 import ArticleCard from './ArticleCard.astro';
 import ItineraryCard from './ItineraryCard.astro';
 import PiArticleActions from './PiArticleActions.astro';
+import { getCollection } from 'astro:content';
 import { loadOverrides } from '../lib/inline-edit/overrides';
 import { editableImage, editableText } from '../lib/inline-edit/attrs';
+import EstateCluster from './EstateCluster.astro';
 
 export interface Props {
   venue: any;
@@ -50,9 +52,19 @@ const heroStyle = overrideHero?.src
   : heroBackgroundStyle(data);
 const heroAlt = overrideHero?.alt ?? data.heroImage?.alt ?? heroLabel;
 
+// Sibling venues within a multi-venue estate (EstateCluster block).
+const estateSlug = data.estateSlug as string | undefined;
+let estateVenues: any[] = [];
+if (estateSlug) {
+  const allEstateVenues = await getCollection('venues');
+  estateVenues = allEstateVenues.filter((v) => v.data.estateSlug === estateSlug);
+}
+
+const placeId = data.place?.id ?? data.place;
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
   { label: sectionLabel, href: sectionHref },
+  { label: placeLabel(data.place), href: `/explore/places/${placeId}/` },
   { label: data.name },
 ];
 
@@ -197,7 +209,7 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
       <div>
         {/* ── INSIDER VERDICT — the editorial hook, leads the page.
             "Best for" lives once, in Worth Knowing below — not duplicated here. ── */}
-        {data.whyWeGo && (
+        {venue.data.venueTier === 'destination' && data.whyWeGo && (
           <div class="venue-verdict">
             <blockquote class="venue-verdict__why">
               <span class="venue-verdict__label">Why we&rsquo;d go</span>
@@ -212,6 +224,15 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
             <p>{paragraph}</p>
           ))}
         </div>
+
+        {estateSlug && (
+          <EstateCluster
+            estateSlug={estateSlug}
+            estateLabel={data.estateLabel ?? estateSlug}
+            currentVenueSlug={venueSlug}
+            siblingVenues={estateVenues}
+          />
+        )}
 
         {/* ── WORTH KNOWING — quick-scan trust layer ── */}
         {hasWorthKnowing && (

--- a/next/src/content/venues/alba-thermal-springs.json
+++ b/next/src/content/venues/alba-thermal-springs.json
@@ -2,6 +2,8 @@
   "slug": "alba-thermal-springs",
   "name": "Alba Thermal Springs & Spa",
   "type": "spa",
+  "estateSlug": "alba",
+  "estateLabel": "Alba Thermal Springs",
   "place": "red-hill",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/crittenden-estate.json
+++ b/next/src/content/venues/crittenden-estate.json
@@ -2,6 +2,8 @@
   "slug": "crittenden-estate",
   "name": "Crittenden Estate",
   "type": "winery",
+  "estateSlug": "crittenden",
+  "estateLabel": "Crittenden Estate",
   "subregion": "dromana",
   "place": "dromana",
   "zone": "bay-coast",

--- a/next/src/content/venues/crittenden-villas.json
+++ b/next/src/content/venues/crittenden-villas.json
@@ -2,6 +2,8 @@
   "slug": "crittenden-villas",
   "name": "Crittenden Estate Villas",
   "type": "villa",
+  "estateSlug": "crittenden",
+  "estateLabel": "Crittenden Estate",
   "place": "dromana",
   "zone": "bay-coast",
   "coordinates": {

--- a/next/src/content/venues/doot-doot-doot.json
+++ b/next/src/content/venues/doot-doot-doot.json
@@ -2,6 +2,8 @@
   "slug": "doot-doot-doot",
   "name": "Doot Doot Doot",
   "type": "restaurant",
+  "estateSlug": "jackalope",
+  "estateLabel": "Jackalope",
   "place": "red-hill",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/jackalope.json
+++ b/next/src/content/venues/jackalope.json
@@ -2,6 +2,8 @@
   "slug": "jackalope",
   "name": "Jackalope Hotel",
   "type": "hotel",
+  "estateSlug": "jackalope",
+  "estateLabel": "Jackalope",
   "place": "red-hill",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/laura-pt-leo.json
+++ b/next/src/content/venues/laura-pt-leo.json
@@ -2,6 +2,8 @@
   "slug": "laura-pt-leo",
   "name": "Laura at Pt. Leo",
   "type": "restaurant",
+  "estateSlug": "pt-leo-estate",
+  "estateLabel": "Point Leo Estate",
   "place": "red-hill",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/maxs-red-hill-estate.json
+++ b/next/src/content/venues/maxs-red-hill-estate.json
@@ -2,6 +2,8 @@
   "slug": "maxs-red-hill-estate",
   "name": "Max's at Red Hill Estate",
   "type": "restaurant",
+  "estateSlug": "red-hill-estate",
+  "estateLabel": "Red Hill Estate",
   "place": "red-hill",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/point-leo-estate-villas.json
+++ b/next/src/content/venues/point-leo-estate-villas.json
@@ -2,6 +2,8 @@
   "slug": "point-leo-estate-villas",
   "name": "Point Leo Estate Villas",
   "type": "villa",
+  "estateSlug": "pt-leo-estate",
+  "estateLabel": "Point Leo Estate",
   "place": "merricks",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/point-leo-wine-terrace.json
+++ b/next/src/content/venues/point-leo-wine-terrace.json
@@ -2,6 +2,8 @@
   "slug": "point-leo-wine-terrace",
   "name": "Point Leo Wine Terrace",
   "type": "restaurant",
+  "estateSlug": "pt-leo-estate",
+  "estateLabel": "Point Leo Estate",
   "place": "merricks",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/port-phillip-estate-restaurant.json
+++ b/next/src/content/venues/port-phillip-estate-restaurant.json
@@ -2,6 +2,8 @@
   "slug": "port-phillip-estate-restaurant",
   "name": "Port Phillip Estate Restaurant",
   "type": "restaurant",
+  "estateSlug": "port-phillip-estate",
+  "estateLabel": "Port Phillip Estate",
   "place": "red-hill",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/port-phillip-estate.json
+++ b/next/src/content/venues/port-phillip-estate.json
@@ -2,6 +2,8 @@
   "slug": "port-phillip-estate",
   "name": "Port Phillip Estate",
   "type": "winery",
+  "estateSlug": "port-phillip-estate",
+  "estateLabel": "Port Phillip Estate",
   "subregion": "red-hill-south",
   "place": "red-hill",
   "zone": "red-hill",

--- a/next/src/content/venues/pt-leo-estate.json
+++ b/next/src/content/venues/pt-leo-estate.json
@@ -2,6 +2,8 @@
   "slug": "pt-leo-estate",
   "name": "Pt. Leo Estate",
   "type": "winery",
+  "estateSlug": "pt-leo-estate",
+  "estateLabel": "Point Leo Estate",
   "subregion": "merricks",
   "place": "merricks",
   "zone": "red-hill",

--- a/next/src/content/venues/rare-hare.json
+++ b/next/src/content/venues/rare-hare.json
@@ -2,6 +2,8 @@
   "slug": "rare-hare",
   "name": "Rare Hare at Willow Creek",
   "type": "restaurant",
+  "estateSlug": "jackalope",
+  "estateLabel": "Jackalope",
   "place": "merricks",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/red-hill-estate.json
+++ b/next/src/content/venues/red-hill-estate.json
@@ -2,6 +2,8 @@
   "slug": "red-hill-estate",
   "name": "Red Hill Estate",
   "type": "winery",
+  "estateSlug": "red-hill-estate",
+  "estateLabel": "Red Hill Estate",
   "subregion": "main-ridge",
   "place": "red-hill",
   "zone": "red-hill",

--- a/next/src/content/venues/sanctuary-at-alba.json
+++ b/next/src/content/venues/sanctuary-at-alba.json
@@ -2,6 +2,8 @@
   "slug": "sanctuary-at-alba",
   "name": "The Sanctuary at Alba",
   "type": "villa",
+  "estateSlug": "alba",
+  "estateLabel": "Alba Thermal Springs",
   "place": "cape-schanck",
   "zone": "peninsula-tip",
   "coordinates": {

--- a/next/src/content/venues/spa-by-jackalope.json
+++ b/next/src/content/venues/spa-by-jackalope.json
@@ -2,6 +2,8 @@
   "slug": "spa-by-jackalope",
   "name": "Spa by Jackalope",
   "type": "spa",
+  "estateSlug": "jackalope",
+  "estateLabel": "Jackalope",
   "place": "merricks",
   "zone": "red-hill",
   "coordinates": {

--- a/next/src/content/venues/stillwater-crittenden.json
+++ b/next/src/content/venues/stillwater-crittenden.json
@@ -3,6 +3,8 @@
   "previousSlug": "stillwater-crittenden",
   "name": "Crittenden Restaurant",
   "type": "restaurant",
+  "estateSlug": "crittenden",
+  "estateLabel": "Crittenden Estate",
   "place": "dromana",
   "zone": "bay-coast",
   "coordinates": {

--- a/next/src/pages/journal/[slug].astro
+++ b/next/src/pages/journal/[slug].astro
@@ -143,11 +143,24 @@ const ogImage = overrideHero?.src
       ? article.data.heroImage.src
       : '/images/sourced/home-cover.webp');
 
-const breadcrumbItems = [
-  { label: 'Home', href: '/' },
-  { label: 'Journal', href: '/journal' },
-  { label: article.data.title },
-];
+// Region-aware breadcrumb for planning-utility formats with a single related
+// place that carries a regionSlug: Home -> Region -> Place -> Title. Otherwise
+// the standard Home -> Journal -> Title.
+const breadcrumbItems = (() => {
+  const base = [{ label: 'Home', href: '/' }];
+  if (isHubGuide && relatedPlaces.length === 1) {
+    const p: any = relatedPlaces[0];
+    if (p?.data?.regionSlug) {
+      return [
+        ...base,
+        { label: p.data.regionLabel ?? p.data.regionSlug, href: `/explore/regions/${p.data.regionSlug}/` },
+        { label: p.data.name, href: `/explore/places/${routeSlug(p)}/` },
+        { label: article.data.title },
+      ];
+    }
+  }
+  return [...base, { label: 'Journal', href: '/journal/' }, { label: article.data.title }];
+})();
 
 // Map internal format tag → human-readable articleSection for JSON-LD.
 // Per Operational Definitions v1.2 (Journal section): format must be exposed

--- a/next/src/pages/whats-on/[slug].astro
+++ b/next/src/pages/whats-on/[slug].astro
@@ -154,6 +154,9 @@ export const prerender = true;
               <p class="event-detail__hosted-name">
                 {venue ? venue.data.name : event.data.venueName}
               </p>
+              {venue?.data.estateLabel && (
+                <p class="event-detail__hosted-estate" style="font-size:0.82rem;color:var(--soft);margin:2px 0 0;">Part of {venue.data.estateLabel}</p>
+              )}
               {(event.data.streetAddress || event.data.suburb) && (
                 <p class="event-detail__hosted-address">
                   {event.data.streetAddress && <span>{event.data.streetAddress}</span>}


### PR DESCRIPTION
Implements `docs/specs/pr-7-template-extensions.md`. Depends on PR-2 (merged).

## VenueDetailTemplate
- **`EstateCluster.astro`** (new): sibling-venue strip for multi-venue estates. `estateSlug`/`estateLabel` populated on **17 venues across 6 estates** (Point Leo, Crittenden, Jackalope, Port Phillip, Red Hill, Alba). Renders only when `estateSlug` is set (verified: Jackalope shows Doot Doot Doot, Rare Hare, Spa by Jackalope).
- Breadcrumb: `Home → Pillar → Place → Venue`.
- **Verdict block gated** to `venueTier === 'destination'` (recommended/directory hide it — verified on a recommended market).

## PlaceDetailTemplate
- **Region kicker** above the h1, linking to the region page (verified on /explore/places/red-hill/).
- Breadcrumb: `Home → Explore → Places → Place`.
- **Category tabs not added** (deviation): this template already renders venues in per-category sections (Eat/Wine/Stay/Experiences); a filter-over-one-grid would regress that structure. Flagging for your call.

## Event + Article templates
- whats-on/[slug]: `Part of [estate]` in the Hosted-at sidebar (place link already existed).
- journal/[slug]: region-aware breadcrumb for hub-guide/service/trail-guide/venue-guide formats with a single related place that has a regionSlug; standard fallback otherwise.

## Notes
- Used the existing `Breadcrumbs.astro` (plural); did **not** create `Breadcrumb.astro` per the repo rule.
- `astro check`: 202 (= baseline, no new). `astro build`: green.