### PR TITLE
fix(content): remove em-dashes blocking the production deploy

### DIFF
--- a/next/src/content/articles/insider-picks-2026-07-06.md
+++ b/next/src/content/articles/insider-picks-2026-07-06.md
@@ -1,5 +1,5 @@
 ---
-title: "Insider Picks — 6 July: The Winter Edit"
+title: "Insider Picks, 6 July: The Winter Edit"
 dek: "Quealy Winemakers's winter kitchen, the Cape Schanck boardwalk at its most dramatic, and MPRG's current show before it closes."
 author: "editorial"
 houseByline: true
@@ -29,10 +29,10 @@ faq:
   - question: "Where is Quealy Winemakers and do you need to book?"
     answer: "Red Hill Road, Balnarring. Bookings essential on weekends. Open Thu–Sun for lunch, Fri–Sat for dinner. Cellar door open daily for tastings without booking."
   - question: "How long is the Cape Schanck Lighthouse Walk?"
-    answer: "The Cape Schanck Lighthouse walk is a 4-kilometre return track to Pulpit Rock, taking approximately 90 minutes. It is rated easy difficulty but the boardwalk section is exposed. Check wind conditions before you go. Lighthouse tours run on selected days — see parksvictoria.vic.gov.au for details."
+    answer: "The Cape Schanck Lighthouse walk is a 4-kilometre return track to Pulpit Rock, taking approximately 90 minutes. It is rated easy difficulty but the boardwalk section is exposed. Check wind conditions before you go. Lighthouse tours run on selected days. See parksvictoria.vic.gov.au for details."
 ---
 
-The kitchen at Quealy is running its winter menu through August — and the mushroom tart with truffle cream is worth the drive to Balnarring alone.
+The kitchen at Quealy is running its winter menu through August, and the mushroom tart with truffle cream is worth the drive to Balnarring alone.
 
 ## Quealy Winemakers
 
@@ -40,27 +40,27 @@ Winemakers Kathleen Quealy and Kevin McCarthy have been farming this site for th
 
 Red Hill Road, Balnarring. Bookings essential on weekends. Open Thu–Sun for lunch, Fri–Sat for dinner. Cellar door open daily for tastings without booking.
 
-Pair lunch with a cellar door tasting — the Turbul Meunier is the current standout.
+Pair lunch with a cellar door tasting: the Turbul Meunier is the current standout.
 
 ## The walk for this weather
 
-The boardwalk at Cape Schanck is at its most theatrical right now — Bass Strait in full winter swell, the lighthouse tracking through grey sky, the headland emptied of the summer crowd.
+The boardwalk at Cape Schanck is at its most theatrical right now: Bass Strait in full winter swell, the lighthouse tracking through grey sky, the headland emptied of the summer crowd.
 
-The 4-kilometre return track to Pulpit Rock is one of the most dramatic short walks in Victoria, and mid-winter is when it earns that. The boardwalk extends out over sheer rock with water on both sides. In the right conditions — high swell, overcast — it feels genuinely wild.
+The 4-kilometre return track to Pulpit Rock is one of the most dramatic short walks in Victoria, and mid-winter is when it earns that. The boardwalk extends out over sheer rock with water on both sides. In the right conditions (high swell, overcast) it feels genuinely wild.
 
 Cape Schanck Road, Cape Schanck. 90 minutes return. Easy difficulty. Wear layers. Check wind conditions before the boardwalk. Lighthouse tours run selected days.
 
-Finish with lunch at the Flinders Hotel — 10 minutes' drive, warm room, long menu.
+Finish with lunch at the Flinders Hotel, 10 minutes' drive, warm room, long menu.
 
 ## Worth making time for
 
-The Mornington Peninsula Regional Gallery has a new winter show running through mid-August — and the Thursday evening openings are when the rooms are worth being in.
+The Mornington Peninsula Regional Gallery has a new winter show running through mid-August, and the Thursday evening openings are when the rooms are worth being in.
 
 MPRG is consistently underestimated. The main gallery runs contemporary Australian works alongside Peninsula-focused shows in the side rooms. The winter program tends toward darker, more interior work that suits the season. Entry is free, which makes it the most overlooked cultural proposition on the Peninsula.
 
-2/350 Dunns Road, Mornington. Free entry. Open most days — check mprg.mornpen.vic.gov.au for current hours. 5 minutes from Main Street.
+2/350 Dunns Road, Mornington. Free entry. Open most days. Check mprg.mornpen.vic.gov.au for current hours. 5 minutes from Main Street.
 
-Walk down to Mornington Pier afterwards if the rain holds off — coffee at any of the Main Street cafes on the way back.
+Walk down to Mornington Pier afterwards if the rain holds off, coffee at any of the Main Street cafes on the way back.
 
 ---
 


### PR DESCRIPTION
## Why

The `build-and-deploy` pipeline on `main` has been **failing since 2026-07-06 morning** (fails at ~54s), so nothing has deployed — including the just-merged Content Strategy Brain (#268).

Root cause: the daily-content engine's `next/src/content/articles/insider-picks-2026-07-06.md` contains 10 em-dashes, which `lint:house-style` rejects as a BRAND-PI hard-rule violation. This is a pre-existing failure in auto-generated content, not from #268.

## Fix

Replaced each em-dash with sanctioned punctuation (colon / comma / period / parentheses), preserving the editorial voice.

## Verification (run locally)
- `lint:house-style` → ✓ no em-dashes
- `lint:no-pricing` → ✓ clean
- `lint:region-images` → ✓ passed
- `lint:surfaces` → ✓ passed

Unblocks the deploy of #268 (agent-discoverability `llms.txt`, sitemap indexation fix) plus the site's latest content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_