### PR TITLE
fix(events): archive 13 lapsed events [maintenance-batch]

### DIFF
--- a/next/src/content/events/boneo-community-market.json
+++ b/next/src/content/events/boneo-community-market.json
@@ -48,7 +48,7 @@
   "editorialPriority": 3,
   "nearbyAttractions": "Rye beach; Rye Foreshore playground; Rosebud foreshore",
   "suggestedItineraryPairing": "Morning market then Rye beach afternoon",
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "worthTheDrive": false,
   "firstTimer": false,

--- a/next/src/content/events/dromana-community-market.json
+++ b/next/src/content/events/dromana-community-market.json
@@ -48,7 +48,7 @@
   "editorialPriority": 1,
   "nearbyAttractions": "Dromana Beach; Dromana Indoor Market; Peninsula Hot Springs",
   "suggestedItineraryPairing": "Day trip with beach visit",
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "worthTheDrive": false,
   "firstTimer": false,

--- a/next/src/content/events/emu-plains-market-balnarring.json
+++ b/next/src/content/events/emu-plains-market-balnarring.json
@@ -49,7 +49,7 @@
   "editorialPriority": 3,
   "nearbyAttractions": "Coolart Wetlands and Homestead (adjacent); Balnarring Beach; Womin Djeka Ngargee site",
   "suggestedItineraryPairing": "Combine with Coolart Homestead and Balnarring Beach visit",
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "worthTheDrive": true,
   "firstTimer": true,

--- a/next/src/content/events/mornington-peninsula-regional-gallery-school-holiday-workshops.json
+++ b/next/src/content/events/mornington-peninsula-regional-gallery-school-holiday-workshops.json
@@ -52,7 +52,7 @@
   "editorNote": "MPRG runs hands-on, artist-led workshops every school holiday break, tied to whatever is on the gallery walls at the time. Kids 8+ get the workshops proper; the family activity space runs year-round and is free.\n\nBookings are essential, places go quickly and the gallery posts dates roughly four weeks ahead on Facebook. Workshop pricing varies but stays sensible. Gallery entry is ticketed, with a concession rate.\n\nPlan a full Mornington morning: workshop 10am to 1pm, lunch on Main Street, foreshore walk if the weather is on. The Wednesday Main Street market overlaps if you can time it.",
   "worthTheDrive": false,
   "firstTimer": true,
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "lens": [
     "rainy-day",

--- a/next/src/content/events/mornington-tourist-railway-school-holiday-special-runs.json
+++ b/next/src/content/events/mornington-tourist-railway-school-holiday-special-runs.json
@@ -54,7 +54,7 @@
   "editorNote": "The Mornington Tourist Railway runs a 5km heritage line between Moorooduc and Mornington, with selected Sundays year-round and additional special runs during school holidays. Steam or diesel depending on the day, vintage carriages, volunteer-operated.\n\nFor general Sunday runs you can usually walk up. School holiday specials and themed events need booking. Check the website close to dates because the schedule shifts.\n\nThe extra trick is to align with the Moorooduc Station Market on the same site for a doubled-up morning.",
   "worthTheDrive": false,
   "firstTimer": true,
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "lens": [
     "family-saturday",

--- a/next/src/content/events/mprg-autumn-exhibition.json
+++ b/next/src/content/events/mprg-autumn-exhibition.json
@@ -1,6 +1,6 @@
 {
   "slug": "mprg-autumn-exhibition",
-  "status": "published",
+  "status": "archived",
   "title": "Mornington Peninsula Regional Gallery  -  Autumn Exhibition",
   "summary": "The Peninsula's most serious public art institution, running a rotating autumn exhibition calendar that's quietly one of the best regional programmes in Victoria.",
   "startDate": "2026-04-01",

--- a/next/src/content/events/mt-eliza-farmers-market.json
+++ b/next/src/content/events/mt-eliza-farmers-market.json
@@ -54,7 +54,7 @@
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "worthTheDrive": true,
   "firstTimer": true,

--- a/next/src/content/events/pearcedale-community-market.json
+++ b/next/src/content/events/pearcedale-community-market.json
@@ -49,7 +49,7 @@
   "editorialPriority": 3,
   "nearbyAttractions": "Moonlit Sanctuary wildlife park; Coolart Wetlands",
   "suggestedItineraryPairing": "Morning market + Moonlit Sanctuary wildlife visit",
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "worthTheDrive": false,
   "firstTimer": false,

--- a/next/src/content/events/peninsula-hot-springs-sunday-sessions.json
+++ b/next/src/content/events/peninsula-hot-springs-sunday-sessions.json
@@ -57,7 +57,7 @@
   "suggestedItineraryPairing": "Pair with an afternoon at the hot springs followed by sunset dinner in Rye or Sorrento",
   "internalNotes": "Artist lineup changes weekly \u2013 check PHS events page before booking; amphitheatre pool fills fast",
   "manualFollowUpRequired": false,
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-04-09",
   "lens": [
     "weekend-pick",

--- a/next/src/content/events/sorrento-solstice-festival-2026.json
+++ b/next/src/content/events/sorrento-solstice-festival-2026.json
@@ -59,7 +59,7 @@
     "credit": "Peninsula Insider",
     "license": "other-licensed"
   },
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "lens": [
     "weekend-pick",

--- a/next/src/content/events/sorrento-solstice-festival-fire-night.json
+++ b/next/src/content/events/sorrento-solstice-festival-fire-night.json
@@ -58,7 +58,7 @@
   "editorNote": "The Saturday of Sorrento Solstice does the heavy lifting: 2pm to 9pm on the foreshore, two stages, fire and light installations, an illuminated path of Australian-animal lanterns, projection art on the historic buildings, food trucks, local producers pouring, silent disco, sound healing, roving performers, kids activities, artisan stalls, tarot, face painting, lantern making, storytelling. At 6:30pm the 6-metre handcrafted effigy ('Bernie') is set alight on the bay.\n\nThe practical move: free but ticketed, reserve in advance. Arrive by 4pm to walk the lantern path while you can still see your feet, get a position for the burn by 6, dinner in the village from 7:30 onwards (book ahead, the village fills).\n\nDress for a winter night on the bay: thermals, beanie, gloves, a coat that handles wind. Bring kids for the early afternoon and the lanterns, hand them off before the late music if you want a long night.",
   "worthTheDrive": true,
   "firstTimer": true,
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "lens": [
     "weekend-pick",

--- a/next/src/content/events/winter-camp-2026-the-ranch.json
+++ b/next/src/content/events/winter-camp-2026-the-ranch.json
@@ -54,7 +54,7 @@
   "editorNote": "Three days and two nights at The Ranch in Boneo, theme 'Hit the Switch'. For 8+. Mountainboarding, giant swing, flying fox, horse riding, bush cooking, night hike under the stars, snug cabin accommodation, hearty meals. Run by experienced camp staff who know how to wear out a ten-year-old.\n\nBook direct on The Ranch website, dates 30 June to 2 July 2026 confirmed.\n\nDrop-off 9:30am, pickup 3:30pm three days later. Bring a sleeping bag, weather-appropriate layers, sturdy shoes, and a torch. Phone-free for most kids, which is half the point.",
   "worthTheDrive": false,
   "firstTimer": false,
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "lens": [
     "school-holidays",

--- a/next/src/content/events/youth-services-school-holiday-program.json
+++ b/next/src/content/events/youth-services-school-holiday-program.json
@@ -47,7 +47,7 @@
   "editorNote": "The Shire runs free school holiday drop-in days at four Youth Hubs (Hastings, Mornington, Rosebud, Somerville). Qualified youth workers, free wifi, video games, pool tables, art supplies, board games, food. Weekly excursions go on the program but places are limited and need an expression of interest.\n\nFor day-to-day attendance there is no booking required, but every young person needs Operoo registration done once with a parent or guardian (do this before the holidays, not at the door).\n\nFor teens who are over the kid-friendly stuff but not quite ready to be left alone for a week, this is the right shape of thing.",
   "worthTheDrive": false,
   "firstTimer": true,
-  "status": "published",
+  "status": "archived",
   "publishedAt": "2026-05-04",
   "lens": [
     "rainy-day",


### PR DESCRIPTION
## Summary

Archives 13 lapsed events flagged by the maintenance sweep (`pi_maintenance_findings`, kind=`stale_content`, findings dated 2026-07-11). Each change is a single-line flip of `"status": "published"` -> `"status": "archived"`, matching the site's existing archive convention (same pattern as the `ops(events): auto-archive expired events` commits).

No other fields were touched. All 13 files re-validated as parseable JSON.

## Events archived (13)

| # | Slug | Category | Last date | Recurrence |
|---|------|----------|-----------|------------|
| 1 | sorrento-solstice-festival-fire-night | festival | 2026-06-20 | annual |
| 2 | sorrento-solstice-festival-2026 | festival | 2026-06-21 | one-off |
| 3 | peninsula-hot-springs-sunday-sessions | live-music | 2026-06-28 | weekly series (lapsed) |
| 4 | mprg-autumn-exhibition | exhibition | 2026-06-30 | seasonal |
| 5 | winter-camp-2026-the-ranch | family-programs | 2026-07-02 | annual |
| 6 | mornington-tourist-railway-school-holiday-special-runs | family-programs | 2026-07-05 | one-off |
| 7 | mornington-peninsula-regional-gallery-school-holiday-workshops | family-programs | 2026-07-10 | ongoing (term-bound) |
| 8 | youth-services-school-holiday-program | family-programs | 2026-07-10 | ongoing (term-bound) |
| 9 | boneo-community-market | market | 2026-06-20 | monthly |
| 10 | emu-plains-market-balnarring | market | 2026-06-20 | monthly |
| 11 | pearcedale-community-market | market | 2026-06-20 | monthly |
| 12 | mt-eliza-farmers-market | market | 2026-06-24 | monthly |
| 13 | dromana-community-market | market | 2026-06-28 | monthly |

Note: the maintenance finding listed the slug `mprg-school-holiday-workshops`; the actual content file is `mornington-peninsula-regional-gallery-school-holiday-workshops.json` (same event, full-name slug). It is item 7 above.

## Recurring: needs fresh dates from source

These 5 community/farmers markets are recurring series archived only because their listed occurrence has passed. Each should be re-published once next dates are confirmed from the organiser:

- boneo-community-market (monthly; `nextOccurrence` 2026-07-18 unverified)
- emu-plains-market-balnarring (monthly; `nextOccurrence` 2026-07-18 unverified)
- pearcedale-community-market (monthly; `nextOccurrence` 2026-07-18 unverified)
- mt-eliza-farmers-market (monthly; `nextOccurrence` 2026-07-26 unverified)
- dromana-community-market (monthly; `nextOccurrence` 2026-07-25 unverified)

peninsula-hot-springs-sunday-sessions is also a weekly series and could return with fresh dates from the venue.

## Provenance

- Source: maintenance sweep findings 2026-07-11 (`pi_maintenance_findings`, kind=`stale_content`)
- Correlation: `corr:acbc6319-eacd-4c7d-910c-995211251871`

Awaiting James's merge: production deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
