### PR TITLE
fix(engine): sanitize em-dashes in the content pipeline

### DIFF
--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -595,10 +595,31 @@ def get_season(month: int) -> str:
     return seasons.get(month, "summer")
 
 
+def sanitize_house_style(article_path: Path) -> int:
+    """Deterministically enforce the BRAND-PI em-dash hard rule that the build's
+    lint:house-style gate checks. Generated content routinely contains em-dashes,
+    which would fail the deploy — so we normalise them to ' - ' here, before the
+    file is ever committed, keeping the autonomous loop self-consistent with the
+    build. En-dashes and Markdown '---' rules are intentionally left untouched.
+    Returns the number of em-dashes replaced."""
+    if not article_path.exists():
+        return 0
+    import re as _re
+    content = article_path.read_text()
+    count = content.count("—")
+    if count:
+        content = _re.sub(r"\s*—\s*", " - ", content)
+        article_path.write_text(content)
+        print(f"    Sanitised {count} em-dash(es) in {article_path.name}")
+    return count
+
+
 def run_style_gate(article_path: Path) -> str:
     """Run style checks. Returns PASS or FAIL."""
     if not article_path.exists():
         return "FAIL"
+    # Normalise house-style violations the build enforces (em-dashes) before checks.
+    sanitize_house_style(article_path)
     content = article_path.read_text()
     prohibited = ["stunning", "vibrant", "nestled", "charming", "hidden gem",
                   "must-visit", "you won't be disappointed", "world-class"]

--- a/engine/test_strategy_engine.py
+++ b/engine/test_strategy_engine.py
@@ -355,6 +355,37 @@ class DeskRouting(unittest.TestCase):
         self.assertEqual(se.route_desk("/whats-on/mornington-cup-2026/"), "dispatch-desk")
 
 
+class HouseStyleSanitizer(unittest.TestCase):
+    """Guards the em-dash sanitizer in the orchestrator's style gate — an
+    em-dash regression here silently breaks every content deploy."""
+
+    def _sanitize(self, text: str) -> str:
+        import tempfile
+        import orchestrator as orch
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "a.md"
+            p.write_text(text)
+            orch.sanitize_house_style(p)
+            return p.read_text()
+
+    def test_replaces_spaced_em_dash(self):
+        self.assertEqual(self._sanitize("winter menu — and the tart"),
+                         "winter menu - and the tart")
+
+    def test_replaces_bare_and_tight_em_dash(self):
+        self.assertEqual(self._sanitize("A—B"), "A - B")
+
+    def test_leaves_hyphen_rule_and_en_dash(self):
+        # Markdown '---' rule and en-dashes (Thu–Sun) must survive untouched.
+        out = self._sanitize("---\nOpen Thu–Sun\n---")
+        self.assertIn("---", out)
+        self.assertIn("Thu–Sun", out)
+
+    def test_result_has_no_em_dashes(self):
+        out = self._sanitize("Title — sub — end. Days — see site.")
+        self.assertNotIn("—", out)
+
+
 if __name__ == "__main__":
     verbosity = 1 if "--quiet" in sys.argv else 2
     argv = [a for a in sys.argv if a != "--quiet"]

--- a/next/src/content/articles/insider-picks-2026-07-06.md
+++ b/next/src/content/articles/insider-picks-2026-07-06.md
@@ -1,5 +1,5 @@
 ---
-title: "Insider Picks — 6 July: The Winter Edit"
+title: "Insider Picks - 6 July: The Winter Edit"
 dek: "Quealy Winemakers's winter kitchen, the Cape Schanck boardwalk at its most dramatic, and MPRG's current show before it closes."
 author: "editorial"
 houseByline: true
@@ -29,10 +29,10 @@ faq:
   - question: "Where is Quealy Winemakers and do you need to book?"
     answer: "Red Hill Road, Balnarring. Bookings essential on weekends. Open Thu–Sun for lunch, Fri–Sat for dinner. Cellar door open daily for tastings without booking."
   - question: "How long is the Cape Schanck Lighthouse Walk?"
-    answer: "The Cape Schanck Lighthouse walk is a 4-kilometre return track to Pulpit Rock, taking approximately 90 minutes. It is rated easy difficulty but the boardwalk section is exposed. Check wind conditions before you go. Lighthouse tours run on selected days — see parksvictoria.vic.gov.au for details."
+    answer: "The Cape Schanck Lighthouse walk is a 4-kilometre return track to Pulpit Rock, taking approximately 90 minutes. It is rated easy difficulty but the boardwalk section is exposed. Check wind conditions before you go. Lighthouse tours run on selected days - see parksvictoria.vic.gov.au for details."
 ---
 
-The kitchen at Quealy is running its winter menu through August — and the mushroom tart with truffle cream is worth the drive to Balnarring alone.
+The kitchen at Quealy is running its winter menu through August - and the mushroom tart with truffle cream is worth the drive to Balnarring alone.
 
 ## Quealy Winemakers
 
@@ -40,27 +40,27 @@ Winemakers Kathleen Quealy and Kevin McCarthy have been farming this site for th
 
 Red Hill Road, Balnarring. Bookings essential on weekends. Open Thu–Sun for lunch, Fri–Sat for dinner. Cellar door open daily for tastings without booking.
 
-Pair lunch with a cellar door tasting — the Turbul Meunier is the current standout.
+Pair lunch with a cellar door tasting - the Turbul Meunier is the current standout.
 
 ## The walk for this weather
 
-The boardwalk at Cape Schanck is at its most theatrical right now — Bass Strait in full winter swell, the lighthouse tracking through grey sky, the headland emptied of the summer crowd.
+The boardwalk at Cape Schanck is at its most theatrical right now - Bass Strait in full winter swell, the lighthouse tracking through grey sky, the headland emptied of the summer crowd.
 
-The 4-kilometre return track to Pulpit Rock is one of the most dramatic short walks in Victoria, and mid-winter is when it earns that. The boardwalk extends out over sheer rock with water on both sides. In the right conditions — high swell, overcast — it feels genuinely wild.
+The 4-kilometre return track to Pulpit Rock is one of the most dramatic short walks in Victoria, and mid-winter is when it earns that. The boardwalk extends out over sheer rock with water on both sides. In the right conditions - high swell, overcast - it feels genuinely wild.
 
 Cape Schanck Road, Cape Schanck. 90 minutes return. Easy difficulty. Wear layers. Check wind conditions before the boardwalk. Lighthouse tours run selected days.
 
-Finish with lunch at the Flinders Hotel — 10 minutes' drive, warm room, long menu.
+Finish with lunch at the Flinders Hotel - 10 minutes' drive, warm room, long menu.
 
 ## Worth making time for
 
-The Mornington Peninsula Regional Gallery has a new winter show running through mid-August — and the Thursday evening openings are when the rooms are worth being in.
+The Mornington Peninsula Regional Gallery has a new winter show running through mid-August - and the Thursday evening openings are when the rooms are worth being in.
 
 MPRG is consistently underestimated. The main gallery runs contemporary Australian works alongside Peninsula-focused shows in the side rooms. The winter program tends toward darker, more interior work that suits the season. Entry is free, which makes it the most overlooked cultural proposition on the Peninsula.
 
-2/350 Dunns Road, Mornington. Free entry. Open most days — check mprg.mornpen.vic.gov.au for current hours. 5 minutes from Main Street.
+2/350 Dunns Road, Mornington. Free entry. Open most days - check mprg.mornpen.vic.gov.au for current hours. 5 minutes from Main Street.
 
-Walk down to Mornington Pier afterwards if the rain holds off — coffee at any of the Main Street cafes on the way back.
+Walk down to Mornington Pier afterwards if the rain holds off - coffee at any of the Main Street cafes on the way back.
 
 ---
 


### PR DESCRIPTION
## Why

The first live daily cycle ran green **through the engine**, but exposed a systemic bug: the content generator emits em-dashes, and the build's `lint:house-style` gate rejects them as a BRAND-PI hard-rule violation. So the daily content commit (`insider-picks-2026-07-06.md`, 10 em-dashes) **fails the deploy** — the same failure that blocked #268 earlier. Fixing individual files is whack-a-mole; this fixes the root cause.

## Fix

- **`engine/orchestrator.py`** — `sanitize_house_style()` normalises em-dashes to `' - '` at the top of `run_style_gate` (covers daily/weekly/monthly paths), *before* any file is committed. Mirrors exactly what the build enforces. En-dashes and Markdown `---` rules are left untouched. The autonomous loop can no longer commit content that fails the deploy on this rule.
- **`engine/test_strategy_engine.py`** — 4 tests guarding the sanitizer, run by the pre-flight gate so an em-dash regression fails loudly.
- **`insider-picks-2026-07-06.md`** — sanitized (unblocks the currently-failing deploy).

## Verification
- Real build lint (`node scripts/lint-house-style.mjs`) → ✓ clean
- Full engine self-test suite → **32 passed** (incl. the 4 new sanitizer tests)
- `py_compile` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_