### PR TITLE
fix(ci): run editable-coverage gate from repo root

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,9 +43,7 @@ jobs:
           npm ci --prefer-offline
 
       - name: CMS editable-coverage gate
-        run: |
-          cd next
-          node scripts/check-editable-coverage.mjs
+        run: node next/scripts/check-editable-coverage.mjs
 
       - name: Build
         run: |


### PR DESCRIPTION
Hotfix for the deploy failure introduced by #279: the gate step cd'd into next/ but the script resolves next/src from cwd, so it scanned next/next/src and ENOENT-failed every deploy since 21:07Z. One-line fix, verified passing locally from repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)