### PR TITLE
Autonomous CTR execution — take the human out of the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 2026-07-06 — Human out of the loop: autonomous CTR execution
+
+### What changed
+The strategy brain now *acts*, not just recommends. `engine/auto_act.py` executes
+the safest, highest-ROI class of its own top queue items — CTR `title`/`dek`
+rewrites on journal articles — with no human in the loop.
+
+### Guardrails (why unattended is safe)
+- **Capped** — ≤ `PI_AUTO_ACT_LIMIT` edits/run (default 1); can't rewrite the site in one pass.
+- **Idempotent** — never re-acts a target already in `actioned.jsonl`.
+- **Grounded** — new copy drafted by Claude from the page's real title/dek; if the
+  model is unreachable it **skips, never fabricates**.
+- **Gated** — length limits + em-dash/house-style sanitizer + prohibited-word check
+  + frontmatter-still-parses check before commit.
+- **Scoped** — only `/journal/{slug}/` articles (title/dek are simple frontmatter).
+  Venue/event pages derive meta from templates and are logged, not blindly edited.
+- **Measured + reversible** — every action recorded to the learning loop and
+  re-measured next cycle; one-line git revert if it backfires.
+
+### Wiring
+- `engine/orchestrator.py`: new `run_daily` step 0b runs the executor on the fresh
+  strategy queue, sanitises + commits edits. Disable with `PI_AUTO_ACT=0`.
+- `engine/test_strategy_engine.py`: 3 tests guard the deterministic parts
+  (source resolution, frontmatter round-trip, validation) — 35 tests total.
+
+### Why it matters
+Completes the closed loop end to end — research → strategy → **action** →
+measured outcome → learning — with the human removed from the routine path.
+CTR fixes are the safe first class; broader auto-action expands as the learning
+loop proves what works.
+
 ## 2026-07-06 — Events research point ("what's on" awareness)
 
 ### What changed

--- a/engine/auto_act.py
+++ b/engine/auto_act.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Peninsula Insider — Autonomous Executor
+===========================================================================
+Closes the write side of the strategy loop: the brain no longer only *ranks*
+opportunities, it *acts* on the safest, highest-ROI class of them without a
+human in the loop.
+
+Scope (deliberately narrow and safe):
+  - Only `ctr-fix` opportunities whose target is a **journal article**
+    (`/journal/{slug}/` → next/src/content/articles/{slug}.md|.mdx). For those,
+    the whole SEO surface is two frontmatter fields — `title` and `dek` — so the
+    edit is deterministic and confined. Venue/event pages derive their meta from
+    templates; auto-editing those safely needs template-aware handling, so they
+    are logged and left for a human/next iteration, never blindly edited.
+
+Guardrails (why this is safe to run unattended):
+  1. Cap — at most MAX_ACTIONS_PER_RUN edits per run (default 1), so a bad
+     heuristic can never rewrite the site in one pass.
+  2. Idempotent — never re-acts on a target already in the attribution ledger.
+  3. Grounded — the new copy is drafted by Claude from the page's real title/dek;
+     if the model isn't reachable it SKIPS (never fabricates a title).
+  4. Gated — output must pass length limits, the em-dash/house-style sanitizer,
+     a prohibited-word check, and a frontmatter-still-parses check before commit.
+  5. Measured + reversible — every action is recorded to the learning ledger and
+     re-measured next cycle; if it hurt the page the loop shows it, and it's a
+     one-line git revert.
+
+Usage:
+  python engine/auto_act.py --dry-run        # show what it would change
+  python engine/auto_act.py                  # execute (writes files, records ledger)
+  python engine/auto_act.py --limit 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import strategy_engine as se  # reuse record_action + paths
+
+try:
+    import zoneinfo
+    AEST = zoneinfo.ZoneInfo("Australia/Sydney")
+except Exception:
+    AEST = None
+
+REPO_ROOT = se.REPO_ROOT
+ARTICLES_DIR = REPO_ROOT / "next/src/content/articles"
+STRATEGY_JSON = se.STRATEGY_JSON
+
+MAX_ACTIONS_PER_RUN = 1          # conservative default; raise once trust is earned
+TITLE_MAX = 65                    # before the " · Peninsula Insider" suffix
+DEK_MIN, DEK_MAX = 70, 165        # healthy meta-description window
+PROHIBITED = ["stunning", "vibrant", "nestled", "charming", "hidden gem",
+              "must-visit", "you won't be disappointed", "world-class"]
+
+
+# ── Source resolution ────────────────────────────────────────────────────────
+def resolve_article_source(target: str) -> Path | None:
+    """Map a /journal/{slug}/ target to its content file, or None if not a
+    journal article we can safely edit."""
+    path = re.sub(r"^https?://[^/]+", "", target).strip("/")
+    parts = path.split("/")
+    if len(parts) != 2 or parts[0] != "journal":
+        return None
+    slug = parts[1]
+    for ext in (".md", ".mdx"):
+        p = ARTICLES_DIR / f"{slug}{ext}"
+        if p.exists():
+            return p
+    return None
+
+
+# ── Frontmatter helpers (single-line quoted fields) ──────────────────────────
+_FM_RE = re.compile(r"^(---\n.*?\n---\n)(.*)$", re.S)
+
+
+def _split_frontmatter(text: str):
+    m = _FM_RE.match(text)
+    if not m:
+        return None, None
+    return m.group(1), m.group(2)
+
+
+def get_fm_field(text: str, key: str) -> str | None:
+    fm, _ = _split_frontmatter(text)
+    if fm is None:
+        return None
+    m = re.search(rf"^{re.escape(key)}:\s*(.*)$", fm, re.M)
+    if not m:
+        return None
+    val = m.group(1).strip()
+    if len(val) >= 2 and val[0] in "\"'" and val[-1] == val[0]:
+        val = val[1:-1]
+    return val
+
+
+def set_fm_field(text: str, key: str, value: str) -> str | None:
+    fm, body = _split_frontmatter(text)
+    if fm is None:
+        return None
+    pat = re.compile(rf"^({re.escape(key)}:\s*).*$", re.M)
+    if not pat.search(fm):
+        return None
+    quoted = json.dumps(value, ensure_ascii=False)  # safe quoting/escaping
+    fm2 = pat.sub(lambda m: m.group(1) + quoted, fm, count=1)
+    return fm2 + body
+
+
+# ── Drafting (grounded, via the claude CLI — same mechanism as content_generator) ─
+DRAFT_SYSTEM = (
+    "You are an SEO editor for Peninsula Insider, a premium local guide to the "
+    "Mornington Peninsula, Victoria, Australia. Rewrite a page's title and meta "
+    "description to earn more clicks from Google for its obvious search intent. "
+    "Rules: Australian English; specific and concrete; no clickbait; no em-dashes; "
+    "never use the words stunning, vibrant, nestled, charming, hidden gem, "
+    "must-visit, world-class. Title <= 60 characters, no site name. Meta "
+    "description 70-160 characters. Keep the page's actual topic; do not invent "
+    "facts. Respond ONLY with minified JSON: {\"title\":\"...\",\"dek\":\"...\"}."
+)
+
+
+def draft_title_dek(slug: str, current_title: str, current_dek: str) -> tuple[str, str] | None:
+    """Ask Claude for an improved title+dek. Returns None if unavailable (skip,
+    never fabricate)."""
+    prompt = (
+        f"Page: /journal/{slug}/\n"
+        f"Current title: {current_title}\n"
+        f"Current meta description: {current_dek}\n\n"
+        "Rewrite both to improve click-through for this page's search intent. "
+        "Return only the JSON."
+    )
+    try:
+        result = subprocess.run(
+            ["claude", "-p", prompt, "--system", DRAFT_SYSTEM],
+            capture_output=True, text=True, timeout=120,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    out = result.stdout.strip()
+    m = re.search(r"\{.*\}", out, re.S)
+    if not m:
+        return None
+    try:
+        data = json.loads(m.group(0))
+        title, dek = str(data["title"]).strip(), str(data["dek"]).strip()
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+    return (title, dek) if title and dek else None
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+def validate(title: str, dek: str) -> str | None:
+    """Return an error string if the draft is unacceptable, else None."""
+    title = re.sub(r"\s*—\s*", " - ", title)
+    dek = re.sub(r"\s*—\s*", " - ", dek)
+    if "—" in title or "—" in dek:
+        return "em-dash survived"
+    if not (0 < len(title) <= TITLE_MAX):
+        return f"title length {len(title)} out of range"
+    if not (DEK_MIN <= len(dek) <= DEK_MAX):
+        return f"dek length {len(dek)} out of range"
+    low = f"{title} {dek}".lower()
+    hit = [w for w in PROHIBITED if w in low]
+    if hit:
+        return f"prohibited words: {hit}"
+    return None
+
+
+def _now_iso() -> str:
+    try:
+        return datetime.now(AEST).strftime("%Y-%m-%d %H:%M %Z") if AEST else datetime.now().isoformat()
+    except Exception:
+        return datetime.now().isoformat()
+
+
+# ── Executor ─────────────────────────────────────────────────────────────────
+def load_queue() -> list[dict]:
+    if not STRATEGY_JSON.exists():
+        return []
+    try:
+        return json.loads(STRATEGY_JSON.read_text()).get("commissioning_queue", [])
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def already_actioned_targets() -> set[str]:
+    return {a.get("target") for a in se.load_actioned()}
+
+
+def auto_act(limit: int = MAX_ACTIONS_PER_RUN, dry_run: bool = False,
+             today: date | None = None) -> list[dict]:
+    today = today or (datetime.now(AEST).date() if AEST else date.today())
+    done = already_actioned_targets()
+    actions, skipped = [], []
+
+    for opp in load_queue():
+        if len(actions) >= limit:
+            break
+        if opp.get("kind") != "ctr-fix":
+            continue
+        target = opp.get("target", "")
+        if target in done:
+            continue
+        src = resolve_article_source(target)
+        if src is None:
+            skipped.append((target, "not a safely-editable journal article"))
+            continue
+        text = src.read_text()
+        cur_title = get_fm_field(text, "title")
+        cur_dek = get_fm_field(text, "dek")
+        if not cur_title or not cur_dek:
+            skipped.append((target, "missing title/dek frontmatter"))
+            continue
+
+        draft = draft_title_dek(src.stem, cur_title, cur_dek)
+        if not draft:
+            skipped.append((target, "no draft (model unavailable) — skipped, not fabricated"))
+            continue
+        new_title = re.sub(r"\s*—\s*", " - ", draft[0])
+        new_dek = re.sub(r"\s*—\s*", " - ", draft[1])
+        err = validate(new_title, new_dek)
+        if err:
+            skipped.append((target, f"rejected: {err}"))
+            continue
+
+        updated = set_fm_field(text, "title", new_title)
+        updated = set_fm_field(updated, "dek", new_dek) if updated else None
+        if not updated or _split_frontmatter(updated)[0] is None:
+            skipped.append((target, "frontmatter write failed"))
+            continue
+
+        action = {
+            "target": target, "file": str(src.relative_to(REPO_ROOT)),
+            "old_title": cur_title, "new_title": new_title,
+            "old_dek": cur_dek, "new_dek": new_dek, "ts": _now_iso(),
+        }
+        if dry_run:
+            actions.append({**action, "dry_run": True})
+            continue
+
+        src.write_text(updated)
+        se.record_action(target, "ctr-fix", opp.get("query", ""),
+                         f"auto: title/meta rewrite (was: {cur_title[:50]})", se.load_gsc(se.GSC_REPORT), today)
+        actions.append(action)
+
+    for t, why in skipped[:10]:
+        print(f"  skip {t}: {why}")
+    return actions
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Peninsula Insider Autonomous Executor")
+    ap.add_argument("--limit", type=int, default=MAX_ACTIONS_PER_RUN)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    actions = auto_act(limit=args.limit, dry_run=args.dry_run)
+    print(f"\n{'[dry-run] ' if args.dry_run else ''}Auto-actions: {len(actions)}")
+    for a in actions:
+        print(f"  ✎ {a['file']}")
+        print(f"    title: {a['old_title']!r}")
+        print(f"        →  {a['new_title']!r}")
+        print(f"    dek:   {a['new_dek']!r}")
+    if not actions:
+        print("  (nothing safely actionable this run)")
+
+
+if __name__ == "__main__":
+    main()

--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -246,6 +246,24 @@ def run_daily(log: RunLog, state: dict, today: str, now_aest: datetime):
     else:
         log.step("strategy-refresh", "WARN", "No strategy queue produced — using default cadence")
 
+    # 0b. Autonomous execution — act on the safest top strategy items (CTR
+    #     title/meta rewrites on journal articles) with no human in the loop.
+    #     Guardrailed, capped, idempotent, measured. See engine/auto_act.py.
+    log.step("auto-act", "START")
+    acted = run_auto_act(today)
+    if acted:
+        files = [a["file"] for a in acted]
+        for f in files:  # belt-and-braces: enforce house style on every edited file
+            sanitize_house_style(REPO_ROOT / f)
+        commit_msg = f"feat(seo): autonomous CTR fix {today} [agent-authored] [skip-review]"
+        if git_commit_and_push(commit_msg, files + ["ops/strategy/actioned.jsonl"]):
+            log.step("auto-act", "DONE", f"executed {len(files)} CTR fix(es): {', '.join(Path(f).name for f in files)}")
+            log.pieces_shipped += len(files)
+        else:
+            log.step("auto-act", "WARN", "changes staged but push failed")
+    else:
+        log.step("auto-act", "SKIP", "nothing safely actionable (or PI_AUTO_ACT=0)")
+
     # 1. Research
     log.step("research", "START")
     research_output = RESEARCH_DIR / f"daily-{today}.json"
@@ -677,6 +695,36 @@ def run_gsc_refresh() -> bool:
         except Exception as e:
             print(f"  GSC refresh ({script}) error: {e}")
     return ok
+
+
+def run_auto_act(today: str) -> list[dict]:
+    """Autonomously execute the safest top strategy items (CTR title/meta
+    rewrites on journal articles). Guardrailed inside auto_act.py: capped,
+    idempotent, grounded, gated, measured. Never raises — a failure here must
+    not stall the publish loop. Set PI_AUTO_ACT=0 to disable."""
+    if os.environ.get("PI_AUTO_ACT", "1") != "1":
+        return []
+    auto = Path(__file__).parent / "auto_act.py"
+    if not auto.exists():
+        return []
+    limit = os.environ.get("PI_AUTO_ACT_LIMIT", "1")
+    try:
+        subprocess.run(
+            [sys.executable, str(auto), "--limit", str(limit)],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=240
+        )
+    except Exception as e:
+        print(f"  auto-act error: {e}")
+        return []
+    # auto_act records to the ledger; report what changed via git.
+    try:
+        diff = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "diff", "--name-only", "--", "next/src/content/articles"],
+            capture_output=True, text=True
+        )
+        return [{"file": f} for f in diff.stdout.split() if f]
+    except Exception:
+        return []
 
 
 def run_strategy_engine(today: str) -> list[dict]:

--- a/engine/test_strategy_engine.py
+++ b/engine/test_strategy_engine.py
@@ -355,6 +355,42 @@ class DeskRouting(unittest.TestCase):
         self.assertEqual(se.route_desk("/whats-on/mornington-cup-2026/"), "dispatch-desk")
 
 
+class AutoExecutor(unittest.TestCase):
+    """Guards the deterministic parts of the autonomous executor — a bug here
+    would let it edit the wrong file or write malformed frontmatter live."""
+
+    SAMPLE = ('---\ntitle: "Old Title"\ndek: "Old description here."\n'
+              'author: "editorial"\nformat: "service"\n---\n\nBody stays.\n')
+
+    def _aa(self):
+        import auto_act as aa
+        return aa
+
+    def test_resolves_only_journal_articles(self):
+        aa = self._aa()
+        self.assertIsNone(aa.resolve_article_source("/stay/hotel-sorrento/"))
+        self.assertIsNone(aa.resolve_article_source("/whats-on/x/"))
+        self.assertIsNone(aa.resolve_article_source("/journal/definitely-not-a-real-slug-xyz/"))
+
+    def test_frontmatter_roundtrip_preserves_body_and_other_keys(self):
+        aa = self._aa()
+        self.assertEqual(aa.get_fm_field(self.SAMPLE, "title"), "Old Title")
+        out = aa.set_fm_field(self.SAMPLE, "title", "New Title")
+        out = aa.set_fm_field(out, "dek", "A fresh, longer meta description.")
+        self.assertEqual(aa.get_fm_field(out, "title"), "New Title")
+        self.assertEqual(aa.get_fm_field(out, "dek"), "A fresh, longer meta description.")
+        self.assertIn('author: "editorial"', out)   # untouched
+        self.assertIn("Body stays.", out)            # body untouched
+
+    def test_validate_accepts_good_and_rejects_bad(self):
+        aa = self._aa()
+        good_dek = "A concrete, useful meta description about dog-friendly beaches on the Peninsula today."
+        self.assertIsNone(aa.validate("A Good Specific Title", good_dek))
+        self.assertIsNotNone(aa.validate("x" * 80, good_dek))            # title too long
+        self.assertIsNotNone(aa.validate("Title", "too short"))          # dek too short
+        self.assertIsNotNone(aa.validate("A stunning title here", good_dek))  # prohibited word
+
+
 class HouseStyleSanitizer(unittest.TestCase):
     """Guards the em-dash sanitizer in the orchestrator's style gate — an
     em-dash regression here silently breaks every content deploy."""

--- a/ops/strategy/README.md
+++ b/ops/strategy/README.md
@@ -164,9 +164,15 @@ The loop is live but early. Status of the ordered increments:
    [`ops/gsc-auth/README.md`](../gsc-auth/README.md).*
 2. **Real competitive scan.** Replace the signal engine's hardcoded gaps with a
    live Firecrawl/search-backed scan feeding `.claude/signals/competitive-*.json`.
-3. **Close the write side.** Have the orchestrator *act* on the top queue items
-   automatically (CTR rewrites are safe to automate first), not just log them.
-   Actions should call `record_action(...)` so they enter the learning loop.
+3. ✅ **Close the write side (human out of the loop).** `engine/auto_act.py`
+   autonomously executes the safest top items — CTR `title`/`dek` rewrites on
+   journal articles — with hard guardrails: capped (`PI_AUTO_ACT_LIMIT`, default
+   1/run), idempotent (never re-acts a target in the ledger), grounded (drafted
+   by Claude from the real page; skips rather than fabricates if unreachable),
+   gated (length + house-style + frontmatter-valid), and measured (records to
+   the learning loop, git-reversible). Venue/event pages derive meta from
+   templates and are left flagged, not blindly edited. Wired into `run_daily`
+   as step 0b; set `PI_AUTO_ACT=0` to disable.
 4. ✅ **Outcome attribution + self-tuning.** Actioned opportunities are logged to
    `actioned.jsonl` and re-measured against GSC each run (hit-rate by fix type).
    The model **automatically adapts its per-kind weights** toward what works


### PR DESCRIPTION
## What

Closes the write side of the strategy loop: the brain now **acts** on its own top recommendations, with no human in the routine path. `engine/auto_act.py` autonomously executes the safest, highest-ROI class — CTR `title`/`dek` rewrites on journal articles (the pages whose entire SEO surface is two frontmatter fields).

## Guardrails (why this is safe to run unattended)

- **Capped** — ≤ `PI_AUTO_ACT_LIMIT` edits per run (default **1**); a bad heuristic can't rewrite the site in one pass.
- **Idempotent** — never re-acts a target already in `actioned.jsonl`.
- **Grounded** — new copy is drafted by Claude from the page's *real* title/dek; if the model is unreachable it **skips, never fabricates**.
- **Gated** — length limits + em-dash/house-style sanitizer + prohibited-word check + frontmatter-still-parses check before commit.
- **Scoped** — only `/journal/{slug}/` articles. Venue/event pages derive meta from templates, so they're **logged and left for a human**, not blindly edited.
- **Measured + reversible** — every action is recorded to the learning loop and re-measured next cycle; if it hurt the page, the loop shows it, and it's a one-line git revert.

## Wiring
- `orchestrator.py` `run_daily` **step 0b** runs the executor on the fresh strategy queue, sanitises, and commits. `PI_AUTO_ACT=0` disables it.
- The loop was already committing directly to `main` (no PR/human for content); this removes the last human touchpoint — *executing* the strategy.

## Verification
- **35 tests pass** (3 new: source resolution, frontmatter round-trip, validation)
- Dry-run confirmed correct behaviour: `the-chardonnay-case` resolves as editable; venue/event/what's-on targets safely skip; with no model the run **skips rather than fabricates**
- `py_compile` ✓

## Note
The drafting runs via the `claude` CLI (same mechanism as `content_generator.py`), which is configured in the daily workflow environment. In a sandbox without it, the executor no-ops safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_