### PR TITLE
design(home): rework hero story pager into proper carousel segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ For each meaningful change, include:
 
 ## 2026-06-10 — Claude (design)
 
+### Hero pager polish (post-deploy fix)
+
+**Summary**
+The story-switcher bars shipped earlier today read as stray dashes on mobile (full-width 2px lines, left-aligned, stranded between two hairline borders). Reworked as a conventional carousel pager: fixed-width 4px rounded segments, centred under the hero, with a visible focus ring. Removed the doubled hairline where the cover's border-bottom met the section-nav's border-top.
+
+**Files changed**
+- `next/src/pages/index.astro`
+
+**Pages affected**
+- `/` (homepage)
+
+**Verification**
+- `npm run build` passes (1485 pages); 5 pager segments in built homepage.
+
 ### Homepage top-section simplification (cognitive-load pass)
 
 **Summary**

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -643,34 +643,41 @@ export const prerender = true;
   }
 
   /* ── Cover story nav strip ─────────────────────────────────────────────────── */
+  /* Carousel pager: short, fixed-width rounded segments, centred. Fixed
+     widths (not flex: 1) so the row reads as a deliberate control rather
+     than stray dashes; the active segment fills with the story timer. */
   .cover__nav {
     background: #FFFFFF;
-    border-top: 1px solid rgba(23, 20, 19, 0.08);
-    padding: 0.85rem 0;
+    padding: 0 0 0.5rem;
   }
   .cover__nav-inner {
     display: flex;
-    gap: 0.6rem;
-    max-width: 24rem;
+    justify-content: center;
+    gap: 0.5rem;
   }
   .cover__nav-btn {
     display: block;
-    flex: 1;
-    padding: 0.55rem 0;
+    padding: 0.6rem 0;
     background: none;
     border: none;
     cursor: pointer;
   }
   .cover__nav-bar {
     display: block;
-    height: 2px;
-    width: 100%;
-    background: rgba(23, 20, 19, 0.12);
+    height: 4px;
+    width: 2.1rem;
+    border-radius: 999px;
+    background: rgba(23, 20, 19, 0.14);
     position: relative;
     overflow: hidden;
     transition: background 0.2s ease;
   }
-  .cover__nav-btn:hover .cover__nav-bar { background: rgba(23, 20, 19, 0.3); }
+  .cover__nav-btn:hover .cover__nav-bar { background: rgba(23, 20, 19, 0.32); }
+  .cover__nav-btn:focus-visible {
+    outline: 2px solid #A0541F;
+    outline-offset: 2px;
+    border-radius: 999px;
+  }
   .cover__nav-btn.is-active .cover__nav-bar::after {
     content: '';
     position: absolute;
@@ -717,12 +724,12 @@ export const prerender = true;
     .cover__visual-frame { aspect-ratio: 16 / 9; }
     .cover__headline { font-size: clamp(2.625rem, 11vw, 3.6rem); line-height: 0.98; max-width: none; }
     .cover__dispatch { margin-bottom: 1.5rem; }
-    .cover__nav-inner { padding: 0 clamp(1rem, 4vw, 2rem); }
   }
 
   /* ── Section nav ─────────────────────────────────────────────────────────── */
   .hp-section-nav {
-    border-top: 1px solid var(--line, #D9D1BE);
+    /* No border-top: the cover section above already closes with its own
+       hairline; two adjacent 1px lines read as a glitch. */
     border-bottom: 1px solid var(--line, #D9D1BE);
     background: var(--paper-warm, #F3EDDE);
     overflow: hidden;


### PR DESCRIPTION
Follow-up to #234. The hero story-switcher bars looked like stray dashes on mobile (flex-stretched 2px lines, left-aligned, sitting in an empty band between two hairline borders — screenshot from James).

Changes (`next/src/pages/index.astro` only):
- Pager segments are now fixed-width (2.1rem) 4px rounded pills, centred under the hero — they read as a conventional carousel pager; the active segment still fills with the 10s story timer
- Added a visible `:focus-visible` ring on the pager buttons
- Collapsed the doubled hairline where the cover's border-bottom met the section nav's border-top

`npm run build` green (1485 pages).

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo

---
_Generated by [Claude Code](https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo)_