### PR TITLE
design: hero at 75% viewport height; /map/ mobile is map-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ For each meaningful change, include:
 
 ## 2026-06-11 — Claude (design)
 
+### Hero at 75% height; /map/ mobile is map-only
+
+**Summary**
+1. **Homepage hero** now takes 75% of the viewport below the masthead (was 100%) — the next section peeks above the fold as a scroll affordance. Verified at exactly 75% on 390×844 and 1280×900 with overlay and controls still inside the slide.
+2. **/map/ on mobile** hides the entries list and the List/Map tab bar — the map is the single mobile view and Leaflet initialises through the existing lazy path. Desktop keeps the side-by-side list + map. Tab markup and controller retained for an easy revert.
+
+**Files changed**
+- `next/src/pages/index.astro`
+- `next/src/pages/map.astro`
+- `next/src/styles/global.css`
+
+**Verification**
+Headless Chromium: hero 75% at both form factors; map page at 390px shows map only (no list/tabs), at 1280px list renders beside the map. `npm run build` passes (1485 pages).
+
 ### Three live-site fixes: mobile ribbon leak, map pins, hero slider stale images
 
 **1. Desktop pillar ribbon leaking onto mobile (regression, mine).** The Phase-1 v4.css rewrite replaced the wrong `@media (max-width: 760px)` block and dropped `.v4-masthead-nav { display: none; }` — the desktop pillar nav then rendered (wrapped, squished) on phones, which also inflated the sticky masthead and made the /map/ heading appear clipped under the sticky breadcrumb. Rule restored; verified hidden ≤760px and visible ≥765px at six widths.

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -701,10 +701,12 @@ export const prerender = true;
     border: 0;
     background: var(--bg-dark);
     --masthead-h: 150px;          /* desktop: utility + brand + nav rows */
-    --cover-h: calc(100svh - var(--masthead-h));
+    /* 75% of the viewport below the masthead (James, 2026-06-11) — the
+       next section peeks above the fold as a scroll affordance. */
+    --cover-h: calc((100svh - var(--masthead-h)) * 0.75);
   }
   @supports not (height: 100svh) {
-    .cover { --cover-h: calc(100vh - var(--masthead-h)); }
+    .cover { --cover-h: calc((100vh - var(--masthead-h)) * 0.75); }
   }
   .cover__carousel { display: grid; }
   .cover__slide {

--- a/next/src/pages/map.astro
+++ b/next/src/pages/map.astro
@@ -189,8 +189,8 @@ export const prerender = true;
 
       <!-- Mobile tab bar: List / Map. Desktop hides this. -->
       <div class="map-page__tabs" role="tablist" aria-label="Map view" data-map-tabs>
-        <button type="button" class="map-page__tab map-page__tab--active" role="tab" aria-selected="true" data-map-tab="list">List</button>
-        <button type="button" class="map-page__tab" role="tab" aria-selected="false" data-map-tab="map">Map</button>
+        <button type="button" class="map-page__tab" role="tab" aria-selected="false" data-map-tab="list">List</button>
+        <button type="button" class="map-page__tab map-page__tab--active" role="tab" aria-selected="true" data-map-tab="map">Map</button>
       </div>
 
       <div class="map-page__layout">
@@ -537,15 +537,17 @@ export const prerender = true;
       // On desktop breakpoint, always show both panels regardless of tab state
       var mq = window.matchMedia('(min-width: 880px)');
       function onBreakpoint(e) {
-        panels.forEach(function (p) { p.hidden = !e.matches && p.dataset.mapPanel !== 'list'; });
+        panels.forEach(function (p) { p.hidden = !e.matches && p.dataset.mapPanel !== 'map'; });
         if (e.matches) {
           panels.forEach(function (p) { p.hidden = false; });
         }
       }
       mq.addEventListener ? mq.addEventListener('change', onBreakpoint) : mq.addListener(onBreakpoint);
 
-      // Default state: list visible on mobile
-      activateTab('list');
+      // Default state: map visible on mobile (the list is hidden on
+      // phones per James 2026-06-11 — desktop shows both side by side).
+      // Going through activateTab('map') also runs the lazy Leaflet init.
+      activateTab('map');
 
       // Expose globally so the map marker-click handler can switch tabs
       window.piMapActivateTab = activateTab;

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -9225,9 +9225,12 @@ body.menu-open .subscribe-pill {
   padding-left: 0.2rem;
 }
 
-/* Mobile List/Map tab bar — hidden on desktop */
+/* List/Map tab bar — retired 2026-06-11: mobile is map-only (the list
+   is hidden on phones per James), desktop always shows both panels, so
+   the bar has no remaining job. Markup + controller kept for an easy
+   revert. */
 .map-page__tabs {
-  display: flex;
+  display: none;
   border-bottom: 2px solid var(--border);
   background: var(--paper, #fbf7f0);
 }
@@ -9270,6 +9273,10 @@ body.menu-open .subscribe-pill {
   }
 }
 
+@media (max-width: 879px) {
+  /* Mobile is map-only — hide the list panel (James 2026-06-11). */
+  .map-page__list { display: none !important; }
+}
 .map-page__list {
   border-bottom: 1px solid var(--border);
   display: flex;


### PR DESCRIPTION
Two requested tweaks:

**Hero at 75% height** — homepage hero slides now fill 75% of the viewport below the masthead (was 100%), so the big-four rows peek above the fold as a scroll affordance. Verified at exactly 75% on 390×844 and 1280×900, with the overlay and control strip still inside the slide.

**/map/ mobile is map-only** — the entries list and the List/Map tab bar are hidden on phones; the map is the single mobile view, initialising through the existing lazy path (no double-init — `init()` self-guards). Desktop keeps the side-by-side list + map. Tab markup and controller are retained for an easy revert.

Headless-Chromium verified at 390px (map only, no list/tabs) and 1280px (list renders beside map). `npm run build` green (1485 pages).

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo

---
_Generated by [Claude Code](https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo)_