### PR TITLE
fix(ci): grant contents:write so the deploy can push gh-pages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,6 +10,10 @@ on:
       - 'next/package.json'
   workflow_dispatch:
 
+# GITHUB_TOKEN must be able to push the built site to gh-pages.
+permissions:
+  contents: write
+
 # Cancel any in-progress deploy on new push
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Second and final deploy unblock. After the Node 22 fix (#259), the build went green and correctly staged the gh-pages sync (including purging the leaked `v2-staging`/`v4`/internal trees), but the push was rejected: `Permission to richmondjw/peninsula-insider.git denied to github-actions[bot]` — the workflow declares no `permissions`, and the repo's default `GITHUB_TOKEN` grant is read-only.

Adds `permissions: contents: write` at the workflow level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz)_