### PR TITLE
fix(ci): Node 22 for all build workflows (unblocks the live deploy)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: next/package-lock.json
 

--- a/.github/workflows/daily-content.yml
+++ b/.github/workflows/daily-content.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js (for content scripts)
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install engine dependencies
         run: |

--- a/.github/workflows/monthly-content.yml
+++ b/.github/workflows/monthly-content.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/weekly-content.yml
+++ b/.github/workflows/weekly-content.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install engine dependencies
         run: |


### PR DESCRIPTION
The deploy run for merged PR #258 failed in 46 seconds: all lints passed, then `astro build` refused to start because Astro requires Node ≥22.12.0 and every workflow pinned `node-version: '20'`.

This bumps Node to 22 in `build-and-deploy.yml`, `daily-content.yml`, `weekly-content.yml`, and `monthly-content.yml`. It also explains the pre-existing scheduled build failures and why `gh-pages` was being pushed manually: CI builds have been failing at the Astro version check.

Merging this and re-running `build-and-deploy.yml` completes the "push live" for #258 (the workflow publishes `next/dist` to `gh-pages`, which also purges the leaked internal trees from the served branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz)_