### PR TITLE
Add admin-toggleable "Magenta Stone" theme (Phase 0–1)

### DIFF
--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ import '../styles/concierge.css';   // chat & drawer styles, loaded on every pag
 import '../styles/search.css';      // site-search overlay + /search page styles
 import '../styles/v4.css';          // V4 mega-menu chrome, additive tokens scoped --v4-*
 import '../styles/inline-edit.css'; // admin-only inline editor chrome, inert unless edit mode is on
+import '../styles/magenta-stone.css'; // Magenta Stone theme — inert unless html[data-theme="magenta-stone"]
 import { ClientRouter } from 'astro:transitions';
 // V4 menu promotion (2026-05-06): the V2 Masthead is replaced by V4Masthead.
 // V2 Masthead.astro stays in the codebase as reference but is no longer
@@ -142,7 +143,7 @@ const isAskPage = rawPathname.startsWith('/ask');
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Outfit:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;700&family=Space+Mono:wght@400&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Hanken+Grotesk:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=Outfit:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;700&family=Space+Mono:wght@400;700&display=swap"
     rel="stylesheet"
   />
   <title>{title}</title>
@@ -249,6 +250,20 @@ const isAskPage = rawPathname.startsWith('/ask');
       try {
         var s = localStorage.getItem('pi-text-scale');
         if (s === '2' || s === '3') document.documentElement.dataset.textScale = s;
+      } catch (e) {}
+    })();
+  </script>
+
+  <!-- Admin theme preview — applied before first paint so a previewing admin
+       doesn't see a flash of the classic theme. Only the admin-gated toggle
+       (lib/inline-edit/client.ts) ever writes 'pi-theme', so general users
+       never have the key set and the override stylesheet stays inert. -->
+  <script is:inline>
+    (function () {
+      try {
+        if (localStorage.getItem('pi-theme') === 'magenta-stone') {
+          document.documentElement.dataset.theme = 'magenta-stone';
+        }
       } catch (e) {}
     })();
   </script>

--- a/next/src/lib/inline-edit/client.ts
+++ b/next/src/lib/inline-edit/client.ts
@@ -33,6 +33,7 @@ const EDIT_MODE_FLAG = 'pi.editMode';
 let editMode = false;
 let isAdmin = false;
 let toggleEl: HTMLButtonElement | null = null;
+let themeToggleEl: HTMLButtonElement | null = null;
 let menuEl: HTMLDivElement | null = null;
 let toastEl: HTMLDivElement | null = null;
 let toastTimer: ReturnType<typeof setTimeout> | null = null;
@@ -67,7 +68,7 @@ export async function bootInlineEditor(): Promise<void> {
   if (!supa) { console.warn('[pi-edit] no supabase client at boot'); return; }
 
   const { data: { session } } = await supa.auth.getSession();
-  if (!session) { ensureToggleRemoved(); return; }
+  if (!session) { ensureToggleRemoved(); ensureThemeToggleRemoved(); return; }
 
   // Check allowlist membership for UX. RLS will also reject writes from
   // non-allowlisted users, but verifying upfront lets us not render UI
@@ -87,6 +88,7 @@ export async function bootInlineEditor(): Promise<void> {
   // re-render on every page-load event. Delegation is installed at module
   // load above, so no per-boot install needed here.
   mountToggle();
+  mountThemeToggle();
 
   // Restore previous edit-mode preference. Body class is page-scoped so we
   // re-apply it here every boot. Patching overrides is gated to edit-mode
@@ -109,6 +111,7 @@ export async function bootInlineEditor(): Promise<void> {
       isAdmin = false;
       setEditMode(false);
       ensureToggleRemoved();
+      ensureThemeToggleRemoved();
     }
   });
 }
@@ -116,6 +119,63 @@ export async function bootInlineEditor(): Promise<void> {
 function ensureToggleRemoved() {
   document.querySelectorAll('.pi-edit-toggle').forEach((n) => n.remove());
   toggleEl = null;
+}
+
+// --------------------------------------------------------------------------
+// Theme toggle (admin-only Classic ↔ Magenta Stone preview)
+// --------------------------------------------------------------------------
+//
+// Flips html[data-theme="magenta-stone"] and persists the choice in
+// localStorage('pi-theme'). The no-flash script in BaseLayout's <head> applies
+// it before first paint on subsequent loads. Only this admin-gated button ever
+// writes the key, so general users never see the theme. The override styles
+// live in src/styles/magenta-stone.css.
+
+const THEME_KEY = 'pi-theme';
+const MAGENTA_STONE = 'magenta-stone';
+
+function currentTheme(): string {
+  try { return localStorage.getItem(THEME_KEY) || 'classic'; } catch { return 'classic'; }
+}
+
+function applyTheme(theme: string) {
+  const on = theme === MAGENTA_STONE;
+  if (on) document.documentElement.dataset.theme = MAGENTA_STONE;
+  else delete document.documentElement.dataset.theme;
+  try { localStorage.setItem(THEME_KEY, on ? MAGENTA_STONE : 'classic'); } catch {}
+  updateThemeToggleLabel(on);
+}
+
+function updateThemeToggleLabel(on: boolean) {
+  if (!themeToggleEl) return;
+  themeToggleEl.dataset.themeOn = on ? 'on' : 'off';
+  themeToggleEl.setAttribute('aria-pressed', on ? 'true' : 'false');
+  const label = themeToggleEl.querySelector('.pi-theme-toggle__label');
+  if (label) label.textContent = on ? 'Magenta Stone' : 'Classic theme';
+}
+
+function mountThemeToggle() {
+  const existing = document.querySelector<HTMLButtonElement>('.pi-theme-toggle');
+  if (existing) {
+    themeToggleEl = existing;
+    updateThemeToggleLabel(currentTheme() === MAGENTA_STONE);
+    return;
+  }
+  themeToggleEl = document.createElement('button');
+  themeToggleEl.type = 'button';
+  themeToggleEl.className = 'pi-theme-toggle';
+  themeToggleEl.setAttribute('aria-label', 'Preview site theme (admin only)');
+  themeToggleEl.innerHTML = '<span class="pi-theme-toggle__dot" aria-hidden="true"></span><span class="pi-theme-toggle__label">Classic theme</span>';
+  themeToggleEl.addEventListener('click', () => {
+    applyTheme(currentTheme() === MAGENTA_STONE ? 'classic' : MAGENTA_STONE);
+  });
+  document.body.appendChild(themeToggleEl);
+  updateThemeToggleLabel(currentTheme() === MAGENTA_STONE);
+}
+
+function ensureThemeToggleRemoved() {
+  document.querySelectorAll('.pi-theme-toggle').forEach((n) => n.remove());
+  themeToggleEl = null;
 }
 
 // --------------------------------------------------------------------------

--- a/next/src/styles/inline-edit.css
+++ b/next/src/styles/inline-edit.css
@@ -50,6 +50,53 @@ body[data-pi-edit-mode="on"] .pi-edit-toggle__dot {
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
 }
 
+/* -- Theme toggle (admin-only Classic ↔ Magenta Stone preview) -------------- */
+/* Sits just below the Edit-mode button, top-right. Always rendered for a
+   signed-in admin; controls the html[data-theme] attribute. */
+
+.pi-theme-toggle {
+  position: fixed;
+  top: 3.4rem;
+  right: 1rem;
+  z-index: 9999;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  background: #faf7f0;
+  color: #1a1a1a;
+  font: 600 0.75rem/1 'Outfit', system-ui, sans-serif;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.pi-theme-toggle:hover { background: #f4ead7; }
+.pi-theme-toggle:active { transform: scale(0.98); }
+
+.pi-theme-toggle__dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #b0b0b0;
+  flex: none;
+}
+
+.pi-theme-toggle[data-theme-on="on"] {
+  background: #be1e63;
+  color: #ffffff;
+  border-color: #be1e63;
+}
+
+.pi-theme-toggle[data-theme-on="on"] .pi-theme-toggle__dot {
+  background: #e4d08a;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
+}
+
 /* -- Editable affordances (only active when edit mode is on) --------------- */
 
 body[data-pi-edit-mode="on"] [data-pi-edit] {
@@ -563,6 +610,14 @@ body[data-pi-edit-mode="on"] [role="img"]:not([data-pi-edit]):not([data-pi-no-ed
   .pi-edit-toggle {
     top: auto;
     bottom: 1rem;
+    right: 1rem;
+    padding: 0.65rem 1rem;
+    font-size: 0.8rem;
+  }
+  /* Stack the theme toggle directly above the edit-mode button. */
+  .pi-theme-toggle {
+    top: auto;
+    bottom: 3.9rem;
     right: 1rem;
     padding: 0.65rem 1rem;
     font-size: 0.8rem;

--- a/next/src/styles/magenta-stone.css
+++ b/next/src/styles/magenta-stone.css
@@ -1,0 +1,170 @@
+/* ════════════════════════════════════════════════════════════════════════
+   Magenta Stone — admin-previewable theme override layer.
+
+   A magenta-accented, cool-greystone redesign of the site. Everything here is
+   scoped under `html[data-theme="magenta-stone"]`, so this file is globally
+   imported but INERT until the admin theme toggle sets the attribute (see
+   src/lib/inline-edit/client.ts + the no-flash script in BaseLayout.astro).
+   With the attribute absent, the public site is byte-for-byte the classic
+   warm-editorial design.
+
+   Strategy: re-map the existing semantic CSS variables (so tokenised
+   components restyle automatically), define the component-level fallback vars
+   that Footer / NewsletterBlock / hp-plans consume (--ink, --ochre, --serif,
+   --deep, …), and re-map the hardcoded fonts that don't flow through tokens.
+
+   Source: design_handoff_magenta_stone (tokens.css / tokens.json).
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── A. Token value overrides ─────────────────────────────────────────────
+   `html[data-theme="magenta-stone"]` (specificity 0,1,1) out-specifies the
+   bare `:root` (0,1,0), so these win and cascade to every var() consumer. */
+html[data-theme="magenta-stone"] {
+  /* global.css :root semantic tokens (consumed via var(--accent) etc.) */
+  --bg:         #FFFFFF;   /* surface */
+  --bg-alt:     #EEF1ED;   /* surface-sunken (was warm cream #F6F2EA) */
+  --bg-dark:    #3E0820;   /* wine-900 dark surfaces (was #1E1B18) */
+  --text:       #1C201E;   /* ink */
+  --soft:       #5E6561;   /* ink-muted */
+  --accent:     #BE1E63;   /* magenta-500 */
+  --acc-h:      #9E1452;   /* magenta-600 pressed */
+  --gold:       #E4D08A;   /* amber-base — decorative + dark-banner CTA */
+  --gold-text:  #9E1452;   /* amber-deep fails AA as text → use magenta-600 */
+  --dark:       #1C201E;   /* ink (heading colour) */
+  --white:      #FFFFFF;
+  --border:     #D4D9D4;   /* grey-200 hairline */
+  --sage:       #7E72AE;   /* lilac-deep stand-in (no green analogue in MS) */
+
+  /* Component-level fallback vars (Footer / NewsletterBlock / hp-plans read
+     these via var(--name, <warm-default>); defining them here themes those
+     surfaces without touching the components). */
+  --ink:        #1C201E;
+  --ink-soft:   #444A47;
+  --ink-muted:  #5E6561;
+  --line:       #D4D9D4;
+  --ochre:      #BE1E63;   /* footer / newsletter-card accent → magenta */
+  --paper:      #FFFFFF;
+  --paper-warm: #EEF1ED;   /* footer background → surface-sunken */
+  --cream:      #EEF1ED;   /* hp-plans background */
+  --deep:       #3E0820;   /* newsletter band base → wine-900 */
+  --serif:      'Newsreader', Georgia, serif;
+  --sans:       'Hanken Grotesk', system-ui, sans-serif;
+
+  /* New Magenta Stone font tokens (scoped) */
+  --ms-font-display: 'Newsreader', Georgia, serif;       /* weight 300 */
+  --ms-font-text:    'Hanken Grotesk', system-ui, sans-serif;
+  --ms-font-mono:    'Space Mono', ui-monospace, monospace;
+
+  /* Radius → Magenta Stone scale */
+  --radius-card-sm: 5px;
+  --radius-card-md: 9px;
+  --radius-card-lg: 13px;
+  --tile-image-radius: 9px;
+}
+
+/* ── B. Font remaps (the hardcoded-font fix) ──────────────────────────────
+   MS type: Newsreader (display) for hero + section titles (h1/h2); Hanken
+   Grotesk for body, UI, and sub-headings (h3+, per the MS spec); Space Mono
+   for eyebrows/labels. */
+html[data-theme="magenta-stone"] body {
+  font-family: var(--ms-font-text);
+}
+html[data-theme="magenta-stone"] :is(h1, h2) {
+  font-family: var(--ms-font-display);
+  font-weight: 300;
+  letter-spacing: -0.01em;
+}
+html[data-theme="magenta-stone"] :is(h3, h4, h5, h6) {
+  font-family: var(--ms-font-text);
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+/* Large editorial titles that hardcode Cormorant on a class (and may not be
+   h1/h2 elements) — keep them Newsreader display. */
+html[data-theme="magenta-stone"] :is(
+  .cover__headline,
+  .hp-big4__name,
+  .hp-rail__title,
+  .hp-plans__title,
+  .places__title,
+  .hp-notebook__headline,
+  .v2-np__title
+) {
+  font-family: var(--ms-font-display);
+  font-weight: 300;
+  letter-spacing: -0.01em;
+}
+
+/* Eyebrows / labels → Space Mono, uppercase, tracked, magenta on light. */
+html[data-theme="magenta-stone"] :is(
+  .label,
+  [class*="__eyebrow"],
+  .cover__chip,
+  .cover__hours,
+  .hp-big4__secondary a,
+  .hp-rail__more,
+  .hp-notebook__section,
+  .v2-np__mark,
+  .v2-np__foot
+) {
+  font-family: var(--ms-font-mono);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+html[data-theme="magenta-stone"] :is(.label, .v2-newsletter__eyebrow) {
+  color: var(--accent);
+}
+
+/* ── C. The unconditional `!important` font swaps on the landing page ──────
+   index.astro's <style is:global> forces these to Outfit !important; match
+   with !important to re-point them at the MS families. */
+html[data-theme="magenta-stone"] :is(
+  .masthead__tagline,
+  .cover__dispatch,
+  .melb-strip__text
+) {
+  font-family: var(--ms-font-text) !important;
+}
+html[data-theme="magenta-stone"] .hp-notebook__headline {
+  font-family: var(--ms-font-display) !important;
+}
+
+/* ── D. Landing-surface restyles (where token remap is insufficient) ───────── */
+
+/* Cover hero: magenta CTA already flows via var(--accent); soften the warm
+   gold italic accent to amber, and round the CTA to the MS 9px. */
+html[data-theme="magenta-stone"] .cover__headline em {
+  color: #E4D08A;            /* amber-base on the dark scrim */
+}
+html[data-theme="magenta-stone"] .cover__chip {
+  color: #E4D08A;
+}
+html[data-theme="magenta-stone"] .cover__cta {
+  border-radius: 9px;
+}
+
+/* Big-four nav + rails: warm band → cool surface-sunken (handled by --bg-alt
+   token); hover accents already magenta via var(--accent). Nothing extra. */
+
+/* Newsletter → the signature Magenta Stone dark wine banner.
+   --deep/--gold/--serif/--sans/--ink/--ochre/--line are themed in block A, so
+   only the band's gradient and the amber CTA contrast need overriding. */
+html[data-theme="magenta-stone"] .v2-newsletter {
+  background: linear-gradient(100deg, #3E0820, #5C0B30 55%, #7C0F40);
+}
+html[data-theme="magenta-stone"] .v2-newsletter::before {
+  background: radial-gradient(circle at center, rgba(190, 30, 99, 0.18), transparent 65%);
+}
+html[data-theme="magenta-stone"] .v2-newsletter__submit {
+  color: #3E0820;            /* amber CTA, wine text (MS dark-banner spec) */
+}
+html[data-theme="magenta-stone"] .v2-newsletter__submit:hover {
+  background: #C2A857;       /* amber-deep */
+}
+
+/* ── E. Accessibility / containment notes ─────────────────────────────────
+   - prefers-reduced-motion and html[data-text-scale] live independently on
+     <html>; this theme adds no always-on motion and no font-size rules, so
+     both behaviours are preserved.
+   - When the attribute is absent every selector above is inert. */


### PR DESCRIPTION
## What & why

Applies the new **Magenta Stone** design system (created in Claude design) to the site as an **admin-previewable theme override layer**, flipped with a hidden admin-only button. This lets us review and sign off the redesign **in stages** without touching what the public sees.

Magenta Stone = cool greystone greys with a sparing magenta accent (`#BE1E63`), lilac/amber secondaries, and new type — **Newsreader** (display), **Hanken Grotesk** (text/UI), **Space Mono** (eyebrows). It replaces the warm cream/terracotta + Outfit/Cormorant look.

## How the switch works
- A new `html[data-theme="magenta-stone"]` flag gates the whole override layer. When absent, the site is **byte-for-byte the current design**.
- An **admin-only toggle button** mounts beside the existing "Edit mode" control in `inline-edit/client.ts`, gated by the same Supabase `admin_user_allowlist` check. Clicking it writes `pi-theme` to `localStorage` and flips `data-theme`.
- A **no-flash** inline `<head>` script applies the saved theme before first paint (mirrors the existing `data-text-scale` pattern).
- **Hidden by construction:** only the admin-gated button ever writes `pi-theme`, so general users never have the flag and the override CSS stays inert.

## Changes
- **`next/src/styles/magenta-stone.css`** (new) — scoped override layer: remaps the existing semantic vars (colours flow to tokenised components automatically), defines the fallback vars Footer/NewsletterBlock/hp-plans consume, swaps the hardcoded fonts, and restyles landing surfaces incl. the signature **dark wine-banner newsletter**.
- **`next/src/layouts/BaseLayout.astro`** — import the sheet, load the new fonts, extend the no-flash script.
- **`next/src/lib/inline-edit/client.ts`** — mount the admin theme toggle (same gating + view-transition remount lifecycle as the edit toggle).
- **`next/src/styles/inline-edit.css`** — toggle button styling.

## Verification
- `astro build` passes (1,477 pages); no type errors in touched files.
- Confirmed in the build output: no-flash script + new fonts in `<head>`, theme tokens/scoped rules + `.pi-theme-toggle` in the CSS bundle, and (with Supabase env enabled) the toggle JS + `Classic theme`/`Magenta Stone` labels bundle into the client chunk.
- Toggle off / non-admin → site is identical to classic.

## Staged rollout (this PR = Phase 0–1)
- **Phase 0** — switch + token/font remap (recolours + retypes the whole site when on).
- **Phase 1** — landing-page polish (cover, rails, plans, notebook, wine-banner newsletter, masthead/footer). **← sign off here.**
- Later — `/eat/`, a journal article, `/search`, then remaining pages; final fold-in cutover.

## Notes for review
- It's a genuine mood change (warm cream → cool greystone + magenta), not a tint.
- The old **gold**/**sage** tokens have no clean Magenta Stone analogue (amber-deep fails AA as text; sage's "green = nature/verified" meaning is lost) — mapped pragmatically (gold→amber decorative, gold-as-text→magenta, sage→lilac); flagged for audit in later phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWQbYJH4zDnm751zLvxoAh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWQbYJH4zDnm751zLvxoAh)_