### PR TITLE
Hub directory pagination, content-engine checkout fix, overhaul changelog

### DIFF
--- a/.github/workflows/daily-content.yml
+++ b/.github/workflows/daily-content.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   daily-content:
     runs-on: ubuntu-latest
@@ -25,7 +28,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_CONTENT_PUSH }}
+          # Prefer the PAT (its pushes trigger build-and-deploy); fall back to
+          # the workflow token so the engine still runs when the secret is
+          # unset. GITHUB_TOKEN pushes do NOT trigger other workflows, so with
+          # the fallback a content commit needs a manual deploy dispatch.
+          token: ${{ secrets.PAT_CONTENT_PUSH || github.token }}
           fetch-depth: 1
 
       - name: Setup Python

--- a/.github/workflows/monthly-content.yml
+++ b/.github/workflows/monthly-content.yml
@@ -13,6 +13,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   monthly-content:
     runs-on: ubuntu-latest
@@ -22,7 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_CONTENT_PUSH }}
+          # Prefer the PAT (its pushes trigger build-and-deploy); fall back to
+          # the workflow token so the engine still runs when the secret is
+          # unset. GITHUB_TOKEN pushes do NOT trigger other workflows, so with
+          # the fallback a content commit needs a manual deploy dispatch.
+          token: ${{ secrets.PAT_CONTENT_PUSH || github.token }}
           fetch-depth: 1
 
       - name: Setup Python

--- a/.github/workflows/weekly-content.yml
+++ b/.github/workflows/weekly-content.yml
@@ -11,6 +11,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   weekly-content:
     runs-on: ubuntu-latest
@@ -20,7 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_CONTENT_PUSH }}
+          # Prefer the PAT (its pushes trigger build-and-deploy); fall back to
+          # the workflow token so the engine still runs when the secret is
+          # unset. GITHUB_TOKEN pushes do NOT trigger other workflows, so with
+          # the fallback a content commit needs a manual deploy dispatch.
+          token: ${{ secrets.PAT_CONTENT_PUSH || github.token }}
           fetch-depth: 1
 
       - name: Setup Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2026-07-05 — Site-wide overhaul: deployment hygiene, IA, brand compliance, UX (PRs #258-#261)
+
+### What changed
+Executed the full remediation plan from the 2026-07-04 UX/IA/brand review, then repaired the CI deploy pipeline (Node 22, contents:write, build:search) so gh-pages publishes cleanly from `next/dist` with no manual pushes.
+
+### Highlights
+- Removed staging sites, homepage drafts, source trees, and internal tooling from the public deploy; hardened robots.txt; `.nojekyll` at root
+- Concierge, auth, saves sync, and all submission forms revived (production API URL + publishable-key fallback); newsletter fake-success removed
+- Peninsula This Weekend now displays an honest staleness notice once its weekend passes
+- Plans restored as the 7th masthead pillar; Specialist guides column added to Explore; /spa/ migration finished (740 inbound links repointed)
+- About and the new /editorial-approach/ page carry the canonical positioning; tagline locked to "Every venue visited. Every opinion earned."
+- Em-dashes: 32,652 → 0 in built output; consumer prices: 686 → 0 (B2B rate cards exempt); lint-no-pricing extended to prose with the markdown blind spot closed
+- Skip link, AA-safe sage text token, <time> elements, per-venue directions, bylines + checked-dates on handwritten SEO pages
+- Venue directories on /eat/, /stay/, /wine/ now page at 30 cards with a filter-aware "Show more"
+
+### Follow-ups
+- `PUBLIC_ACCESS_GATE: 'off'` in build-and-deploy.yml launches the site publicly
+- Verify the concierge Vercel API is live; scrub em-dashes from Supabase cms_* rows; audit RLS on write tables
+
 ## 2026-06-29 — Agentic Content Engine v1.0
 
 ### What changed

--- a/next/public/admin/media-registry.json
+++ b/next/public/admin/media-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T00:07:52.928Z",
+  "generatedAt": "2026-07-05T03:23:32.276Z",
   "source": "next/scripts/build-media-registry.mjs",
   "assetCount": 143,
   "assets": [

--- a/next/src/components/VenueDirectory.astro
+++ b/next/src/components/VenueDirectory.astro
@@ -16,6 +16,8 @@ import VenueCard from './VenueCard.astro';
 import { getCollection } from 'astro:content';
 
 export interface Props {
+  /** Cards shown before the reader clicks "Show more". 0 disables paging. */
+  pageSize?: number;
   /** Stable id; used to scope the filter form to its grid. */
   id: string;
   /** Pre-filtered venue list (e.g. only restaurants and cafés for /eat/). */
@@ -49,6 +51,7 @@ const {
   typeOptions,
   moodOptions = [],
   toggles = { dogFriendly: false, hatted: false },
+  pageSize = 0,
 } = Astro.props as Props;
 
 // Build the place options from the venue list itself so the dropdown only
@@ -197,12 +200,20 @@ const showHatted = !!toggles.hatted;
     </form>
 
     <div class="venues__grid" data-filter-grid={id}>
-      {venues.map((venue) => (
-        <div {...venueAttrs(venue)}>
+      {venues.map((venue, i) => (
+        <div {...venueAttrs(venue)} class:list={[{ 'is-paged-out': pageSize > 0 && i >= pageSize }]}>
           <VenueCard venue={venue} hrefPrefix={hrefPrefix} />
         </div>
       ))}
     </div>
+
+    {pageSize > 0 && venues.length > pageSize && (
+      <p class="venues__more">
+        <button type="button" class="venues__more-btn" data-filter-more={id}>
+          Show more
+        </button>
+      </p>
+    )}
 
     <p class="venues__empty" data-filter-empty={id} hidden>
       No venues match those filters. Try removing one of them, or
@@ -211,7 +222,7 @@ const showHatted = !!toggles.hatted;
   </div>
 </section>
 
-<script is:inline define:vars={{ scopeId: id }}>
+<script is:inline define:vars={{ scopeId: id, pageSize }}>
   /* VenueDirectory filter controller. Scoped by id so multiple directories
      on the same page (rare, but possible later) don't trample each other. */
   (function () {
@@ -227,6 +238,8 @@ const showHatted = !!toggles.hatted;
       var totalCount = cards.length;
 
       var state = { place: '', type: '', price: '', mood: '', dog: false, hatted: false };
+      var moreBtn = document.querySelector('[data-filter-more="' + scopeId + '"]');
+      var shownLimit = pageSize > 0 ? pageSize : Infinity;
 
       function readUrl() {
         var p = new URLSearchParams(window.location.search);
@@ -266,7 +279,8 @@ const showHatted = !!toggles.hatted;
       }
 
       function apply() {
-        var visible = 0;
+        var matches = 0;
+        var shown = 0;
         cards.forEach(function (card) {
           var ok = true;
           if (state.place && card.getAttribute('data-place') !== state.place) ok = false;
@@ -279,21 +293,48 @@ const showHatted = !!toggles.hatted;
           if (ok && state.dog && card.getAttribute('data-dog-friendly') !== '1') ok = false;
           if (ok && state.hatted && card.getAttribute('data-hatted') !== '1') ok = false;
           card.classList.toggle('is-filtered-out', !ok);
-          if (ok) visible++;
+          if (ok) {
+            matches++;
+            var paged = matches > shownLimit;
+            card.classList.toggle('is-paged-out', paged);
+            if (!paged) shown++;
+          } else {
+            card.classList.remove('is-paged-out');
+          }
         });
         if (countEl) {
           var anyActive = state.place || state.type || state.price || state.mood || state.dog || state.hatted;
-          countEl.textContent = anyActive
-            ? 'Showing ' + visible + ' of ' + totalCount
-            : 'Showing all ' + totalCount;
+          var base = anyActive ? matches + ' of ' + totalCount : 'all ' + totalCount;
+          countEl.textContent = shown < matches
+            ? 'Showing ' + shown + ' of ' + matches
+            : 'Showing ' + base;
+        }
+        if (moreBtn) {
+          var remaining = matches - shown;
+          if (remaining > 0) {
+            moreBtn.removeAttribute('hidden');
+            moreBtn.textContent = 'Show ' + Math.min(remaining, pageSize) + ' more';
+          } else {
+            moreBtn.setAttribute('hidden', '');
+          }
         }
         if (emptyEl) {
-          if (visible === 0) emptyEl.removeAttribute('hidden');
+          if (matches === 0) emptyEl.removeAttribute('hidden');
           else emptyEl.setAttribute('hidden', '');
         }
       }
 
-      function commit() { syncControls(); apply(); writeUrl(); }
+      function commit() {
+        shownLimit = pageSize > 0 ? pageSize : Infinity;
+        syncControls();
+        apply();
+        writeUrl();
+      }
+
+      if (moreBtn) moreBtn.addEventListener('click', function () {
+        shownLimit += pageSize;
+        apply();
+      });
 
       form.querySelectorAll('[data-filter-value]').forEach(function (btn) {
         btn.addEventListener('click', function () {

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -416,6 +416,7 @@ export const prerender = true;
     typeOptions={venueTypeOptions}
     moodOptions={moodFilterOptions}
     toggles={{ dogFriendly: true, hatted: true }}
+    pageSize={30}
   />
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/pages/stay/index.astro
+++ b/next/src/pages/stay/index.astro
@@ -292,6 +292,7 @@ export const prerender = true;
       { value: 'big-group',   label: 'Big group' },
     ]}
     toggles={{ dogFriendly: true, hatted: false }}
+    pageSize={30}
   />
 
   <SectionDivider />

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -311,7 +311,8 @@ export const prerender = true;
         { value: 'cellar-door', label: 'Cellar door' },
       ]}
       toggles={{ dogFriendly: true, hatted: false }}
-    />
+      pageSize={30}
+  />
   )}
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -8795,6 +8795,29 @@ body.menu-open .subscribe-pill {
 
 /* Filtering: hide cards whose wrappers carry the is-filtered-out class.
    Wrapper itself, not the inner VenueCard, so the layout reflows cleanly. */
+.venues__grid > [data-venue].is-paged-out {
+  display: none;
+}
+.venues__more {
+  margin: 1.5rem 0 0;
+  text-align: center;
+}
+.venues__more-btn {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.7rem 1.6rem;
+  background: none;
+  border: 1px solid var(--border, #E5E0D6);
+  color: var(--text, #2B2520);
+  cursor: pointer;
+}
+.venues__more-btn:hover {
+  border-color: var(--accent, #8B4E3B);
+  color: var(--accent, #8B4E3B);
+}
 .venues__grid > [data-venue].is-filtered-out {
   display: none;
 }


### PR DESCRIPTION
Closes out the remaining in-repo items from the review plan.

## Hub pagination
`VenueDirectory` gains a `pageSize` prop with a filter-aware "Show more" control. The `/eat/`, `/stay/`, `/wine/` directories now render 30 cards at first paint (pre-cut server-side, so no flash) and reveal the rest in batches; applying a filter resets paging and the count reads "Showing X of Y". Verified in the built output: 92 wrappers on /eat/, 62 pre-paged out. Cards remain in the DOM for SEO and client-side filtering — this addresses render cost and scannability, not transfer size.

## Content engine unblocked (second defect found by dry run)
A `workflow_dispatch` dry run of `daily-content.yml` on Node 22 surfaced the next failure: checkout dies with `Input required and not supplied: token` because the `PAT_CONTENT_PUSH` secret is not configured. All three content workflows now fall back to `github.token` (with `contents: write`) so the engine runs. Caveat, documented in-line: GITHUB_TOKEN pushes don't trigger `build-and-deploy.yml`, so content commits made via the fallback need a manual deploy dispatch — **setting the `PAT_CONTENT_PUSH` secret restores full automation.**

## Housekeeping
- CHANGELOG entry for the 2026-07-05 overhaul (PRs #258–#261)
- Verified non-issues closed during this pass: cross-device save sync already exists at source (`lib/saves/cloud.ts` + `CloudSync`) and was revived by the anon-key fix — only the server-side `pi.user_saves` table/RLS needs confirming; the homepage "missing alt" audit finding was an `<img>` inside an HTML comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz)_