### PR TITLE
The Edition × The Atlantic: Front Page, Archive, sectioned index

### DIFF
--- a/next/public/admin/media-registry.json
+++ b/next/public/admin/media-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T09:51:38.814Z",
+  "generatedAt": "2026-07-05T11:30:17.553Z",
   "source": "next/scripts/build-media-registry.mjs",
   "assetCount": 143,
   "assets": [

--- a/next/src/components/edition/EditionArchive.astro
+++ b/next/src/components/edition/EditionArchive.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * EditionArchive - "From the archive" (the Atlantic's institutional-memory
+ * move, tuned for a seasonal publication).
+ *
+ * Resurfaces pieces at least 45 days old that still fit the season:
+ * priority to articles matching the current season's vocabulary, then
+ * evergreen service and guide formats. Each card is stamped with its
+ * original month, worn proudly - the point is that the masthead's back
+ * catalogue holds up. Omits itself while the archive is thin.
+ */
+import { getCollection } from 'astro:content';
+import { formatLabel, routeSlug } from '../../lib/editorial';
+
+const now = new Date();
+const month = Number(
+  new Intl.DateTimeFormat('en-AU', { month: 'numeric', timeZone: 'Australia/Melbourne' }).format(now),
+);
+const season =
+  month >= 6 && month <= 8 ? 'winter'
+  : month >= 9 && month <= 11 ? 'spring'
+  : month === 12 || month <= 2 ? 'summer'
+  : 'autumn';
+
+const EVERGREEN = new Set(['service', 'hub-guide', 'trail-guide', 'slow-peninsula']);
+const cutoff = new Date(now.getTime() - 45 * 864e5);
+
+const published = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .filter((a) => a.data.format !== 'weekend-picker' && a.data.publishedAt < cutoff);
+
+const seasonal = published.filter((a) =>
+  `${a.data.title} ${(a.data.tags ?? []).join(' ')}`.toLowerCase().includes(season),
+);
+const evergreen = published.filter((a) => EVERGREEN.has(a.data.format) && !seasonal.includes(a));
+
+const picks = [...seasonal, ...evergreen]
+  .sort((a, b) => a.data.publishedAt.getTime() - b.data.publishedAt.getTime())
+  .slice(0, 3);
+
+const stamp = (d: Date) =>
+  d.toLocaleDateString('en-AU', { month: 'long', year: 'numeric', timeZone: 'Australia/Melbourne' });
+const iso = (d: Date) => d.toISOString().split('T')[0];
+const seasonLabel = season.charAt(0).toUpperCase() + season.slice(1);
+---
+
+{picks.length === 3 && (
+  <section class="ed-archive" aria-label="From the archive">
+    <div class="container">
+      <div class="ed-archive__head">
+        <h2 class="ed-archive__title">From the <em>archive.</em></h2>
+        <p class="ed-archive__note">Still true this {seasonLabel.toLowerCase()}. That is the test.</p>
+      </div>
+      <div class="ed-archive__grid">
+        {picks.map((a) => (
+          <a class="ed-archive__card" href={`/journal/${routeSlug(a)}/`}>
+            <time class="ed-archive__stamp" datetime={iso(a.data.publishedAt)}>{stamp(a.data.publishedAt)}</time>
+            <p class="ed-archive__kicker">{formatLabel[a.data.format] ?? 'Feature'}</p>
+            <h3 class="ed-archive__headline">{a.data.title}</h3>
+            {a.data.dek && <p class="ed-archive__dek">{a.data.dek}</p>}
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+)}

--- a/next/src/components/edition/EditionFooterIndex.astro
+++ b/next/src/components/edition/EditionFooterIndex.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * EditionFooterIndex - the sectioned index (the Atlantic's dense footer,
+ * mapped to the seven lanes).
+ *
+ * Each lane shows its two freshest entries drawn from the lane's own
+ * collection: venues for Eat/Wine/Stay, experiences for Explore, plans
+ * for Plans, events for What's On, articles for Journal. Real content,
+ * regenerated every build, so the index doubles as a freshness signal
+ * and an internal-linking layer. Sits above the main site footer.
+ */
+import { getCollection } from 'astro:content';
+import { routeSlug, venueHrefPrefix } from '../../lib/editorial';
+
+const [venues, experiences, itineraries, events, articles] = await Promise.all([
+  getCollection('venues'),
+  getCollection('experiences'),
+  getCollection('itineraries'),
+  getCollection('events'),
+  getCollection('articles', ({ data }) => data.status === 'published'),
+]);
+
+const newest = (list: any[], n = 2) =>
+  [...list]
+    .sort((a, b) => (b.data.publishedAt?.getTime?.() ?? 0) - (a.data.publishedAt?.getTime?.() ?? 0))
+    .slice(0, n);
+
+const EAT = new Set(['restaurant', 'cafe', 'bakery', 'pub', 'market']);
+const WINE = new Set(['winery', 'producer', 'brewery', 'distillery']);
+const STAY = new Set(['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa']);
+
+const venueLinks = (types: Set<string>) =>
+  newest(venues.filter((v) => types.has(v.data.type))).map((v) => ({
+    label: v.data.name,
+    href: `${venueHrefPrefix(v.data.type)}${routeSlug(v)}/`,
+  }));
+
+const lanes = [
+  { label: 'Eat & Drink', href: '/eat/', items: venueLinks(EAT) },
+  { label: 'Wine', href: '/wine/', items: venueLinks(WINE) },
+  { label: 'Stay', href: '/stay/', items: venueLinks(STAY) },
+  {
+    label: 'Explore', href: '/explore/',
+    items: newest(experiences).map((e) => ({ label: e.data.name ?? e.data.title, href: `/explore/${routeSlug(e)}/` })),
+  },
+  {
+    label: 'Plans', href: '/explore/plans/',
+    items: newest(itineraries).map((p) => ({ label: p.data.title, href: `/explore/plans/${routeSlug(p)}/` })),
+  },
+  {
+    label: "What's On", href: '/whats-on/',
+    items: newest(events).map((e) => ({ label: e.data.title ?? e.data.name, href: `/whats-on/${routeSlug(e)}/` })),
+  },
+  {
+    label: 'Journal', href: '/journal/',
+    items: newest(articles.filter((a) => a.data.format !== 'weekend-picker')).map((a) => ({
+      label: a.data.title, href: `/journal/${routeSlug(a)}/`,
+    })),
+  },
+].filter((lane) => lane.items.length > 0);
+---
+
+<section class="ed-index" aria-label="Section index">
+  <div class="container">
+    <div class="ed-index__grid">
+      {lanes.map((lane) => (
+        <div class="ed-index__lane">
+          <h3 class="ed-index__lane-title"><a href={lane.href}>{lane.label}</a></h3>
+          <ul class="ed-index__list">
+            {lane.items.map((item) => (
+              <li><a href={item.href}>{item.label}</a></li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/next/src/components/edition/EditionFrontPage.astro
+++ b/next/src/components/edition/EditionFrontPage.astro
@@ -1,0 +1,112 @@
+---
+/**
+ * EditionFrontPage - the newspaper package (the Atlantic move).
+ *
+ * Simultaneity with discipline: one lead story with image flanked by two
+ * columns of headline-only items, small-caps kickers, bylines, hairline
+ * rules. Draws the stories AFTER the four the cover already used, so the
+ * two acts never repeat each other. Renders nothing if the well runs dry
+ * (fewer than four stories left) rather than padding with filler.
+ */
+import { getCollection } from 'astro:content';
+import { formatLabel, routeSlug } from '../../lib/editorial';
+import { resolveHero } from '../../lib/inline-edit/resolve-hero';
+
+const authors = await getCollection('authors');
+const authorName = new Map(authors.map((a) => [a.id, a.data.name]));
+
+const published = (await getCollection('articles', ({ data }) => data.status === 'published'))
+  .filter((a) => a.data.format !== 'weekend-picker')
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+// The cover consumes: featured (or newest) + next three.
+const coverLead = published.find((a) => a.data.featured) ?? published[0];
+const coverSet = new Set([coverLead, ...published.filter((a) => a !== coverLead).slice(0, 3)]);
+const pool = published.filter((a) => !coverSet.has(a));
+
+// Front pages die of monotony. Two guards:
+//  - the lead must actually have a hero image;
+//  - no format may take more than a third of the package (the hub-guide
+//    engine publishes in runs, and nine identical kickers reads as a
+//    content farm, which is the register this masthead refuses).
+const MAX_PER_FORMAT = 3;
+const counts: Record<string, number> = {};
+const diverse: typeof pool = [];
+const overflow: typeof pool = [];
+for (const a of pool) {
+  const fmt = a.data.format ?? 'feature';
+  if ((counts[fmt] ?? 0) < MAX_PER_FORMAT) {
+    counts[fmt] = (counts[fmt] ?? 0) + 1;
+    diverse.push(a);
+  } else {
+    overflow.push(a);
+  }
+}
+const selection = [...diverse, ...overflow].slice(0, 9);
+
+const leadIdx = selection.findIndex((a) => a.data.heroImage?.src);
+const lead = leadIdx >= 0 ? selection[leadIdx] : selection[0];
+const others = selection.filter((a) => a !== lead);
+const sideA = others.slice(0, 4);
+const sideB = others.slice(4, 8);
+
+const byline = (a: any) => {
+  if (a.data.houseByline) return 'Peninsula Insider editors';
+  const id = a.data.author?.id ?? a.data.author;
+  return authorName.get(id) ?? 'Peninsula Insider editors';
+};
+const kicker = (a: any) => formatLabel[a.data.format] ?? 'Feature';
+const href = (a: any) => `/journal/${routeSlug(a)}/`;
+
+const leadHero = lead ? await resolveHero('article', routeSlug(lead), lead.data, 'hero') : null;
+const enough = lead && sideA.length >= 2;
+---
+
+{enough && (
+  <section class="ed-front" aria-label="The front page">
+    <div class="container">
+      <div class="ed-front__rule" aria-hidden="true">
+        <span class="ed-front__rule-label">The front page</span>
+      </div>
+
+      <div class="ed-front__grid">
+        <div class="ed-front__col ed-front__col--side">
+          {sideA.map((a) => (
+            <article class="ed-front__item">
+              <a href={href(a)}>
+                <p class="ed-front__kicker">{kicker(a)}</p>
+                <h3 class="ed-front__headline">{a.data.title}</h3>
+                <p class="ed-front__byline">{byline(a)}</p>
+              </a>
+            </article>
+          ))}
+        </div>
+
+        <article class="ed-front__lead">
+          <a href={href(lead)}>
+            <figure class="ed-front__lead-media">
+              <img src={leadHero.src} alt={lead.data.heroImage?.alt ?? lead.data.title} loading="lazy" />
+            </figure>
+            <p class="ed-front__kicker">{kicker(lead)}</p>
+            <h2 class="ed-front__lead-headline">{lead.data.title}</h2>
+            <p class="ed-front__lead-dek">{lead.data.dek}</p>
+            <p class="ed-front__byline">{byline(lead)}</p>
+          </a>
+        </article>
+
+        <div class="ed-front__col ed-front__col--side">
+          {sideB.map((a) => (
+            <article class="ed-front__item">
+              <a href={href(a)}>
+                <p class="ed-front__kicker">{kicker(a)}</p>
+                <h3 class="ed-front__headline">{a.data.title}</h3>
+                <p class="ed-front__byline">{byline(a)}</p>
+              </a>
+            </article>
+          ))}
+          <p class="ed-front__more"><a href="/journal/">All journal stories →</a></p>
+        </div>
+      </div>
+    </div>
+  </section>
+)}

--- a/next/src/pages/index.astro
+++ b/next/src/pages/index.astro
@@ -20,6 +20,9 @@ import EditionContents from '../components/edition/EditionContents.astro';
 import EditionAsk from '../components/edition/EditionAsk.astro';
 import EditionWeekendBuilder from '../components/edition/EditionWeekendBuilder.astro';
 import EditionNotebook from '../components/edition/EditionNotebook.astro';
+import EditionFrontPage from '../components/edition/EditionFrontPage.astro';
+import EditionArchive from '../components/edition/EditionArchive.astro';
+import EditionFooterIndex from '../components/edition/EditionFooterIndex.astro';
 import WeekendPickerBlock from '../components/WeekendPickerBlock.astro';
 import NewsletterBlock from '../components/NewsletterBlock.astro';
 import { dispatchWeekend } from '../lib/editorial';
@@ -49,11 +52,15 @@ export const prerender = true;
     <WeekendPickerBlock dispatch={weekendDispatch} weekend={`This weekend · ${dispatchWindow.label}`} />
   </div>
 
+  <div class="ed-reveal"><EditionFrontPage /></div>
+
   <div class="ed-reveal"><EditionAsk /></div>
 
   <div class="ed-reveal"><EditionWeekendBuilder /></div>
 
   <div class="ed-reveal"><EditionNotebook /></div>
+
+  <div class="ed-reveal"><EditionArchive /></div>
 
   <div class="ed-reveal">
     <NewsletterBlock
@@ -61,6 +68,8 @@ export const prerender = true;
       sub="Curated and sent weekly by Peninsula Insider."
     />
   </div>
+
+  <EditionFooterIndex />
 </BaseLayout>
 
 <script is:inline>

--- a/next/src/styles/edition.css
+++ b/next/src/styles/edition.css
@@ -318,3 +318,111 @@
   .ed-contents__row a { grid-template-columns: 2.4rem 1fr auto; }
   .ed-contents__dek { grid-column: 2 / -1; grid-row: 2; }
 }
+
+/* ---- Front page (the newspaper package) ---------------------------------- */
+.ed-front { padding: clamp(3.5rem, 7vw, 6rem) 0; background: var(--bg, #fff); }
+.ed-front__rule {
+  display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem;
+  border-top: 2px solid var(--text, #2B2520); padding-top: .7rem;
+}
+.ed-front__rule-label {
+  font-family: 'Outfit', sans-serif; font-size: .74rem; font-weight: 600;
+  letter-spacing: .22em; text-transform: uppercase; color: var(--text, #2B2520);
+}
+.ed-front__grid {
+  display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.9fr) minmax(0, 1fr);
+  gap: clamp(1.6rem, 3vw, 3rem);
+}
+.ed-front__col--side { display: flex; flex-direction: column; }
+.ed-front__item { border-bottom: 1px solid var(--border, #E5E0D6); }
+.ed-front__item:first-child { border-top: 0; }
+.ed-front__item a { display: block; padding: 1rem 0; text-decoration: none; color: inherit; }
+.ed-front__kicker {
+  font-family: 'Outfit', sans-serif; font-size: .64rem; font-weight: 600;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--accent, #8B4E3B);
+  margin: 0 0 .4rem;
+}
+.ed-front__headline {
+  font-family: 'Cormorant Garamond', serif; font-weight: 600;
+  font-size: 1.22rem; line-height: 1.22; margin: 0 0 .45rem; color: var(--text, #2B2520);
+  transition: color .2s ease;
+}
+.ed-front__item a:hover .ed-front__headline { color: var(--accent, #8B4E3B); }
+.ed-front__byline {
+  font-family: 'Outfit', sans-serif; font-size: .66rem; font-weight: 500;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--soft, #5F574E); margin: 0;
+}
+.ed-front__lead a { display: block; text-decoration: none; color: inherit; }
+.ed-front__lead-media { margin: 0 0 1.1rem; aspect-ratio: 3 / 2; overflow: hidden; background: var(--bg-alt, #F6F2EA); }
+.ed-front__lead-media img { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform .6s ease; }
+.ed-front__lead a:hover .ed-front__lead-media img { transform: scale(1.03); }
+@media (prefers-reduced-motion: reduce) { .ed-front__lead a:hover .ed-front__lead-media img { transform: none; } }
+.ed-front__lead-headline {
+  font-family: 'Cormorant Garamond', serif; font-weight: 600;
+  font-size: clamp(1.7rem, 2.8vw, 2.4rem); line-height: 1.08; margin: 0 0 .7rem;
+  color: var(--text, #2B2520); text-wrap: balance; transition: color .2s ease;
+}
+.ed-front__lead a:hover .ed-front__lead-headline { color: var(--accent, #8B4E3B); }
+.ed-front__lead-dek { font-size: .98rem; line-height: 1.6; color: var(--soft, #5F574E); margin: 0 0 .7rem; }
+.ed-front__more { margin: auto 0 0; padding-top: 1rem; font-size: .88rem; }
+.ed-front__more a { color: var(--accent, #8B4E3B); text-decoration: none; }
+.ed-front__more a:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+/* ---- Archive --------------------------------------------------------------- */
+.ed-archive { padding: clamp(3.5rem, 7vw, 6rem) 0; background: var(--bg, #fff); border-top: 1px solid var(--border, #E5E0D6); }
+.ed-archive__head { display: flex; align-items: baseline; justify-content: space-between; gap: 2rem; margin-bottom: 1.8rem; }
+.ed-archive__title {
+  font-family: 'Cormorant Garamond', serif; font-weight: 600;
+  font-size: clamp(1.9rem, 3vw, 2.6rem); margin: 0; color: var(--text, #2B2520);
+}
+.ed-archive__title em { font-style: italic; color: var(--gold-text, #7A6340); }
+.ed-archive__note { font-family: 'Cormorant Garamond', serif; font-style: italic; font-size: 1.05rem; color: var(--soft, #5F574E); margin: 0; }
+.ed-archive__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.2rem; }
+.ed-archive__card {
+  display: flex; flex-direction: column; gap: .55rem;
+  padding: 1.4rem; text-decoration: none; color: inherit;
+  background: var(--bg-alt, #F6F2EA); border: 1px solid var(--border, #E5E0D6);
+  transition: transform .25s ease, box-shadow .25s ease;
+}
+.ed-archive__card:hover { transform: translateY(-3px); box-shadow: 0 14px 30px rgba(34,24,16,.08); }
+@media (prefers-reduced-motion: reduce) { .ed-archive__card:hover { transform: none; } }
+.ed-archive__stamp {
+  font-family: 'Cormorant Garamond', serif; font-style: italic;
+  font-size: .98rem; color: var(--gold-text, #7A6340);
+}
+.ed-archive__kicker {
+  font-family: 'Outfit', sans-serif; font-size: .64rem; font-weight: 600;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--soft, #5F574E); margin: 0;
+}
+.ed-archive__headline {
+  font-family: 'Cormorant Garamond', serif; font-weight: 600;
+  font-size: 1.3rem; line-height: 1.2; margin: 0; color: var(--text, #2B2520);
+}
+.ed-archive__card:hover .ed-archive__headline { color: var(--accent, #8B4E3B); }
+.ed-archive__dek { font-size: .92rem; line-height: 1.55; color: var(--soft, #5F574E); margin: 0; }
+
+/* ---- Section index ----------------------------------------------------------- */
+.ed-index { padding: clamp(2.5rem, 5vw, 4rem) 0; background: var(--bg, #fff); border-top: 2px solid var(--text, #2B2520); }
+.ed-index__grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.8rem 2.2rem; }
+.ed-index__lane-title { margin: 0 0 .6rem; }
+.ed-index__lane-title a {
+  font-family: 'Outfit', sans-serif; font-size: .74rem; font-weight: 700;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--text, #2B2520);
+  text-decoration: none;
+}
+.ed-index__lane-title a:hover { color: var(--accent, #8B4E3B); }
+.ed-index__list { list-style: none; margin: 0; padding: 0; }
+.ed-index__list li + li { margin-top: .45rem; }
+.ed-index__list a {
+  font-family: 'Cormorant Garamond', serif; font-weight: 500;
+  font-size: 1.02rem; line-height: 1.3; color: var(--soft, #44372b);
+  text-decoration: none;
+}
+.ed-index__list a:hover { color: var(--accent, #8B4E3B); text-decoration: underline; text-underline-offset: 3px; }
+
+@media (max-width: 960px) {
+  .ed-front__grid { grid-template-columns: 1fr; }
+  .ed-front__lead { order: -1; }
+  .ed-archive__grid { grid-template-columns: 1fr; }
+  .ed-index__grid { grid-template-columns: repeat(2, 1fr); }
+}


### PR DESCRIPTION
Three modules of newspaper front-page discipline added to the Edition homepage, per the Atlantic-hybrid direction:

- **The Front Page** — an image-led lead flanked by two columns of headline-only stories with small-caps kickers and bylines. Pulls from the stories *after* the cover's four (no repetition between acts), requires the lead to carry a hero image, and caps any single format at a third of the package so the engine's hub-guide runs can't turn it monotonous. Renders nothing when the well runs dry rather than padding.
- **From the Archive** — resurfaces pieces 45+ days old that still fit the current season, stamped with their original month. Institutional memory as a feature.
- **Sectioned index** — the seven lanes above the footer, each with its two freshest entries from its own collection; regenerates every build.

Deliberately skipped from the reference: ads, algorithmic recommendations, above-the-fold clutter. Verified by Playwright at 1440/390 after a diversity-guard iteration caught the first render producing eight identical "Hub Guide" kickers and an imageless lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_0198DuW8Z9hoqZ82v9RJwMaz)_