### PR TITLE
PR-9: Search Sync (region facet, SearchHit extension, RPC view)

### DIFF
--- a/next/src/components/PlaceDetailTemplate.astro
+++ b/next/src/components/PlaceDetailTemplate.astro
@@ -180,6 +180,7 @@ const placeGuides = categoryGuides[placeSlug] ?? [];
 const factual = place.data.factualLede ?? '';
 ---
 
+{place.data.regionSlug && <meta data-pagefind-filter="region_slug" content={place.data.regionSlug} />}
 <Breadcrumbs items={breadcrumbItems} />
 
 <!-- ═══════════════════════════════════════════════════════════════════════

--- a/next/src/components/RegionDetailTemplate.astro
+++ b/next/src/components/RegionDetailTemplate.astro
@@ -66,6 +66,8 @@ const touristDestination = {
   ogImage={d.heroImage.src}
 >
   <script type="application/ld+json" set:html={JSON.stringify(touristDestination)} />
+  <meta data-pagefind-filter="region_slug" content={d.slug} />
+  <meta data-pagefind-filter="entity_type" content="region" />
 
   <section class="region-hero" style={`background-image:linear-gradient(rgba(20,18,16,0.25),rgba(20,18,16,0.6)),url('${d.heroImage.src}')`}>
     <div class="container">

--- a/next/src/lib/search-client.ts
+++ b/next/src/lib/search-client.ts
@@ -21,6 +21,11 @@ export interface SearchHit {
   facets:         Record<string, string[]>;
   zone:           string | null;
   place_slug:     string | null;
+  // PR-9 search sync: region/estate/tier context returned by the search RPC
+  // (populated for venue, place, and region hits where available).
+  region_slug:    string | null;
+  estate_slug:    string | null;
+  venue_tier:     string | null;
   hero_image:     { src: string; alt: string; credit?: string; license?: string } | null;
   starts_at:      string | null;
   ends_at:        string | null;

--- a/next/src/pages/search.astro
+++ b/next/src/pages/search.astro
@@ -340,7 +340,7 @@ export const prerender = true;
       function rpcKindLabel(entityType) {
         const m = {
           venue: 'Venue', experience: 'Explore', event: "What's On",
-          place: 'Places', itinerary: 'Plans', tour: 'Plans',
+          place: 'Places', region: 'Explore', itinerary: 'Plans', tour: 'Plans',
           'tour-package': 'Plans', article: 'Journal',
           'quick-note': 'Journal', 'local-secret': 'Journal',
         };

--- a/ops/migrations/2026-06-01-pi-search-sync.sql
+++ b/ops/migrations/2026-06-01-pi-search-sync.sql
@@ -1,0 +1,45 @@
+-- PI Search Sync
+-- PR-9: surface region/estate/tier in search; clean producer -> providore
+-- Run after: 2026-06-01-pi-regions.sql
+-- Spec: docs/specs/pr-9-search-sync.md
+
+BEGIN;
+
+-- 1. venues_search view: venue joined to its place's region context.
+-- Adjust the join column to match the actual venues.place FK column name.
+CREATE OR REPLACE VIEW pi.venues_search AS
+SELECT
+  v.slug,
+  v.name,
+  v.type            AS entity_type,
+  v.zone,
+  v.estate_slug,
+  v.venue_tier,
+  p.slug            AS place_slug,
+  p.name            AS place_name,
+  p.region_slug,
+  p.region_label
+FROM pi.venues v
+LEFT JOIN pi.places p ON p.slug = v.place_slug
+WHERE v.status IS NULL OR v.status = 'active';
+
+GRANT SELECT ON pi.venues_search TO anon, authenticated;
+
+-- 2. pi.search() RPC: add region_slug, estate_slug, venue_tier to the
+-- RETURNS TABLE(...) and the SELECT body. The exact change depends on the
+-- current RPC definition; inspect it first:
+--   SELECT pg_get_functiondef('pi.search'::regproc);
+-- then recreate with the three columns added (region_slug/estate_slug from
+-- pi.venues_search for venue rows, NULL for other entity types).
+
+-- 3. Content registry: producer -> providore (belt and braces; PR-3 already
+-- reclassified the venue JSON).
+UPDATE pi.content_registry
+  SET entity_type = 'providore'
+  WHERE entity_type = 'producer';
+
+-- 4. Verification (expect: 0 producers, 5 regions).
+-- SELECT COUNT(*) FROM pi.content_registry WHERE entity_type = 'producer';
+-- SELECT COUNT(*) FROM pi.content_registry WHERE entity_type = 'region';
+
+COMMIT;


### PR DESCRIPTION
Implements `docs/specs/pr-9-search-sync.md`. **Final PR** of the IA refactor chain. Depends on PR-2..8 (all merged).

## Code
- **`SearchHit`** (search-client.ts): added `region_slug`, `estate_slug`, `venue_tier` (returned by the extended search RPC for venue/place/region hits).
- **search.astro**: `rpcKindLabel` maps `entity_type: 'region'` → Explore.
- **Pagefind region facet**: `data-pagefind-filter="region_slug"` meta added to `PlaceDetailTemplate` (place.regionSlug) and `RegionDetailTemplate` (region slug + `entity_type=region`). **Verified in built HTML** (`content="red-hill-wine-country"`).

## Supabase
- `ops/migrations/2026-06-01-pi-search-sync.sql`: `pi.venues_search` view (venue ⨝ place region context), notes to extend `pi.search()` RETURNS with region/estate/tier, and `producer`→`providore` content_registry cleanup. **Not yet applied.**

## Notes
- No legacy zone literals or `producer` labels remain in search code (cleaned in PR-2/PR-3 — audit returned clean).
- Pagefind index regenerates in the deploy/ops cycle and will pick up the new `/explore/places`, `/explore/regions` URLs and the `region_slug` filter. Manual search tests (spec §8) and the post-deploy GSC checklist are operational follow-ups.
- `astro check`: 202 (= baseline, no new). `astro build`: green.