### PR TITLE
design(header): Vivid-style mobile masthead (Phase 1 of homepage uplift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ For each meaningful change, include:
 
 ## 2026-06-10 — Claude (design)
 
+### Vivid-style homepage uplift — Phase 1: mobile header
+
+**Summary**
+First phase of the homepage redesign benchmarked on vividsydney.com mobile (James's brief). Mobile masthead re-laid out Vivid-style: wordmark left, a two-line edition stamp beside it ("Winter / June 2026", shown ≥405px where it fits), then a right icon cluster — search · map (`/map/`) · saved bookmark · burger. Icons are borderless on mobile (circles stay on desktop nav). Replaces this morning's burger-left layout per the approved plan.
+
+**Verification**
+Headless-Chromium geometry sweep at 320/360/375/390/414/430/600/760/765/1280px: correct order, no overlaps, no wordmark clipping, no horizontal overflow, mobile controls hidden ≥761px. Screenshots shared. `npm run build` passes (1485 pages).
+
+**Files changed**
+- `next/src/components/v4/V4Masthead.astro`
+- `next/src/styles/v4.css`
+
+**Follow-up**
+- Phase 2: full-screen hero slider with text overlay; Phase 3: big-four section rows; Phase 4: horizontal card rails; Phase 5: final audit.
+
 ### Mobile masthead rebuilt and browser-verified (burger · wordmark · bookmark · search)
 
 **Summary**

--- a/next/src/components/v4/V4Masthead.astro
+++ b/next/src/components/v4/V4Masthead.astro
@@ -71,46 +71,58 @@ const {
 
   <!-- Row 2 — Brand (V2 carry-over).
        On desktop, .masthead__brand is centred and the burger is hidden by V2
-       global.css. On mobile, V4's mobile CSS re-shows the brand row as a
-       flex bar with logo left, burger right (.container becomes the flex
-       parent for both children). -->
+       global.css. On mobile, V4's mobile CSS lays the row out Vivid-style
+       (2026-06-10, James): wordmark left + edition stamp beside it, then a
+       right icon cluster — search · map · saved · burger. -->
   <div class="masthead__brand">
     <div class="container">
-      <!-- Mobile order (left to right): burger · wordmark · bookmark + search.
-           The burger is a direct grid child so it can sit in column 1 —
-           it must NOT live inside .v4-mobile-actions (column 3) or it
-           drags the whole cluster layout sideways. Hidden on desktop by
-           the .masthead__burger base rule + v4 guard. V4 chrome rebinds
-           it to open V4MobileDrawer (see BaseLayout script). -->
-      <button
-        class="masthead__burger v4-burger"
-        aria-label="Open menu"
-        aria-expanded="false"
-        aria-controls="v4Drawer"
-      >
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="masthead__brand-inner">
         <a href="/" class="masthead__logo" aria-label="Peninsula Insider, home">
           Peninsula <span>Insider</span>
         </a>
       </div>
 
-      <!-- Mobile action cluster: saved (bookmark) + search.
-           Hidden on desktop (display: none in v4.css). -->
+      <!-- Mobile-only edition stamp next to the wordmark (two lines, like a
+           festival date block). "Insider" is dropped from the season line —
+           redundant beside the wordmark. Desktop shows the full edition in
+           the utility row. -->
+      <span class="v4-edition-stamp" aria-label={`Current edition: ${issueLabel}`}>
+        {issueLabel.replace(' Insider', '').split('·').map((part) => (
+          <span class="v4-edition-stamp__line">{part.trim()}</span>
+        ))}
+      </span>
+
+      <!-- Mobile action cluster: search · map · saved · burger.
+           Hidden on desktop (display: none in v4.css). Flex row, so the
+           burger can safely live inside it as the last item. V4 chrome
+           rebinds the burger to open V4MobileDrawer (BaseLayout script). -->
       <div class="v4-mobile-actions">
-        <a href="/saved/" class="v4-iconbtn" aria-label="Saved — your shortlist">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M6 3.5h12a.5.5 0 0 1 .5.5v16.6a.4.4 0 0 1-.63.33L12 16.5l-5.87 4.43a.4.4 0 0 1-.63-.33V4a.5.5 0 0 1 .5-.5Z" />
-          </svg>
-        </a>
-        <a href={v4Utility.search.href} class="v4-iconbtn" aria-label="Explore Peninsula Insider" data-open-search>
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <a href={v4Utility.search.href} class="v4-iconbtn" aria-label="Search Peninsula Insider" data-open-search>
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="11" cy="11" r="7" />
             <line x1="21" y1="21" x2="16.5" y2="16.5" />
           </svg>
         </a>
+        <a href="/map/" class="v4-iconbtn" aria-label="Peninsula map">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 4 3.5 6v14L9 18l6 2 5.5-2V4L15 6 9 4Z" />
+            <line x1="9" y1="4" x2="9" y2="18" />
+            <line x1="15" y1="6" x2="15" y2="20" />
+          </svg>
+        </a>
+        <a href="/saved/" class="v4-iconbtn" aria-label="Saved — your shortlist">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 3.5h12a.5.5 0 0 1 .5.5v16.6a.4.4 0 0 1-.63.33L12 16.5l-5.87 4.43a.4.4 0 0 1-.63-.33V4a.5.5 0 0 1 .5-.5Z" />
+          </svg>
+        </a>
+        <button
+          class="masthead__burger v4-burger"
+          aria-label="Open menu"
+          aria-expanded="false"
+          aria-controls="v4Drawer"
+        >
+          <span></span><span></span><span></span>
+        </button>
       </div>
     </div>
   </div>

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -220,21 +220,6 @@ body[data-v4="true"] .v4-burger {
 
 /* Hide V4 nav on mobile — mobile drawer handles it. */
 @media (max-width: 760px) {
-  .v4-masthead-nav { display: none; }
-}
-
-/* =========================================================
-   V4 MOBILE MASTHEAD
-   ---------------------------------------------------------
-   V2's global.css hides .masthead__utility AND .masthead__brand
-   on mobile to make room for V2's third nav row. V4 doesn't use
-   that nav row, so we re-show the brand row in a compacted form
-   (logo left, burger right) and keep utility hidden.
-
-   Scoped to body[data-v4="true"] so V2 staging pages or the
-   /v3/ surface aren't affected.
-   ========================================================= */
-@media (max-width: 760px) {
   /* Hide the utility row entirely on mobile (2026-05-13). The ribbon
      previously held a thin Login link, but Login is also reachable from the
      drawer's account row, so the 20px of fixed chrome was not earning its
@@ -243,78 +228,86 @@ body[data-v4="true"] .v4-burger {
     display: none !important;
   }
 
-  /* Re-show the brand row (V2 hides it on mobile to make room for V2's nav row,
-     which V4 doesn't use). Make it a flex bar with the container as the flex
-     wrapper. */
+  /* Re-show the brand row (V2 hides it on mobile). Vivid-style layout
+     (2026-06-10, James): wordmark left, edition stamp beside it, icon
+     cluster (search · map · saved · burger) pushed right with auto margin. */
   body[data-v4="true"] .masthead__brand {
     display: block !important;
     padding: 0;
   }
   body[data-v4="true"] .masthead__brand .container {
-    display: grid;
-    /* Side cells sized for the widest cluster (two 36px icon buttons +
-       6px gap = 78px) and kept symmetric so the wordmark stays truly
-       centred. The wordmark scales down via clamp() to fit the
-       narrower middle cell. */
-    grid-template-columns: 78px minmax(0, 1fr) 78px;
-    grid-template-rows: 56px;
+    display: flex;
     align-items: center;
-    gap: 8px;
-    padding-top: 14px;
-    padding-bottom: 14px;
+    gap: 10px;
+    padding-top: 12px;
+    padding-bottom: 12px;
     min-height: 56px;
   }
   body[data-v4="true"] .masthead__brand-inner {
-    grid-column: 2;
-    grid-row: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-self: center;
-    gap: 0;
+    flex: 0 1 auto;
     min-width: 0;
-    /* justify-self: center sizes the item to fit-content, which lets
-       nowrap text overflow the track and collide with the icon cluster
-       on narrow screens — cap it at the track width so the logo's
-       ellipsis can engage. */
-    max-width: 100%;
   }
   body[data-v4="true"] .masthead__brand .masthead__logo {
-    font-size: clamp(17px, 5.6vw, 33px); /* fits beside two icon buttons */
+    font-size: clamp(18px, 5vw, 24px);
     line-height: 1.1;
     text-decoration: none;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    /* The flex-column parent centres the logo at fit-content width, so
-       without this cap the nowrap text can overflow the grid cell and
-       collide with the icon cluster on very narrow screens (320px). */
     max-width: 100%;
+    display: block;
   }
   /* Hide the desktop tagline on mobile — too long for the bar. */
   body[data-v4="true"] .masthead__brand .masthead__tagline { display: none; }
 
-  /* Mobile order: burger left, wordmark centred, saved + search right.
-     The cluster is one grid item laid out as a flex row — previously
-     display: contents put every icon in the same 44px cell, stacking
-     the saved and search buttons on top of each other. */
+  /* Edition stamp — two tiny stacked lines next to the wordmark, like a
+     festival date block. Desktop keeps the edition in the utility row. */
+  .v4-edition-stamp {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding-left: 10px;
+    border-left: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .v4-edition-stamp__line {
+    font-family: 'Outfit', system-ui, sans-serif;
+    font-size: 0.6rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--soft);
+    line-height: 1.4;
+    white-space: nowrap;
+  }
+
+  /* Icon cluster — borderless icons on mobile (Vivid-style) so four
+     controls fit beside the wordmark; circles stay on desktop. */
   body[data-v4="true"] .v4-mobile-actions {
     display: inline-flex;
-    gap: 6px;
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
+    align-items: center;
+    gap: 0;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+  body[data-v4="true"] .v4-mobile-actions .v4-iconbtn {
+    width: 34px;
+    height: 34px;
+    border: none;
   }
   body[data-v4="true"] .v4-mobile-actions .v4-ask-pill {
     display: none !important;
   }
   body[data-v4="true"] .v4-burger {
     display: flex !important;
-    grid-column: 1;
-    grid-row: 1;
-    justify-self: start;
     flex-shrink: 0;
+    padding: 8px 0 8px 6px;
   }
+}
+
+/* Edition stamp exists for the mobile bar only. */
+@media (min-width: 761px) {
+  .v4-edition-stamp { display: none; }
 }
 
 /* Extra-small screens: tighten the bar height. */
@@ -327,12 +320,10 @@ body[data-v4="true"] .v4-burger {
   body[data-v4="true"] .masthead__brand .masthead__logo { font-size: clamp(16px, 5.6vw, 30px); }
 }
 
-/* Very narrow screens (<=340px): shrink the icon circles and side
-   columns so the centred wordmark keeps enough room to render without
-   an ellipsis. */
-@media (max-width: 340px) {
-  body[data-v4="true"] .v4-mobile-actions .v4-iconbtn { width: 32px; height: 32px; }
-  body[data-v4="true"] .masthead__brand .container { grid-template-columns: 70px minmax(0, 1fr) 70px; }
+/* Narrow screens: drop the edition stamp so the wordmark and four icons
+   keep comfortable room (the wordmark starts clipping below ~405px). */
+@media (max-width: 404px) {
+  .v4-edition-stamp { display: none; }
 }
 
 /* =========================================================


### PR DESCRIPTION
Phase 1 of the Vivid-Sydney-benchmarked homepage uplift (approved plan, phases 1–5).

Mobile masthead re-laid out Vivid-style: **wordmark left · edition stamp ("Winter / June 2026", shown ≥405px) · search · map · saved bookmark · burger**. Icons are borderless on mobile; desktop is unchanged. The burger now safely lives inside the flex cluster (the earlier stacking bug was grid-cell assignment, not containment).

Verified by headless-Chromium geometry sweep at 320/360/375/390/414/430/600/760/765/1280px: correct element order, zero overlaps, no wordmark clipping, no horizontal overflow, mobile controls hidden ≥761px. Screenshots shared in session. `npm run build` green (1485 pages).

Next phases on this brief: full-screen hero slider (2), big-four section rows (3), horizontal card rails (4), final audit (5).

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo

---
_Generated by [Claude Code](https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo)_