### PR TITLE
fix(ci): deploy build must run build:search so pagefind ships

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build
         run: |
           cd next
-          npm run build
+          npm run build:search
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}


### PR DESCRIPTION
The first successful CI deploy (after #259 and #260) shipped a clean site but with no `/pagefind/` directory — the workflow ran `npm run build`, which skips the pagefind indexer, so live search would find nothing. `build:search` is the same pipeline `build-live.sh` uses: media registry, editorial lints, astro build, pagefind index.

Verified against the deployed `gh-pages` tree: everything else is correct (internal trees purged, `.nojekyll` present); only the search index is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz)_