### PR TITLE
design(fix): unstack masthead icons; remove count/verified tags site-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ For each meaningful change, include:
 
 ## 2026-06-10 — Claude (design)
 
+### Masthead icon overlap fix + count/verified tag removal
+
+**Summary**
+Two fixes from James's live-site review:
+
+1. **Mobile masthead overlap** — the saved and search icons stacked on top of each other: the mobile brand row's `display: contents` rule placed every `.v4-iconbtn` in the same 44px grid cell. The action cluster is now a single flex grid item, side cells widened to a symmetric 84px so the wordmark stays truly centred, and the wordmark scales via `clamp(21px, 6vw, 33px)` to fit the narrower middle.
+2. **Inventory counts + "Last verified" stamps removed site-wide** — hero eyebrows on 13 section/guide pages (eat, stay, wine, explore, escape, what's-on, golf, beaches, markets + v4 variants) reduced to the section name; dynamic count items removed from GuideHero meta rows (read-times and editorial facts like "3 world-ranked" kept); "Last verified:" sub-lines removed from the three tour detail templates. Kept: the fishing species "Verified stamp" block (regulatory disclaimer citing the Victorian Fisheries Authority) and preview/staging pages.
+
+**Files changed**
+- `next/src/styles/v4.css`
+- `next/src/components/GuideHero.astro` (doc comment)
+- 13 section index pages + 3 tour templates under `next/src/pages/`
+
+**Why it matters**
+The icon overlap was a visible bug on every mobile page. The count/verified tags ("41 wineries · 6 other producers · Last verified 30 Apr 2026", "0 producers") were reader-facing database noise; verification methodology lives at /methodology.
+
+**Verification**
+- `npm run build` passes (1485 pages); built eat/stay/wine/explore pages contain no count or verified strings.
+
 ### Hero pager polish (post-deploy fix)
 
 **Summary**

--- a/next/src/components/GuideHero.astro
+++ b/next/src/components/GuideHero.astro
@@ -19,7 +19,9 @@ import { editableText, editableImage, type CmsEntityType } from '../lib/inline-e
 import { loadOverrides } from '../lib/inline-edit/overrides';
 
 export interface Props {
-  /** Small caps eyebrow, e.g. "EAT & DRINK · 101 VENUES MAPPED · LAST VERIFIED 30 APR 2026". */
+  /** Small caps eyebrow, e.g. "EAT & DRINK". Keep it to the section name —
+      inventory counts and "last verified" stamps were removed site-wide
+      2026-06-10 (reader-facing noise; verification belongs in /methodology). */
   eyebrow?: string;
   /** Main headline. Italic <em> tags inside render in accent. */
   title: string;

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -197,15 +197,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Eat & Drink · ${venues.length} venues mapped · Last verified 30 Apr 2026`}
+    eyebrow="Eat & Drink"
     title="The dining rooms that justify the <em>drive</em>"
     dek="The Peninsula has more serious cellar door restaurants, more hatted venues, and more long-lunch tables than any region within ninety minutes of Melbourne. This is the editorial guide, not the directory."
-    meta={[
-      { label: `${twoHatCount} two-hat restaurants` },
-      { label: `${totalHats} GFG hats total` },
-      { label: `${hattedCount} hatted venues` },
-      { label: '10 min read' },
-    ]}
+    meta={[{ label: '10 min read' }]}
     heroImage="/images/sourced/venue-italian-dining-01.webp"
     imageAlt="An Italian-leaning Peninsula dining room, table laid, light low"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/explore/beaches.astro
+++ b/next/src/pages/explore/beaches.astro
@@ -118,14 +118,10 @@ export const prerender = true;
   <Breadcrumbs items={breadcrumbItems} />
 
   <GuideHero
-    eyebrow={`Explore guide · ${beaches.length} beaches · Last verified 23 Apr 2026`}
+    eyebrow="Explore guide"
     title="Mornington Peninsula <em>Beaches</em>"
     dek="Two coasts, one peninsula. The bay side is calm, warm, and family-safe. The ocean side is wild, rip-heavy, and worth visiting only if you know which side you're on."
-    meta={[
-      { label: `${bayBeaches.length} bay beaches` },
-      { label: `${oceanBeaches.length} ocean beaches` },
-      { label: '8 min read' },
-    ]}
+    meta={[{ label: '8 min read' }]}
     heroImage="/images/sourced/explore-gunnamatta-01.webp"
     imageAlt="Gunnamatta Ocean Beach — Bass Strait surf and dune ridges at the Peninsula's southern edge"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/explore/golf.astro
+++ b/next/src/pages/explore/golf.astro
@@ -192,15 +192,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Explore guide · ${golfCourses.length} courses · Last verified 30 Apr 2026`}
+    eyebrow="Explore guide"
     title="Mornington Peninsula <em>Golf</em>"
     dek="Australia's most concentrated cluster of serious public-access golf. Three world-ranked courses within 10 minutes of each other, all within 90 minutes of Melbourne."
-    meta={[
-      { label: `${golfCourses.length} courses assessed` },
-      { label: '3 world-ranked' },
-      { label: `${golfCourses.filter(e => e.data.golf?.access === 'public').length} with public green fees` },
-      { label: '12 min read' },
-    ]}
+    meta={[{ label: '3 world-ranked' }, { label: '12 min read' }]}
     heroImage="/images/sourced/golf-rye-sunrise-01.webp"
     imageAlt="Coastal golf landscape on the Mornington Peninsula at sunrise"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -140,15 +140,9 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Explore · ${experiences.length} Peninsula moves · Last verified 30 Apr 2026`}
+    eyebrow="Explore"
     title="The Peninsula gets better once you leave the <em>table</em>"
     dek="The strongest weekends here are not built on bookings alone. They need coastline, weather, a market detour, or one good walk between lunch and sunset. This section maps those moves properly."
-    meta={[
-      { label: `${walks.length} walks` },
-      { label: `${beaches.length} beaches` },
-      { label: `${lookouts.length} lookouts` },
-      { label: `${markets.length + wellness.length + galleriesAttractions.length} cultural & wellness` },
-    ]}
     heroImage="/images/sourced/explore-cape-schanck-lighthouse-01.webp"
     imageAlt="Cape Schanck Lighthouse and the Bass Strait coast, the Peninsula at its most explorable"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/explore/markets.astro
+++ b/next/src/pages/explore/markets.astro
@@ -232,15 +232,10 @@ export const prerender = true;
 
   <!-- 1. HERO -->
   <GuideHero
-    eyebrow={`Explore guide · ${markets.length} markets · Last verified 17 May 2026`}
+    eyebrow="Explore guide"
     title="Mornington Peninsula <em>Markets</em>"
     dek="Genuine producers, hinterland growers, and the social calendar of the upper Peninsula. Five markets ranked, the monthly rhythm mapped, and the one-line rule for getting the best of each."
-    meta={[
-      { label: `${markets.length} markets assessed` },
-      { label: '2 flagship · monthly' },
-      { label: 'Year-round bar Rye' },
-      { label: '6 min read' },
-    ]}
+    meta={[{ label: '6 min read' }]}
     heroImage="/images/sourced/article-red-hill-saturday-01.webp"
     imageAlt="Morning crowds and produce stalls at a Mornington Peninsula market"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/stay/index.astro
+++ b/next/src/pages/stay/index.astro
@@ -113,15 +113,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Stay · ${venues.length} properties · Last verified 30 Apr 2026`}
+    eyebrow="Stay"
     title="Choose the base, and the whole <em>weekend</em> changes"
     dek="The Peninsula is a region of distinct moods packed close together. A Red Hill country-house weekend produces a different trip from a Sorrento main-street hotel. This hub sorts the beds by the kind of weekend you actually want."
-    meta={[
-      { label: `${venues.length} stays mapped` },
-      { label: `${ridgeStays.length} ridge & hinterland` },
-      { label: `${coastStays.length} coastal village` },
-      { label: '9 min read' },
-    ]}
+    meta={[{ label: '9 min read' }]}
     heroImage="/images/sourced/venue-jackalope-hotel-01.webp"
     imageAlt="Jackalope Hotel, Merricks North vineyard at dusk"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/tour-packages/[slug].astro
+++ b/next/src/pages/tour-packages/[slug].astro
@@ -90,7 +90,6 @@ export const prerender = true;
         entityType: 'tour-package', entitySlug: slug, fieldPath: 'intro',
         label: `${data.name} — intro`,
       })}>{data.intro}</p>
-      <p class="venues__sub" style="font-size:0.8rem;color:var(--soft)">Last verified: {data.lastVerified?.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}</p>
     </div>
   </SubpageHero>
 

--- a/next/src/pages/tour/[slug].astro
+++ b/next/src/pages/tour/[slug].astro
@@ -106,7 +106,6 @@ export const prerender = true;
         entityType: 'tour', entitySlug: slug, fieldPath: 'intro',
         label: `${data.name} — intro`,
       })}>{data.intro}</p>
-      <p class="venues__sub" style="font-size:0.8rem;color:var(--soft)">Last verified: {data.lastVerified?.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}</p>
     </div>
   </SubpageHero>
 

--- a/next/src/pages/tour/operators/[slug].astro
+++ b/next/src/pages/tour/operators/[slug].astro
@@ -66,7 +66,6 @@ export const prerender = true;
   >
     <div class="prose">
       <p>{data.intro}</p>
-      <p class="venues__sub" style="font-size:0.8rem;color:var(--soft)">Last verified: {data.lastVerified?.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}</p>
     </div>
   </SubpageHero>
 

--- a/next/src/pages/v4/eat/index.astro
+++ b/next/src/pages/v4/eat/index.astro
@@ -134,15 +134,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Eat & Drink · ${venues.length} venues mapped · Last verified 30 Apr 2026`}
+    eyebrow="Eat & Drink"
     title="The dining rooms that justify the <em>drive</em>"
     dek="The Peninsula has more serious cellar door restaurants, more hatted venues, and more long-lunch tables than any region within ninety minutes of Melbourne. This is the editorial guide, not the directory."
-    meta={[
-      { label: `${twoHatCount} two-hat restaurants` },
-      { label: `${totalHats} GFG hats total` },
-      { label: `${hattedCount} hatted venues` },
-      { label: '10 min read' },
-    ]}
+    meta={[{ label: '10 min read' }]}
     heroImage="/images/sourced/venue-italian-dining-01.webp"
     imageAlt="An Italian-leaning Peninsula dining room, table laid, light low"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/v4/escape/index.astro
+++ b/next/src/pages/v4/escape/index.astro
@@ -100,15 +100,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Plans · ${itineraries.length} weekend itineraries · Last verified 30 Apr 2026`}
+    eyebrow="Plans"
     title="Good Peninsula weekends are built in the <em>sequence</em>"
     dek="The region is small enough to overdo and varied enough to get wrong. These escape plans are our answer, fewer bookings, better pacing, and just enough structure that the whole thing feels inevitable rather than overplanned."
-    meta={[
-      { label: `${twoNight.length} two-night escapes` },
-      { label: `${oneNight.length} one-night quick resets` },
-      { label: `${longer.length} longer trips` },
-      { label: '7 min read' },
-    ]}
+    meta={[{ label: '7 min read' }]}
     heroImage="/images/sourced/article-sunset-01.webp"
     imageAlt="Golden hour on the Mornington Peninsula, the moment a weekend earns the drive"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/v4/explore/index.astro
+++ b/next/src/pages/v4/explore/index.astro
@@ -132,15 +132,9 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Explore · ${experiences.length} Peninsula moves · Last verified 30 Apr 2026`}
+    eyebrow="Explore"
     title="The Peninsula gets better once you leave the <em>table</em>"
     dek="The strongest weekends here are not built on bookings alone. They need coastline, weather, a market detour, or one good walk between lunch and sunset. This section maps those moves properly."
-    meta={[
-      { label: `${walks.length} walks` },
-      { label: `${beaches.length} beaches` },
-      { label: `${lookouts.length} lookouts` },
-      { label: `${markets.length + wellness.length + galleriesAttractions.length} cultural & wellness` },
-    ]}
     heroImage="/images/sourced/explore-cape-schanck-lighthouse-01.webp"
     imageAlt="Cape Schanck Lighthouse and the Bass Strait coast, the Peninsula at its most explorable"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/v4/stay/index.astro
+++ b/next/src/pages/v4/stay/index.astro
@@ -111,15 +111,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Stay · ${venues.length} properties · Last verified 30 Apr 2026`}
+    eyebrow="Stay"
     title="Choose the base, and the whole <em>weekend</em> changes"
     dek="The Peninsula is a region of distinct moods packed close together. A Red Hill country-house weekend produces a different trip from a Sorrento main-street hotel. This hub sorts the beds by the kind of weekend you actually want."
-    meta={[
-      { label: `${venues.length} stays mapped` },
-      { label: `${ridgeStays.length} ridge & hinterland` },
-      { label: `${coastStays.length} coastal village` },
-      { label: '9 min read' },
-    ]}
+    meta={[{ label: '9 min read' }]}
     heroImage="/images/sourced/venue-jackalope-hotel-01.webp"
     imageAlt="Jackalope Hotel, Merricks North vineyard at dusk"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/v4/whats-on/index.astro
+++ b/next/src/pages/v4/whats-on/index.astro
@@ -159,15 +159,10 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`What's On · ${totalEvents} curated events · Reviewed weekly`}
+    eyebrow="What's On"
     title="Peninsula events, with an <em>opinion</em> for a change"
     dek="The Peninsula event web is a list-and-walk-away zone. Every other site publishes the calendar; nobody adds much context. This page does: weekend picks, worth-the-drive flags, and useful planning notes when the logistics matter."
-    meta={[
-      { label: `${totalEvents} curated events` },
-      { label: `${totalGroups} categories` },
-      { label: `${recurringCount} seasonal programmes` },
-      { label: 'Reviewed weekly' },
-    ]}
+    meta={[{ label: 'Reviewed weekly' }]}
     heroImage="/images/sourced/category-market-02.webp"
     imageAlt="Saturday morning at a Peninsula farmers market, part of the seasonal rhythm of the calendar"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/v4/wine/index.astro
+++ b/next/src/pages/v4/wine/index.astro
@@ -94,15 +94,9 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Wine Country · ${wineries.length} wineries · ${producers.length + breweries.length + distilleries.length} other producers · Last verified 30 Apr 2026`}
+    eyebrow="Wine Country"
     title="The Peninsula's best bottles start on the <em>ridge</em>"
     dek="Pinot noir and chardonnay built on basalt, plus the breweries, distilleries, and producers rounding out the region. Sorted by what they're actually for, long lunches, appointment tastings, and afternoons that earn the drive."
-    meta={[
-      { label: `${wineries.length} wineries` },
-      { label: `${breweries.length} breweries` },
-      { label: `${distilleries.length} distilleries` },
-      { label: `${producers.length} producers` },
-    ]}
     heroImage="/images/sourced/article-cellar-door-01.webp"
     imageAlt="A Peninsula cellar door, bottles open, glasses poured, the moment before the tasting"
     imageCredit="Peninsula Insider"

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -101,15 +101,9 @@ export const prerender = true;
        1. CINEMATIC HERO
        ═══════════════════════════════════════════════════════════════ -->
   <GuideHero
-    eyebrow={`Wine Country · ${wineries.length} wineries · ${producers.length + breweries.length + distilleries.length} other producers · Last verified 30 Apr 2026`}
+    eyebrow="Wine Country"
     title="The Peninsula's best bottles start on the <em>ridge</em>"
     dek="Pinot noir and chardonnay built on basalt, plus the breweries, distilleries, and producers rounding out the region. Sorted by what they're actually for, long lunches, appointment tastings, and afternoons that earn the drive."
-    meta={[
-      { label: `${wineries.length} wineries` },
-      { label: `${breweries.length} breweries` },
-      { label: `${distilleries.length} distilleries` },
-      { label: `${producers.length} producers` },
-    ]}
     heroImage="/images/sourced/article-cellar-door-01.webp"
     imageAlt="A Peninsula cellar door, bottles open, glasses poured, the moment before the tasting"
     imageCredit="Peninsula Insider"

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -242,10 +242,14 @@ body[data-v4="true"] .masthead {
   }
   body[data-v4="true"] .masthead__brand .container {
     display: grid;
-    grid-template-columns: 44px minmax(0, 1fr) 44px;
+    /* Side cells sized for the widest cluster (two 36px icon buttons +
+       6px gap = 78px) and kept symmetric so the wordmark stays truly
+       centred. The wordmark scales down via clamp() to fit the
+       narrower middle cell. */
+    grid-template-columns: 84px minmax(0, 1fr) 84px;
     grid-template-rows: 56px;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
     padding-top: 14px;
     padding-bottom: 14px;
     min-height: 56px;
@@ -261,7 +265,7 @@ body[data-v4="true"] .masthead {
     min-width: 0;
   }
   body[data-v4="true"] .masthead__brand .masthead__logo {
-    font-size: 33px;     /* 22px base × 1.5 = 33px */
+    font-size: clamp(21px, 6vw, 33px);   /* fits beside two icon buttons */
     line-height: 1.1;
     text-decoration: none;
     white-space: nowrap;
@@ -271,11 +275,13 @@ body[data-v4="true"] .masthead {
   /* Hide the desktop tagline on mobile — too long for the bar. */
   body[data-v4="true"] .masthead__brand .masthead__tagline { display: none; }
 
-  /* Mobile order: burger left, wordmark centred, search right. */
+  /* Mobile order: burger left, wordmark centred, saved + search right.
+     The cluster is one grid item laid out as a flex row — previously
+     display: contents put every icon in the same 44px cell, stacking
+     the saved and search buttons on top of each other. */
   body[data-v4="true"] .v4-mobile-actions {
-    display: contents;
-  }
-  body[data-v4="true"] .v4-mobile-actions .v4-iconbtn {
+    display: inline-flex;
+    gap: 6px;
     grid-column: 3;
     grid-row: 1;
     justify-self: end;
@@ -298,7 +304,7 @@ body[data-v4="true"] .masthead {
     padding-bottom: 12px;
     min-height: 52px;
   }
-  body[data-v4="true"] .masthead__brand .masthead__logo { font-size: 30px; }  /* 20px base × 1.5 = 30px */
+  body[data-v4="true"] .masthead__brand .masthead__logo { font-size: clamp(20px, 6vw, 30px); }
 }
 
 /* =========================================================


### PR DESCRIPTION
Two live-site fixes from James's mobile review:

**1. Masthead icons stacked on top of each other** (screenshot-reported). The mobile brand row used `display: contents` on the action cluster, which placed every `.v4-iconbtn` into the same 44px grid cell — fine with one icon, broken once the saved bookmark joined search. The cluster is now a single flex grid item; side columns are a symmetric 84px so the wordmark stays truly centred; the wordmark scales via `clamp(21px, 6vw, 33px)` to fit.

**2. Inventory counts and "Last verified" stamps removed site-wide.** Hero eyebrows on 13 section/guide pages (eat, stay, wine, explore, escape, what's-on, golf, beaches, markets + v4 variants) reduced to the section name; dynamic count items ("41 wineries", "0 producers") dropped from GuideHero meta rows, keeping read-times and editorial facts; "Last verified:" sub-lines removed from the three tour detail templates. Kept deliberately: the fishing species "Verified stamp" block (regulatory disclaimer citing the Victorian Fisheries Authority).

`npm run build` green (1485 pages); built section pages contain no count/verified strings.

Note: `GuideHero.astro` and `explore/beaches.astro` show whole-file diffs from CRLF→LF normalization; the content change there is a few lines (`git diff -w` shows 58+/102− total).

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo

---
_Generated by [Claude Code](https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo)_