### PR TITLE
fix: mobile ribbon leak, map pins race, hero slider stale images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ For each meaningful change, include:
 
 ---
 
+## 2026-06-11 — Claude (design)
+
+### Three live-site fixes: mobile ribbon leak, map pins, hero slider stale images
+
+**1. Desktop pillar ribbon leaking onto mobile (regression, mine).** The Phase-1 v4.css rewrite replaced the wrong `@media (max-width: 760px)` block and dropped `.v4-masthead-nav { display: none; }` — the desktop pillar nav then rendered (wrapped, squished) on phones, which also inflated the sticky masthead and made the /map/ heading appear clipped under the sticky breadcrumb. Rule restored; verified hidden ≤760px and visible ≥765px at six widths.
+
+**2. /map/ pins never rendering after client-side navigation.** The map controller waited for `L` (Leaflet) but not for `L.markerClusterGroup`. Under Astro's ClientRouter, re-injected CDN scripts execute async, so Leaflet could land while markercluster was still in flight — the map initialised (tiles visible) and then threw at `markerClusterGroup`, leaving zero pins. Now waits for both (up to ~8s) and degrades to an unclustered `L.layerGroup()` rather than no pins. Also removed the "{n} editorially verified entries across the region — places, dining rooms…" line from the map intro per James; the how-to sentence remains.
+
+**3. Hero slider showing stale images outside edit mode.** The homepage cover scenes hard-coded image paths, bypassing `resolveHero` — exactly the bug class the resolver's "THE RULE" comment documents (the 2026-05-29 /explore/plans/ regression). Edit mode showed the current CMS images; the static build kept rendering the old hard-coded files. Each journal-linked scene now resolves through `resolveHero('article', slug, …)`: published CMS override → article frontmatter hero → hard-coded fallback. The homepage's own `cover.image` override still wins for the cover scene. Build output confirms scenes now pick up the articles' real heroes (e.g. flinders scene: `explore-bushrangers-bay-walk-01` → `article-flinders-weekend-01`).
+
+**Files changed**
+- `next/src/styles/v4.css`
+- `next/src/pages/map.astro`
+- `next/src/pages/index.astro`
+
+**Verification**
+- Pillar nav sweep at 390/430/600/760/765/1280px (hidden ≤760, visible ≥765). Map sub-text absent from built output; cluster guard present. Hero scene srcs in built homepage now match article heroes. `check-editable-coverage` passes. `npm run build` passes (1485 pages).
+
 ## 2026-06-10 — Claude (design)
 
 ### Vivid-style homepage uplift — Phase 4: horizontal card rails

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -29,6 +29,7 @@ import ArticleCard from '../components/ArticleCard.astro';
 import ScrollReveal from '../components/react/ScrollReveal.tsx';
 import { routeSlug, dispatchWeekend } from '../lib/editorial';
 import { loadPublishedHomepageOverrides, getHomepageAdminContent } from '../lib/content/homepage';
+import { resolveHero } from '../lib/inline-edit/resolve-hero';
 import { editableText, editableImage } from '../lib/inline-edit/attrs';
 // ── CMS overrides ─────────────────────────────────────────────────────────
 const cmsOverrides = await loadPublishedHomepageOverrides();
@@ -203,6 +204,27 @@ const scenes: Scene[] = [
   },
 ];
 
+
+// ── Scene heroes resolve through the CMS (THE RULE in resolve-hero.ts) ─────
+// The hard-coded image paths above are only the final fallback. Each scene
+// that points at a journal article takes that article's hero: published CMS
+// override first, then the article frontmatter. This is why edit mode used
+// to show different (current) images than the static page — the static
+// build was reading the stale hard-coded paths and never consulting the
+// override slot. The homepage's own cover.image override still wins for the
+// cover scene, since that's an explicit editor choice for this surface.
+for (const scene of scenes) {
+  if (scene.id === 'cover' && coverImageOverride?.src) continue;
+  const m = scene.primaryHref.match(/^\/journal\/([^/]+)\/?$/);
+  if (!m) continue;
+  const slug = m[1];
+  const article = articles.find((a) => routeSlug(a) === slug);
+  const hero = await resolveHero('article', slug, article?.data ?? {}, 'hero');
+  if (hero.hasPhoto && hero.src) {
+    scene.image = hero.src;
+    if (hero.alt) scene.imageAlt = hero.alt;
+  }
+}
 
 export const prerender = true;
 ---

--- a/next/src/pages/map.astro
+++ b/next/src/pages/map.astro
@@ -167,7 +167,7 @@ export const prerender = true;
       <div class="container">
         <p class="label label--accent">The Insider Map</p>
         <h1 class="map-page__title">The whole Peninsula, on one screen.</h1>
-        <p class="map-page__sub">{allPins.length} editorially verified entries across the region — places, dining rooms, cellar doors, stays, and the experiences worth the drive. Filter by category, click a pin for the editor's note, or open any entry in full.</p>
+        <p class="map-page__sub">Filter by category, click a pin for the editor's note, or open any entry in full.</p>
       </div>
     </div>
 
@@ -240,11 +240,18 @@ export const prerender = true;
       function init() {
         var container = document.getElementById('theInsiderMap');
         if (!container || container._piMapBound) return;
-        if (typeof L === 'undefined') {
-          // Leaflet hasn't finished loading yet — retry once on next tick.
+        // Under the ClientRouter, the re-injected CDN scripts execute
+        // async — L can exist while markercluster is still in flight,
+        // which used to throw at L.markerClusterGroup and leave a tile
+        // map with zero pins. Wait for both (up to ~8s), then degrade
+        // to an uncluster ed layer group rather than no pins at all.
+        container._piMapTries = (container._piMapTries || 0) + 1;
+        var pluginReady = typeof L !== 'undefined' && typeof L.markerClusterGroup === 'function';
+        if (!pluginReady && container._piMapTries < 80) {
           setTimeout(init, 100);
           return;
         }
+        if (typeof L === 'undefined') return; // Leaflet truly unavailable
         container._piMapBound = true;
 
         var map = L.map(container, {
@@ -303,10 +310,12 @@ export const prerender = true;
             + '</div>';
         }
 
-        var clusterGroup = L.markerClusterGroup({
-          showCoverageOnHover: false,
-          maxClusterRadius: 45,
-        });
+        var clusterGroup = typeof L.markerClusterGroup === 'function'
+          ? L.markerClusterGroup({
+              showCoverageOnHover: false,
+              maxClusterRadius: 45,
+            })
+          : L.layerGroup();
 
         var markersById = {};
         var entriesById = {};

--- a/next/src/styles/v4.css
+++ b/next/src/styles/v4.css
@@ -218,8 +218,15 @@ body[data-v4="true"] .v4-burger {
 }
 .v4-subscribe-cta:focus-visible { outline: none; box-shadow: var(--v4-focus-ring); }
 
-/* Hide V4 nav on mobile — mobile drawer handles it. */
+/* =========================================================
+   V4 MOBILE MASTHEAD (≤760px)
+   ========================================================= */
 @media (max-width: 760px) {
+  /* Hide the V4 pillar nav row on mobile — the drawer handles it.
+     (This rule was accidentally dropped in the 2026-06-10 Phase-1
+     rewrite, which let the desktop ribbon leak onto phones.) */
+  .v4-masthead-nav { display: none; }
+
   /* Hide the utility row entirely on mobile (2026-05-13). The ribbon
      previously held a thin Login link, but Login is also reachable from the
      drawer's account row, so the 20px of fixed chrome was not earning its


### PR DESCRIPTION
Three live-site fixes reported by James:

**1. Desktop pillar ribbon leaking onto mobile** (my regression). The Phase-1 `v4.css` rewrite replaced the wrong `max-width: 760px` media block and dropped `.v4-masthead-nav { display: none; }`. Restored — verified hidden ≤760px / visible ≥765px at six widths. This also fixes the squished `/map/` heading: the leaked ribbon inflated the sticky masthead, pushing the sticky breadcrumb over the title.

**2. `/map/` shows tiles but zero pins.** The controller waited for `L` but not `L.markerClusterGroup`. Under the ClientRouter, re-injected CDN scripts run async — Leaflet can land while markercluster is in flight, so the map initialised then threw before adding markers. Now waits for both (up to ~8s) and degrades to an unclustered `L.layerGroup()` instead of no pins. Also removed the "{n} editorially verified entries across the region…" intro line per James; the how-to sentence stays.

**3. Hero slider showing stale images outside edit mode.** The homepage scenes hard-coded image paths, bypassing `resolveHero` — the exact bug class documented as "THE RULE" in `resolve-hero.ts` after the May `/explore/plans/` regression. Edit mode resolved current CMS images; the static build kept the stale hard-coded files. Journal-linked scenes now resolve: published CMS override → article frontmatter hero → hard-coded fallback (homepage `cover.image` override still wins for the cover scene). Build output confirms the scenes now pick up the articles' real heroes.

`check-editable-coverage` passes; `npm run build` green (1485 pages).

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo

---
_Generated by [Claude Code](https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo)_