### PR TITLE
fix(responsive): mobile overflow — venue pages, cookie banner, sitewide audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ For each meaningful change, include:
 
 ## 2026-06-11 — Claude (design)
 
+### Sitewide responsive audit — mobile overflow fixes
+
+**Summary**
+James reported clipped content on /stay/hotel-sorrento/ (mobile). Audited all 1,483 built pages headlessly at 390px with a clipped-text detector (text protruding past non-scrollable clip boundaries). One bug family dominated: **grid `1fr` tracks whose min-content floor lets unbreakable content blow the column past the viewport**, plus separator runs rendered with no whitespace (one giant unbreakable "word").
+
+Fixes:
+- **Venue detail pages (~600 pages)** — "Filed under" and "Known for" tag runs rendered `·` separators with no surrounding whitespace; the unbreakable run forced the mobile grid track to 477px and the page clipped. Separators now include real spaces; `.venue-detail__grid` mobile collapse hardened to `minmax(0, 1fr)`.
+- **Cookie banner (every page)** — `1fr auto` grid let the nowrap mobile body force the banner to 498px, defeating its one-line ellipsis. Now `minmax(0, 1fr) auto`.
+- **`.letter__frame`** mobile collapses (two breakpoints) hardened to `minmax(0, 1fr)` — same family, defensive.
+- **Partner print sheets** (/partners/founders-prospectus/, /partners/advertising-kit/) — A4 sheets (794px) clipped on phones. PrintLayout screen-preview now zooms sheets to viewport width ≤830px with a hidden-scrollbar pan fallback. Print output unaffected.
+
+**Out of scope**: remaining flags are all under /v2-staging/ (noindexed design sandbox, 71 prototype pages).
+
+**Verification**
+Final full sweep at 390px: zero clipped-text flags on production pages. Hotel Sorrento, Montalto, Rare Hare, region explorers, homepage rails, plans all verified; cookie banner exactly 390px with intended one-line truncation; partner sheets scale (zoom 0.48). `npm run build` passes (1484 pages, surface-hardening audit green).
+
+**Files changed**
+- `next/src/components/VenueDetailTemplate.astro`
+- `next/src/components/CookieBanner.astro`
+- `next/src/layouts/PrintLayout.astro`
+- `next/src/styles/global.css`
+
+
+
 ### /journal/peninsula-hot-springs-vs-alba/ — modular redesign of the top SEO page
 
 **Summary**

--- a/next/src/components/CookieBanner.astro
+++ b/next/src/components/CookieBanner.astro
@@ -199,7 +199,7 @@
     margin: 0 auto;
     padding: 1.1rem clamp(1rem, 4vw, 2rem);
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 1.25rem;
     align-items: center;
   }
@@ -352,7 +352,7 @@
   /* ── Mobile: slim bottom bar ──────────────────────────────────────────── */
   @media (max-width: 720px) {
     .cookie-banner__inner {
-      grid-template-columns: 1fr auto;
+      grid-template-columns: minmax(0, 1fr) auto;
       gap: 0.6rem 0.75rem;
       padding: 0.65rem clamp(1rem, 4vw, 1.5rem);
       align-items: center;

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -141,7 +141,7 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
         <span class="venue-known-for__label">Known for</span>
         <span class="venue-known-for__items">
           {data.knownFor.map((item: string, i: number) => (
-            <>{i > 0 && <span class="venue-known-for__sep" aria-hidden="true">·</span>}{item}</>
+            <>{i > 0 && <span class="venue-known-for__sep" aria-hidden="true"> · </span>}{item}</>
           ))}
         </span>
       </p>
@@ -308,7 +308,7 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
             <span class="venue-detail__filed-label">Filed under</span>
             <span class="venue-detail__filed-items">
               {allTags.map((tag: string, i: number) => (
-                <>{i > 0 && <span class="venue-detail__filed-sep" aria-hidden="true">·</span>}{titleize(tag)}</>
+                <>{i > 0 && <span class="venue-detail__filed-sep" aria-hidden="true"> · </span>}{titleize(tag)}</>
               ))}
             </span>
           </p>
@@ -986,7 +986,7 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
   }
   .venue-known-for__sep {
     color: var(--gold, #B69A6B);
-    margin: 0 0.55rem;
+    margin: 0 0.4rem;
   }
 
   /* ── Filed under — demoted discovery tags (quiet, not pills) ── */
@@ -1006,7 +1006,7 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
   }
   .venue-detail__filed-sep {
     color: var(--border, #E5E0D6);
-    margin: 0 0.4rem;
+    margin: 0 0.25rem;
   }
 
   /* ── Insider Verdict block ── */

--- a/next/src/layouts/PrintLayout.astro
+++ b/next/src/layouts/PrintLayout.astro
@@ -981,6 +981,19 @@ const { title, description = 'Peninsula Insider partnership document.' } = Astro
         box-shadow: 0 4mm 16mm rgba(0, 0, 0, 0.45);
       }
     }
+    /* Phones: scale each A4 sheet to the viewport so the document is
+       readable without clipping. `zoom` keeps layout size in sync
+       (unlike transform). Where calc-division zoom is unsupported the
+       scrollable body still lets readers pan the full sheet. */
+    @media screen and (max-width: 830px) {
+      body {
+        padding: 4mm 0;
+        overflow-x: auto;
+        scrollbar-width: none;
+      }
+      body::-webkit-scrollbar { display: none; }
+      .pi-page { zoom: calc((100vw - 8px) / 794px); margin: 0 auto 4mm; }
+    }
   </style>
 </head>
 <body>

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -4849,7 +4849,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   align-items: start;
 }
 @media (max-width: 840px) {
-  .letter__frame { grid-template-columns: 1fr; gap: 2rem; }
+  .letter__frame { grid-template-columns: minmax(0, 1fr); gap: 2rem; }
 }
 .letter__body-col {
   max-width: 42ch;
@@ -8497,7 +8497,7 @@ body[data-path^="/ask"] .concierge-fab {
     font-weight: inherit;
     font-style: inherit;
   }
-  .letter__frame { grid-template-columns: 1fr; gap: 1.2rem; }
+  .letter__frame { grid-template-columns: minmax(0, 1fr); gap: 1.2rem; }
   .letter__side { order: -1; max-width: 280px; }
   .letter__image { aspect-ratio: 16 / 10; }
   .letter__image-cap { font-size: 0.82rem; }

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -2983,7 +2983,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
    ========================================================= */
 @media (max-width: 900px) {
   .venues__grid { grid-template-columns: repeat(2, 1fr); }
-  .venue-detail__grid { grid-template-columns: 1fr; }
+  .venue-detail__grid { grid-template-columns: minmax(0, 1fr); }
 }
 @media (max-width: 768px) {
   .cover__inner { grid-template-columns: 1fr; }


### PR DESCRIPTION
Sitewide responsive audit after James's report of clipped content on /stay/hotel-sorrento/ (mobile). All 1,483 built pages were swept headlessly at 390px with a clipped-text detector; one bug family dominated — **grid `1fr` tracks whose min-content floor lets unbreakable content push the column past the viewport**.

Fixes:

- **Venue detail pages (~600 pages)** — the "Filed under" and "Known for" tag runs rendered their `·` separators with no whitespace, making each run one unbreakable word (477px on Hotel Sorrento); the mobile grid track grew to fit and the page clipped at the right edge. Separators now include real spaces, and `.venue-detail__grid`'s mobile collapse is hardened to `minmax(0, 1fr)`.
- **Cookie banner (every page)** — `1fr auto` grid let the nowrap mobile body force the banner to 498px, defeating its one-line ellipsis. Now `minmax(0, 1fr) auto`.
- **`.letter__frame`** mobile collapses (two breakpoints) hardened to `minmax(0, 1fr)` — same family, defensive.
- **Partner A4 print sheets** (founders-prospectus, advertising-kit) — 794px-wide sheets clipped on phones; PrintLayout's screen preview now zooms sheets to viewport width ≤830px (hidden-scrollbar pan as fallback). Print/PDF output unaffected.

Remaining flags are all under `/v2-staging/` (noindexed design sandbox) — left as-is.

**Verification**: final full sweep at 390px reports zero clipped text on production pages. Hotel Sorrento, Montalto, Rare Hare, region explorers, homepage rails, and plans pages verified individually; partner sheets scale correctly (zoom 0.48). Build green (1,484 pages), surface-hardening audit passes.

https://claude.ai/code/session_013in6f2JTF9ZZ8joFv5hVRo