### PR TITLE
WS0: shared Anthropic SDK client (real generation in CI)

### DIFF
--- a/engine/auto_act.py
+++ b/engine/auto_act.py
@@ -138,16 +138,12 @@ def draft_title_dek(slug: str, current_title: str, current_dek: str) -> tuple[st
         "Rewrite both to improve click-through for this page's search intent. "
         "Return only the JSON."
     )
-    try:
-        result = subprocess.run(
-            ["claude", "-p", prompt, "--system", DRAFT_SYSTEM],
-            capture_output=True, text=True, timeout=120,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import llm
+    out = llm.complete(prompt, system=DRAFT_SYSTEM, max_tokens=400)
+    if not out:
         return None
-    if result.returncode != 0 or not result.stdout.strip():
-        return None
-    out = result.stdout.strip()
     m = re.search(r"\{.*\}", out, re.S)
     if not m:
         return None

--- a/engine/content_generator.py
+++ b/engine/content_generator.py
@@ -156,19 +156,14 @@ heroImage src should be: {HERO_IMAGES.get(season, HERO_IMAGES['winter'])}
 
 Remember: no brochure language. Specific. Local. Opinionated. Start with the thing, not with "This week"."""
 
-    # Call Claude via subprocess (OpenClaw environment)
-    # In production: openclaw.run_prompt(prompt, system=PI_VOICE_SYSTEM_PROMPT)
-    # Here we try the claude CLI if available, otherwise produce a template
-    
-    try:
-        result = subprocess.run(
-            ["claude", "-p", prompt, "--system", PI_VOICE_SYSTEM_PROMPT],
-            capture_output=True, text=True, timeout=120
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
+    # Generate via the shared LLM client (Anthropic SDK in CI, `claude` CLI
+    # locally). Returns None if neither backend is available -> template fallback.
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import llm
+    out = llm.complete(prompt, system=PI_VOICE_SYSTEM_PROMPT, max_tokens=2000)
+    if out:
+        return out
 
     # Fallback: structured template
     return generate_template_picks(date_str, season)

--- a/engine/llm.py
+++ b/engine/llm.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Shared LLM client for the content engine.
+
+Resolution order (first that works wins):
+  1. Anthropic SDK  — works headless / in CI when ANTHROPIC_API_KEY is set
+     (the daily/weekly/monthly workflows already provide it). This is why
+     generation + auto-act drafting previously no-op'd in CI: only the `claude`
+     CLI path existed and the CLI isn't installed on the runners.
+  2. `claude` CLI   — for OpenClaw / local dev environments.
+  3. None           — neither available, so callers SKIP (never fabricate).
+
+Stdlib-only import surface; the `anthropic` package is imported lazily so this
+module is safe to import even where the SDK isn't installed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+# Default model: strong quality/cost balance for editorial drafting. Override
+# per-call or via PI_LLM_MODEL. IDs: claude-opus-4-8 / claude-sonnet-5 / claude-haiku-4-5.
+DEFAULT_MODEL = os.environ.get("PI_LLM_MODEL", "claude-sonnet-5")
+DEFAULT_TIMEOUT = 120
+
+
+def complete(prompt: str, system: str = "", model: str | None = None,
+             max_tokens: int = 2000, timeout: int = DEFAULT_TIMEOUT) -> str | None:
+    """Return the model's text, or None if no backend is available."""
+    model = model or DEFAULT_MODEL
+    out = _try_sdk(prompt, system, model, max_tokens, timeout)
+    if out is not None:
+        return out
+    return _try_cli(prompt, system, timeout)
+
+
+def available() -> str:
+    """Report which backend would be used: 'sdk', 'cli', or 'none'. For diagnostics."""
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        try:
+            import anthropic  # noqa: F401
+            return "sdk"
+        except ImportError:
+            pass
+    try:
+        subprocess.run(["claude", "--version"], capture_output=True, timeout=10)
+        return "cli"
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return "none"
+
+
+def _try_sdk(prompt: str, system: str, model: str, max_tokens: int,
+             timeout: int) -> str | None:
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return None
+    try:
+        import anthropic
+    except ImportError:
+        return None
+    try:
+        client = anthropic.Anthropic()
+        kwargs = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}],
+            "timeout": timeout,
+        }
+        if system:
+            kwargs["system"] = system
+        msg = client.messages.create(**kwargs)
+        text = "".join(
+            getattr(b, "text", "") for b in msg.content
+            if getattr(b, "type", None) == "text"
+        ).strip()
+        return text or None
+    except Exception as e:  # network/auth/rate-limit — degrade, don't crash the loop
+        print(f"  LLM SDK error: {e}")
+        return None
+
+
+def _try_cli(prompt: str, system: str, timeout: int) -> str | None:
+    cmd = ["claude", "-p", prompt]
+    if system:
+        cmd += ["--system", system]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip()
+    return None

--- a/engine/test_strategy_engine.py
+++ b/engine/test_strategy_engine.py
@@ -422,6 +422,19 @@ class HouseStyleSanitizer(unittest.TestCase):
         self.assertNotIn("—", out)
 
 
+class LLMClient(unittest.TestCase):
+    def test_sdk_skipped_without_key(self):
+        import os
+        from unittest import mock
+        import llm
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(llm._try_sdk("hi", "", "claude-sonnet-5", 100, 5))
+
+    def test_available_returns_valid_backend(self):
+        import llm
+        self.assertIn(llm.available(), {"sdk", "cli", "none"})
+
+
 class VerifyGate(unittest.TestCase):
     """Guards the real factual verify gate — it can BLOCK a live publish, so its
     hard-fail logic must not silently regress."""


### PR DESCRIPTION
Foundation workstream. Content generation and auto-act drafting only had a `claude` CLI path — and the CLI isn't installed on the GitHub Actions runners — so in CI they **silently no-op'd (auto-act skipped) or fell back to static templates**. That's why the live daily run committed template content and fired no CTR rewrite.

## `engine/llm.py`
`complete()` resolves a backend in order: **Anthropic SDK** (works headless with the `ANTHROPIC_API_KEY` secret the workflows already provide) → **`claude` CLI** (local/OpenClaw) → **None** (callers skip, never fabricate). Lazy `anthropic` import; degrades safely on network/auth/rate-limit.

## Wiring
`content_generator.generate_insider_picks` and `auto_act.draft_title_dek` now call `llm.complete()`. Both still fall back exactly as before when no backend is reachable.

## Effect
In CI, the daily loop now produces **real LLM-authored content** and can execute **real CTR rewrites**, instead of templating/skipping. Local behaviour unchanged.

## Verification
- Sandbox (no key): `complete()` → `None` → content_generator falls back to template ✓
- 2 new deterministic tests (no-key SDK skip, backend detection) → **42 tests pass** (incl. `PI_REPO_ROOT` unset).

Next: WS1 (Event JSON-LD + "what's on" freshness) and WS4 (broaden autonomy behind the WS3 verify gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_