### PR TITLE
fix: make orchestrator import-safe (unblock daily self-test gate)

### DIFF
--- a/.github/workflows/daily-content.yml
+++ b/.github/workflows/daily-content.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Validate strategy engine (pre-flight gate)
         # A broken parser or scoring path would silently publish bad strategy
         # every day. Fail loudly here before the engine runs. Fast, no deps.
+        env:
+          PI_REPO_ROOT: ${{ github.workspace }}
         run: |
           python engine/test_strategy_engine.py --quiet
 

--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -29,9 +29,14 @@ SLATES_DIR = REPO_ROOT / ".claude/newsroom/slates"
 LOOP_STATE_FILE = REPO_ROOT / ".claude/newsroom/loop-state/current.json"
 AGENTS_DIR = Path(__file__).parent.parent / "agents"
 
-# Ensure dirs exist
+# Ensure dirs exist. Guarded so importing this module (e.g. from the self-test
+# gate) never fails when REPO_ROOT points somewhere unwritable — the run itself
+# sets PI_REPO_ROOT to a writable workspace.
 for d in [SIGNALS_DIR, RESEARCH_DIR, RUNS_DIR, SLATES_DIR, LOOP_STATE_FILE.parent]:
-    d.mkdir(parents=True, exist_ok=True)
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
 
 
 # ── Loop State ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The autonomous daily run (#12) failed at the **pre-flight self-test gate** with `PermissionError: [Errno 13] Permission denied: '/home/node'` (4 test errors). The new `HouseStyleSanitizer` tests import `orchestrator`, which ran `mkdir` at *import time* under the hardcoded default `REPO_ROOT` (`/home/node/...`) because `PI_REPO_ROOT` wasn't set in the test-gate step.

## Fix
- `engine/orchestrator.py`: guard the import-time `mkdir` loop with `try/except OSError`, so the module imports safely anywhere (the run itself sets `PI_REPO_ROOT` to a writable workspace).
- `daily-content.yml`: also set `PI_REPO_ROOT` in the pre-flight step (belt-and-braces).

## Verification
- Reproduced the CI condition locally: `env -u PI_REPO_ROOT python3 engine/test_strategy_engine.py` → **35 tests pass** (was 4 errors).
- `py_compile` ✓

This unblocks the autonomous loop so the auto-executor can actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_