### PR TITLE
WS3: real factual verify gate (blocks bad publishes)

### DIFF
--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -654,16 +654,42 @@ def run_style_gate(article_path: Path) -> str:
 
 
 def run_verify_gate(article_path: Path, today: str) -> str:
-    """Run basic verification. Returns PASS or FAIL."""
+    """Factual verification gate. Returns PASS or FAIL.
+
+    Two layers: (1) frontmatter completeness, then (2) the real factual gate
+    (engine/verify_gate.py) — referential integrity, day-of-week correctness,
+    internal-link 404s. A hard FAIL there BLOCKS the publish; flags are logged
+    but ship. Degrades to the frontmatter check if the gate can't be imported."""
     if not article_path.exists():
         return "FAIL"
     content = article_path.read_text()
-    # Check frontmatter fields present
     required_fields = ["title:", "author:", "publishedAt:", "format:", "tags:"]
     missing = [f for f in required_fields if f not in content]
     if missing:
         print(f"    Missing frontmatter: {missing}")
         return "FAIL"
+
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import verify_gate
+        report = verify_gate.verify_content(
+            article_path,
+            content_dir=REPO_ROOT / "next/src/content",
+            sitemap_path=REPO_ROOT / "sitemap.xml",
+        )
+    except Exception as e:
+        print(f"    Verify gate unavailable ({e}) — frontmatter-only pass")
+        return "PASS"
+
+    for flag in report.get("flags", []):
+        print(f"    [verify-flag] {flag}")
+    if report["result"] == "FAIL":
+        for f in report["fails"]:
+            print(f"    [verify-FAIL] {f}")
+        return "FAIL"
+    print(f"    Verify: {report['result']} "
+          f"({len(report.get('venue_checks', []))} venue, "
+          f"{len(report.get('date_checks', []))} date checks)")
     return "PASS"
 
 

--- a/engine/test_strategy_engine.py
+++ b/engine/test_strategy_engine.py
@@ -422,6 +422,53 @@ class HouseStyleSanitizer(unittest.TestCase):
         self.assertNotIn("—", out)
 
 
+class VerifyGate(unittest.TestCase):
+    """Guards the real factual verify gate — it can BLOCK a live publish, so its
+    hard-fail logic must not silently regress."""
+
+    def _run(self, body: str, *, slugs=("real-venue",), paths=("/eat/real-venue",)):
+        import tempfile
+        import verify_gate as vg
+        with tempfile.TemporaryDirectory() as d:
+            content = Path(d) / "content"
+            (content / "venues").mkdir(parents=True)
+            for s in slugs:
+                (content / "venues" / f"{s}.json").write_text("{}")
+            sitemap = Path(d) / "sitemap.xml"
+            locs = "".join(f"<loc>https://peninsulainsider.com.au{p}/</loc>" for p in paths)
+            sitemap.write_text(f"<urlset>{locs}</urlset>")
+            f = Path(d) / "a.md"
+            f.write_text(body)
+            return vg.verify_content(f, content_dir=content, sitemap_path=sitemap)
+
+    def test_clean_passes(self):
+        body = ('---\ntitle: "x"\npublishedAt: 2026-07-06\nrelatedVenues: [real-venue]\n---\n'
+                "A calm note with no dates or risky claims.")
+        self.assertEqual(self._run(body)["result"], "PASS")
+
+    def test_missing_venue_fails(self):
+        body = ('---\npublishedAt: 2026-07-06\nrelatedVenues: [ghost-venue]\n---\nhi')
+        r = self._run(body)
+        self.assertEqual(r["result"], "FAIL")
+        self.assertTrue(any("ghost-venue" in f for f in r["fails"]))
+
+    def test_wrong_weekday_fails(self):
+        # 26 July 2026 is a Sunday, not a Saturday.
+        body = ('---\npublishedAt: 2026-07-06\n---\nJoin us Saturday 26 July.')
+        r = self._run(body)
+        self.assertEqual(r["result"], "FAIL")
+        self.assertTrue(any("26 Jul" in f for f in r["fails"]))
+
+    def test_correct_weekday_passes(self):
+        # 26 July 2026 is a Sunday.
+        body = ('---\npublishedAt: 2026-07-06\n---\nJoin us Sunday 26 July.')
+        self.assertNotEqual(self._run(body)["result"], "FAIL")
+
+    def test_unknown_section_link_fails(self):
+        body = ('---\npublishedAt: 2026-07-06\nclusterLinks:\n  - href: "/made-up/x/"\n---\nhi')
+        self.assertEqual(self._run(body)["result"], "FAIL")
+
+
 if __name__ == "__main__":
     verbosity = 1 if "--quiet" in sys.argv else 2
     argv = [a for a in sys.argv if a != "--quiet"]

--- a/engine/verify_gate.py
+++ b/engine/verify_gate.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Peninsula Insider — Factual Verify Gate (real implementation)
+===========================================================================
+Replaces the frontmatter-presence stub with the offline, deterministic parts of
+`.claude/agents/verify-agent.md`. The loop auto-publishes to production, so a
+real gate that can BLOCK a bad publish is the safety net that makes expanding
+autonomy responsible.
+
+What it can prove offline (-> hard FAIL, blocks publish):
+  1. Referential integrity — a venue/experience slug referenced in frontmatter
+     that does not exist in next/src/content/ (mirrors the CMS integrity rule).
+  2. Day-of-week correctness — "Saturday 26 July" where the next real 26 July is
+     not a Saturday. Deterministic for forward-looking "what's on" content.
+  3. Internal links whose top-level section does not exist at all (clear 404).
+
+What it flags but does not block (-> PASS_WITH_FLAGS, logged):
+  - Internal links not yet in the sitemap (may just be newer than the last build).
+  - Stated prices, "booking essential", specific opening hours — web-only claims.
+
+Web verification (venue open/closed, live URL 200s) is intentionally out of scope
+here — it needs network + is non-deterministic; those remain flags. This gate is
+stdlib-only so it runs inside the pre-flight self-test gate.
+
+Usage:
+  python3 engine/verify_gate.py <path.md> [--anchor YYYY-MM-DD]
+  exit code 0 = PASS/PASS_WITH_FLAGS, 2 = FAIL
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTENT_DIR = REPO_ROOT / "next/src/content"
+SITEMAP = REPO_ROOT / "sitemap.xml"
+
+# Slug-addressable entity collections we can confirm a reference against.
+ENTITY_COLLECTIONS = [
+    "venues", "experiences", "places", "events", "articles", "tours",
+    "tour-operators", "tour-packages", "signature-events", "fishing-charters",
+    "fishing-locations", "boat-ramps", "boat-hire", "species", "itineraries",
+    "local-secrets", "quick-notes", "weekend-picks", "regions",
+]
+
+_DAYS = {"monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+         "friday": 4, "saturday": 5, "sunday": 6}
+_MONTHS = {m[:3]: i for i, m in enumerate(
+    ["january", "february", "march", "april", "may", "june", "july",
+     "august", "september", "october", "november", "december"], start=1)}
+
+# "Saturday 26 July" / "Sat, 26th of July"
+_DATE_RE = re.compile(
+    r"(?i)\b(mon|tues|wednes|thurs|fri|satur|sun)day\s*,?\s*(?:the\s+)?"
+    r"(\d{1,2})(?:st|nd|rd|th)?\s+(?:of\s+)?"
+    r"(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*")
+
+# Top-level site sections that legitimately exist (for 404 sniffing).
+_KNOWN_SECTIONS = {
+    "eat", "wine", "stay", "explore", "journal", "whats-on", "events",
+    "places", "guides", "fishing", "boating", "tour", "weddings",
+    "corporate-events", "dog-friendly", "about", "methodology", "our-approach",
+    "editorial-approach", "ethics", "corrections", "accessibility", "contact",
+    "newsletter", "submit", "partners", "partner-with-us", "ask", "insiders-30",
+}
+
+
+def known_entity_slugs(content_dir: Path) -> set[str]:
+    slugs = set()
+    for coll in ENTITY_COLLECTIONS:
+        d = content_dir / coll
+        if not d.exists():
+            continue
+        for f in glob.glob(str(d / "*.json")) + glob.glob(str(d / "*.md")):
+            slugs.add(Path(f).stem)
+    return slugs
+
+
+def known_site_paths(sitemap_path: Path) -> set[str]:
+    paths = set()
+    if sitemap_path.exists():
+        xml = sitemap_path.read_text(encoding="utf-8")
+        for loc in re.findall(r"<loc>(.*?)</loc>", xml):
+            p = re.sub(r"^https?://[^/]+", "", loc).rstrip("/")
+            paths.add(p or "/")
+    return paths
+
+
+def _frontmatter(text: str) -> str:
+    m = re.match(r"^---\n(.*?)\n---", text, re.S)
+    return m.group(1) if m else ""
+
+
+def _referenced_slugs(fm: str) -> list[str]:
+    out = []
+    for field in ("relatedVenues", "relatedExperiences"):
+        m = re.search(rf"{field}:\s*\[([^\]]*)\]", fm)
+        if m:
+            out += [s.strip().strip("'\"") for s in m.group(1).split(",") if s.strip()]
+    return out
+
+
+def _internal_links(text: str, fm: str) -> list[str]:
+    links = re.findall(r'href:\s*["\'](/[^"\']+)["\']', fm)        # clusterLinks
+    links += re.findall(r"\]\((/[^)\s]+)\)", text)                  # inline markdown
+    # normalise: strip trailing slash, drop anchors/queries
+    norm = []
+    for l in links:
+        l = re.sub(r"[?#].*$", "", l).rstrip("/") or "/"
+        norm.append(l)
+    return sorted(set(norm))
+
+
+def check_venues(fm: str, known: set[str]) -> tuple[list[str], list[dict]]:
+    fails, checks = [], []
+    for slug in _referenced_slugs(fm):
+        if slug in known:
+            checks.append({"venue": slug, "status": "confirmed-in-pi-content"})
+        else:
+            fails.append(f"Referenced entity '{slug}' does not exist in next/src/content/")
+            checks.append({"venue": slug, "status": "MISSING"})
+    return fails, checks
+
+
+def check_dates(text: str, anchor: date) -> tuple[list[str], list[dict]]:
+    """For each 'Weekday DD Month', resolve the next real occurrence on/after the
+    anchor and verify the weekday. Deterministic for upcoming-events content."""
+    fails, checks = [], []
+    for m in _DATE_RE.finditer(text):
+        day_name = (m.group(1) + "day").lower()
+        day_num = int(m.group(2))
+        month = _MONTHS.get(m.group(3).lower()[:3])
+        if not month or not (1 <= day_num <= 31):
+            continue
+        intended = _next_occurrence(month, day_num, anchor)
+        if intended is None:
+            continue
+        stated = _DAYS[day_name]
+        claim = f"{m.group(1).title()}day {day_num} {m.group(3).title()}"
+        if intended.weekday() == stated:
+            checks.append({"claim": claim, "status": "correct"})
+        else:
+            actual = [k for k, v in _DAYS.items() if v == intended.weekday()][0].title()
+            fails.append(f"{claim} is wrong: {intended.isoformat()} is a {actual}, not "
+                         f"{m.group(1).title()}day")
+            checks.append({"claim": claim, "status": "WRONG_DAY",
+                           "resolved": intended.isoformat(), "actual_day": actual})
+    return fails, checks
+
+
+def _next_occurrence(month: int, day: int, anchor: date) -> date | None:
+    for yr in (anchor.year, anchor.year + 1, anchor.year + 2):
+        try:
+            cand = date(yr, month, day)
+        except ValueError:
+            return None  # impossible date like 30 Feb
+        if cand >= anchor:
+            return cand
+    return None
+
+
+def check_links(text: str, fm: str, site_paths: set[str]) -> tuple[list[str], list[str]]:
+    fails, flags = [], []
+    for link in _internal_links(text, fm):
+        if link in site_paths or link == "/":
+            continue
+        section = link.strip("/").split("/")[0]
+        if section not in _KNOWN_SECTIONS:
+            fails.append(f"Internal link '{link}' points to unknown section '/{section}/' (likely 404)")
+        else:
+            flags.append(f"Internal link '{link}' not in sitemap yet — verify it resolves")
+    return fails, flags
+
+
+def _soft_flags(text: str) -> list[str]:
+    flags = []
+    if re.search(r"\$\d", text):
+        flags.append("Contains a numeric price — BRAND-PI forbids prices; confirm/remove")
+    if re.search(r"(?i)\bbookings?\s+essential\b", text):
+        flags.append("'Bookings essential' stated — verify directly with venue")
+    if re.search(r"(?i)\bopen\s+(?:daily|most days|thu|fri|sat|sun|mon|tue|wed)", text):
+        flags.append("Opening hours stated — remind reader to confirm with venue")
+    return flags
+
+
+def verify_content(path: Path, content_dir: Path = CONTENT_DIR,
+                   sitemap_path: Path = SITEMAP, anchor: date | None = None) -> dict:
+    if not path.exists():
+        return {"result": "FAIL", "fails": [f"File not found: {path}"], "flags": [],
+                "venue_checks": [], "date_checks": [], "link_checks": []}
+    text = path.read_text(encoding="utf-8")
+    fm = _frontmatter(text)
+    if anchor is None:
+        pub = re.search(r"publishedAt:\s*(\d{4}-\d{2}-\d{2})", fm)
+        anchor = date.fromisoformat(pub.group(1)) if pub else date.today()
+
+    vf, vchecks = check_venues(fm, known_entity_slugs(content_dir))
+    df, dchecks = check_dates(text, anchor)
+    lf, lflags = check_links(text, fm, known_site_paths(sitemap_path))
+
+    fails = vf + df + lf
+    flags = lflags + _soft_flags(text)
+    result = "FAIL" if fails else ("PASS_WITH_FLAGS" if flags else "PASS")
+    return {
+        "result": result,
+        "fails": fails,
+        "flags": flags,
+        "venue_checks": vchecks,
+        "date_checks": dchecks,
+        "link_checks": {"failed": lf, "flagged": lflags},
+        "lastVerified": (anchor or date.today()).isoformat(),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Peninsula Insider factual verify gate")
+    ap.add_argument("path")
+    ap.add_argument("--anchor", default=None, help="Anchor date YYYY-MM-DD (default: publishedAt)")
+    args = ap.parse_args()
+    anchor = date.fromisoformat(args.anchor) if args.anchor else None
+    r = verify_content(Path(args.path), anchor=anchor)
+    print(json.dumps(r, indent=2))
+    sys.exit(2 if r["result"] == "FAIL" else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First workstream from the enhancement plan. The loop auto-publishes to production, but the "verify" gate only checked that frontmatter fields existed — no fact-checking. This makes it a **real gate that can BLOCK a publish**, the safety net that makes expanding autonomy (WS4) responsible.

## `engine/verify_gate.py` (stdlib-only, runs in the pre-flight gate)
Implements the offline, deterministic parts of `.claude/agents/verify-agent.md`:
- **Referential integrity** — `relatedVenues`/`relatedExperiences` slugs must exist in `next/src/content/` → hard FAIL if not (mirrors the CMS integrity rule).
- **Day-of-week correctness** — "Saturday 26 July" is resolved to the next real 26 July; hard FAIL if that date isn't a Saturday. Deterministic for forward-looking "what's on" content.
- **Internal-link 404 sniffing** — a link into a nonexistent top-level section FAILs; a link merely missing from the sitemap is flagged (may be newer than the last build), not blocked.
- **Soft flags** (numeric prices, "bookings essential", stated hours) → `PASS_WITH_FLAGS`, logged not blocked.

Web verification (venue open/closed, live 200s) is intentionally out of scope here — non-deterministic, needs network — those stay flags.

## Wiring
`orchestrator.run_verify_gate()` now runs this after the frontmatter check: hard FAIL blocks the publish, flags are logged, and it degrades to frontmatter-only if the module can't be imported.

## Verification
- Live `insider-picks-2026-07-06.md` → `PASS_WITH_FLAGS` (venue confirmed, sensible soft flags)
- Fixture with a fake venue + two wrong weekdays + a 404 link → `FAIL`, exit 2, all four caught
- 5 new tests in the pre-flight suite → **40 tests pass** (incl. under the CI condition, `PI_REPO_ROOT` unset)

## Next in the plan
WS0 (Anthropic SDK so generation/auto-act actually run in CI), WS1 (Event schema + "what's on" freshness), then WS4 (broaden autonomy behind this gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_