### PR TITLE
WS1: machine-readable "what's on" feed for agents

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -186,6 +186,7 @@ Peninsula Insider covers the whole Mornington Peninsula: Sorrento, Portsea, Blai
 
 ## Optional
 
+- [What's on — upcoming events feed (JSON)](https://peninsulainsider.com.au/whats-on/upcoming.json): machine-readable, forward-dated Peninsula events for agents answering "what's on this weekend / soon"
 - [Full URL index (llms-full.txt)](https://peninsulainsider.com.au/llms-full.txt): every indexable page, grouped by section
 - [Sitemap](https://peninsulainsider.com.au/sitemap.xml): machine sitemap for crawlers
 - [Editorial method & standards](https://peninsulainsider.com.au/methodology/): how coverage is researched, verified and kept current

--- a/next/src/pages/whats-on/upcoming.json.ts
+++ b/next/src/pages/whats-on/upcoming.json.ts
@@ -1,0 +1,81 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { routeSlug } from '../../lib/editorial';
+import { upcomingWeekend, eventInWindow } from '../../lib/events';
+
+// Machine-readable "what's on" feed for AI assistants and agents. The site
+// already emits rich Event JSON-LD per page and llms.txt for site structure;
+// this is the one surface that answers "what's on the Mornington Peninsula
+// this weekend / soon" as a single clean, forward-dated JSON document — the
+// highest-value query class for both people and agents. Regenerated on every
+// build (like sitemap.xml), so it stays fresh with the events pipeline.
+
+const SITE = 'https://peninsulainsider.com.au';
+const WINDOW_DAYS = 90;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const iso = (d: Date): string => d.toISOString().split('T')[0];
+
+export const GET: APIRoute = async () => {
+  const now = new Date();
+  const horizon = new Date(now.getTime() + WINDOW_DAYS * DAY_MS);
+  const weekend = upcomingWeekend(now);
+
+  const events = await getCollection('events', ({ data }) => !data.sitemapExclude);
+
+  const upcoming = events
+    .filter((e) => {
+      const start = e.data.startDate;
+      const end = e.data.endDate ?? e.data.startDate;
+      const recurring = e.data.recurrence && e.data.recurrence !== 'one-off';
+      if (recurring) return true; // recurring events remain valid
+      const stillCurrent = end && end.getTime() >= now.getTime() - DAY_MS;
+      const withinHorizon = start && start.getTime() <= horizon.getTime();
+      return Boolean(stillCurrent && withinHorizon);
+    })
+    .sort((a, b) => (a.data.startDate?.getTime() ?? 0) - (b.data.startDate?.getTime() ?? 0))
+    .map((e) => {
+      const slug = routeSlug(e);
+      return {
+        title: e.data.title,
+        url: `${SITE}/whats-on/${slug}/`,
+        startDate: e.data.startDate ? iso(e.data.startDate) : null,
+        endDate: e.data.endDate ? iso(e.data.endDate) : null,
+        recurrence: e.data.recurrence ?? 'one-off',
+        category: e.data.category ?? null,
+        place: (e.data.place as { id?: string } | undefined)?.id ?? null,
+        venue: (e.data.venue as { id?: string } | undefined)?.id ?? null,
+        freePaid: e.data.freePaid ?? null,
+        summary: e.data.summary ?? '',
+        thisWeekend: eventInWindow(e, weekend.start, weekend.end),
+      };
+    });
+
+  const body = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: "What's on — Mornington Peninsula (upcoming)",
+    description:
+      'Machine-readable feed of upcoming Mornington Peninsula events for AI ' +
+      'assistants and agents. Forward-dated; regenerated on each build. See ' +
+      `${SITE}/llms.txt for the full site map.`,
+    generated: iso(now),
+    site: SITE,
+    windowDays: WINDOW_DAYS,
+    thisWeekend: {
+      start: iso(weekend.start),
+      end: iso(weekend.end),
+      label: weekend.label,
+      count: upcoming.filter((x) => x.thisWeekend).length,
+    },
+    count: upcoming.length,
+    events: upcoming,
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/ops/scripts/generate-llms-txt.mjs
+++ b/ops/scripts/generate-llms-txt.mjs
@@ -219,6 +219,7 @@ function renderCurated({ bySection }) {
     }
   }
   out += `\n## Optional\n\n`;
+  out += `- [What's on — upcoming events feed (JSON)](${SITE}/whats-on/upcoming.json): machine-readable, forward-dated Peninsula events for agents answering "what's on this weekend / soon"\n`;
   out += `- [Full URL index (llms-full.txt)](${SITE}/llms-full.txt): every indexable page, grouped by section\n`;
   out += `- [Sitemap](${SITE}/sitemap.xml): machine sitemap for crawlers\n`;
   out += `- [Editorial method & standards](${SITE}/methodology/): how coverage is researched, verified and kept current\n`;


### PR DESCRIPTION
"What's on the Mornington Peninsula this weekend" is the single highest-value query for both people and AI agents. The site already emits rich `Event` JSON-LD per page (`src/lib/events.ts` — my earlier map was wrong that it was missing) and `llms.txt` for structure, but there was **no single machine-readable surface that answers "what's on soon"** as one clean document.

## `GET /whats-on/upcoming.json`
An Astro endpoint (same pattern as `sitemap.xml.ts`) emitting a forward-dated JSON `ItemList` of upcoming events — `title, url, startDate, endDate, place, venue, category, freePaid, summary`, plus a `thisWeekend` flag. Built with the existing `upcomingWeekend()` / `eventInWindow()` helpers; recurring events kept, past one-offs dropped; regenerated on every build so it stays fresh. Linked from `llms.txt` so agents discover it.

## Verified with a real build
`astro build` → **919 pages built**, feed renders valid JSON: **71 upcoming events, 15 flagged for the 11–12 July weekend, zero past one-offs leaked.**

This is the agent-facing complement to the human `/whats-on/this-weekend/` page — it makes PI the *citable* source when an assistant is asked what's on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_