### PR TITLE
Design: readability pass, reader utilities, homepage simplification, radius tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ For each meaningful change, include:
 
 ---
 
+## 2026-06-10 — Claude (design)
+
+### Card radius tokens (design review 2026-W22)
+
+**Summary**
+Implemented the 2026-W22 design review recommendation: added `--radius-card-sm/md/lg` tokens to `:root` and collapsed the nine bespoke card `border-radius` values in `global.css` onto them (Weekend Picker, CompareBlock columns, newsletter frames/embed, place-typeahead grid, stay card panel).
+
+One deviation from the memo: `.newsletter__embed` at desktop (was `0.9rem`) maps to `--radius-card-sm`, not `md` as the memo listed — it is the same nested embed slot the memo maps to `sm` at mobile, and `sm` is the closest token (0.8px shift vs 5.6px).
+
+**Files changed**
+- `next/src/styles/global.css`
+
+**Pages affected**
+- Site-wide (any page using Weekend Picker, CompareBlock, newsletter blocks, typeahead grid)
+
+**Why it matters**
+Removes radius drift across visually-peer card surfaces and makes future radius changes one-line edits. Visual shifts are 1–4px on three surfaces (newsletter frames 1.35→1.5rem, mobile form-frame 1.05→1.25rem).
+
+**Verification**
+- `npm run build` passes (1485 pages).
+
+**Follow-up**
+- Backlog from the same memo: `--shadow-*` tokens (17 distinct values), a `--text-*` font-size scale (70+ values), and 30+ ad-hoc hex colours outside `:root`.
+
 ## 2026-06-01 — Codex
 
 ### Footer advertising link removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,37 @@ For each meaningful change, include:
 
 ## 2026-06-10 — Claude (design)
 
+### Homepage top-section simplification (cognitive-load pass)
+
+**Summary**
+Reviewed by James against mobile screenshots: the first four viewports routed the same three intents repeatedly (Ask ×3, weekend ×4, plans ×3), each repeat with its own eyebrow/heading/microcopy. Changes:
+
+- **Removed `ThreeMissionBar`** from the homepage — its Ask panel duplicated the floating Ask button, its This Weekend panel duplicated the Weekend Dispatch card (and listed long-running events like "1 April – 30 June" under a "This Weekend" heading), and its Plans panel duplicated the `hp-plans` grid below.
+- **Removed `MelbourneEntryStrip`** — its single link now lives as a quiet line inside the Weekend Dispatch card ("Coming from Melbourne? Here's where to start →").
+- **Removed the Ask chip** from `hp-section-nav` (the floating Ask button is the one Ask surface).
+- **`WeekendPickerBlock` simplified** — dropped the eyebrow + cadence label column ("Peninsula This Weekend" / "Published for the weekend ahead · one pick, one backup…"), which repeated the kicker and the dispatch title. Now: one date kicker, title, dek, two CTAs, Melbourne line. Single-column card (also renders on `/v4/whats-on/`).
+- **Hero story-switcher** — replaced the uppercase label tabs ("SLOW PENINSULA / FEATURE / WALK"), which read as content filters, with quiet equal-width progress bars; accessible names now carry "Story n of 5: {headline}".
+
+Net effect on mobile: hero → section chips → one weekend card → editorial content. Background rhythm now alternates white/cream naturally (the big cream routing zone is gone).
+
+**Files changed**
+- `next/src/pages/index.astro`
+- `next/src/components/WeekendPickerBlock.astro`
+- `next/src/styles/global.css`
+
+**Pages affected**
+- `/` (homepage), `/v4/whats-on/` (shared weekend block)
+
+**Why it matters**
+Cuts ~3 viewports of duplicated routing to one; every intent now has exactly one surface above the fold.
+
+**Verification**
+- `npm run build` passes (1485 pages). TMB/strip markup confirmed absent from built homepage; Melbourne link present in weekend card on both consumers; 5 story-nav buttons with descriptive aria-labels.
+
+**Follow-up**
+- `ThreeMissionBar.astro` and `MelbourneEntryStrip.astro` are now only used by `/preview-home-redesign/`; retire with that preview when it goes.
+- CMS text fields `weekend.eyebrow` / `weekend.cadence` no longer have a rendering surface.
+
 ### Mobile/site-wide readability + reader-utility pass
 
 **Summary**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,41 @@ For each meaningful change, include:
 
 ## 2026-06-10 — Claude (design)
 
+### Mobile/site-wide readability + reader-utility pass
+
+**Summary**
+Readability and accessibility upgrade requested by James (benchmarked against The Age Good Food mobile experience), plus three reader-utility features:
+
+1. **Typography weight/size** — body text `0.95rem`/weight 300 → `1rem`/weight 400; `.prose` to `1.0625rem`/400; cover/section-hero deks, place-detail intro, and newsletter input from 300 → 400. The light 300 weight was the main cause of low-contrast "grey" reading texture.
+2. **Contrast tokens** — `--soft` darkened `#7A726A` → `#5F574E` (4.7:1 → 7.1:1 on white; was failing AA on `--bg-alt`). New `--gold-text: #7A6340` token for gold-as-text on light surfaces (`--gold` is 2.7:1, decorative only); applied to editors-desk label and share-button copied state.
+3. **Italic cull** — 15 multi-line body-copy italic rules (article/news/home/guide deks, shortlist/insider-stripe/event-verdict bodies, prose blockquote, standfirsts) converted to roman, Cormorant blocks bumped to weight 500. Italics retained for display headline `em` accents, brand taglines, signatures, and semantic `.prose em`.
+4. **Browser font-size preference respected** — `html { font-size: 16px }` → `100%`.
+5. **Three-step text-size control (A/A/A)** — new `TextScaleControl.astro` in the `PiArticleActions` byline row (journal articles, weekend pages, venue detail). Sets `data-text-scale` on `<html>` (steps map to 108.75% / 118% root size), persists in localStorage, re-applied pre-paint by an inline BaseLayout script.
+6. **Saved shortcut in masthead** — bookmark icon (`v4-iconbtn`) next to search in both V4 masthead action clusters (desktop + mobile), linking to `/saved/`.
+7. **Google preferred-source button** — footer contact column, deeplink `https://google.com/preferences/source?q=peninsularinsider.com.au` per Google Search Central guidance.
+
+**Files changed**
+- `next/src/styles/global.css`
+- `next/src/components/TextScaleControl.astro` (new)
+- `next/src/components/PiArticleActions.astro`
+- `next/src/components/v4/V4Masthead.astro`
+- `next/src/components/Footer.astro`
+- `next/src/layouts/BaseLayout.astro`
+
+**Pages affected**
+Site-wide.
+
+**Why it matters**
+Body text was the single biggest readability complaint (weight-300 Outfit at 15.2px reads grey, especially on mobile). Secondary text was failing WCAG AA on cream sections. Multi-line Cormorant italic deks were hard to read at small sizes. The control and buttons match reader-utility patterns from major mastheads.
+
+**Verification**
+- `npm run build` passes (1485 pages); new rules confirmed in bundled output, which cascades after the legacy `/assets/styles.css`.
+
+**Follow-up**
+- `public/assets/styles.css` is a stale pre-Astro copy still linked first in `BaseLayout` — consider retiring it; it currently re-states the old typography (overridden by cascade order, but a drift risk).
+- Verify the site appears in Google's source-preferences tool for AU users (feature is region-gated).
+- Backlog: `--text-*` font-size token scale (70+ distinct sizes, tail below 12px).
+
 ### Card radius tokens (design review 2026-W22)
 
 **Summary**

--- a/next/src/components/Footer.astro
+++ b/next/src/components/Footer.astro
@@ -149,6 +149,20 @@ const legalLinks: Link[] = [
             </a>
           </div>
         </div>
+        <a
+          class="pi-foot__google-source"
+          href="https://google.com/preferences/source?q=peninsularinsider.com.au"
+          target="_blank"
+          rel="noopener"
+        >
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+            <path fill="#4285F4" d="M23.5 12.27c0-.85-.08-1.66-.22-2.45H12v4.64h6.45a5.52 5.52 0 0 1-2.39 3.62v3h3.86c2.26-2.08 3.58-5.15 3.58-8.81Z"/>
+            <path fill="#34A853" d="M12 24c3.24 0 5.96-1.07 7.94-2.91l-3.86-3a7.24 7.24 0 0 1-10.8-3.8H1.3v3.1A12 12 0 0 0 12 24Z"/>
+            <path fill="#FBBC05" d="M5.28 14.29a7.2 7.2 0 0 1 0-4.58v-3.1H1.3a12 12 0 0 0 0 10.78l3.98-3.1Z"/>
+            <path fill="#EA4335" d="M12 4.75c1.77 0 3.35.61 4.6 1.8l3.42-3.42A11.55 11.55 0 0 0 12 0 12 12 0 0 0 1.3 6.61l3.98 3.1A7.18 7.18 0 0 1 12 4.75Z"/>
+          </svg>
+          <span>Add us as a preferred source on Google</span>
+        </a>
       </div>
     </div>
 
@@ -313,6 +327,36 @@ const legalLinks: Link[] = [
     outline-offset: 2px;
   }
   .pi-foot__social-row svg { width: 16px; height: 16px; }
+
+  /* "Add us as a preferred source on Google" — official deeplink to
+     Google's source-preferences flow (see Search Central, Preferred
+     Sources). Sits with the other social CTAs per Google's guidance. */
+  .pi-foot__google-source {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 1.25rem;
+    padding: 0.6rem 1rem;
+    background: #FFFFFF;
+    border: 1px solid var(--line, #D9D1BE);
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    line-height: 1.3;
+    color: var(--ink, #171413);
+    text-decoration: none;
+    transition: border-color .18s ease, box-shadow .18s ease;
+  }
+  .pi-foot__google-source:hover,
+  .pi-foot__google-source:focus-visible {
+    border-color: var(--ink, #171413);
+    box-shadow: 0 1px 6px rgba(23, 20, 19, 0.12);
+  }
+  .pi-foot__google-source:focus-visible {
+    outline: 2px solid var(--ochre, #A0541F);
+    outline-offset: 2px;
+  }
+  .pi-foot__google-source svg { flex-shrink: 0; }
 
   .pi-foot__aoc {
     margin: 0 auto 1.5rem;

--- a/next/src/components/PiArticleActions.astro
+++ b/next/src/components/PiArticleActions.astro
@@ -17,6 +17,7 @@
  * v2/SaveButton. Wave 3 of the Save & Share rebuild.
  */
 import PiSaveActions from './PiSaveActions.astro';
+import TextScaleControl from './TextScaleControl.astro';
 
 export interface Props {
   /** Save kind — defaults to 'article' for journal pieces. */
@@ -45,6 +46,7 @@ const resolvedHref = href ?? `/${section}/${slug}/`;
     imageUrl={imageUrl}
     floating={false}
   />
+  <TextScaleControl />
 </div>
 
 <aside

--- a/next/src/components/TextScaleControl.astro
+++ b/next/src/components/TextScaleControl.astro
@@ -1,0 +1,93 @@
+---
+/**
+ * TextScaleControl — three-step reader text-size control (A A A).
+ *
+ * Sets data-text-scale="1|2|3" on <html>; global.css maps steps 2 and 3
+ * to a larger root font-size (108.75% / 118%), so the whole rem-based
+ * sheet scales. The choice persists in localStorage ('pi-text-scale')
+ * and is re-applied before first paint by an inline script in
+ * BaseLayout, so there is no size flash on navigation.
+ *
+ * Rendered inside the PiArticleActions byline row on reading surfaces.
+ */
+---
+
+<div class="text-scale" role="group" aria-label="Text size" data-text-scale-control>
+  <button type="button" class="text-scale__btn text-scale__btn--1" data-scale="1" aria-pressed="true" aria-label="Default text size">A</button>
+  <button type="button" class="text-scale__btn text-scale__btn--2" data-scale="2" aria-pressed="false" aria-label="Larger text size">A</button>
+  <button type="button" class="text-scale__btn text-scale__btn--3" data-scale="3" aria-pressed="false" aria-label="Largest text size">A</button>
+</div>
+
+<script is:inline>
+  (function () {
+    var KEY = 'pi-text-scale';
+
+    function applyScale(scale) {
+      if (scale === '1') {
+        delete document.documentElement.dataset.textScale;
+      } else {
+        document.documentElement.dataset.textScale = scale;
+      }
+      document.querySelectorAll('[data-text-scale-control]').forEach(function (group) {
+        group.querySelectorAll('.text-scale__btn').forEach(function (btn) {
+          btn.setAttribute('aria-pressed', btn.dataset.scale === scale ? 'true' : 'false');
+        });
+      });
+    }
+
+    function init() {
+      var current = '1';
+      try { current = localStorage.getItem(KEY) || '1'; } catch (e) {}
+      applyScale(current);
+      document.querySelectorAll('[data-text-scale-control]').forEach(function (group) {
+        if (group._piWired) return;
+        group._piWired = true;
+        group.addEventListener('click', function (e) {
+          var btn = e.target.closest('.text-scale__btn');
+          if (!btn) return;
+          try { localStorage.setItem(KEY, btn.dataset.scale); } catch (e2) {}
+          applyScale(btn.dataset.scale);
+        });
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+    document.addEventListener('astro:page-load', init);
+  })();
+</script>
+
+<style is:global>
+  .text-scale {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.15rem;
+  }
+
+  .text-scale__btn {
+    appearance: none;
+    background: none;
+    border: 0;
+    padding: 0.2rem 0.3rem;
+    cursor: pointer;
+    font-family: 'Outfit', system-ui, sans-serif;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--soft);
+    border-bottom: 2px solid transparent;
+    transition: color .2s var(--ease), border-color .2s var(--ease);
+  }
+
+  .text-scale__btn--1 { font-size: 0.8rem; }
+  .text-scale__btn--2 { font-size: 0.95rem; }
+  .text-scale__btn--3 { font-size: 1.1rem; }
+
+  .text-scale__btn:hover { color: var(--accent); }
+  .text-scale__btn[aria-pressed="true"] {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+</style>

--- a/next/src/components/WeekendPickerBlock.astro
+++ b/next/src/components/WeekendPickerBlock.astro
@@ -30,8 +30,9 @@ const dispatchSlug: string | undefined = dispatch?.slug ?? dispatch?.id;
 const globalOv = await loadOverrides('page', '_global');
 const articleOv = dispatchSlug ? await loadOverrides('article', dispatchSlug) : { text: {}, image: {} };
 
-const eyebrow      = globalOv.text['weekend.eyebrow']     ?? 'Peninsula This Weekend';
-const cadence      = globalOv.text['weekend.cadence']     ?? 'Published for the weekend ahead · one pick, one backup, one useful planning note';
+// Simplified 2026-06-10 (homepage cognitive-load pass): the eyebrow +
+// cadence label column repeated what the kicker and the dispatch title
+// already say. One label, one title, one dek, two CTAs.
 const ctaPrimary   = globalOv.text['weekend.cta.primary'] ?? "Read this week's dispatch →";
 const ctaGhostRaw  = globalOv.text['weekend.cta.ghost']   ?? 'View What’s On →';
 const ctaGhost     = /all events/i.test(ctaGhostRaw) ? 'View What’s On →' : ctaGhostRaw;
@@ -43,22 +44,6 @@ const dispatchDek   = articleOv.text['dek']   ?? dispatch?.data?.dek   ?? '';
 <section class="weekend-picker" aria-label="Peninsula This Weekend">
   <div class="container">
     <div class="weekend-picker__inner">
-      <div class="weekend-picker__label-block">
-        <span
-          class="label label--accent"
-          {...editableText({
-            entityType: 'page', entitySlug: '_global',
-            fieldPath: 'weekend.eyebrow', label: 'Weekend block eyebrow',
-          })}
-        >{eyebrow}</span>
-        <p
-          class="weekend-picker__cadence"
-          {...editableText({
-            entityType: 'page', entitySlug: '_global',
-            fieldPath: 'weekend.cadence', label: 'Weekend block cadence note',
-          })}
-        >{cadence}</p>
-      </div>
       <div class="weekend-picker__content">
         <p class="weekend-picker__kicker">
           {weekend ?? 'This weekend'}
@@ -97,6 +82,10 @@ const dispatchDek   = articleOv.text['dek']   ?? dispatch?.data?.dek   ?? '';
             })}
           >{ctaGhost}</a>
         </div>
+        <p class="weekend-picker__melb">
+          Coming from Melbourne?
+          <a href="/explore/plans/?intent=melbourne-weekend">Here&rsquo;s where to start →</a>
+        </p>
       </div>
     </div>
   </div>

--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -92,6 +92,11 @@ const {
             <line x1="21" y1="21" x2="16.5" y2="16.5" />
           </svg>
         </a>
+        <a href="/saved/" class="v4-iconbtn" aria-label="Saved — your shortlist">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 3.5h12a.5.5 0 0 1 .5.5v16.6a.4.4 0 0 1-.63.33L12 16.5l-5.87 4.43a.4.4 0 0 1-.63-.33V4a.5.5 0 0 1 .5-.5Z" />
+          </svg>
+        </a>
         <button
           class="masthead__burger v4-burger"
           aria-label="Open menu"
@@ -134,6 +139,11 @@ const {
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <circle cx="11" cy="11" r="7" />
               <line x1="21" y1="21" x2="16.5" y2="16.5" />
+            </svg>
+          </a>
+          <a href="/saved/" class="v4-iconbtn" aria-label="Saved — your shortlist">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M6 3.5h12a.5.5 0 0 1 .5.5v16.6a.4.4 0 0 1-.63.33L12 16.5l-5.87 4.43a.4.4 0 0 1-.63-.33V4a.5.5 0 0 1 .5-.5Z" />
             </svg>
           </a>
           {/* "Ask PI" pill removed from the masthead (2026-05-13) per James.

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -240,6 +240,19 @@ const isAskPage = rawPathname.startsWith('/ask');
   <link rel="stylesheet" href="/assets/mobile-fixes.css" />
   <link rel="stylesheet" href="/assets/scroll-animations.css" />
 
+  <!-- Reader text-size preference — applied before first paint so pages
+       don't flash at the default size. The control itself lives in
+       TextScaleControl.astro (rendered on article surfaces); steps are
+       mapped to root font-size in global.css. -->
+  <script is:inline>
+    (function () {
+      try {
+        var s = localStorage.getItem('pi-text-scale');
+        if (s === '2' || s === '3') document.documentElement.dataset.textScale = s;
+      } catch (e) {}
+    })();
+  </script>
+
   <!-- Google tag (gtag.js) — gated on user consent.
        The loader checks localStorage 'pi-consent-v1' and only injects
        gtag if analytics consent is true. CookieBanner dispatches

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -3,12 +3,17 @@
  * Homepage — Editorial magazine cover for the Mornington Peninsula guide.
  *
  * Cover carousel: full article rotates (text + image together).
- * Below the fold: ThreeMissionBar → Section nav → Melbourne strip →
- *   Weekend Dispatch → Places rail → Plans → Shortlist → Editor's Letter
- *   → Notebook → Newsletter.
+ * Below the fold: Section nav → Weekend Dispatch → Places rail → Plans
+ *   → Shortlist → Editor's Letter → Notebook → Newsletter.
  *
  * Promoted from /preview-home-redesign/ on 2026-05-25, replacing the
  * cinematic fullbleed cover that lives in git history.
+ *
+ * Simplified 2026-06-10: ThreeMissionBar and MelbourneEntryStrip removed —
+ * each routed intents (Ask / weekend / plans) that already have exactly one
+ * surface elsewhere on this screen (Ask floating button, the Weekend
+ * Dispatch card, the Plans grid). The Melbourne entry link now lives
+ * inside WeekendPickerBlock.
  */
 
 import { getCollection } from 'astro:content';
@@ -19,8 +24,6 @@ import PlaceCard from '../components/PlaceCard.astro';
 import ItineraryCard from '../components/ItineraryCard.astro';
 import WeekendPickerBlock from '../components/WeekendPickerBlock.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
-import ThreeMissionBar from '../components/ThreeMissionBar.astro';
-import MelbourneEntryStrip from '../components/MelbourneEntryStrip.astro';
 import ScrollReveal from '../components/react/ScrollReveal.tsx';
 import { routeSlug, dispatchWeekend } from '../lib/editorial';
 import { loadPublishedHomepageOverrides, getHomepageAdminContent } from '../lib/content/homepage';
@@ -36,16 +39,7 @@ const articles    = (await getCollection('articles', ({ data }) => data.status =
 const places      = await getCollection('places');
 const itineraries = await getCollection('itineraries');
 
-// ── Upcoming events for the ThreeMissionBar "This Weekend" panel ───────────
 const now = new Date();
-const upcomingEvents = (await getCollection('events'))
-  .filter((e) => {
-    if (e.data.status === 'archived' || e.data.status === 'draft') return false;
-    const end = (e.data as any).endDate ?? e.data.startDate;
-    return end >= now;
-  })
-  .sort((a, b) => a.data.startDate.getTime() - b.data.startDate.getTime())
-  .slice(0, 3);
 
 // ── Quick notes (The Notebook) ─────────────────────────────────────────────
 const notebookNote = (await getCollection('quickNotes', ({ data }) => data.status === 'published' && data.expiresAt > now))
@@ -78,10 +72,6 @@ const weekendDispatch = articles
 const dispatchWindow = weekendDispatch
   ? dispatchWeekend(weekendDispatch.data.publishedAt)
   : { start: new Date(0), end: new Date(0), sat: new Date(), sun: new Date(), label: 'This weekend' };
-
-const dispatchHref = weekendDispatch
-  ? `/journal/${routeSlug(weekendDispatch)}/`
-  : '/whats-on/this-weekend/';
 
 const editorPicks = articles
   .filter((a) => routeSlug(a) !== routeSlug(featured))
@@ -239,7 +229,10 @@ export const prerender = true;
       ))}
     </div>
 
-    {/* Story navigation strip */}
+    {/* Story navigation — quiet progress bars, one per story. Labels were
+        removed 2026-06-10: tiny uppercase tags ("SLOW PENINSULA", "WALK")
+        read as content filters and meant nothing before the stories were
+        seen. Accessible names carry the story headline instead. */}
     <nav class="cover__nav" aria-label="Switch story">
       <div class="container cover__nav-inner">
         {scenes.map((scene, i) => (
@@ -247,9 +240,8 @@ export const prerender = true;
             class={`cover__nav-btn${i === 0 ? ' is-active' : ''}`}
             data-target={i}
             type="button"
-            aria-label={`View: ${scene.label}`}
+            aria-label={`Story ${i + 1} of ${scenes.length}: ${scene.headline.replace(/<[^>]+>/g, '')}`}
           >
-            <span class="cover__nav-label">{scene.label}</span>
             <span class="cover__nav-bar" aria-hidden="true"></span>
           </button>
         ))}
@@ -257,17 +249,9 @@ export const prerender = true;
     </nav>
   </section>
 
-  {/* ── ZONE 2: Three-Mission Bar (REDESIGN — replaces "Also in this issue") */}
-  <ThreeMissionBar
-    weekendLabel={dispatchWindow.label}
-    dispatchHref={dispatchHref}
-    events={upcomingEvents}
-  />
-
-  {/* ── ZONE 3: Section navigation strip (Ask added as first chip) ───────── */}
+  {/* ── ZONE 2: Section navigation strip ─────────────────────────────────── */}
   <nav class="hp-section-nav" aria-label="Browse sections">
     <div class="hp-section-nav__track">
-      <a class="hp-section-nav__chip hp-section-nav__chip--ask" href="/ask/" data-pi-trigger="true">Ask</a>
       <a class="hp-section-nav__chip" href="/whats-on/">What&rsquo;s On</a>
       <a class="hp-section-nav__chip" href="/explore/plans/">Plans</a>
       <a class="hp-section-nav__chip" href="/eat/">Eat &amp; Drink</a>
@@ -279,10 +263,7 @@ export const prerender = true;
     </div>
   </nav>
 
-  {/* ── ZONE 4: Melbourne entry strip (REDESIGN — new) ───────────────────── */}
-  {weekendDispatch && <MelbourneEntryStrip />}
-
-  {/* ── ZONE 5: Weekend Dispatch ─────────────────────────────────────────── */}
+  {/* ── ZONE 3: Weekend Dispatch ─────────────────────────────────────────── */}
   {weekendDispatch && (
     <ScrollReveal client:visible>
       <WeekendPickerBlock
@@ -669,45 +650,27 @@ export const prerender = true;
   }
   .cover__nav-inner {
     display: flex;
-    gap: 0;
-    overflow-x: auto;
-    scrollbar-width: none;
+    gap: 0.6rem;
+    max-width: 24rem;
   }
-  .cover__nav-inner::-webkit-scrollbar { display: none; }
   .cover__nav-btn {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.45rem;
-    padding: 0.35rem 1.5rem 0.35rem 0;
+    display: block;
+    flex: 1;
+    padding: 0.55rem 0;
     background: none;
     border: none;
     cursor: pointer;
-    flex-shrink: 0;
   }
-  .cover__nav-btn:first-child { padding-left: 0; }
-  .cover__nav-label {
-    font-family: 'Outfit', system-ui, sans-serif;
-    font-size: 0.6rem;
-    font-weight: 700;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: rgba(23, 20, 19, 0.35);
-    transition: color 0.2s ease;
-    white-space: nowrap;
-  }
-  .cover__nav-btn.is-active .cover__nav-label { color: #A0541F; }
-  .cover__nav-btn:hover .cover__nav-label { color: rgba(23, 20, 19, 0.65); }
-  .cover__nav-btn.is-active:hover .cover__nav-label { color: #A0541F; }
   .cover__nav-bar {
     display: block;
     height: 2px;
     width: 100%;
-    min-width: 3.5rem;
-    background: rgba(23, 20, 19, 0.1);
+    background: rgba(23, 20, 19, 0.12);
     position: relative;
     overflow: hidden;
+    transition: background 0.2s ease;
   }
+  .cover__nav-btn:hover .cover__nav-bar { background: rgba(23, 20, 19, 0.3); }
   .cover__nav-btn.is-active .cover__nav-bar::after {
     content: '';
     position: absolute;
@@ -787,8 +750,6 @@ export const prerender = true;
   .hp-section-nav__chip:hover, .hp-section-nav__chip:focus-visible {
     color: var(--ochre, #A0541F); background: transparent;
   }
-  /* Ask chip is visually accented */
-  .hp-section-nav__chip--ask { color: var(--ochre, #A0541F); font-weight: 600; }
   @media (min-width: 768px) {
     .hp-section-nav { display: none; }
   }

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -33,6 +33,13 @@
   --prose-w:    680px;
   --ease:       cubic-bezier(0.25, 0.46, 0.45, 0.94);
   --tile-image-radius: 10px;
+  /* Card surface radii — collapse the bespoke card radii onto one scale.
+     sm = nested elements inside a card (embed slots, sub-tiles).
+     md = standard panel (CompareBlock column, typeahead grid).
+     lg = hero-weight panel (Weekend Picker, newsletter frame). */
+  --radius-card-sm: 0.85rem;
+  --radius-card-md: 1.25rem;
+  --radius-card-lg: 1.5rem;
 }
 
 /* Shared image treatment for editorial tiles/cards */
@@ -1147,7 +1154,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   display: flex;
   flex-direction: column;
   gap: 0;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-card-lg);
   border: 1px solid rgba(121, 92, 58, 0.14);
   box-shadow: 0 18px 40px rgba(34, 24, 16, 0.06);
   transition: transform 0.22s var(--ease), box-shadow 0.22s var(--ease), border-color 0.22s var(--ease);
@@ -2859,7 +2866,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   max-width: 480px;
   margin-left: auto;
   margin-right: auto;
-  border-radius: 0.9rem;
+  border-radius: var(--radius-card-sm);
 }
 .newsletter__stack .newsletter__proofs {
   display: grid;
@@ -4396,7 +4403,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   position: relative;
   background: linear-gradient(180deg, rgba(255,252,247,0.98) 0%, rgba(248,243,236,0.98) 100%);
   border: 1px solid rgba(121, 92, 58, 0.14);
-  border-radius: 1.5rem;
+  border-radius: var(--radius-card-lg);
   box-shadow: 0 18px 40px rgba(34, 24, 16, 0.06);
   padding: clamp(2rem, 4vw, 3rem);
   display: grid;
@@ -5276,7 +5283,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   position: relative;
   background: linear-gradient(180deg, rgba(255,252,247,0.98) 0%, rgba(248,243,236,0.98) 100%);
   border: 1px solid rgba(121, 92, 58, 0.14);
-  border-radius: 1.25rem;
+  border-radius: var(--radius-card-md);
   padding: clamp(1.6rem, 3vw, 2.2rem);
   box-shadow: 0 18px 40px rgba(34, 24, 16, 0.06);
   overflow: hidden;
@@ -5552,7 +5559,7 @@ p.has-drop-cap::first-letter {
   gap: 1px;
   background: rgba(121, 92, 58, 0.18);
   border: 1px solid rgba(121, 92, 58, 0.18);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-card-sm);
   overflow: hidden;
 }
 .hub-formats__cell {
@@ -7908,7 +7915,7 @@ p.has-drop-cap::first-letter {
   width: min(100%, 30rem);
   margin: 0 auto;
   padding: 0.55rem;
-  border-radius: 1.35rem;
+  border-radius: var(--radius-card-lg);
   background: linear-gradient(180deg, rgba(255,255,255,0.16) 0%, rgba(255,255,255,0.06) 100%);
   border: 1px solid rgba(214, 196, 154, 0.24);
   box-shadow: 0 24px 50px rgba(0,0,0,0.24);
@@ -7991,14 +7998,14 @@ p.has-drop-cap::first-letter {
   .newsletter__form-frame {
     width: min(100%, 23rem);
     padding: 0.45rem;
-    border-radius: 1.05rem;
+    border-radius: var(--radius-card-md);
   }
 
   .newsletter__embed {
     min-height: 112px !important;
     height: 112px !important;
     max-height: 112px !important;
-    border-radius: 0.85rem;
+    border-radius: var(--radius-card-sm);
   }
 
   .newsletter__proof-row {
@@ -8059,7 +8066,7 @@ p.has-drop-cap::first-letter {
   width: min(100%, 30rem);
   margin: 0 auto;
   padding: 1.4rem 1.25rem;
-  border-radius: 1.35rem;
+  border-radius: var(--radius-card-lg);
   background: linear-gradient(180deg, rgba(36, 31, 28, 0.94) 0%, rgba(24, 21, 19, 0.92) 100%);
   border: 1px solid rgba(193, 173, 123, 0.24);
   box-shadow: 0 24px 52px rgba(0,0,0,0.24), inset 0 1px 0 rgba(255,255,255,0.05);

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -21,10 +21,14 @@
   --bg-alt:     #F6F2EA;
   --bg-dark:    #1E1B18;
   --text:       #2B2520;
-  --soft:       #7A726A;
+  --soft:       #5F574E;
   --accent:     #8B4E3B;
   --acc-h:      #6D3A2B;
   --gold:       #B69A6B;
+  /* Gold as READABLE text on light surfaces — --gold itself is 2.7:1 on
+     white, decorative use only. This darker cut passes WCAG AA (5.7:1 on
+     white, 5.1:1 on bg-alt). */
+  --gold-text:  #7A6340;
   --dark:       #1E1B18;
   --white:      #FDFCFA;
   --border:     #E5E0D6;
@@ -57,7 +61,13 @@
    RESET
    ========================================================= */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: auto; font-size: 16px; }
+/* 100% (not a fixed px value) so the reader's browser font-size
+   preference is respected. The whole sheet is rem-based, so everything
+   scales with it — including the three-step reader text-size control,
+   which sets data-text-scale on <html> (see TextScaleControl.astro). */
+html { scroll-behavior: auto; font-size: 100%; }
+html[data-text-scale="2"] { font-size: 108.75%; }
+html[data-text-scale="3"] { font-size: 118%; }
 
 /* =========================================================
    VIEW TRANSITIONS — page fade between routes
@@ -85,8 +95,8 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.75;
-  font-size: 0.95rem;
-  font-weight: 300;
+  font-size: 1rem;
+  font-weight: 400;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
@@ -556,7 +566,6 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   color: var(--bg);
   border-color: var(--accent);
 }
-
 /* Mobile-only wordmark — sits in the centre of the merged mobile nav
    row. Hidden on desktop, where the dedicated brand row carries the
    full wordmark + tagline. */
@@ -654,7 +663,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   line-height: 1.65;
   color: var(--soft);
   max-width: 42ch;
-  font-weight: 300;
+  font-weight: 400;
 }
 .cover__visual {
   position: relative;
@@ -720,7 +729,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   line-height: 1.7;
   color: var(--soft);
   max-width: 50ch;
-  font-weight: 300;
+  font-weight: 400;
 }
 .section-hero__visual {
   position: relative;
@@ -905,7 +914,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .pillar-row__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
   font-size: clamp(0.95rem, 1.05vw, 1.05rem);
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   color: var(--soft);
   line-height: 1.35;
 }
@@ -1688,7 +1698,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .article-hero__title em { color: var(--accent); font-style: italic; font-weight: 600; }
 .article-hero__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: clamp(1.1rem, 1.6vw, 1.32rem);
   line-height: 1.55;
   color: #44372b;
@@ -1858,10 +1869,10 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .prose {
   max-width: var(--prose-w);
   margin: 0 auto;
-  font-size: 1.05rem;
+  font-size: 1.0625rem;
   line-height: 1.85;
   color: var(--text);
-  font-weight: 300;
+  font-weight: 400;
 }
 .prose p {
   margin-bottom: 1.5rem;
@@ -1893,7 +1904,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .prose blockquote {
   border-left: 2px solid var(--accent);
   padding-left: 1.25rem;
-  font-style: italic;
+  font-style: normal;
   color: var(--soft);
   margin: 2rem 0;
 }
@@ -2171,7 +2182,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   font-size: 1.1rem;
   line-height: 1.7;
   color: var(--soft);
-  font-weight: 300;
+  font-weight: 400;
   margin-bottom: 2.5rem;
 }
 .place-detail__hero {
@@ -2351,7 +2362,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .news-hero__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: clamp(1.15rem, 1.6vw, 1.35rem);
   line-height: 1.5;
   color: var(--soft);
@@ -2490,7 +2502,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .news-sample__sub {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1.1rem;
   line-height: 1.55;
   color: #6b4f33;
@@ -2586,7 +2599,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .news-editions__note {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 0.95rem;
   color: var(--soft);
   line-height: 1.5;
@@ -2735,7 +2749,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .news-close__title em { color: rgba(245, 220, 178, 0.95); font-style: italic; }
 .news-close__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1.1rem;
   line-height: 1.55;
   color: rgba(253, 252, 250, 0.78);
@@ -2891,7 +2906,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   color: var(--white);
   font-family: 'Outfit', sans-serif;
   font-size: 0.9rem;
-  font-weight: 300;
+  font-weight: 400;
   outline: none;
   transition: background .2s var(--ease), border-color .2s var(--ease);
 }
@@ -4032,7 +4047,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .editors-desk__formats .label {
   font-size: 0.65rem;
   letter-spacing: 0.2em;
-  color: var(--gold);
+  color: var(--gold-text);
   margin-bottom: 1.25rem;
 }
 .editors-desk__format-list {
@@ -4543,7 +4558,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .insider-stripe__body {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1.05rem;
   line-height: 1.55;
   color: rgba(253, 252, 250, 0.78);
@@ -4686,7 +4702,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .shortlist__body {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1.1rem;
   line-height: 1.55;
   color: #44372b;
@@ -5014,7 +5031,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .home-cover__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: clamp(1.1rem, 1.6vw, 1.35rem);
   line-height: 1.55;
   color: #44372b;
@@ -5156,7 +5174,8 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .guide-hero__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: clamp(1.05rem, 1.5vw, 1.28rem);
   line-height: 1.55;
   color: #44372b;
@@ -5507,7 +5526,7 @@ p.has-drop-cap::first-letter {
 .section-standfirst,
 .venues__sub--standfirst {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
   font-size: clamp(1.1rem, 1.55vw, 1.32rem);
   line-height: 1.5;
   color: #6b4f33;
@@ -5544,7 +5563,8 @@ p.has-drop-cap::first-letter {
 }
 .hub-formats__dek {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1.1rem;
   line-height: 1.55;
   color: #6b4f33;
@@ -6080,7 +6100,8 @@ p.has-drop-cap::first-letter {
 }
 .event-card__verdict p {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.45;
   color: var(--dark);
@@ -6260,7 +6281,8 @@ p.has-drop-cap::first-letter {
 }
 .event-verdict__body {
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-style: italic;
+  font-style: normal;
+  font-weight: 500;
   font-size: 1.2rem;
   line-height: 1.5;
   color: var(--dark);
@@ -6852,8 +6874,8 @@ p.has-drop-cap::first-letter {
   color: var(--accent);
 }
 .article__share-btn.is-copied {
-  border-color: var(--gold);
-  color: var(--gold);
+  border-color: var(--gold-text);
+  color: var(--gold-text);
   background: rgba(182,154,107,0.06);
 }
 @media (max-width: 600px) {

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -4421,10 +4421,6 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   border-radius: var(--radius-card-lg);
   box-shadow: 0 18px 40px rgba(34, 24, 16, 0.06);
   padding: clamp(2rem, 4vw, 3rem);
-  display: grid;
-  grid-template-columns: 1fr 2.2fr;
-  gap: clamp(2rem, 4vw, 4rem);
-  align-items: start;
   overflow: hidden;
 }
 .weekend-picker__inner::before {
@@ -4433,15 +4429,6 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   inset: 0 0 auto 0;
   height: 5px;
   background: linear-gradient(90deg, rgba(167,118,55,0.95), rgba(223,197,158,0.65), rgba(167,118,55,0.14));
-}
-.weekend-picker__label-block .label--accent { color: var(--accent); }
-.weekend-picker__cadence {
-  margin-top: 0.9rem;
-  font-size: 0.78rem;
-  letter-spacing: 0.02em;
-  color: var(--soft);
-  line-height: 1.5;
-  max-width: 28ch;
 }
 .weekend-picker__kicker {
   font-size: 0.68rem;
@@ -4500,6 +4487,24 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   background: rgba(121, 92, 58, 0.08);
   color: var(--dark);
   border-color: rgba(121, 92, 58, 0.4);
+}
+/* Quiet Melbourne entry line — absorbed the former MelbourneEntryStrip
+   (2026-06-10) so weekend intent has a single surface on the homepage. */
+.weekend-picker__melb {
+  margin-top: 1.4rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--soft);
+}
+.weekend-picker__melb a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(139, 78, 59, 0.35);
+  transition: color .18s var(--ease), border-color .18s var(--ease);
+}
+.weekend-picker__melb a:hover {
+  color: var(--acc-h);
+  border-color: var(--acc-h);
 }
 
 /* =========================================================


### PR DESCRIPTION
Design session 2026-06-10. Three commits, each logged in `CHANGELOG.md`:

**1. Card radius tokens** (design review 2026-W22) — `--radius-card-sm/md/lg` in `:root`, nine bespoke card radii collapsed onto them. One deviation from the memo: `.newsletter__embed` desktop maps to `sm` (closest token, matches its mobile mapping).

**2. Site-wide readability + reader utilities** (benchmarked against The Age Good Food mobile):
- Body/prose weight 300 → 400, base size 0.95rem → 1rem (prose 1.0625rem) — the light weight was the main "grey text" complaint
- `--soft` darkened to `#5F574E` (passes WCAG AA on white *and* cream); new `--gold-text` token for gold-as-text on light surfaces
- 15 multi-line body-copy italic rules converted to roman (Cormorant blocks to weight 500); display `em` accents and brand taglines keep italics
- `html` font-size 16px → 100% so browser font-size preferences are respected
- New `TextScaleControl.astro` — three-step A/A/A text sizing on article surfaces, persisted in localStorage, pre-paint applied in BaseLayout
- Saved bookmark icon in both V4 masthead action clusters → `/saved/`
- Footer "Add us as a preferred source on Google" button (official deeplink format per Google Search Central; verify the site surfaces in the source-preferences tool for AU users before relying on it)

**3. Homepage top-section simplification** — the first four mobile viewports routed the same three intents 3–4× each. Removed `ThreeMissionBar` and `MelbourneEntryStrip` (each duplicated surfaces that remain: floating Ask button, weekend dispatch card, plans grid), removed the Ask chip from the section nav, simplified `WeekendPickerBlock` (one kicker, title, dek, two CTAs, quiet Melbourne line), and replaced the hero's label tabs with equal-width progress bars with descriptive aria-labels.

**Verification:** `npm run build` green on every commit (1485 pages). Suggested visual spot-checks before merge: homepage at 375px, newsletter frame, CompareBlock columns, an article page for the A/A/A control.

**Note:** the CHANGELOG.md diff in the first commit looks large because the file's CRLF line endings were normalized to LF; content change is just the new entries.

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo