### PR TITLE
WS4: broaden autonomous executor to striking-distance

### DIFF
--- a/engine/auto_act.py
+++ b/engine/auto_act.py
@@ -7,10 +7,11 @@ opportunities, it *acts* on the safest, highest-ROI class of them without a
 human in the loop.
 
 Scope (deliberately narrow and safe):
-  - Only `ctr-fix` opportunities whose target is a **journal article**
-    (`/journal/{slug}/` → next/src/content/articles/{slug}.md|.mdx). For those,
-    the whole SEO surface is two frontmatter fields — `title` and `dek` — so the
-    edit is deterministic and confined. Venue/event pages derive their meta from
+  - `ctr-fix` and `striking-distance` opportunities whose target is a **journal
+    article** (`/journal/{slug}/` → next/src/content/articles/{slug}.md|.mdx). For
+    those, the whole SEO surface is two frontmatter fields — `title` and `dek` —
+    so the edit is deterministic and confined (a striking-distance rewrite is
+    optimised for the driving query). Venue/event pages derive their meta from
     templates; auto-editing those safely needs template-aware handling, so they
     are logged and left for a human/next iteration, never blindly edited.
 
@@ -57,6 +58,11 @@ ARTICLES_DIR = REPO_ROOT / "next/src/content/articles"
 STRATEGY_JSON = se.STRATEGY_JSON
 
 MAX_ACTIONS_PER_RUN = 1          # conservative default; raise once trust is earned
+
+# Opportunity kinds safe to auto-execute today: both edit only a journal
+# article's title + meta description (reversible, no new factual claims). CTR
+# fixes target low-CTR page-1 pages; striking-distance targets near-page-1 queries.
+ACTIONABLE_KINDS = {"ctr-fix", "striking-distance"}
 TITLE_MAX = 65                    # before the " · Peninsula Insider" suffix
 DEK_MIN, DEK_MAX = 70, 165        # healthy meta-description window
 PROHIBITED = ["stunning", "vibrant", "nestled", "charming", "hidden gem",
@@ -128,16 +134,25 @@ DRAFT_SYSTEM = (
 )
 
 
-def draft_title_dek(slug: str, current_title: str, current_dek: str) -> tuple[str, str] | None:
-    """Ask Claude for an improved title+dek. Returns None if unavailable (skip,
-    never fabricate)."""
-    prompt = (
+def _draft_prompt(slug: str, current_title: str, current_dek: str, query: str = "") -> str:
+    """Build the drafting prompt. When a driving query is known (striking-distance),
+    the rewrite is optimised for that exact query."""
+    intent = (f"Optimise the rewrite for the search query: \"{query}\". "
+              if query else "Rewrite both to improve click-through for this page's "
+              "obvious search intent. ")
+    return (
         f"Page: /journal/{slug}/\n"
         f"Current title: {current_title}\n"
         f"Current meta description: {current_dek}\n\n"
-        "Rewrite both to improve click-through for this page's search intent. "
-        "Return only the JSON."
+        f"{intent}Return only the JSON."
     )
+
+
+def draft_title_dek(slug: str, current_title: str, current_dek: str,
+                    query: str = "") -> tuple[str, str] | None:
+    """Ask Claude for an improved title+dek. Returns None if unavailable (skip,
+    never fabricate)."""
+    prompt = _draft_prompt(slug, current_title, current_dek, query)
     import sys as _sys
     _sys.path.insert(0, str(Path(__file__).resolve().parent))
     import llm
@@ -203,7 +218,8 @@ def auto_act(limit: int = MAX_ACTIONS_PER_RUN, dry_run: bool = False,
     for opp in load_queue():
         if len(actions) >= limit:
             break
-        if opp.get("kind") != "ctr-fix":
+        kind = opp.get("kind")
+        if kind not in ACTIONABLE_KINDS:
             continue
         target = opp.get("target", "")
         if target in done:
@@ -219,7 +235,7 @@ def auto_act(limit: int = MAX_ACTIONS_PER_RUN, dry_run: bool = False,
             skipped.append((target, "missing title/dek frontmatter"))
             continue
 
-        draft = draft_title_dek(src.stem, cur_title, cur_dek)
+        draft = draft_title_dek(src.stem, cur_title, cur_dek, opp.get("query", ""))
         if not draft:
             skipped.append((target, "no draft (model unavailable) — skipped, not fabricated"))
             continue
@@ -246,7 +262,7 @@ def auto_act(limit: int = MAX_ACTIONS_PER_RUN, dry_run: bool = False,
             continue
 
         src.write_text(updated)
-        se.record_action(target, "ctr-fix", opp.get("query", ""),
+        se.record_action(target, kind, opp.get("query", ""),
                          f"auto: title/meta rewrite (was: {cur_title[:50]})", se.load_gsc(se.GSC_REPORT), today)
         actions.append(action)
 

--- a/engine/test_strategy_engine.py
+++ b/engine/test_strategy_engine.py
@@ -422,6 +422,22 @@ class HouseStyleSanitizer(unittest.TestCase):
         self.assertNotIn("—", out)
 
 
+class AutoActScope(unittest.TestCase):
+    def test_actionable_kinds(self):
+        import auto_act as aa
+        self.assertIn("ctr-fix", aa.ACTIONABLE_KINDS)
+        self.assertIn("striking-distance", aa.ACTIONABLE_KINDS)
+        self.assertNotIn("coverage-gap", aa.ACTIONABLE_KINDS)
+        self.assertNotIn("indexation", aa.ACTIONABLE_KINDS)
+
+    def test_query_aware_prompt(self):
+        import auto_act as aa
+        with_q = aa._draft_prompt("dog-friendly", "T", "D", query="dog beaches mornington")
+        without_q = aa._draft_prompt("dog-friendly", "T", "D")
+        self.assertIn("dog beaches mornington", with_q)
+        self.assertNotIn("search query:", without_q)
+
+
 class LLMClient(unittest.TestCase):
     def test_sdk_skipped_without_key(self):
         import os


### PR DESCRIPTION
With the real verify gate (WS3) in place and real generation (WS0) wired, it's now safe to widen the autonomous executor. The engine map flagged "auto-act does 1 of 6 kinds, 1 edit/day" as the biggest velocity limiter.

## Change
`engine/auto_act.py` now acts on **both `ctr-fix` and `striking-distance`** opportunities (`ACTIONABLE_KINDS`) — the same safe, reversible edit surface (a journal article's `title` + `dek`), no new factual claims. A striking-distance rewrite is **optimised for the driving query** via a query-aware draft prompt (`_draft_prompt`). The learning loop attributes each action to its actual kind.

Unchanged guardrails: venue/event/template pages are still skipped (never blindly edited); the per-run cap stays env-configurable (`PI_AUTO_ACT_LIMIT`, default 1); drafting still skips rather than fabricates when no model is reachable.

## Verification
- 2 new tests (kind membership, query-aware prompt) → **44 tests pass**
- Dry-run against the live strategy queue: striking-distance targets now resolve and attempt a draft (e.g. `the-chardonnay-case`), where before only `ctr-fix` was considered.

This roughly doubles the executor's coverage of the safe surface. Next: WS1 (Event JSON-LD + "what's on" freshness), WS6 (real alerting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_