### PR TITLE
Launch plan tranches A-D: freshness automation, analytics coverage, venue page, reference integrity

### DIFF
--- a/.github/workflows/content-freshness.yml
+++ b/.github/workflows/content-freshness.yml
@@ -1,0 +1,83 @@
+name: Content Freshness - Peninsula Insider
+
+on:
+  schedule:
+    # 5:00 AM AEST = 19:00 UTC (AEST is UTC+10)
+    # One hour ahead of the daily content engine (20:00 UTC) so the engine
+    # commissions against fresh nextOccurrence / lens / status values, and
+    # ahead of the quick-note cron chain (19:45 UTC) so the day's briefs are
+    # drafted onto a page that has already shed its lapsed notes.
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: content-freshness
+  cancel-in-progress: false
+
+jobs:
+  content-freshness:
+    name: Recompute occurrence, archive expired, rederive lenses
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Prefer the PAT (its pushes trigger build-and-deploy); fall back to
+          # the workflow token so the freshness pass still runs when the secret
+          # is unset. GITHUB_TOKEN pushes do NOT trigger other workflows, so
+          # with the fallback a freshness commit needs a manual deploy dispatch.
+          token: ${{ secrets.PAT_CONTENT_PUSH || github.token }}
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup Node.js (for the pre-commit house-style fixers)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Configure git identity
+        run: |
+          git config user.name "Peninsula Insider Engine"
+          git config user.email "engine@peninsulainsider.com.au"
+          # Auto-fix BRAND-PI house style (em-dashes) on staged content before
+          # the freshness pass commits, so generated content can't break the
+          # deploy.
+          git config core.hooksPath .githooks
+
+      # The four freshness scripts are stdlib-only, take no arguments, resolve
+      # their content directories relative to their own path, and mutate JSON /
+      # frontmatter in place. None of them commits: the commit step below owns
+      # the whole diff. Order matters: archive-expired-events reads
+      # nextOccurrence to decide whether an annual event is waiting on next
+      # year's date, so recompute-occurrence must run first.
+
+      - name: Recompute event nextOccurrence
+        run: python next/scripts/recompute-occurrence.py
+
+      - name: Archive expired events
+        run: python next/scripts/archive-expired-events.py
+
+      - name: Rederive event lenses
+        run: python next/scripts/rederive-lenses.py
+
+      - name: Archive expired quick notes
+        run: python next/scripts/archive-expired-quick-notes.py
+
+      - name: Commit and push freshness diff
+        run: |
+          git add next/src/content/events next/src/content/quick-notes
+          if git diff --cached --quiet; then
+            echo "No freshness changes today."
+            exit 0
+          fi
+          git commit -m "chore(content): daily content freshness pass $(date -u +%Y-%m-%d) [skip-review]"
+          git push

--- a/docs/peninsula-insider-status-2026-05-10.md
+++ b/docs/peninsula-insider-status-2026-05-10.md
@@ -3,13 +3,23 @@
 **Author:** Remy
 **For:** James, Emma
 
+> **Correction notice (2026-07-25):** this status update overstated what was
+> running. The three event-maintenance workflows it describes as live did not
+> exist. See the correction under "Recently completed" below. The rest of the
+> document is left as written, as the record of what was believed on
+> 2026-05-10.
+
 ## TL;DR
 Approval model and publication ledger are live and wired into the deploy workflow plus three event-maintenance crons. Five strategic docs landed today (uncommitted). Next move: pause new mutating automation; run the P0 control-hardening tranche before anything else.
+
+*(2026-07-25: "plus three event-maintenance crons" was inaccurate. Those crons were wired for the first time on 2026-07-25 via `.github/workflows/content-freshness.yml`.)*
 
 ## Recently completed
 - **Tiered approval model** — implemented in `ops/editorial-jobs.json` and core PI docs. Low-risk operational changes auto-approve / system-approve, medium-risk gets light review, high-risk editorial requires founder approval.
 - **Canonical publication ledger** — `ops/publication-ledger/` with `ops/scripts/publication-ledger.py` for validate / dry-run append flows. Template validates; append works.
 - **Ledger writes wired into runtime** — `deploy.yml` writes a site-deploy ledger entry before commit/push. Three event-maintenance workflows (`events-archive-expired`, `events-recompute-occurrence`, `events-rederive-lenses`) write low-risk system-approved entries when they mutate event files. Diff verified. (YAML lint deferred — PyYAML not in this workspace runtime.)
+  - **CORRECTION, 2026-07-25:** the second sentence above was never true. The three event-maintenance workflows did not exist; `.github/workflows/` contained no such files on 2026-05-10 and contained none on 2026-07-25. The three scripts (`next/scripts/recompute-occurrence.py`, `archive-expired-events.py`, `rederive-lenses.py`) were written, stdlib-only and working, but nothing invoked them, so no event maintenance ran between 2026-05-10 and 2026-07-25 and no ledger entries were written by them. "Diff verified" referred to a local script run, not to a workflow. The `deploy.yml` claim is also stale: the deploy workflow in the repository is `build-and-deploy.yml`.
+  - **Now wired:** `.github/workflows/content-freshness.yml` (added 2026-07-25) runs the three scripts daily at 19:00 UTC in dependency order, plus a new fourth script, `next/scripts/archive-expired-quick-notes.py`, which retires quick notes past their `expiresAt`. It commits and pushes its own diff. It does **not** write publication-ledger entries yet; that remains open. Status is `partial` in `ops/operating-surface.md` until a scheduled run is observed.
 - **Strategic docs landed today (2026-05-10, uncommitted in `peninsula-insider/docs/`):**
   - `peninsula-insider-content-architecture-ia-blueprint-2026-05-10.md`
   - `peninsula-insider-content-architecture-ux-model-2026-05-10.md`

--- a/next/package.json
+++ b/next/package.json
@@ -7,14 +7,15 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:region-images && npm run lint:surfaces && astro build",
-    "build:search": "npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && astro build && npx pagefind --site dist",
+    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && astro build",
+    "build:search": "npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
     "lint:no-pricing": "node scripts/lint-no-pricing.mjs",
     "lint:region-images": "node scripts/lint-region-images.mjs",
     "lint:surfaces": "node scripts/audit-surface-hardening.mjs",
+    "lint:nav-budget": "node scripts/lint-nav-budget.mjs",
     "media:registry": "node scripts/build-media-registry.mjs",
     "lint:taxonomy": "node scripts/taxonomy-lint.mjs",
     "lint:taxonomy:strict": "node scripts/taxonomy-lint.mjs --strict",
@@ -30,7 +31,8 @@
     "prebuild": "node scripts/clear-content-cache.mjs",
     "lint:house-style": "node scripts/lint-house-style.mjs",
     "lint:content-caps": "node scripts/lint-content-caps.mjs",
-    "lint:content-caps:strict": "node scripts/lint-content-caps.mjs --strict"
+    "lint:content-caps:strict": "node scripts/lint-content-caps.mjs --strict",
+    "lint:editorial-quality": "python3 ../ops/scripts/editorial-quality-check.py"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/next/scripts/archive-expired-quick-notes.py
+++ b/next/scripts/archive-expired-quick-notes.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+archive-expired-quick-notes.py - daily cron job 4 from the events registry design.
+
+For each quick note whose `expiresAt` is already in the past, flip
+`status: published` to `status: archived`. Quick notes are the daily-cadence
+briefs rendered on /quick-note/ across three horizons (now / today / week);
+once the window has lapsed the note should drop off the live page instead of
+sitting there stale.
+
+Only `published` notes are touched. `draft` notes are left alone (they were
+never live) and `archived` notes are already done. Editor can flag
+`keepLive: true` in the frontmatter to opt out of auto-archive (handy when a
+closure or safety note needs to outlive its stated window).
+
+The script rewrites only the `status:` line of the YAML frontmatter, in place,
+byte-for-byte otherwise: line endings, key order, quoting and body are all
+preserved. Diff is committed by the GitHub Actions workflow.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+NOTE_DIR = Path(__file__).resolve().parent.parent / 'src' / 'content' / 'quick-notes'
+# Quick-note frontmatter carries explicit offsets (+10:00). This is only the
+# fallback for a naive value: the Peninsula runs on Melbourne time.
+SITE_TZ = timezone(timedelta(hours=10))
+FRONTMATTER_FENCE = '---'
+
+
+def parse_datetime(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    value = s.strip().strip('"').strip("'")
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=SITE_TZ)
+    return dt
+
+
+def split_frontmatter(lines: list[str]) -> tuple[int, int] | None:
+    """Return (start, end) indices of the frontmatter body, fences excluded."""
+    if not lines or lines[0].strip() != FRONTMATTER_FENCE:
+        return None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == FRONTMATTER_FENCE:
+            return 1, i
+    return None
+
+
+def read_scalar(lines: list[str], start: int, end: int, key: str) -> str | None:
+    """Read a top-level frontmatter scalar. Nested keys are ignored."""
+    prefix = f'{key}:'
+    for i in range(start, end):
+        line = lines[i]
+        if line.startswith(prefix):
+            return line[len(prefix):].strip()
+    return None
+
+
+def find_line(lines: list[str], start: int, end: int, key: str) -> int | None:
+    prefix = f'{key}:'
+    for i in range(start, end):
+        if lines[i].startswith(prefix):
+            return i
+    return None
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    archived = []
+    skipped_keep_live = []
+    skipped_no_expiry = []
+
+    for path in sorted(NOTE_DIR.glob('*.md')):
+        try:
+            # Bytes, not read_text: three notes are CRLF and universal-newline
+            # translation would rewrite every line of them for no reason.
+            raw = path.read_bytes().decode('utf-8')
+        except Exception as e:
+            print(f"SKIP (read error) {path.name}: {e}")
+            continue
+
+        lines = raw.splitlines(keepends=True)
+        bounds = split_frontmatter(lines)
+        if bounds is None:
+            print(f"SKIP (no frontmatter) {path.name}")
+            continue
+        start, end = bounds
+
+        status = read_scalar(lines, start, end, 'status')
+        if status is None or status.strip('"').strip("'") != 'published':
+            continue
+        if read_scalar(lines, start, end, 'keepLive') == 'true':
+            skipped_keep_live.append(path.stem)
+            continue
+
+        expires = parse_datetime(read_scalar(lines, start, end, 'expiresAt'))
+        if expires is None:
+            skipped_no_expiry.append(path.stem)
+            continue
+        if expires > now:
+            continue
+
+        index = find_line(lines, start, end, 'status')
+        if index is None:
+            continue
+        # Preserve whatever line ending this file uses.
+        ending = lines[index][len(lines[index].rstrip('\r\n')):]
+        lines[index] = f'status: archived{ending}'
+        path.write_bytes(''.join(lines).encode('utf-8'))
+        archived.append(path.stem)
+
+    print(f"Archived: {len(archived)}")
+    for slug in archived[:20]:
+        print(f"  - {slug}")
+    if len(archived) > 20:
+        print(f"  ... and {len(archived) - 20} more")
+    print(f"Skipped (keep-live flag): {len(skipped_keep_live)}")
+    print(f"Skipped (no expiresAt): {len(skipped_no_expiry)}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -25,6 +25,89 @@ const data = venue.data;
 const liveStatusUrl = resolveLiveStatusUrl(data);
 const verifiedLabel = verifiedFreshnessLabel(data.lastVerified);
 
+// ── Opening hours ────────────────────────────────────────────────────────
+// data.visiting.openingHours carries the schema.org shape: full day names
+// plus 24-hour "HH:MM" strings. Three appointment-only producers carry an
+// empty array, so the block is gated on length, never on presence.
+const DAY_ORDER = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+const DAY_SHORT: Record<string, string> = {
+  Monday: 'Mon', Tuesday: 'Tue', Wednesday: 'Wed', Thursday: 'Thu',
+  Friday: 'Fri', Saturday: 'Sat', Sunday: 'Sun',
+};
+
+const normaliseDay = (value: unknown): string | null => {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const cased = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  return DAY_ORDER.includes(cased) ? cased : null;
+};
+
+interface HoursEntry { days: string[]; opens: string; closes: string }
+
+const openingHours: HoursEntry[] = (Array.isArray(data.visiting?.openingHours)
+  ? data.visiting.openingHours
+  : []
+)
+  .map((h: any) => ({
+    days: (Array.isArray(h?.days) ? h.days : h?.days ? [h.days] : [])
+      .map(normaliseDay)
+      .filter((d: string | null): d is string => Boolean(d)),
+    opens: String(h?.opens ?? ''),
+    closes: String(h?.closes ?? ''),
+  }))
+  .filter((h: HoursEntry) => h.days.length > 0 && h.opens && h.closes);
+const hasOpeningHours = openingHours.length > 0;
+
+// "Monday, Tuesday, Wednesday, Thursday" becomes "Mon to Thu". A pair stays
+// listed ("Fri, Sat"), and split runs join with a comma ("Mon to Thu, Sun").
+function formatDays(days: string[]): string {
+  const indexes = [...new Set(days.map((d) => DAY_ORDER.indexOf(d)))].sort((a, b) => a - b);
+  if (indexes.length === DAY_ORDER.length) return 'Every day';
+  const runs: number[][] = [];
+  for (const i of indexes) {
+    const last = runs[runs.length - 1];
+    if (last && i === last[last.length - 1] + 1) last.push(i);
+    else runs.push([i]);
+  }
+  return runs
+    .map((run) => {
+      const first = DAY_SHORT[DAY_ORDER[run[0]]];
+      const final = DAY_SHORT[DAY_ORDER[run[run.length - 1]]];
+      if (run.length === 1) return first;
+      if (run.length === 2) return `${first}, ${final}`;
+      return `${first} to ${final}`;
+    })
+    .join(', ');
+}
+
+// "17:00" becomes "5pm", "10:30" becomes "10:30am". Anything unparseable
+// falls through as the operator wrote it rather than rendering nonsense.
+function formatTime(value: string): string {
+  const match = /^(\d{1,2}):(\d{2})/.exec(value);
+  if (!match) return value;
+  const hours24 = Number(match[1]);
+  const minutes = match[2];
+  const suffix = hours24 < 12 || hours24 >= 24 ? 'am' : 'pm';
+  const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
+  return minutes === '00' ? `${hours12}${suffix}` : `${hours12}:${minutes}${suffix}`;
+}
+
+// Midnight to one minute before midnight is a 24-hour operation (reception
+// desks), not a 23-hour 59-minute one.
+const isAllDay = (h: HoursEntry) =>
+  h.opens === '00:00' && ['23:59', '24:00', '00:00'].includes(h.closes);
+const formatHoursRange = (h: HoursEntry) =>
+  isAllDay(h) ? 'Open 24 hours' : `${formatTime(h.opens)}–${formatTime(h.closes)}`;
+
+const coveredDays = new Set(openingHours.flatMap((h) => h.days));
+const closedDays = DAY_ORDER.filter((d) => !coveredDays.has(d));
+const hoursRows: { days: string; time: string; closed: boolean }[] = [
+  ...openingHours.map((h) => ({ days: formatDays(h.days), time: formatHoursRange(h), closed: false })),
+  ...(closedDays.length > 0 && closedDays.length < DAY_ORDER.length
+    ? [{ days: formatDays(closedDays), time: 'Closed', closed: true }]
+    : []),
+];
+
 // New planning/recommendation layer
 // Worth Knowing panel renders if worthKnowing object has any values, OR if bestFor tags are present
 const hasWorthKnowing = (data.bestFor && data.bestFor.length > 0) ||
@@ -100,7 +183,31 @@ const winemakerName: string | null = isWinery ? (data.wines?.winemaker ?? null) 
 const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seasonTags.includes('all-year')
   ? seasonTags.map((s: string) => s.charAt(0).toUpperCase() + s.slice(1)).join(' and ')
   : null;
+
+// Opening hours as schema.org OpeningHoursSpecification.
+// The venue's main JSON-LD node is built by the page, not here: /wine/ uses
+// buildWinerySchema (lib/schema.ts), which already emits the hours, while
+// /eat/ and /stay/ build an inline node that does not. This block fills that
+// gap, and only on the venue's own canonical surface, so a venue is never
+// described by two competing hours nodes.
+const isCanonicalSurface = venueHrefPrefix(data.type).endsWith(`/${section}`);
+const hoursSchema = hasOpeningHours && isCanonicalSurface && section !== 'wine'
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'LocalBusiness',
+      name: data.name,
+      url: `https://peninsulainsider.com.au/${section}/${venueSlug}/`,
+      openingHoursSpecification: openingHours.map((h) => ({
+        '@type': 'OpeningHoursSpecification',
+        dayOfWeek: h.days,
+        opens: h.opens,
+        closes: h.closes,
+      })),
+    }
+  : null;
 ---
+
+{hoursSchema && <script type="application/ld+json" set:html={JSON.stringify(hoursSchema)} />}
 
 <Breadcrumbs items={breadcrumbItems} />
 
@@ -427,6 +534,22 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
             </>
           )}
 
+          {hasOpeningHours && (
+            <>
+              <dt>Opening hours</dt>
+              <dd>
+                <ul class="facts__hours">
+                  {hoursRows.map((row) => (
+                    <li class:list={['facts__hours-row', row.closed && 'facts__hours-row--closed']}>
+                      <span class="facts__hours-days">{row.days}</span>
+                      <span class="facts__hours-time">{row.time}</span>
+                    </li>
+                  ))}
+                </ul>
+              </dd>
+            </>
+          )}
+
           <>
             <dt>Live status</dt>
             <dd>
@@ -499,13 +622,10 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
       <h2 class="venue-detail-section__title">Visiting</h2>
       <div class="prose">
         {data.visiting.tastingNote && <p>{data.visiting.tastingNote}</p>}
-        {data.visiting.openingHours?.length > 0 && (
-          <ul>
-            {data.visiting.openingHours.map((h: any) => (
-              <li>{Array.isArray(h.days) ? h.days.join(', ') : h.days}: {h.opens}–{h.closes}</li>
-            ))}
-          </ul>
-        )}
+        {/* Opening hours render once, in the At a glance panel above, where
+            readers look for the practical facts. Kept out of here so the
+            same venue never publishes two hours lists. */}
+        {data.visiting.bookingNotes && <p>{data.visiting.bookingNotes}</p>}
         {data.visiting.bookingRequired && (
           <p><strong>Booking required.</strong>{' '}
             {data.bookingUrl
@@ -735,6 +855,27 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
   </div>
 )}
 
+{/* Foot matter: when we last checked this page, and the operator's route to
+    claim it. Verification discipline is worth nothing if the reader cannot
+    see it, so the date is stated plainly; both lines are deliberately quiet
+    so neither competes with the editorial above. */}
+<div class="venue-footnote">
+  <div class="container">
+    <div class="venue-footnote__inner">
+      {verifiedLabel && (
+        <p class="venue-footnote__verified">
+          <span>{verifiedLabel} by Peninsula Insider</span>
+          <span class="venue-footnote__sep" aria-hidden="true"> · </span>
+          <a href="/methodology/">How we check</a>
+        </p>
+      )}
+      <p class="venue-footnote__claim">
+        Is this your venue? <a href="/partners/claim/">Claim it</a>
+      </p>
+    </div>
+  </div>
+</div>
+
 <NewsletterBlock />
 
 <style>
@@ -858,6 +999,67 @@ const wineBestSeason: string | null = isWinery && seasonTags.length > 0 && !seas
   }
   .venue-ask-pi__cta:hover {
     opacity: 0.75;
+  }
+
+  /* ── Opening hours in the At a glance panel ── */
+  .facts__hours {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.2rem;
+  }
+  .facts__hours-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+  .facts__hours-days {
+    color: var(--soft);
+    white-space: nowrap;
+  }
+  .facts__hours-time {
+    text-align: right;
+  }
+  .facts__hours-row--closed .facts__hours-time {
+    color: var(--soft);
+  }
+
+  /* ── Foot matter: verification date + operator claim ── */
+  .venue-footnote {
+    padding: 1.1rem 0 1.6rem;
+    border-top: 1px solid var(--border);
+  }
+  .venue-footnote__inner {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.4rem 1.5rem;
+  }
+  .venue-footnote__verified,
+  .venue-footnote__claim {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: var(--soft);
+  }
+  .venue-footnote__sep {
+    color: var(--border);
+  }
+  .venue-footnote__verified a,
+  .venue-footnote__claim a {
+    color: var(--soft);
+    text-decoration: none;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.1rem;
+    transition: color 0.2s ease, border-color 0.2s ease;
+  }
+  .venue-footnote__verified a:hover,
+  .venue-footnote__claim a:hover {
+    color: var(--accent);
+    border-color: var(--accent);
   }
 
   /* ── Destination hierarchy return link ── */

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -211,6 +211,61 @@ const venues = defineCollection({
      */
     liveStatusUrl: z.string().url().optional(),
     /**
+     * Visiting block - the practical access facts an operator publishes.
+     * Present on 28 venues (25 with real opening hours; three appointment-only
+     * producers carry an empty `openingHours` array, so presence of `visiting`
+     * is never enough on its own - templates must test the length).
+     *
+     * Deliberately permissive. The block was hand-authored before it had a
+     * schema, so the shapes are uneven: `tastingFee` is a string on 15 venues
+     * and an explicit null on 6, `days` is an array everywhere today but the
+     * templates already tolerate a bare string, and times are plain "HH:MM"
+     * strings rather than a validated pattern. A validation failure here fails
+     * the whole build, so every field is optional and no format is enforced.
+     *
+     * openingHours mirrors the schema.org OpeningHoursSpecification shape and
+     * is emitted as such in the venue JSON-LD (lib/schema.ts, and
+     * VenueDetailTemplate for the eat and stay surfaces).
+     */
+    visiting: z
+      .object({
+        openingHours: z
+          .array(
+            z.object({
+              days: z.union([z.array(z.string()), z.string()]).optional(),
+              opens: z.string().optional(),
+              closes: z.string().optional(),
+            })
+          )
+          .optional(),
+        bookingRequired: z.boolean().optional(),
+        bookingNotes: z.string().optional(),
+        tastingFee: z.string().nullable().optional(),
+        tastingNote: z.string().optional(),
+      })
+      .optional(),
+    /**
+     * On-site dining room, for venues whose primary type is not a restaurant
+     * (14 wineries). Drives the Winery kitchens module on the wine hub, the
+     * restaurant section on the venue page, and the Restaurant JSON-LD node.
+     * `hats` is the Good Food Guide count; it is a rating, never a price.
+     */
+    restaurant: z
+      .object({
+        name: z.string().optional(),
+        hats: z.number().optional(),
+        cuisine: z.string().optional(),
+        reservations: z.boolean().optional(),
+        description: z.string().optional(),
+      })
+      .optional(),
+    /**
+     * Long-form editorial verdict (21 venues). Rendered as the pull-quote
+     * verdict block on the venue page and used, trimmed to its first
+     * sentence, as the short verdict on wine hub cards.
+     */
+    editorVerdict: z.string().optional(),
+    /**
      * Entity signals — 3–5 short noun phrases (2–4 words each) naming what
      * the venue is distinctively known for. Renders as a chip row below the
      * signature line (see VenueDetailTemplate.astro) and is emitted as

--- a/next/src/content/articles/autumn-weekend-edit.md
+++ b/next/src/content/articles/autumn-weekend-edit.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-unsplash"
 format: "editors-letter"
 tags: ["autumn", "red-hill", "long-lunch", "walks", "weekend"]
-relatedVenues: ["tedesca-osteria", "montalto", "lindenderry", "ten-minutes-by-tractor", "morning-sun", "paringa-estate", "crittenden-restaurant", "bistro-elba", "allis-wine-bar", "many-little"]
+relatedVenues: ["tedesca-osteria", "montalto", "lindenderry", "ten-minutes-by-tractor", "morning-sun", "paringa-estate", "stillwater-crittenden", "bistro-elba", "allis-wine-bar", "many-little"]
 relatedExperiences: ["bushrangers-bay-walk", "red-hill-market"]
 readingTimeMinutes: 8
 featured: false

--- a/next/src/content/articles/rainy-day-peninsula.md
+++ b/next/src/content/articles/rainy-day-peninsula.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-wikimedia"
 format: "service"
 tags: ["winter", "rainy-day", "indoor", "hot-springs", "fireplace"]
-relatedVenues: ["alba-thermal-springs", "peninsula-hot-springs", "tedesca-osteria", "lindenderry", "bass-and-flinders", "ashcombe-maze", "stringers-sorrento", "mornington-peninsula-chocolates", "red-hill-cheese", "via-boffe"]
+relatedVenues: ["alba-thermal-springs", "peninsula-hot-springs", "tedesca-osteria", "lindenderry", "bass-and-flinders", "stringers-sorrento", "mornington-peninsula-chocolates", "red-hill-cheese", "via-boffe"]
 relatedExperiences: ["mornington-peninsula-gallery"]
 readingTimeMinutes: 6
 featured: false

--- a/next/src/content/articles/sorrento-solstice-festival-2026-guide.md
+++ b/next/src/content/articles/sorrento-solstice-festival-2026-guide.md
@@ -12,7 +12,7 @@ heroImage:
 format: "insider-edit"
 section: "journal"
 tags: ["winter", "solstice", "festival", "sorrento", "event-guide", "weekend-pick", "fire", "free", "family-friendly"]
-relatedVenues: ["hotel-sorrento", "continental-sorrento", "sorrento-back-beach"]
+relatedVenues: ["hotel-sorrento", "the-continental-sorrento"]
 relatedEvents: ["sorrento-solstice-festival-2026"]
 readingTimeMinutes: 7
 featured: false

--- a/next/src/content/articles/the-easter-peninsula.md
+++ b/next/src/content/articles/the-easter-peninsula.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-unsplash"
 format: "service"
 tags: ["easter", "long-weekend", "seasonal", "family", "weekend", "autumn"]
-relatedVenues: ["red-hill-bakery", "balnarring-bakehouse", "flinders-sourdough", "johnny-ripe", "mornington-peninsula-chocolates", "sunny-ridge-strawberry-farm", "ashcombe-maze", "merricks-general-wine-store", "balnarring-pub", "flinders-hotel", "red-hill-brewery", "lindenderry", "polperro-villas", "crittenden-villas", "alba-thermal-springs", "peninsula-hot-springs"]
+relatedVenues: ["red-hill-bakery", "balnarring-bakehouse", "flinders-sourdough", "johnny-ripe", "mornington-peninsula-chocolates", "merricks-general-wine-store", "balnarring-pub", "flinders-hotel", "red-hill-brewery", "lindenderry", "polperro-villas", "crittenden-villas", "alba-thermal-springs", "peninsula-hot-springs"]
 relatedExperiences: ["bushrangers-bay-walk", "cape-schanck-boardwalk", "mornington-foreshore-walk", "balnarring-beach", "mount-martha-beach", "red-hill-market"]
 readingTimeMinutes: 7
 featured: false

--- a/next/src/content/articles/the-long-lunch.md
+++ b/next/src/content/articles/the-long-lunch.md
@@ -12,7 +12,7 @@ heroImage:
   license: "tmp-wikimedia"
 format: "long-lunch-list"
 tags: ["eat", "wine", "weekend", "red-hill", "long-lunch"]
-relatedVenues: ["ten-minutes-by-tractor", "montalto", "pt-leo-estate", "tedesca-osteria", "port-phillip-estate-restaurant", "paringa-estate", "crittenden-restaurant", "pt-leo-estate", "barragunda-dining", "green-olive-red-hill", "morning-sun"]
+relatedVenues: ["ten-minutes-by-tractor", "montalto", "pt-leo-estate", "tedesca-osteria", "port-phillip-estate-restaurant", "paringa-estate", "stillwater-crittenden", "pt-leo-estate", "barragunda-dining", "green-olive-red-hill", "morning-sun"]
 readingTimeMinutes: 8
 featured: true
 status: "published"

--- a/next/src/content/articles/the-market-saturday.md
+++ b/next/src/content/articles/the-market-saturday.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-wikimedia"
 format: "service"
 tags: ["markets", "mornington", "red-hill", "balnarring", "weekend", "producers", "all-year"]
-relatedVenues: ["mornington-farmers-market", "red-hill-market", "balnarring-market", "red-hill-brewery", "red-hill-bakery", "merricks-general-wine-store", "commonfolk-coffee", "red-hill-cheese", "main-ridge-dairy", "sunny-ridge-strawberry-farm", "peninsula-fresh-organics", "somers-general", "balnarring-bakehouse", "johnny-ripe", "mornington-peninsula-chocolates"]
+relatedVenues: ["mornington-farmers-market", "red-hill-market", "balnarring-market", "red-hill-brewery", "red-hill-bakery", "merricks-general-wine-store", "commonfolk-coffee", "red-hill-cheese", "main-ridge-dairy", "peninsula-fresh-organics", "somers-general", "balnarring-bakehouse", "johnny-ripe", "mornington-peninsula-chocolates"]
 relatedExperiences: ["red-hill-market", "mornington-foreshore-walk", "balnarring-beach"]
 readingTimeMinutes: 8
 featured: false

--- a/next/src/content/articles/the-peninsula-with-kids.md
+++ b/next/src/content/articles/the-peninsula-with-kids.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-wikimedia"
 format: "service"
 tags: ["family", "kids", "day-trip", "explore", "mount-martha", "arthurs-seat"]
-relatedVenues: ["red-hill-brewery", "merricks-general-wine-store", "commonfolk-coffee", "epicurean-red-hill", "sunny-ridge-strawberry-farm", "main-ridge-dairy", "ashcombe-maze", "red-gum-bbq", "st-andrews-beach-brewery", "dromana-hotel", "rye-hotel", "sorrento-gelato", "johnny-ripe"]
+relatedVenues: ["red-hill-brewery", "merricks-general-wine-store", "commonfolk-coffee", "epicurean-red-hill", "main-ridge-dairy", "red-gum-bbq", "st-andrews-beach-brewery", "dromana-hotel", "rye-hotel", "sorrento-gelato", "johnny-ripe"]
 relatedExperiences: ["arthurs-seat-lookout", "mount-martha-beach", "balnarring-beach", "mornington-peninsula-gallery"]
 readingTimeMinutes: 7
 featured: false

--- a/next/src/content/articles/the-producer-trail.md
+++ b/next/src/content/articles/the-producer-trail.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-wikimedia"
 format: "service"
 tags: ["producers", "food", "day-trip", "red-hill", "main-ridge", "balnarring", "explore", "all-year"]
-relatedVenues: ["main-ridge-dairy", "red-hill-cheese", "red-hill-truffles", "sunny-ridge-strawberry-farm", "peninsula-fresh-organics", "mornington-peninsula-chocolates", "balnarring-bakehouse", "flinders-sourdough", "red-hill-bakery", "somers-general", "green-olive-red-hill", "epicurean-red-hill", "merricks-general-wine-store", "balnarring-pub"]
+relatedVenues: ["main-ridge-dairy", "red-hill-cheese", "peninsula-fresh-organics", "mornington-peninsula-chocolates", "balnarring-bakehouse", "flinders-sourdough", "red-hill-bakery", "somers-general", "green-olive-red-hill", "epicurean-red-hill", "merricks-general-wine-store", "balnarring-pub"]
 relatedExperiences: ["red-hill-hinterland-cycling", "balnarring-beach", "mornington-foreshore-walk"]
 readingTimeMinutes: 8
 featured: false

--- a/next/src/content/articles/the-rainy-day-peninsula-without-a-booking.md
+++ b/next/src/content/articles/the-rainy-day-peninsula-without-a-booking.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-wikimedia"
 format: "service"
 tags: ["rainy-day", "winter", "local-guide", "indoor", "day-trip"]
-relatedVenues: ["commonfolk-coffee", "merricks-general-wine-store", "red-hill-brewery", "flinders-sourdough", "flinders-hotel", "stringers-sorrento", "ashcombe-maze", "the-bay-hotel-mornington", "balnarring-pub", "red-hill-cheese", "mornington-peninsula-chocolates", "via-boffe"]
+relatedVenues: ["commonfolk-coffee", "merricks-general-wine-store", "red-hill-brewery", "flinders-sourdough", "flinders-hotel", "stringers-sorrento", "the-bay-hotel-mornington", "balnarring-pub", "red-hill-cheese", "mornington-peninsula-chocolates", "via-boffe"]
 relatedExperiences: ["mornington-peninsula-gallery", "cape-schanck-boardwalk", "sorrento-back-beach"]
 readingTimeMinutes: 7
 featured: false

--- a/next/src/content/articles/the-school-holidays-survival-guide.md
+++ b/next/src/content/articles/the-school-holidays-survival-guide.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-unsplash"
 format: "service"
 tags: ["family", "kids", "school-holidays", "activities", "outdoor", "rainy-day", "budget", "all-year"]
-relatedVenues: ["ashcombe-maze", "sunny-ridge-strawberry-farm", "red-hill-brewery", "mornington-peninsula-chocolates", "st-andrews-beach-brewery", "red-gum-bbq", "commonfolk-coffee", "dromana-hotel", "rye-hotel", "sorrento-gelato", "johnny-ripe", "balnarring-pub"]
+relatedVenues: ["red-hill-brewery", "mornington-peninsula-chocolates", "st-andrews-beach-brewery", "red-gum-bbq", "commonfolk-coffee", "dromana-hotel", "rye-hotel", "sorrento-gelato", "johnny-ripe", "balnarring-pub"]
 relatedExperiences: ["arthurs-seat-lookout", "mount-martha-beach", "balnarring-beach", "portsea-front-beach", "mornington-peninsula-gallery", "point-nepean-fort-walk", "bushrangers-bay-walk", "pt-leo-sculpture-park", "dromana-beach", "rye-ocean-beach", "gunnamatta-ocean-beach", "safety-beach-foreshore", "red-hill-market"]
 readingTimeMinutes: 8
 featured: false

--- a/next/src/content/articles/the-spring-peninsula.md
+++ b/next/src/content/articles/the-spring-peninsula.md
@@ -11,7 +11,7 @@ heroImage:
   license: "tmp-unsplash"
 format: "editors-letter"
 tags: ["spring", "seasonal", "weekend", "red-hill", "markets", "walks"]
-relatedVenues: ["montalto", "merricks-general-wine-store", "lindenderry", "ten-minutes-by-tractor", "polperro", "crittenden-estate", "paringa-estate", "red-hill-brewery", "flinders-hotel", "tedesca-osteria", "pt-leo-estate", "sunny-ridge-strawberry-farm", "mornington-farmers-market", "red-hill-market", "balnarring-market"]
+relatedVenues: ["montalto", "merricks-general-wine-store", "lindenderry", "ten-minutes-by-tractor", "polperro", "crittenden-estate", "paringa-estate", "red-hill-brewery", "flinders-hotel", "tedesca-osteria", "pt-leo-estate", "mornington-farmers-market", "red-hill-market", "balnarring-market"]
 relatedExperiences: ["bushrangers-bay-walk", "red-hill-market", "arthurs-seat-lookout", "mount-martha-beach", "mornington-foreshore-walk", "red-hill-hinterland-cycling", "farnsworth-track"]
 readingTimeMinutes: 7
 featured: false

--- a/next/src/layouts/BaseLayout.astro
+++ b/next/src/layouts/BaseLayout.astro
@@ -312,6 +312,23 @@ const isAskPage = rawPathname.startsWith('/ask');
     })();
   </script>
 
+  {/* Global [data-evt] listener.
+      initV5Analytics() installs one delegated, capture-phase click handler on
+      document. It used to be called only from the 13 components that happen to
+      import it, which meant markup carrying data-evt on any other page (Card,
+      FilterBar, WhatsOnScopeBar, MapToggle and friends) recorded nothing, so
+      card_click was measured on an arbitrary subset of pages. Binding it once
+      here from the layout covers every template.
+
+      The listener sits on document, which survives Astro view transitions, and
+      initV5Analytics is idempotent, so the existing per-component calls stay
+      harmless. trackEvent is itself consent-gated, matching the gtag loader
+      above: no consent, no events. */}
+  <script>
+    import { initV5Analytics } from '../lib/v5-analytics';
+    initV5Analytics();
+  </script>
+
   {/* TEMPORARY PASSWORD GATE.
       Client-side only, so it is a soft courtesy gate, not security: the
       content ships in the HTML regardless and crawlers that run JS get

--- a/next/src/lib/schema.ts
+++ b/next/src/lib/schema.ts
@@ -96,13 +96,17 @@ export function buildWinerySchema(data: any, slug: string, section = 'wine') {
     }));
   }
 
-  if (data.editorVerdict) {
-    schema.review = {
-      '@type': 'Review',
-      author: { '@type': 'Organization', name: 'Peninsula Insider' },
-      reviewBody: data.editorVerdict,
-    };
-  }
+  // Deliberately no schema.org Review node. A Review without a reviewRating is
+  // invalid for rich results and Google flags it, but Peninsula Insider does not
+  // score venues, so there is no honest rating to supply and inventing one would
+  // contradict the editorial stance. The verdict still reaches search engines
+  // through `description` above.
+  //
+  // This branch was dormant until 2026-07-25: editorVerdict was absent from the
+  // venues schema, so Zod stripped it and data.editorVerdict was always
+  // undefined. Adding the field to the schema would have switched it on for 21
+  // wineries at once. Revisit only if a published, defensible rating scale ever
+  // exists.
 
   return schema;
 }

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -34,16 +34,10 @@ export const prerender = true;
 // ── Corpus ────────────────────────────────────────────────────────────────
 const wineTypes = ['winery', 'producer', 'brewery', 'distillery'];
 
-// The venues Zod schema strips fields the wine hub needs (visiting.bookingRequired
-// for the walk-in/appointment badge, restaurant for the kitchens module,
-// editorVerdict for short verdicts). Read the raw JSON alongside the collection
-// so those fields survive; schema-validated data still wins where both exist.
-const rawVenueModules = import.meta.glob('../../content/venues/*.json', { eager: true });
-const rawVenueBySlug = new Map<string, any>();
-for (const mod of Object.values(rawVenueModules)) {
-  const raw = (mod as any).default ?? mod;
-  if (raw && typeof raw.slug === 'string') rawVenueBySlug.set(raw.slug, raw);
-}
+// visiting.bookingRequired (walk-in/appointment badge), restaurant (kitchens
+// module) and editorVerdict (short verdicts) are all declared in the venues
+// schema now, so entry.data carries them. The raw-JSON glob that used to work
+// around the schema stripping them is gone (2026-07-25).
 
 const score = (v: any) => Number(v.data.authority?.hallidayScore ?? 0);
 const hatCount = (v: any) => Number(v.data.authority?.hats ?? 0);
@@ -112,15 +106,9 @@ const iso = (d: unknown): string | undefined => {
   return undefined;
 };
 
-/** Schema data merged over the raw JSON, so stripped fields are readable. */
-function fullData(v: any): any {
-  const raw = rawVenueBySlug.get(routeSlug(v)) ?? {};
-  return { ...raw, ...v.data };
-}
-
 // ── Card item builder (SixItem / DirectoryRowItem shape from the hub modules) ──
 function venueItem(v: any) {
-  const data = fullData(v);
+  const data = v.data;
   const slug = routeSlug(v);
   const meta = [areaOf(data), badgeFor(data) ?? typeLabels[data.type]].filter(Boolean) as string[];
   if (data.type === 'winery' && hasKitchen(data) && meta.length < 3) meta.push('Kitchen on site');
@@ -133,7 +121,9 @@ function venueItem(v: any) {
     verdict: verdictFor(data),
     meta,
     priceBand: typeof data.priceBand === 'string' ? data.priceBand : undefined,
-    freshness: iso(data.lastVerified ?? data.lastFactVerified ?? data.publishedAt),
+    // lastVerified is required by the venues schema, so it always wins here;
+    // publishedAt stays as the belt-and-braces fallback.
+    freshness: iso(data.lastVerified ?? data.publishedAt),
     facets: getFacets('venue', data),
     sortTitle: data.name as string,
   };
@@ -148,16 +138,16 @@ const theSixItems = sixSource.map((v) => venueItem(v));
 
 // ── Winery kitchens: reciprocal module, the HUB-01 bridge with /eat/ ──────
 const kitchens = venues
-  .filter((v) => v.data.type === 'winery' && hasKitchen(fullData(v)))
+  .filter((v) => v.data.type === 'winery' && hasKitchen(v.data))
   .sort(
     (a, b) =>
-      Number(fullData(b).restaurant?.hats ?? 0) - Number(fullData(a).restaurant?.hats ?? 0) ||
+      Number(b.data.restaurant?.hats ?? 0) - Number(a.data.restaurant?.hats ?? 0) ||
       score(b) - score(a),
   )
   .slice(0, 6);
 const kitchenItems = kitchens.map((v) => {
   const item = venueItem(v);
-  const dining = firstSentence(fullData(v).restaurant?.description);
+  const dining = firstSentence(v.data.restaurant?.description);
   return {
     ...item,
     verdict: dining && wordCount(dining) <= 25 ? dining : item.verdict,

--- a/ops/notes/cross-collection-refs-2026-07-25.md
+++ b/ops/notes/cross-collection-refs-2026-07-25.md
@@ -1,0 +1,24 @@
+# Cross-collection references removed from relatedVenues
+
+Date: 2026-07-25
+
+These four slugs were listed in article `relatedVenues` but are entries in the
+`experiences` collection, not `venues`. `relatedVenues` is typed
+`reference('venues')`, and `next/src/lib/related.ts` resolves by entry id then
+drops anything unresolvable without warning, so they never rendered.
+
+They have been removed so the reference check can pass. The editorial intent is
+real and worth restoring by adding them to each article's `relatedExperiences`
+instead. Precedent already exists: `the-rainy-day-peninsula-without-a-booking`
+lists `sorrento-back-beach` correctly under `relatedExperiences`.
+
+Recorded here so the links are not lost.
+
+- `sunny-ridge-strawberry-farm` (removed from 6 articles) - experiences: Sunny Ridge Strawberry Farm
+- `ashcombe-maze` (removed from 5 articles) - experiences: Ashcombe Maze & Lavender Gardens
+- `red-hill-truffles` (removed from 1 article) - experiences: Red Hill Truffles
+- `sorrento-back-beach` (removed from 1 article) - experiences: Sorrento Back Beach
+
+Also worth an editor's eye: `sorrento-solstice-festival-2026-guide` has no
+`relatedExperiences` field at all, and its `relatedVenues` is now a single
+entry, so it is the thinnest of the eleven.

--- a/ops/operating-surface.md
+++ b/ops/operating-surface.md
@@ -1,5 +1,6 @@
 # Peninsula Insider — Canonical Operating Surface
 **Last reviewed:** 2026-05-10
+**Last corrected:** 2026-07-25 (Tier-2 github-actions rows only - see the content-freshness note below. The rest of this file has not been re-verified since 2026-05-10.)
 **Owner:** PI operations (Remy)
 **Authority:** This file is the single source of truth for what jobs run against PI, where they run, what they touch, and what state they are in. If an entry conflicts with another doc, this file wins until the entry is updated.
 
@@ -7,7 +8,7 @@
 
 - **Source-of-execution** — where the job is *triggered from*: `github-actions` (CI), `openclaw-cron` (containerised scheduler in `~/.openclaw/cron/jobs.json`), `manual` (no scheduler), or `composite` (multiple).
 - **Mutation** — `scan-only` produces a report and writes nothing to live. `report-only` writes to `ops/reports/` but not to live surfaces. `mutating-content` writes to `next/src/content/`. `mutating-live` writes to live HTML or deploy. `mutating-config` modifies repo configuration (rare).
-- **Status** — `live` is observably running. `partial` is registered but not all integrations are wired. `dormant` is registered but disabled. `planned` is documented but not registered.
+- **Status** — `live` is observably running. `partial` is registered but not all integrations are wired. `dormant` is registered but disabled. `planned` is documented but not registered. `unverified` (added 2026-07-25) is claimed by an earlier revision of this file but with no artifact found to back the claim.
 - **Alert path** — where failures surface. `silent` means failures are not currently surfaced anywhere visible to operators.
 
 ## Tier-1 — Daily mutating publish path (highest risk)
@@ -63,13 +64,32 @@ also regenerates the repo-root copies (artifact parity with root `sitemap.xml`).
 | `pi-daily-venue-healthcheck` | openclaw-cron | daily 06:00 | report-only | live |
 | `pi-daily-seasonality-refresh` | openclaw-cron | daily 06:20 | report-only | live |
 | `pi-daily-link-audit` | openclaw-cron | daily 21:20 | report-only | live |
-| `events-archive-expired` | github-actions | daily | mutating-content | live |
-| `events-recompute-occurrence` | github-actions | daily | mutating-content | live |
-| `events-rederive-lenses` | github-actions | daily | mutating-content | live |
-| `events-editorial-research` | github-actions | scheduled | report-only | live |
-| `events-weekly-rebuild` | github-actions | weekly | mutating-content | live |
-| `insider-usage-report` | github-actions | daily | report-only | live |
-| `refresh-corpus` | github-actions | scheduled | mutating-content | live |
+| `Content Freshness` (`content-freshness.yml`) | github-actions | daily 19:00 | mutating-content | partial - workflow added 2026-07-25, first scheduled run still pending |
+| `events-editorial-research` | github-actions | scheduled | report-only | unverified - no matching file in `.github/workflows/` |
+| `events-weekly-rebuild` | github-actions | weekly | mutating-content | unverified - no matching file in `.github/workflows/` |
+| `insider-usage-report` | github-actions | daily | report-only | unverified - no matching file in `.github/workflows/` |
+| `refresh-corpus` | github-actions | scheduled | mutating-content | unverified - no matching file in `.github/workflows/` |
+
+**Content-freshness note (corrected 2026-07-25):** this row previously listed
+three separate `live` workflows (`events-archive-expired`,
+`events-recompute-occurrence`, `events-rederive-lenses`). No such workflow
+files ever existed. The three scripts were written and tested but referenced by
+nothing, so no event maintenance has actually been running. They are now wired
+into a single daily workflow, `.github/workflows/content-freshness.yml`, which
+runs them in dependency order (`recompute-occurrence.py`, then
+`archive-expired-events.py` (it reads `nextOccurrence`), then
+`rederive-lenses.py`), plus a fourth script,
+`archive-expired-quick-notes.py`, which retires quick notes past their
+`expiresAt`. The workflow commits and pushes its own diff; it does not write a
+publication-ledger entry. Alert path is the GitHub Actions UI. Promote this row
+to `live` once a scheduled run is observed.
+
+**Tier-2 github-actions note (2026-07-25):** the four `unverified` rows above
+were also listed as `live` github-actions jobs, but the repository contains
+only five workflow files (`build-and-deploy.yml`, `daily-content.yml`,
+`weekly-content.yml`, `monthly-content.yml`, `pi-data-refresh.yml`) plus the
+new `content-freshness.yml`. Whatever these four jobs are, they are not running
+as GitHub Actions. Reconciling them is part of item 11.
 
 ## Tier-3 — Weekly editorial and SEO rhythm
 
@@ -130,7 +150,9 @@ These rituals write to `next/.claude/newsroom/` (slates, perf, retros, look-ahea
 ## Cross-cutting observations
 
 ### What is actually running on PI right now
-Counting only `live` rows above: roughly **27 jobs** are observably executing on PI on some recurring schedule. That is the operational footprint to design control around — not the 50+ jobs that documents *imply* exist.
+Counting only `live` rows above: roughly **27 jobs** are observably executing on PI on some recurring schedule. That is the operational footprint to design control around, not the 50+ jobs that documents *imply* exist.
+
+**Correction (2026-07-25):** that count was itself inflated. Seven Tier-2 rows were marked `live` as github-actions jobs with no workflow file behind them. Three of those (the event-maintenance trio) are now genuinely wired via `content-freshness.yml` but have not yet had a scheduled run; the other four remain `unverified`. Treat the live count as **20 confirmed plus 7 to re-verify** until item 11 reconciles the registries.
 
 ### Where the gaps are
 1. **Alert paths are mostly silent.** Almost every `mutating-*` job in Tier-1 has alert path `silent`. Failures are detectable by reading reports, not by being notified. **This is the single highest-impact fix in this backlog.**


### PR DESCRIPTION
Delivers the engineering half of the launch plan. Every change is verified against a passing `npm run build` (964 pages, exit 0) and against the built output, not just the source.

## What landed

**Freshness automation** (`a4e8b16`)
The three event scripts were complete, stdlib-only and idempotent, and wired into nothing, while two ops documents listed them as live. Because `recompute-occurrence` never ran, recurring events' `nextOccurrence` drifted, which is why the calendar looked thinner than it is. Adds `content-freshness.yml` at 19:00 UTC, ordered so `recompute` precedes `archive` (archive reads `nextOccurrence`). Adds `archive-expired-quick-notes.py` in the same shape as its neighbours, with a `keepLive` opt-out: all 33 published quick notes are past `expiresAt`, so `/quick-note/` currently renders an empty shell.

**Analytics coverage** (`b7d2dd3`)
`initV5Analytics()` was called from 13 components and no layout, so `data-evt` markup anywhere else recorded nothing. Verified on the deployed build: `/about/` ships three `data-evt` attributes and loads eight bundles, none containing the listener. Now on 786 of 963 pages; of the 177 without it, 169 are redirect stubs and the other 8 carry no `data-evt` at all.

**Reference integrity** (`5c1a533`)
16 broken `relatedVenues` refs reached readers. Two were name drift; 13 across 4 slugs were entries in `experiences` filed under `relatedVenues`, so they could never resolve. Recorded in `ops/notes/cross-collection-refs-2026-07-25.md` rather than dropped silently, since they belong in `relatedExperiences`.

**Venue page** (`d9a1b3a`)
The schema had no `visiting` key, so Zod stripped structured hours from 28 files and `hoursNote` was populated on 0 of 139 venues. Adds `visiting`, `restaurant` and `editorVerdict`, derived from the data. Venue pages now show hours (25 venues), the `lastVerified` month, and a claim link, which previously had no discovery path from any of the 248 venue pages. Removes the `import.meta.glob` workaround in `wine/index.astro`.

## Two things worth a human eye before merge

**This un-hides authored copy that has never been published.** The schema fix means 21 venues gain an editor verdict, 14 wineries a restaurant section, and 28 a visiting section. It is all pre-existing authored content, but it has never been on the site. Worth spot-checking a few pages.

**A dormant invalid-schema bug became reachable and is fixed here.** `buildWinerySchema` emitted a `Review` with no `reviewRating`, which Google flags as invalid. It never fired because `editorVerdict` was being stripped; adding the field would have switched it on for 21 wineries. Removed rather than given an invented rating, since Peninsula Insider does not score venues. The verdict still reaches search engines via `description`. Built output confirms zero `Review` nodes.

## Notes

- `lint:nav-budget` is now in the build chain and passes at 53/55 header choices. Drawer items sit at exactly 14/14, so any drawer addition will fail the build.
- `lint:editorial-quality` is added as a standalone script only. It exits 1 on three pre-existing house-style violations unrelated to this work, and adding it to the chain would break the daily content engine, which pushes straight to `main`.
- `content-freshness.yml` uses `PAT_CONTENT_PUSH` with a `github.token` fallback. On the fallback the commit will not trigger `build-and-deploy`.
- `media-registry.json` was deliberately left out: it regenerates on every build and only its timestamps changed here.

## Not in this PR

Nothing from the field-work half of the plan, which is the critical path: launch scope, venue re-verification, byline and disclosure policy, photography. Those need decisions or time in the field, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHL1P5qacwGQXHsc5Lyf5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHL1P5qacwGQXHsc5Lyf5i)_