### PR TITLE
WS6: non-silent alert path (failures open a GitHub issue)

### DIFF
--- a/.github/workflows/daily-content.yml
+++ b/.github/workflows/daily-content.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  issues: write   # non-silent alert path opens an issue on failure
 
 jobs:
   daily-content:
@@ -88,6 +89,20 @@ jobs:
           name: daily-run-log-${{ github.run_number }}
           path: .claude/newsroom/runs/
           retention-days: 30
+
+      - name: Alert on failure (non-silent)
+        # Backstop for hard crashes (pre-flight gate, non-zero exit) the
+        # in-process alert can't reach. Opens/reuses a GitHub issue. See engine/alert.py.
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PI_REPO_ROOT: ${{ github.workspace }}
+        run: |
+          python engine/alert.py \
+            --title "Daily content run failed (run #${{ github.run_number }})" \
+            --body "The daily content workflow failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --dedup daily-workflow-failure --severity fatal
 
       - name: Trigger deploy if content was pushed
         if: success()

--- a/.github/workflows/monthly-content.yml
+++ b/.github/workflows/monthly-content.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  issues: write   # non-silent alert path opens an issue on failure
 
 jobs:
   monthly-content:
@@ -81,3 +82,15 @@ jobs:
             .claude/signals/
             .claude/research/
           retention-days: 365
+
+      - name: Alert on failure (non-silent)
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PI_REPO_ROOT: ${{ github.workspace }}
+        run: |
+          python engine/alert.py \
+            --title "Monthly content run failed (run #${{ github.run_number }})" \
+            --body "The monthly content workflow failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --dedup monthly-workflow-failure --severity fatal

--- a/.github/workflows/weekly-content.yml
+++ b/.github/workflows/weekly-content.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  issues: write   # non-silent alert path opens an issue on failure
 
 jobs:
   weekly-content:
@@ -86,3 +87,15 @@ jobs:
             .claude/signals/
             .claude/newsroom/slates/
           retention-days: 90
+
+      - name: Alert on failure (non-silent)
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PI_REPO_ROOT: ${{ github.workspace }}
+        run: |
+          python engine/alert.py \
+            --title "Weekly content run failed (run #${{ github.run_number }})" \
+            --body "The weekly content workflow failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --dedup weekly-workflow-failure --severity fatal

--- a/engine/alert.py
+++ b/engine/alert.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Peninsula Insider — non-silent alert path.
+
+The operating surface's single highest-impact gap: mutating jobs fail silently.
+This gives the autonomous loop a voice. `emit_alert` ALWAYS writes a structured
+alert file under ops/alerts/, and when running in CI (GITHUB_TOKEN +
+GITHUB_REPOSITORY present) it also opens — or reuses — a deduplicated GitHub
+issue so a human is actually notified. Stdlib-only; never raises (an alerting
+failure must not mask the original failure).
+
+Usage (CLI, e.g. from a workflow `if: failure()` step):
+  python engine/alert.py --title "Daily run failed" --body "..." --dedup daily-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("PI_REPO_ROOT", str(Path(__file__).resolve().parent.parent)))
+ALERTS_DIR = REPO_ROOT / "ops/alerts"
+ISSUE_LABEL = "pi-alert"
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")[:60] or "alert"
+
+
+def _now() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_alert_file(title: str, body: str, severity: str, dedup_key: str) -> Path:
+    ALERTS_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.utcnow().strftime("%Y-%m-%d-%H%M%S")
+    path = ALERTS_DIR / f"{stamp}-{_slug(dedup_key)}.json"
+    path.write_text(json.dumps({
+        "title": title, "body": body, "severity": severity,
+        "dedup_key": dedup_key, "created": _now(),
+    }, indent=2), encoding="utf-8")
+    return path
+
+
+def _gh_request(method: str, url: str, token: str, payload: dict | None = None) -> dict | list | None:
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("User-Agent", "peninsula-insider-alert")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def open_or_reuse_issue(title: str, body: str, dedup_key: str) -> str | None:
+    """Open a GitHub issue (or reuse an existing open one carrying the same dedup
+    marker). Returns the issue URL, or None if not in CI / on any failure."""
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        return None
+    marker = f"<!-- pi-alert:{dedup_key} -->"
+    full_body = f"{marker}\n\n{body}\n\n_Emitted by the Peninsula Insider content engine at {_now()}._"
+    try:
+        # Reuse an open alert issue with the same marker to avoid a pile-up.
+        existing = _gh_request(
+            "GET", f"https://api.github.com/repos/{repo}/issues?state=open&labels={ISSUE_LABEL}&per_page=50", token)
+        if isinstance(existing, list):
+            for issue in existing:
+                if marker in (issue.get("body") or ""):
+                    num = issue["number"]
+                    _gh_request("POST", f"https://api.github.com/repos/{repo}/issues/{num}/comments",
+                                token, {"body": f"Recurred at {_now()}.\n\n{body}"})
+                    return issue.get("html_url")
+        created = _gh_request("POST", f"https://api.github.com/repos/{repo}/issues", token,
+                              {"title": title, "body": full_body, "labels": [ISSUE_LABEL]})
+        return created.get("html_url") if isinstance(created, dict) else None
+    except (urllib.error.URLError, urllib.error.HTTPError, KeyError, ValueError, OSError) as e:
+        print(f"  alert: GitHub issue failed ({e}) — alert file still written")
+        return None
+
+
+def emit_alert(title: str, body: str, severity: str = "error",
+               dedup_key: str | None = None) -> dict:
+    """Record an alert (file always; GitHub issue in CI). Never raises."""
+    dedup_key = dedup_key or _slug(title)
+    result = {"title": title, "severity": severity, "file": None, "issue": None}
+    try:
+        result["file"] = str(write_alert_file(title, body, severity, dedup_key))
+    except OSError as e:
+        print(f"  alert: could not write alert file ({e})")
+    result["issue"] = open_or_reuse_issue(title, body, dedup_key)
+    where = result["issue"] or result["file"] or "(nowhere)"
+    print(f"  ALERT [{severity}] {title} -> {where}")
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Emit a Peninsula Insider alert")
+    ap.add_argument("--title", required=True)
+    ap.add_argument("--body", default="")
+    ap.add_argument("--severity", default="error")
+    ap.add_argument("--dedup", default=None)
+    args = ap.parse_args()
+    emit_alert(args.title, args.body, args.severity, args.dedup)
+
+
+if __name__ == "__main__":
+    main()

--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -886,14 +886,32 @@ def main():
     except Exception as e:
         log.error(f"Unhandled exception: {e}")
         print(f"\nFatal error: {e}", file=sys.stderr)
+        _alert(args.tempo, "fatal", f"{args.tempo} run crashed: {e}", log)
         raise
     finally:
         log.save()
         state["last_run"] = {"tempo": args.tempo, "date": today}
         state["stalls"] = state.get("stalls", 0) + log.stalls
         save_loop_state(state)
+        # Non-silent alert path: if any step stalled (even on a "successful" run),
+        # surface it so failures aren't invisible. See engine/alert.py.
+        if log.stalls and log.errors:
+            _alert(args.tempo, "error",
+                   f"{args.tempo} run had {log.stalls} stall(s):\n- " + "\n- ".join(log.errors[:10]), log)
 
     print(f"\n✓ {args.tempo.title()} run complete — {log.pieces_shipped} piece(s) shipped")
+
+
+def _alert(tempo: str, severity: str, body: str, log: "RunLog") -> None:
+    """Emit a non-silent alert. Never raises — alerting must not mask the run."""
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import alert
+        alert.emit_alert(
+            title=f"PI {tempo} run: {severity} ({log.pieces_shipped} shipped, {log.stalls} stalls)",
+            body=body, severity=severity, dedup_key=f"orchestrator-{tempo}")
+    except Exception as e:
+        print(f"  alert emit failed: {e}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/engine/test_strategy_engine.py
+++ b/engine/test_strategy_engine.py
@@ -438,6 +438,30 @@ class AutoActScope(unittest.TestCase):
         self.assertNotIn("search query:", without_q)
 
 
+class AlertPath(unittest.TestCase):
+    def test_writes_alert_file(self):
+        import os, tempfile
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {"PI_REPO_ROOT": d}, clear=False):
+                import importlib
+                import alert
+                importlib.reload(alert)  # pick up PI_REPO_ROOT
+                r = alert.emit_alert("Test fail", "body here", "error", "unit-key")
+                self.assertIsNotNone(r["file"])
+                self.assertTrue(Path(r["file"]).exists())
+                payload = __import__("json").loads(Path(r["file"]).read_text())
+                self.assertEqual(payload["severity"], "error")
+                self.assertEqual(payload["dedup_key"], "unit-key")
+
+    def test_no_issue_without_token(self):
+        import os
+        from unittest import mock
+        import alert
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(alert.open_or_reuse_issue("t", "b", "k"))
+
+
 class LLMClient(unittest.TestCase):
     def test_sdk_skipped_without_key(self):
         import os


### PR DESCRIPTION
The operating-surface doc calls this **"the single highest-impact fix in this backlog"**: ~9 of 10 mutating jobs fail silently. I hit several silent failures myself this session — they only surfaced because I manually checked run status. For a *fully automated* system, that's the critical gap. This gives the loop a voice.

## `engine/alert.py`
`emit_alert()` **always** writes a structured `ops/alerts/` file and, in CI (`GITHUB_TOKEN` + `GITHUB_REPOSITORY` present), **opens or reuses a deduplicated GitHub issue** (marker-based, so recurrences comment on the existing issue instead of piling up). Stdlib-only; never raises — an alerting failure must not mask the original one.

## Wiring
- `orchestrator.main()` emits an alert on a fatal crash **and** on any run that stalled (even a "successful" run with degraded steps).
- `daily` / `weekly` / `monthly` workflows: `issues: write` permission + an `if: failure()` backstop step that opens an issue for hard crashes (pre-flight gate, non-zero exit) the in-process alert can't reach.

## Verification
- `emit_alert` with no token → writes the alert file (confirmed); with a token → issue path exercised via the CLI.
- 2 new tests (file written; no issue without a token) → **46 tests pass**.
- All three workflow YAMLs validated.

Now a failing autonomous run is impossible to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH

---
_Generated by [Claude Code](https://claude.ai/code/session_012zFvVKYv1Np5f6TtVtWgNH)_