### PR TITLE
Rebuild the homepage cover article-driven; restore the lost 4–5 July dispatch

### DIFF
--- a/next/public/admin/media-registry.json
+++ b/next/public/admin/media-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T03:23:32.276Z",
+  "generatedAt": "2026-07-05T05:56:09.688Z",
   "source": "next/scripts/build-media-registry.mjs",
   "assetCount": 143,
   "assets": [
@@ -750,6 +750,12 @@
           "purpose": "hero",
           "entityType": "article",
           "entitySlug": "how-to-build-a-red-hill-saturday"
+        },
+        {
+          "file": "src/content/articles/peninsula-this-weekend-jul-04.md",
+          "purpose": "hero",
+          "entityType": "article",
+          "entitySlug": "peninsula-this-weekend-jul-04"
         },
         {
           "file": "src/content/articles/peninsula-this-weekend-jun-06.md",
@@ -2247,6 +2253,12 @@
           "purpose": "hero",
           "entityType": "article",
           "entitySlug": "insider-picks-2026-06-18"
+        },
+        {
+          "file": "src/content/articles/insider-picks-2026-07-05.md",
+          "purpose": "hero",
+          "entityType": "article",
+          "entitySlug": "insider-picks-2026-07-05"
         },
         {
           "file": "src/content/experiences/cape-schanck-lighthouse-walk.json",

--- a/next/public/admin/media-registry.json
+++ b/next/public/admin/media-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T05:56:09.688Z",
+  "generatedAt": "2026-07-05T05:58:45.372Z",
   "source": "next/scripts/build-media-registry.mjs",
   "assetCount": 143,
   "assets": [

--- a/next/src/components/HomeHeroCarousel.astro
+++ b/next/src/components/HomeHeroCarousel.astro
@@ -2,108 +2,80 @@
 /**
  * HomeHeroCarousel - the homepage full-screen cover slider.
  *
- * SINGLE SOURCE OF TRUTH = the "deck": an ordered array of slides
- * { id, image, imageAlt, label, hours, headline, dispatch, primaryHref,
- *   primaryLabel, scrim? }.
+ * Rebuilt 2026-07-05 after the CMS-deck regression: the previous version's
+ * source of truth was a Supabase "deck" document written by the Hero Editor,
+ * with a committed JSON file as silent fallback. Any build without database
+ * access (CI, a fresh machine) quietly shipped the stale fallback deck - old
+ * stories, old images - with no error. That failure mode is designed out.
  *
- * Resolution (build time, no flash):
- *   1. Published CMS "deck" document - cms_text_fields (page, home-hero, 'deck')
- *      holding the whole deck as JSON. This is what the Hero Editor writes.
- *   2. Otherwise: home-hero-slides.json + any legacy per-field overrides
- *      (slide.<id>.headline / .image …) for backward compatibility, until the
- *      first Hero Editor save replaces them with a deck document.
+ * SINGLE SOURCE OF TRUTH = the articles collection, resolved at build time:
  *
- * Editing: a dedicated, admin-only Hero Editor drawer (lib/hero-editor) is the
- * single editing surface - reorder, edit text + link, add / remove slides, and
- * replace photos. It writes the deck document and re-renders the carousel live;
- * BaseLayout-style hydration applies the published deck for every visitor
- * instantly, and the deck bakes into static HTML on the next build.
+ *   1. The featured article (data.featured, newest first) leads if present.
+ *   2. The remaining slots fill with the latest published articles.
+ *   3. Weekend-picker dispatches are excluded (the What's On rail owns them).
+ *   4. SLIDE_COUNT slides total. No manual deck, no database dependency,
+ *      no hidden fallback: every build renders the same cover for the same
+ *      content, and the cover refreshes itself as articles publish.
  *
- * The hero is deliberately ISOLATED from the generic inline editor: the section
- * carries `data-pi-hero-managed`, which the generic right-click panel and the
- * filename auto-detect ("Pass 2" in lib/inline-edit/client.ts) skip - so the
- * old "images flip in edit mode" problem cannot recur and there is exactly one
- * way to edit the hero.
+ * Images resolve through resolveHero, so a published CMS image-slot override
+ * for an article still wins over its frontmatter image - image curation
+ * stays possible without reintroducing a second source of story truth.
  *
- * CSS: the `.cover*` rules live in the homepage `<style is:global>` in
+ * CSS: the `.cover*` rules live in the homepage <style is:global> in
  * src/pages/index.astro (they depend on load order to neutralise the legacy
  * sitewide /assets/styles.css `.cover` reset).
  */
-import { loadOverrides } from '../lib/inline-edit/overrides';
-import heroSlides from '../data/home-hero-slides.json';
-import HeroEditorMount from '../lib/hero-editor/HeroEditorMount.astro';
+import { getCollection } from 'astro:content';
+import { formatLabel, routeSlug } from '../lib/editorial';
+import { resolveHero } from '../lib/inline-edit/resolve-hero';
 
-const ENTITY_TYPE = 'page' as const;
-const ENTITY_SLUG = 'home-hero';
+const SLIDE_COUNT = 4;
 
-type Slide = {
-  id: string;
-  image: string;
-  imageAlt: string;
-  label: string;
-  hours: string;
-  headline: string;
-  dispatch: string;
-  primaryHref: string;
-  primaryLabel: string;
-  scrim?: number;
-};
+const published = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .filter((a) => a.data.format !== 'weekend-picker')
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
 
-const fileSlides = heroSlides.slides as Slide[];
+const lead = published.find((a) => a.data.featured);
+const rest = published.filter((a) => a !== lead);
+const coverArticles = [lead, ...rest].filter(Boolean).slice(0, SLIDE_COUNT);
 
-const overrides = await loadOverrides(ENTITY_TYPE, ENTITY_SLUG);
+const dateLabel = (d: Date) =>
+  d.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', timeZone: 'Australia/Melbourne' });
 
-// 1. Published deck document wins wholesale when present + valid.
-let deck: Slide[] | null = null;
-const deckRaw = overrides.text['deck'];
-if (deckRaw) {
-  try {
-    const parsed = JSON.parse(deckRaw);
-    if (Array.isArray(parsed) && parsed.length > 0 && parsed.every((s) => s && s.id)) {
-      deck = parsed as Slide[];
-    }
-  } catch {
-    /* malformed deck doc - fall through to the file default */
-  }
-}
-
-// 2. Fallback: file + legacy per-field overrides (pre-Hero-Editor behaviour).
-if (!deck) {
-  deck = fileSlides.map((slide) => {
-    const fp = (f: string) => `slide.${slide.id}.${f}`;
-    const img = overrides.image[fp('image')];
+const deck = await Promise.all(
+  coverArticles.map(async (article) => {
+    const slug = routeSlug(article);
+    const hero = await resolveHero('article', slug, article.data, 'hero');
     return {
-      ...slide,
-      image: img?.src ?? slide.image,
-      imageAlt: img?.alt ?? slide.imageAlt,
-      headline: overrides.text[fp('headline')] ?? slide.headline,
-      dispatch: overrides.text[fp('dispatch')] ?? slide.dispatch,
-      label: overrides.text[fp('label')] ?? slide.label,
-      hours: overrides.text[fp('hours')] ?? slide.hours,
+      id: slug,
+      image: hero.src,
+      imageAlt: article.data.heroImage?.alt ?? article.data.title,
+      label: formatLabel[article.data.format] ?? 'Feature',
+      hours: dateLabel(article.data.publishedAt),
+      headline: article.data.title,
+      dispatch: article.data.dek ?? '',
+      primaryHref: `/journal/${slug}/`,
+      primaryLabel: 'Read the story',
     };
-  });
-}
+  }),
+);
 
-// Stable ids are the reorder/override keys - fail the build on a duplicate.
-const ids = deck.map((s) => s.id);
-if (new Set(ids).size !== ids.length) {
-  throw new Error('[HomeHeroCarousel] duplicate slide id in the hero deck');
+if (deck.length === 0) {
+  throw new Error('[HomeHeroCarousel] no published articles available for the cover');
 }
 ---
 
-{/* ── ZONE 1: Cover carousel - full-screen slides, managed solely by the
-    Hero Editor drawer (data-pi-hero-managed isolates it from the generic
-    inline editor). The SSR deck is embedded as JSON so the client hydration
-    and editor share a baseline without re-reading the file. */}
+{/* ── ZONE 1: Cover carousel. Static article-driven slides; the controller
+    script below owns rotation, arrows, pager, and swipe. */}
+{/* data-pi-hero-managed keeps the generic inline editor away from the cover:
+    the slides are article-driven, so the article page is where edits belong. */}
 <section class="cover" aria-label="Cover stories" data-pi-hero-managed>
-  <script type="application/json" data-pi-hero-deck set:html={JSON.stringify(deck)} />
   <div class="cover__carousel" id="cover-carousel">
     {deck.map((scene, i) => (
       <div
         class={`cover__slide${i === 0 ? ' is-active' : ''}`}
         data-slide-index={i}
         data-slide-id={scene.id}
-        style={scene.scrim != null ? `--scrim: ${scene.scrim}` : undefined}
       >
         <figure class="cover__media">
           <img
@@ -122,8 +94,8 @@ if (new Set(ids).size !== ids.length) {
           </p>
           <a href={scene.primaryHref} class="cover__headline-link">
             {i === 0
-              ? <h1 class="cover__headline" set:html={scene.headline} />
-              : <p class="cover__headline" set:html={scene.headline} />
+              ? <h1 class="cover__headline">{scene.headline}</h1>
+              : <p class="cover__headline">{scene.headline}</p>
             }
           </a>
           <p class="cover__dispatch">{scene.dispatch}</p>
@@ -151,7 +123,7 @@ if (new Set(ids).size !== ids.length) {
           class={`cover__nav-btn${i === 0 ? ' is-active' : ''}`}
           data-target={i}
           type="button"
-          aria-label={`Story ${i + 1} of ${deck.length}: ${scene.headline.replace(/<[^>]+>/g, '')}`}
+          aria-label={`Story ${i + 1} of ${deck.length}: ${scene.headline}`}
         >
           <span class="cover__nav-bar" aria-hidden="true"></span>
         </button>
@@ -166,18 +138,13 @@ if (new Set(ids).size !== ids.length) {
 </section>
 
 {/* Cover carousel controller. Scoped to #cover-carousel, self-guards via
-    el.dataset.carouselReady, idempotent across astro:page-load. Exposes
-    window.piHeroInitCarousel so the Hero Editor / deck hydration can re-init
-    after re-rendering slides. */}
+    el.dataset.carouselReady, idempotent across astro:page-load. */}
 <script is:inline>
   (function () {
     var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     var INTERVAL_MS = 10000;
 
     function initCarousel(el, force) {
-      /* Normal path guards against double-init (setup runs on load AND
-         astro:page-load). force=true tears down and rebuilds - used by the
-         deck hydration / Hero Editor after the slide DOM is replaced. */
       if (el.dataset.carouselReady && !force) return;
       if (el.__coverCleanup) { el.__coverCleanup(); el.__coverCleanup = null; }
       var slides = Array.from(el.querySelectorAll('.cover__slide'));
@@ -253,9 +220,6 @@ if (new Set(ids).size !== ids.length) {
 
       if (!reducedMotion) { timer = setInterval(function () { goTo(current + 1); }, INTERVAL_MS); }
 
-      /* Teardown for a forced re-init (deck hydration / Hero Editor): remove the
-         window/el/observer listeners + timer bound to persistent nodes. Slides,
-         nav, and arrows live in replaced DOM, so their listeners die with it. */
       el.__coverCleanup = function () {
         clearInterval(timer);
         window.removeEventListener('resize', sizeCover);
@@ -266,7 +230,7 @@ if (new Set(ids).size !== ids.length) {
       };
     }
 
-    /* Expose so the Hero Editor / deck hydration can re-init after re-render. */
+    /* Kept for backwards compatibility with anything that re-inits the cover. */
     window.piHeroInitCarousel = initCarousel;
 
     function setup() {
@@ -277,6 +241,3 @@ if (new Set(ids).size !== ids.length) {
     setup();
   })();
 </script>
-
-{/* Deck hydration (all visitors) + Hero Editor drawer (admins, edit mode). */}
-<HeroEditorMount />

--- a/next/src/content/articles/peninsula-this-weekend-jul-04.md
+++ b/next/src/content/articles/peninsula-this-weekend-jul-04.md
@@ -1,0 +1,125 @@
+---
+title: "Peninsula This Weekend - 4 to 5 July"
+dek: "The first full school-holiday weekend of winter is simple: one booked truffle hunt, one Sunday heritage train run, and one indoor family plan that does not feel like a fallback."
+author: "editorial"
+houseByline: true
+publishedAt: 2026-06-29
+heroImage:
+  src: "/images/sourced/article-red-hill-saturday-01.webp"
+  alt: "Red Hill in winter, Mornington Peninsula, early July 2026"
+  credit: "Peninsula Insider"
+  license: "other-licensed"
+format: "weekend-picker"
+tags: ["weekend-picker", "whats-on", "july-planning", "winter", "school-holidays", "truffle", "red-hill", "main-ridge", "mornington"]
+relatedVenues: []
+readingTimeMinutes: 3
+featured: true
+status: "published"
+lastVerified: 2026-06-29
+clusterLinks:
+  - label: "The Cellar Door Short List"
+    href: "/journal/the-cellar-door-short-list/"
+  - label: "How to Build a Red Hill Saturday"
+    href: "/journal/how-to-build-a-red-hill-saturday/"
+  - label: "Things to Do on the Mornington Peninsula"
+    href: "/journal/things-to-do-mornington-peninsula/"
+dispatch:
+  editorLine: "The first school-holiday weekend is not about trying to do everything. Book one proper winter move, leave room for a slow Sunday, and keep one indoor family option in reserve."
+  weather: "Early July on the Peninsula is proper winter: cold mornings, early dark, and enough weather variation that an indoor backup matters. Check Friday's local forecast before locking in outdoor-only plans."
+  lead:
+    title: "Red Hill Truffles: Winter Truffle Hunt Season, Main Ridge"
+    when: "Saturday 4 or Sunday 5 July, booking required"
+    where: "Red Hill Truffles, 1180 Mornington-Flinders Road, Main Ridge"
+    summary: "The cleanest winter booking on the Peninsula remains a Red Hill truffle hunt. The polished version is here: working dogs, oak grove, then lunch or pizza built into the shape of the day. If you want one thing this weekend that feels distinctly seasonal, this is it."
+    bookingLabel: "Book via Red Hill Truffles"
+    bookingUrl: "https://redhilltruffles.com/hunts"
+    eventRef: "red-hill-truffles-winter-truffle-hunt-season"
+  sunday:
+    title: "Mornington Tourist Railway, School Holiday Special Runs"
+    when: "Sunday 5 July, 10:00am–4:00pm"
+    where: "Moorooduc Railway Station, 460 Moorooduc Highway, Moorooduc"
+    summary: "A heritage train ride that does not overcomplicate itself. Vintage carriages, a short line between Moorooduc and Mornington, and the kind of Sunday family plan that works because it is simple."
+    bookingLabel: "Check timetable"
+    bookingUrl: "https://morningtonrailway.org.au/"
+    eventRef: "mornington-tourist-railway-school-holiday-special-runs"
+  rainyDay:
+    title: "Mornington Peninsula Regional Gallery, School Holiday Workshops"
+    when: "Running 1 to 10 July, bookings essential"
+    where: "Mornington Peninsula Regional Gallery, Dunns Road, Mornington"
+    price: "Free and low-cost sessions, workshop pricing varies"
+    summary: "The school-holiday indoor plan that still feels like a real outing: artist-led workshops, family activity spaces, and enough structure to carry a cold or wet day properly."
+    bookingLabel: "See gallery programme"
+    bookingUrl: "https://www.mornpen.vic.gov.au/Arts-Culture/Mornington-Peninsula-Regional-Gallery"
+    eventRef: "mornington-peninsula-regional-gallery-school-holiday-workshops"
+  weekendShape: "Book the truffle hunt if you want the weekend to feel distinctly wintry. Keep Sunday for the railway or a slower Mornington day. If the weather turns, move indoors without pretending the day is lost."
+faq:
+  - question: "What is on this weekend on the Mornington Peninsula, 4–5 July 2026?"
+    answer: "The clearest winter booking is Red Hill Truffles in Main Ridge, running through the weekend by reservation. On Sunday 5 July, Mornington Tourist Railway runs its school-holiday special services from Moorooduc. Through the school-holiday window, Mornington Peninsula Regional Gallery is also running family workshops from 1 to 10 July."
+  - question: "What is the best family plan for Sunday 5 July?"
+    answer: "Mornington Tourist Railway is the simplest family pick for Sunday 5 July: heritage train rides from Moorooduc between 10am and 4pm. If the weather looks rough, switch to the Mornington Peninsula Regional Gallery school-holiday workshops instead."
+  - question: "What is the best winter booking this weekend?"
+    answer: "Red Hill Truffles remains the strongest winter booking if you want a distinctly seasonal Peninsula day. For a quieter alternative, Flinders Truffles is the softer, less polished option and often the better fit if you want the winter farm atmosphere without the busier ridge-lunch format."
+---
+
+*Peninsula This Weekend is our weekly dispatch: the plan we'd actually make for the weekend ahead, the booking worth locking in, and the bit of weekend thinking we'd happily do for you.*
+
+School holidays have started, but the right Peninsula weekend still comes from restraint rather than volume. You do not need three bookings and a route plan. You need one thing that feels seasonal, one Sunday move with enough shape already built in, and one backup if the weather goes sideways.
+
+This weekend, that means truffle country first, a heritage train run on Sunday, and the gallery in Mornington if the family needs an indoor answer.
+
+## The booking worth locking in
+
+### Red Hill Truffles, Main Ridge
+
+If you want the weekend to feel like winter on the Peninsula rather than a generic family outing, this is the booking. Red Hill Truffles is still the polished version of the season: working dogs in the oak grove, proper cold in the air, then lunch or pizza built into the day.
+
+This is the one to book ahead. It is the strongest fit for adults, food-focused families, or anyone trying to make one real day of the ridge rather than drift between cellar doors without a plan.
+
+## The Sunday move
+
+### Mornington Tourist Railway, School Holiday Special Runs
+
+Sunday 5 July is the easy family shape: Moorooduc in the morning, heritage carriages, short line, no elaborate logistics. The appeal is that it does not try to be more than it is. You get a properly run train ride, a winter outing with a beginning and an end, and then you can decide whether the afternoon belongs to Mornington, the foreshore, or home.
+
+For school-holiday weekends that matters. It gives the day enough structure without swallowing the whole day.
+
+## If the weather changes
+
+### Mornington Peninsula Regional Gallery, School Holiday Workshops
+
+MPRG is the indoor answer that still feels considered. The school-holiday workshops run from 1 to 10 July, bookings essential, with family activity spaces and artist-led sessions that work better than the usual "just keep them occupied" fallback. If Saturday turns wet or Sunday gets too cold to linger outside, Mornington is the clean pivot.
+
+This is also the better call for families with kids who have aged out of the simpler holiday stuff but still need a morning or early afternoon with a bit of structure.
+
+## The quieter alternative
+
+If Red Hill feels too booked-out or too polished, Flinders Truffles is the softer version of the same winter idea. The farm is quieter, the shape is looser, and the by-the-fire finish is part of the appeal. Dates move through their own channels, so check before you drive, but it remains the better alternative if you want winter atmosphere without building the whole day around lunch service.
+
+## Weekend shape
+
+Book the truffle hunt if you want the weekend to have one clear centre. Keep Sunday for the railway if there are children in the car. If the weather turns, move indoors to Mornington and do not apologise for it. The Peninsula in early July is at its best when you stop trying to make every hour productive.
+
+---
+
+### Red Hill Truffles
+
+Sat 4 or Sun 5 July · Main Ridge  
+Booking required: redhilltruffles.com/hunts
+
+### Mornington Tourist Railway, School Holiday Special Runs
+
+Sun 5 July · 10am–4pm · Moorooduc Railway Station  
+Check timetable: morningtonrailway.org.au
+
+### Mornington Peninsula Regional Gallery, School Holiday Workshops
+
+Running 1–10 July · Dunns Road, Mornington  
+Free and low-cost sessions · Bookings essential for workshops
+
+### Flinders Truffles
+
+Winter season running through June to August · Flinders  
+Hunt dates vary · Farmgate days run without booking  
+Check current dates: flinderstruffles.com.au/events/
+
+_Prices may change. Confirm current rates directly with each operator before booking._

--- a/next/src/lib/cms/server.ts
+++ b/next/src/lib/cms/server.ts
@@ -26,7 +26,12 @@ const SUPABASE_URL =
 
 const SUPABASE_ANON_KEY =
   (import.meta.env.PUBLIC_SUPABASE_ANON_KEY as string | undefined) ||
-  process.env.PUBLIC_SUPABASE_ANON_KEY;
+  process.env.PUBLIC_SUPABASE_ANON_KEY ||
+  // Publishable key: public by design, RLS is the gate. Without this
+  // fallback, a build on a machine without env vars silently skips ALL
+  // CMS text/image overrides and ships stale content - which is exactly
+  // how the July 2026 homepage regression happened.
+  'sb_publishable_JlZuo95QvNZi2ZNrFyK-Cw_2y0U7HLp';
 
 export const PI_AUTH_COOKIE_PREFIX = 'sb-';
 export const PI_AUTH_TOKEN_COOKIE = 'pi-sb-access-token';


### PR DESCRIPTION
## What happened (root cause)

The old deploy flow was a hand-push of a locally built tree to `gh-pages`. Two things existed only in that local state and vanished when CI took over builds from main:

1. **The 4–5 July Peninsula This Weekend dispatch** — published live on June 29 but never committed to main, so CI rebuilt with the 27–28 June edition as "latest".
2. **The curated homepage cover** — the cover's source of truth was a Supabase "deck" document written by the Hero Editor, with a stale committed JSON file as *silent* fallback. CI builds had no database key, so they quietly shipped the old fallback deck (old stories, old images). The half-initialising client-side deck hydration is also the likely source of the broken alignment.

A forensic diff of the last hand-pushed live tree vs the current build confirmed **nothing else was lost**: all 144 images byte-identical, journal/events/pages sets identical.

## Fixes

**Cover rebuilt from the ground up (`HomeHeroCarousel`).** Slides are now the featured article plus the latest published articles (4 total, weekend-pickers excluded), resolved from the content collection at build time. No manual deck, no database dependency, no silent fallback — every build is deterministic, and the cover refreshes itself as the content engine publishes. Markup, CSS and the proven carousel controller are unchanged; the Supabase deck hydration and Hero Editor mount are removed. CMS image-slot overrides still apply per-article via `resolveHero`.

**4–5 July dispatch restored** (`peninsula-this-weekend-jul-04.md`), reconstructed verbatim from the archived HTML on the old `gh-pages` tip: editor line, weather, all three pick cards, FAQs, and full body. Only mechanical changes: em-dash → house style, and the price fragments the old page carried were omitted (they violate the no-pricing gate that now blocks CI — the old page shipped from a local build that bypassed it). Rolling page, `archive/2026-06-29/`, and the journal redirect all regenerate.

**CMS hydration hardened** (`cms/server.ts`): builds without env vars now fall back to the publishable key instead of silently skipping every CMS text/image override sitewide.

## Verified in the built output
- Cover: exactly 4 slides (Sorrento Solstice lead + today's engine-authored picks + two latest), each with its own article hero image; no deck JSON island; no hero-editor mount.
- `/whats-on/this-weekend/` renders "Peninsula This Weekend - 4 to 5 July" with the staleness guard armed.
- All lint gates green; 917 pages build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz)_