### PR TITLE
fix(content): MPRG article format -> service

### DIFF
--- a/next/src/content/articles/winter-indoors-mprg-rainy-day-circuit.md
+++ b/next/src/content/articles/winter-indoors-mprg-rainy-day-circuit.md
@@ -9,7 +9,7 @@ heroImage:
   alt: "A wet winter day on the Mornington Peninsula, the kind the gallery circuit is made for"
   credit: "Peninsula Insider"
   license: "other-licensed"
-format: "column"
+format: "service"
 tags: [culture, mprg, winter, rainy-day, mornington]
 relatedVenues: []
 relatedExperiences: []


### PR DESCRIPTION
Hotfix: the merged MPRG article used format 'column' which is not in the articles collection enum, breaking the deploy build. Changed to 'service' (matches rainy-day-peninsula, the-peninsula-with-kids). 🤖