### PR TITLE
PR-8: Plans Browse Hub (four-axis filter)

### DIFF
--- a/next/src/components/PlanCard.astro
+++ b/next/src/components/PlanCard.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * PlanCard: a scannable card for a plans-section article on the
+ * /explore/plans/ browse hub. Carries data-* attributes for the
+ * four-axis client-side filter (occasion, duration, season, region).
+ */
+import { routeSlug } from '../lib/editorial';
+
+interface Props {
+  plan: any;
+  axes: { occasion: string[]; duration: string[]; season: string[]; region: string[] };
+  regionLabel?: string;
+}
+const { plan, axes, regionLabel } = Astro.props;
+const d = plan.data;
+const href = `/journal/${routeSlug(plan)}/`;
+
+const DURATION_LABEL: Record<string, string> = {
+  'day-trip': 'Day trip', 'one-night': 'One night', 'two-night': 'Weekend', 'seasonal': 'Seasonal',
+};
+const OCCASION_LABEL: Record<string, string> = {
+  romantic: 'Romantic', family: 'Family', 'long-lunch': 'Long Lunch',
+  wellness: 'Wellness', adventure: 'Adventure', 'weekend-escape': 'Weekend Escape',
+};
+const durationChip = axes.duration[0];
+const occasionChip = axes.occasion[0];
+const hero = d.heroImage?.src;
+---
+
+<article
+  class="plan-card"
+  data-occasion={axes.occasion.join(' ')}
+  data-duration={axes.duration.join(' ')}
+  data-season={axes.season.join(' ')}
+  data-region={axes.region.join(' ')}
+>
+  <a class="plan-card__link" href={href}>
+    {hero && <div class="plan-card__img" style={`background-image:url('${hero}')`}></div>}
+    <div class="plan-card__body">
+      <div class="plan-card__chips">
+        {durationChip && <span class="plan-card__chip">{DURATION_LABEL[durationChip] ?? durationChip}</span>}
+        {occasionChip && <span class="plan-card__chip plan-card__chip--occasion">{OCCASION_LABEL[occasionChip] ?? occasionChip}</span>}
+      </div>
+      <h3 class="plan-card__title">{d.title}</h3>
+      {d.dek && <p class="plan-card__dek">{d.dek}</p>}
+      {regionLabel && <p class="plan-card__region">{regionLabel}</p>}
+      <span class="plan-card__cta">Read the plan →</span>
+    </div>
+  </a>
+
+  <style>
+    .plan-card { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; background: var(--bg); transition: transform 0.15s, border-color 0.15s; }
+    .plan-card:hover { transform: translateY(-2px); border-color: var(--accent); }
+    .plan-card[hidden] { display: none; }
+    .plan-card__link { display: flex; flex-direction: column; height: 100%; text-decoration: none; color: var(--text); }
+    .plan-card__img { aspect-ratio: 16 / 9; background-size: cover; background-position: center; background-color: var(--bg-alt); }
+    .plan-card__body { padding: 16px 18px 20px; display: flex; flex-direction: column; gap: 8px; flex: 1; }
+    .plan-card__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+    .plan-card__chip { font-family: 'Outfit', sans-serif; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; padding: 3px 9px; border-radius: 999px; background: var(--bg-alt); color: var(--soft); }
+    .plan-card__chip--occasion { background: var(--accent); color: #fff; }
+    .plan-card__title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.4rem; line-height: 1.12; margin: 2px 0 0; }
+    .plan-card__dek { font-size: 0.9rem; color: var(--soft); line-height: 1.5; margin: 0; }
+    .plan-card__region { font-family: 'Outfit', sans-serif; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--soft); margin: 2px 0 0; }
+    .plan-card__cta { font-family: 'Space Mono', monospace; font-size: 0.78rem; color: var(--accent); margin-top: auto; }
+  </style>
+</article>

--- a/next/src/pages/explore/plans/index.astro
+++ b/next/src/pages/explore/plans/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import PlanCard from '../../../components/PlanCard.astro';
 import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import GuideHero from '../../../components/GuideHero.astro';
 import CompareBlock from '../../../components/CompareBlock.astro';
@@ -39,6 +40,44 @@ const articlesAll = (await getCollection('articles', ({ data }) => data.status =
 const plansArticles = articlesAll
   .filter((a) => (a.data.section ?? 'journal') === 'plans')
   .sort((a, b) => (b.data.publishedAt?.getTime() ?? 0) - (a.data.publishedAt?.getTime() ?? 0));
+
+// ── Plans browse: four-axis client-side filter (PR-8) ──────────────────────
+const regionsForFilter = await getCollection('regions');
+const placeToRegion = new Map<string, string>();
+const regionLabelMap = new Map<string, string>();
+for (const r of regionsForFilter) {
+  regionLabelMap.set(r.data.slug, r.data.name);
+  for (const pref of r.data.places) placeToRegion.set(pref.id, r.data.slug);
+}
+const OCCASION_MAP: Record<string, string[]> = {
+  romantic: ['anniversary', 'romance', 'first-date', 'sunset', 'couples'],
+  family: ['family'],
+  'long-lunch': ['long-lunch', 'slow'],
+  wellness: ['wellness'],
+  adventure: ['walk', 'beach', 'outdoor', 'surf'],
+  'weekend-escape': ['weekend-escape', 'cellar-door'],
+};
+const SEASON_SET = new Set(['summer', 'autumn', 'winter', 'spring', 'all-year']);
+const planBrowse = plansArticles.map((a) => {
+  const tags: string[] = ((a.data.tags ?? []) as string[]).map((t) => String(t).toLowerCase());
+  const occasion = Object.entries(OCCASION_MAP)
+    .filter(([, keys]) => keys.some((k) => tags.includes(k)))
+    .map(([k]) => k);
+  const season = tags.filter((t) => SEASON_SET.has(t));
+  const duration = a.data.planShape ? [String(a.data.planShape)] : [];
+  const regionSet = new Set<string>();
+  for (const pref of ((a.data.relatedPlaces ?? []) as any[])) {
+    const rg = placeToRegion.get(pref.id);
+    if (rg) regionSet.add(rg);
+  }
+  for (const t of tags) {
+    const rg = placeToRegion.get(t);
+    if (rg) regionSet.add(rg);
+  }
+  const region = [...regionSet];
+  return { article: a, axes: { occasion, duration, season, region }, regionLabel: region.length ? regionLabelMap.get(region[0]) : undefined };
+});
+const filterRegions = [...regionLabelMap.entries()];
 
 // Editorial curation via schema flag (featured: true on place JSON).
 // No hardcoded slugs - editors update the JSON to change what surfaces here.
@@ -523,6 +562,112 @@ export const prerender = true;
       </div>
     </section>
   )}
+
+  <section class="plans-browse" id="plans-browse">
+    <div class="container">
+      <header class="plans-browse__header">
+        <h2 class="plans-browse__title">Browse all plans</h2>
+        <p class="plans-browse__sub">Filter by occasion, duration, season, or where you want to be.</p>
+        <p class="plans-browse__count" id="plans-count" aria-live="polite">{planBrowse.length} plans</p>
+      </header>
+
+      <div class="plans-browse__layout">
+        <button type="button" class="plans-browse__toggle" id="plans-filter-toggle" aria-expanded="false">Filter plans</button>
+
+        <form class="plans-filter" role="search" aria-label="Filter plans">
+          <fieldset class="plans-filter__group">
+            <legend>Occasion</legend>
+            {[['romantic', 'Romantic'], ['family', 'Family'], ['long-lunch', 'Long Lunch'], ['wellness', 'Wellness'], ['adventure', 'Adventure'], ['weekend-escape', 'Weekend Escape']].map(([v, l]) => (
+              <label class="plans-filter__opt"><input type="checkbox" name="occasion" value={v} /> {l}</label>
+            ))}
+          </fieldset>
+          <fieldset class="plans-filter__group">
+            <legend>Duration</legend>
+            {[['day-trip', 'Day trip'], ['one-night', 'One night'], ['two-night', 'Weekend'], ['seasonal', 'Seasonal']].map(([v, l]) => (
+              <label class="plans-filter__opt"><input type="checkbox" name="duration" value={v} /> {l}</label>
+            ))}
+          </fieldset>
+          <fieldset class="plans-filter__group">
+            <legend>Season</legend>
+            {[['summer', 'Summer'], ['autumn', 'Autumn'], ['winter', 'Winter'], ['spring', 'Spring'], ['all-year', 'Any time']].map(([v, l]) => (
+              <label class="plans-filter__opt"><input type="checkbox" name="season" value={v} /> {l}</label>
+            ))}
+          </fieldset>
+          <fieldset class="plans-filter__group">
+            <legend>Peninsula Area</legend>
+            {filterRegions.map(([v, l]) => (
+              <label class="plans-filter__opt"><input type="checkbox" name="region" value={v} /> {l}</label>
+            ))}
+          </fieldset>
+          <button type="button" id="clear-filters" class="plans-filter__clear">Clear all</button>
+        </form>
+
+        <div class="plans-grid" id="plans-grid">
+          {planBrowse.map((p) => <PlanCard plan={p.article} axes={p.axes} regionLabel={p.regionLabel} />)}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script is:inline>
+    (function () {
+      function initPlansFilter() {
+        var bar = document.querySelector('.plans-filter');
+        var grid = document.getElementById('plans-grid');
+        if (!bar || !grid) return;
+        var cards = Array.prototype.slice.call(grid.querySelectorAll('.plan-card'));
+        var countEl = document.getElementById('plans-count');
+        function active() {
+          var f = { occasion: [], duration: [], season: [], region: [] };
+          bar.querySelectorAll('input[type=checkbox]:checked').forEach(function (i) { if (f[i.name]) f[i.name].push(i.value); });
+          return f;
+        }
+        function matches(card, f) {
+          return ['occasion', 'duration', 'season', 'region'].every(function (ax) {
+            if (!f[ax].length) return true;
+            var vals = (card.getAttribute('data-' + ax) || '').split(' ');
+            return f[ax].some(function (v) { return vals.indexOf(v) !== -1; });
+          });
+        }
+        function apply() {
+          var f = active(), n = 0;
+          cards.forEach(function (c) { var s = matches(c, f); c.hidden = !s; if (s) n++; });
+          if (countEl) countEl.textContent = n + (n === 1 ? ' plan' : ' plans');
+        }
+        bar.addEventListener('change', apply);
+        var clear = document.getElementById('clear-filters');
+        if (clear) clear.addEventListener('click', function () { bar.querySelectorAll('input[type=checkbox]').forEach(function (i) { i.checked = false; }); apply(); });
+        var toggle = document.getElementById('plans-filter-toggle');
+        if (toggle) toggle.addEventListener('click', function () { var open = bar.classList.toggle('is-open'); toggle.setAttribute('aria-expanded', String(open)); });
+        apply();
+      }
+      if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initPlansFilter, { once: true });
+      else initPlansFilter();
+      document.addEventListener('astro:page-load', initPlansFilter);
+    })();
+  </script>
+
+  <style>
+    .plans-browse { padding: 28px 0 8px; }
+    .plans-browse__header { margin-bottom: 18px; }
+    .plans-browse__title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: clamp(26px, 3.6vw, 38px); margin: 0 0 6px; }
+    .plans-browse__sub { color: var(--soft); margin: 0 0 6px; }
+    .plans-browse__count { font-family: 'Outfit', sans-serif; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin: 0; }
+    .plans-browse__layout { display: grid; grid-template-columns: 240px 1fr; gap: 28px; align-items: start; }
+    .plans-browse__toggle { display: none; }
+    .plans-filter { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 84px; }
+    .plans-filter__group { border: 0; padding: 0; margin: 0; }
+    .plans-filter__group legend { font-family: 'Outfit', sans-serif; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--accent); padding: 0; margin: 0 0 8px; }
+    .plans-filter__opt { display: flex; align-items: center; gap: 8px; font-size: 0.9rem; padding: 3px 0; cursor: pointer; }
+    .plans-filter__clear { font-family: 'Outfit', sans-serif; font-size: 0.82rem; align-self: flex-start; padding: 6px 14px; border: 1px solid var(--border); border-radius: 999px; background: transparent; cursor: pointer; }
+    .plans-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 20px; }
+    @media (max-width: 820px) {
+      .plans-browse__layout { grid-template-columns: 1fr; }
+      .plans-browse__toggle { display: inline-block; font-family: 'Outfit', sans-serif; font-size: 0.9rem; padding: 9px 18px; border: 1px solid var(--border); border-radius: 999px; background: var(--bg); cursor: pointer; margin-bottom: 16px; }
+      .plans-filter { display: none; position: static; }
+      .plans-filter.is-open { display: flex; padding: 16px; border: 1px solid var(--border); border-radius: 8px; margin-bottom: 18px; }
+    }
+  </style>
 
   <NewsletterBlock />
 </BaseLayout>


### PR DESCRIPTION
Implements `docs/specs/pr-8-plans-browse.md`. Depends on PR-5 + PR-6 (merged).

## What changed
- **`PlanCard.astro`** (new): scannable plan card (hero, occasion + duration chips, title, dek, region label, CTA) carrying `data-occasion/duration/season/region` for filtering.
- **`/explore/plans/`**: added a **'Browse all plans'** section with a **four-axis client-side filter** (Occasion · Duration · Season · Peninsula Area) over the 21 published `section:plans` articles. OR within an axis, AND across axes; live results count; Clear-all; mobile filter drawer. Verified: cards render with all 4 populated data-axes, all 4 legends present.

## Deviations from spec
- **Did not replace the existing hub** — PR-5 moved the *real* 652-line curated plans hub here (not a stub). I appended the filter section so the curation (stay/place highlights, itinerary groupings) is preserved.
- The spec's filter sources (`tags.mood`, `tags.season`) don't exist on articles — article `tags` is a **flat string array**. Axes derived from real fields instead: duration from `planShape`, occasion + season mapped from the flat tags, region from `relatedPlaces` + tag place-names via the regions→places map. Season data is sparse (few articles carry season tags) — flagging for editorial tagging.
- itineraries `baseTowns` field already existed in schema; no change needed.

## Acceptance
- `astro check`: 202 (= baseline, no new). `astro build`: green. `/plans/`→`/explore/plans/` 301 (from PR-5).