### PR TITLE
Fix homepage hero clipping its headline

### DIFF
--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -501,9 +501,13 @@ export const prerender = true;
     grid-area: 1 / 1;
     position: relative;
     z-index: 0;
-    height: var(--cover-h);
-    min-height: 430px;
-    max-height: 960px;
+    /* Grow-to-fit (James, 2026-06-20): the slide is AT LEAST --cover-h tall
+       (clamped 430–960px), but it is no longer a fixed, clip-to-fit box. The
+       overlay flows in this grid and bottom-aligns, so a tall headline +
+       standfirst + CTA pushes the slide taller instead of being clipped off
+       the top edge under the masthead. min-height (not height) is the key. */
+    display: grid;
+    min-height: clamp(430px, var(--cover-h), 960px);
     overflow: hidden;
     pointer-events: none;
   }
@@ -563,9 +567,15 @@ export const prerender = true;
   }
 
   .cover__overlay {
-    position: absolute;
-    inset: auto 0 0 0;
+    /* In flow within the slide grid, pinned to the bottom — so the overlay's
+       own height sets the slide's floor and the top lines (meta + headline)
+       can never be clipped, however tall the type or short the viewport. */
+    position: relative;
+    grid-area: 1 / 1;
+    align-self: end;
+    z-index: 2;
     margin: 0 auto;               /* .container handles max-width + padding */
+    padding-top: 2rem;            /* breathing room when the overlay drives height */
     padding-bottom: 5.25rem;      /* clears the control strip */
     color: #FDFCFA;
   }
@@ -726,7 +736,7 @@ export const prerender = true;
   /* ── Cover mobile ──────────────────────────────────────────────────────── */
   @media (max-width: 760px) {
     .cover { --masthead-h: 59px; --cover-ratio: 0.75; }   /* compact brand row; 75% hero */
-    .cover__slide { max-height: 850px; }
+    .cover__slide { min-height: clamp(430px, var(--cover-h), 850px); }  /* cap the floor; still grows to fit text */
     .cover__dispatch { display: none; }  /* Vivid economy: headline + CTA only */
     .cover__overlay { padding-bottom: 4.6rem; }
     .cover__headline { margin-bottom: 1.25rem; }


### PR DESCRIPTION
## What

The homepage cover/hero could clip the top of its text — the meta chip and the first line of the headline (e.g. "The lighthouse" in "The lighthouse at the edge of everything") disappeared off the top edge under the masthead.

## Why

Each cover slide used a **fixed, `overflow:hidden` height** — `clamp(430px, --cover-h, 960px)` via `height` + `min/max-height` — with the overlay **absolutely positioned and pinned to the bottom**. When the masthead is tall (e.g. logged-in / edit mode) or the viewport is short, `--cover-h` collapses to the `430px` floor, but the stacked content (meta + headline + standfirst + CTA + bottom padding) is taller than that. Because the overlay grows upward from the bottom, the top lines overflowed the fixed box and were clipped.

## Fix

Switch the slide to a **grow-to-fit grid**:
- `.cover__slide` now uses `display: grid` with `min-height: clamp(430px, var(--cover-h), 960px)` instead of a fixed `height`. `--cover-h` becomes a *floor*, not a hard cap.
- `.cover__overlay` returns to flow (`position: relative`, `grid-area: 1/1`, `align-self: end`) so it bottom-aligns as before, but its own height can now push the slide taller when the text needs the room. A small `padding-top` gives breathing room when the overlay drives the height.
- Mobile mirrors the same model (`min-height: clamp(430px, var(--cover-h), 850px)`).

Net effect: the hero is never shorter than its text, so the headline can no longer be obscured. On tall viewports the behaviour is unchanged (slide sits at the clamped `--cover-h`); the media/scrim stay absolutely positioned and continue to cover the slide.

## Testing

Pure CSS change within the existing homepage `<style is:global>` block. Prebuild + lint steps pass; the `astro` binary isn't installed in the CI container so a full build wasn't run here. Recommend a visual check at a short viewport height and with the masthead expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR1W75UYi83f53H8cnqfJ6)_