### PR TITLE
design(fix): rebuild mobile masthead — burger | wordmark | bookmark | search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ For each meaningful change, include:
 
 ## 2026-06-10 — Claude (design)
 
+### Mobile masthead rebuilt and browser-verified (burger · wordmark · bookmark · search)
+
+**Summary**
+The previous masthead icon fix regressed the layout: the burger button lives inside `.v4-mobile-actions`, so turning that container into a right-aligned flex item dragged the burger to the right and the three-wide cluster overflowed into the wordmark. Rebuilt properly:
+
+- Burger moved out of the cluster in `V4Masthead.astro` markup — now a direct grid child in column 1 (left). Cluster is exactly bookmark + search (that order), column 3.
+- Added a `display: none !important` guard on `.v4-burger` outside the mobile block — the legacy `global.css` shows `.masthead__burger` at ≤768px but the v4 grid only exists at ≤760px, so the burger floated loose in the 761–768px window.
+- Wordmark stays truly centred: symmetric 78px side columns, `max-width: 100%` on both the logo and `.masthead__brand-inner` (whose `justify-self: center` sized it to fit-content, letting nowrap text escape the grid track — the actual cause of the original overlap), font on a `clamp(…, 5.6vw, …)` curve, and a ≤340px step that shrinks the icon circles to 70px columns.
+
+**Verification (headless Chromium, real rendering)**
+Geometry audit at 320/340/360/375/390/414/430/600/760/765/1280px: element order burger | wordmark | saved | search, wordmark off-centre 0px at every mobile width, zero overlaps, no wordmark ellipsis, no horizontal overflow; burger and cluster hidden ≥761px. Screenshots shared with James. `npm run build` passes (1485 pages).
+
+**Files changed**
+- `next/src/components/v4/V4Masthead.astro`
+- `next/src/styles/v4.css`
+
 ### Masthead icon overlap fix + count/verified tag removal
 
 **Summary**

--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -76,35 +76,41 @@ const {
        parent for both children). -->
   <div class="masthead__brand">
     <div class="container">
+      <!-- Mobile order (left to right): burger · wordmark · bookmark + search.
+           The burger is a direct grid child so it can sit in column 1 —
+           it must NOT live inside .v4-mobile-actions (column 3) or it
+           drags the whole cluster layout sideways. Hidden on desktop by
+           the .masthead__burger base rule + v4 guard. V4 chrome rebinds
+           it to open V4MobileDrawer (see BaseLayout script). -->
+      <button
+        class="masthead__burger v4-burger"
+        aria-label="Open menu"
+        aria-expanded="false"
+        aria-controls="v4Drawer"
+      >
+        <span></span><span></span><span></span>
+      </button>
+
       <div class="masthead__brand-inner">
         <a href="/" class="masthead__logo" aria-label="Peninsula Insider, home">
           Peninsula <span>Insider</span>
         </a>
       </div>
 
-      <!-- Mobile action cluster: search + Ask PI + burger.
-           Hidden on desktop (display: none in v4.css). V4 chrome rebinds the
-           burger to open V4MobileDrawer (see BaseLayout script). -->
+      <!-- Mobile action cluster: saved (bookmark) + search.
+           Hidden on desktop (display: none in v4.css). -->
       <div class="v4-mobile-actions">
+        <a href="/saved/" class="v4-iconbtn" aria-label="Saved — your shortlist">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 3.5h12a.5.5 0 0 1 .5.5v16.6a.4.4 0 0 1-.63.33L12 16.5l-5.87 4.43a.4.4 0 0 1-.63-.33V4a.5.5 0 0 1 .5-.5Z" />
+          </svg>
+        </a>
         <a href={v4Utility.search.href} class="v4-iconbtn" aria-label="Explore Peninsula Insider" data-open-search>
           <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="11" cy="11" r="7" />
             <line x1="21" y1="21" x2="16.5" y2="16.5" />
           </svg>
         </a>
-        <a href="/saved/" class="v4-iconbtn" aria-label="Saved — your shortlist">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M6 3.5h12a.5.5 0 0 1 .5.5v16.6a.4.4 0 0 1-.63.33L12 16.5l-5.87 4.43a.4.4 0 0 1-.63-.33V4a.5.5 0 0 1 .5-.5Z" />
-          </svg>
-        </a>
-        <button
-          class="masthead__burger v4-burger"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="v4Drawer"
-        >
-          <span></span><span></span><span></span>
-        </button>
       </div>
     </div>
   </div>

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -121,10 +121,20 @@ body[data-v4="true"] .masthead {
   gap: 8px;
 }
 
-/* Mobile brand-row action cluster (search + Ask PI + burger).
+/* Mobile brand-row action cluster (saved bookmark + search).
    Hidden on desktop; shown inside the mobile breakpoint block below. */
 .v4-mobile-actions {
   display: none;
+}
+/* The v4 burger is a direct child of the brand-row container (it must
+   not live inside .v4-mobile-actions — see V4Masthead.astro). Keep it
+   hidden outside the v4 mobile block: the legacy global.css rule
+   `.masthead__burger { display: flex !important }` kicks in at 768px
+   but the v4 grid only exists at 760px, so without this guard the
+   burger floats loose in the 761–768px window. !important + higher
+   specificity beats the legacy rule; the mobile block below re-shows it. */
+body[data-v4="true"] .v4-burger {
+  display: none !important;
 }
 .v4-iconbtn {
   display: inline-flex;
@@ -246,10 +256,10 @@ body[data-v4="true"] .masthead {
        6px gap = 78px) and kept symmetric so the wordmark stays truly
        centred. The wordmark scales down via clamp() to fit the
        narrower middle cell. */
-    grid-template-columns: 84px minmax(0, 1fr) 84px;
+    grid-template-columns: 78px minmax(0, 1fr) 78px;
     grid-template-rows: 56px;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     padding-top: 14px;
     padding-bottom: 14px;
     min-height: 56px;
@@ -263,14 +273,23 @@ body[data-v4="true"] .masthead {
     justify-self: center;
     gap: 0;
     min-width: 0;
+    /* justify-self: center sizes the item to fit-content, which lets
+       nowrap text overflow the track and collide with the icon cluster
+       on narrow screens — cap it at the track width so the logo's
+       ellipsis can engage. */
+    max-width: 100%;
   }
   body[data-v4="true"] .masthead__brand .masthead__logo {
-    font-size: clamp(21px, 6vw, 33px);   /* fits beside two icon buttons */
+    font-size: clamp(17px, 5.6vw, 33px); /* fits beside two icon buttons */
     line-height: 1.1;
     text-decoration: none;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    /* The flex-column parent centres the logo at fit-content width, so
+       without this cap the nowrap text can overflow the grid cell and
+       collide with the icon cluster on very narrow screens (320px). */
+    max-width: 100%;
   }
   /* Hide the desktop tagline on mobile — too long for the bar. */
   body[data-v4="true"] .masthead__brand .masthead__tagline { display: none; }
@@ -290,6 +309,7 @@ body[data-v4="true"] .masthead {
     display: none !important;
   }
   body[data-v4="true"] .v4-burger {
+    display: flex !important;
     grid-column: 1;
     grid-row: 1;
     justify-self: start;
@@ -304,7 +324,15 @@ body[data-v4="true"] .masthead {
     padding-bottom: 12px;
     min-height: 52px;
   }
-  body[data-v4="true"] .masthead__brand .masthead__logo { font-size: clamp(20px, 6vw, 30px); }
+  body[data-v4="true"] .masthead__brand .masthead__logo { font-size: clamp(16px, 5.6vw, 30px); }
+}
+
+/* Very narrow screens (<=340px): shrink the icon circles and side
+   columns so the centred wordmark keeps enough room to render without
+   an ellipsis. */
+@media (max-width: 340px) {
+  body[data-v4="true"] .v4-mobile-actions .v4-iconbtn { width: 32px; height: 32px; }
+  body[data-v4="true"] .masthead__brand .container { grid-template-columns: 70px minmax(0, 1fr) 70px; }
 }
 
 /* =========================================================


### PR DESCRIPTION
Rebuilds the mobile masthead to the requested order: **hamburger · wordmark (centred) · bookmark · search**.

Root cause of the regression in #240: the burger button lives inside `.v4-mobile-actions`, so making that container a right-aligned flex item dragged the burger to the right, and the three-wide cluster overflowed into the wordmark.

Fix:
- Burger moved out of the cluster (`V4Masthead.astro`) — direct grid child, column 1
- Cluster is exactly bookmark + search, column 3; symmetric 78px side columns keep the wordmark truly centred
- `max-width: 100%` on the logo and `.masthead__brand-inner` — its `justify-self: center` sized it to fit-content, which let nowrap text escape the grid track (the original overlap cause)
- Guard hides the v4 burger at 761–768px where legacy CSS (`.masthead__burger { display: flex !important }` at ≤768px) would float it loose outside the ≤760px v4 grid
- ≤340px step shrinks the icon circles so the wordmark fits without ellipsis

**Verified with a real headless-Chromium geometry audit** at 320/340/360/375/390/414/430/600/760/765/1280px: correct element order, wordmark 0px off-centre at every mobile width, zero overlaps, no ellipsis, no horizontal overflow; burger/cluster hidden on desktop. Screenshots shared in session. `npm run build` green (1485 pages).

Note: whole-file diffs on the two touched files are CRLF→LF normalization; `git diff -w` shows the real change is small.

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo

---
_Generated by [Claude Code](https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo)_