### PR TITLE
ci: restore CMS editable-coverage gate to deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,6 +42,11 @@ jobs:
           cd next
           npm ci --prefer-offline
 
+      - name: CMS editable-coverage gate
+        run: |
+          cd next
+          node scripts/check-editable-coverage.mjs
+
       - name: Build
         run: |
           cd next


### PR DESCRIPTION
Restores the CI enforcement documented in docs/cms-architecture.md: `check-editable-coverage.mjs` currently has **no caller anywhere** (it was wired into the old deploy.yml, which build-and-deploy.yml replaced without carrying it over). This re-adds it as a static pre-build gate — fails fast on any *Card.astro missing editor attrs, needs no secrets.

Part of Sprint 1 (S1.4: single deploy path + CI guardrails) of the agentic publication OS blueprint.

Note for reviewer: the sibling registry-refresh guardrail is deliberately NOT re-added here — it needs the SUPABASE_SERVICE_KEY repo secret rotated to the current project first, and engine/orchestrator.py already runs it in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)