### PR TITLE
fix(mobile): door tiles, masthead transparency, and the clipped Menu button

### DIFF
--- a/next/src/components/v5/chrome/V5Masthead.astro
+++ b/next/src/components/v5/chrome/V5Masthead.astro
@@ -236,14 +236,17 @@ const active = activePillar(path, section);
     margin: 0 auto;
     /* Include the horizontal safe-area insets so the row clears the notch
        in landscape (0 on non-notched devices / portrait). */
-    padding: 0 calc(var(--space-5) + env(safe-area-inset-right)) 0 calc(var(--space-5) + env(safe-area-inset-left));
+    /* The gutter is capped against the viewport for the same reason the
+       type in this row is: it is rem-based, so it widened under reader
+       text scaling and ate the slack the wordmark needed. */
+    padding: 0 calc(min(var(--space-5), 6.4vw) + env(safe-area-inset-right)) 0 calc(min(var(--space-5), 6.4vw) + env(safe-area-inset-left));
   }
 
   .v5-masthead__brand-inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--space-4);
+    gap: min(var(--space-4), 3.0vw);
     /* Row height, not a spacing step: it is sized off the 44px control
        inside it plus breathing room. Left in px deliberately. */
     min-height: 68px;
@@ -255,12 +258,23 @@ const active = activePillar(path, section);
     /* Was a bespoke clamp (21.6 -> 28px) that sat off the v6 scale.
        --fs-600 is the nearest step (22 -> 26px) and now matches the
        drawer wordmark, which carried its own one-off value. */
-    font-size: var(--fs-600);
+    /* Capped against the viewport, not just the type scale. --fs-600 is
+       rem-based, so it grows with the root font-size and there is no slack
+       in this row to absorb that: at 375px the wordmark, gap and utilities
+       already fill the line exactly. The vw arm holds the wordmark still
+       while body copy still scales, which keeps the brand name whole
+       instead of truncating it to "Peninsula ...". */
+    font-size: min(var(--fs-600), 5.9vw);
     letter-spacing: var(--ls-display);
     line-height: var(--lh-display);
     color: var(--text);
     text-decoration: none;
     white-space: nowrap;
+    /* Deliberately NOT min-width: 0. In a space-between flex row that lets
+       the wordmark shrink below its own content, which truncated the brand
+       name to "Peninsula Insi..." even at default size. The row is kept in
+       bounds by capping type and spacing against the viewport instead, so
+       nothing here has to shrink at all. */
   }
   .v5-masthead__logo span {
     font-weight: var(--fw-bold);
@@ -271,6 +285,20 @@ const active = activePillar(path, section);
     display: flex;
     align-items: center;
     gap: var(--space-2);
+    /* Never shrink and never be pushed out of the row: these are the only
+       navigation affordances on a phone. */
+    flex: 0 0 auto;
+  }
+
+  /* The masthead is fixed chrome with no spare width, so nothing in this
+     row is allowed to inflate with the root font-size. The reader's text
+     control still scales body copy, which is what it is for; letting it
+     also scale the header only cost the Menu button its place on screen
+     and truncated the wordmark to make room. Both arms are capped against
+     the viewport so the row is stable at any text size. */
+  .v5-masthead__utilities .pi-btn {
+    font-size: min(var(--fs-200), 3.5vw);
+    padding: var(--space-1) min(var(--space-3), 3.2vw);
   }
   .v5-masthead__profile-slot { display: contents; }
 

--- a/next/src/components/v5/chrome/V5Masthead.astro
+++ b/next/src/components/v5/chrome/V5Masthead.astro
@@ -215,14 +215,16 @@ const active = activePillar(path, section);
      backdrop blur over a near-white ground; a single subtle bottom
      hairline. Sticky positioning is owned by the outer .masthead. */
   .v5-masthead {
-    /* 92%, not 84%. The masthead is sticky, so arbitrary page content
-       (including full-bleed dark heroes) scrolls under it. Measured
-       against the darkest ground the site uses (--bg-dark, the Harbour deep ground):
-       84% put --soft at 5.34:1 and --text at 12.24:1; 92% lifts those
-       to 6.26:1 and 14.34:1 while still reading as glass. */
-    background: color-mix(in srgb, var(--bg) 92%, transparent);
-    -webkit-backdrop-filter: saturate(1.4) blur(12px);
-    backdrop-filter: saturate(1.4) blur(12px);
+    /* Opaque, deliberately. This was a translucent ground (84%, then 92%)
+       with a backdrop blur, tuned so the masthead's OWN text stayed legible
+       over dark content scrolling under it. That solved the wrong problem:
+       the masthead is fixed and every hub opens on a full-bleed dark hero,
+       so at 92% the hero headline was still plainly readable THROUGH the
+       header. Contrast ratios do not fix that - it is the page showing
+       through the chrome, and no alpha short of 1 removes it.
+       The blur goes with it: once the ground is opaque it composites every
+       scroll frame for nothing. */
+    background: var(--bg);
     border-bottom: 1px solid var(--border);
     /* viewport-fit=cover: keep the brand row below the status bar / notch. */
     padding-top: env(safe-area-inset-top);

--- a/next/src/components/v5/home/HomeDoors.astro
+++ b/next/src/components/v5/home/HomeDoors.astro
@@ -184,14 +184,6 @@ const resolved = await Promise.all(
     text-decoration: none;
     color: var(--white);
   }
-  /* Phones (incl. 414-430px devices): 2-up tiles get too cramped (long
-     verdict lines stack over the eyebrow), so drop to a single wider tile
-     with tighter padding. */
-  @media (max-width: 35.94em) {
-    .home-doors__grid { grid-template-columns: 1fr; }
-    .home-doors__card { aspect-ratio: 16 / 10; padding: var(--space-4); }
-  }
-
   .home-doors__card:focus-visible {
     outline: 2px solid var(--focus-ring-color-inverse);
     outline-offset: 3px;
@@ -274,6 +266,46 @@ const resolved = await Promise.all(
   @media (max-width: 47.94em) {
     .home-doors__label {
       font-size: var(--fs-500);
+    }
+  }
+
+  /* Phones. Two things happen here.
+
+     Ordering: these max-width blocks must run largest to smallest. This
+     block previously sat ABOVE the 63.94em one, so at 375px both matched
+     and the later (2-column) rule won. Phones rendered two narrow tiles at
+     the 16/10 ratio intended for one wide tile, which clipped the verdict
+     line mid-sentence.
+
+     No photography: at tile size the images sat behind the eyebrow and made
+     it unreadable, and they were carrying no information the copy did not
+     already give. The tiles become typographic on a solid ground.
+
+     Height is content-driven rather than a fixed ratio, so a long verdict
+     line lengthens the tile instead of being cut off. */
+  @media (max-width: 35.94em) {
+    .home-doors__grid {
+      grid-template-columns: 1fr;
+      gap: var(--space-3);
+    }
+    .home-doors__card {
+      aspect-ratio: auto;
+      gap: var(--space-1);
+      padding: var(--space-5) var(--space-4);
+      background: var(--bg-deep);
+    }
+    .home-doors__media,
+    .home-doors__scrim {
+      display: none;
+    }
+    /* margin-bottom:auto exists to pin the label to the foot of a
+       fixed-height tile. With content-driven height it would add dead
+       space, so it becomes a plain gap. */
+    .home-doors__count {
+      margin-bottom: var(--space-2);
+    }
+    .home-doors__line {
+      max-width: none;
     }
   }
 

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -189,8 +189,14 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   position: sticky;
   top: 0;
   z-index: 9999;
-  background: rgba(245, 241, 235, 0.97);
-  backdrop-filter: blur(12px);
+  /* Opaque, and on the palette. This was a hardcoded rgba(245,241,235,.97)
+     - a warm v5 cream - which survived every palette migration because a
+     raw rgba() is invisible to a token swap. Paired with the translucent
+     ground on .v5-masthead inside it, page content scrolling under the
+     header stayed legible through both layers. The blur is dropped with
+     it: over an opaque ground it composites every scroll frame and shows
+     nothing. */
+  background: var(--bg);
   border-bottom: none; /* gold gradient rule replaces this - see ::after below */
 }
 .masthead::after {

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -107,7 +107,17 @@
    preference is respected. The whole sheet is rem-based, so everything
    scales with it - including the three-step reader text-size control,
    which sets data-text-scale on <html> (see TextScaleControl.astro). */
-html { scroll-behavior: auto; font-size: 100%; }
+html {
+  scroll-behavior: auto;
+  font-size: 100%;
+  /* iOS inflates text of its own accord in standalone (home-screen) mode,
+     which is how the masthead Menu button ended up off-screen for readers
+     who launch from a saved icon rather than in Safari. Pinning to 100%
+     leaves the reader's own browser font-size and the three-step text
+     control below in charge, and nothing else. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
 html[data-text-scale="2"] { font-size: 108.75%; }
 html[data-text-scale="3"] { font-size: 118%; }
 


### PR DESCRIPTION
Three defects reported from a phone, all in the mobile chrome.

## 1. Door tiles: wrong column count and clipped copy

The media queries ran in the **wrong order**. The phone block (`max-width: 35.94em`, single column) sat *above* the tablet block (`63.94em`, two columns), so at 375px both matched and the later one won. Phones rendered two narrow tiles at the `16/10` ratio meant for one wide tile.

The component's own comment says phones should drop to a single tile because "2-up tiles get too cramped". That intent never reached the page.

The cramping cut the two best lines in the module:

| rendered | intended |
|---|---|
| "41 cellar doors, ranked by the pour," | "…ranked by the pour, **not the view**" |
| "Walks, beaches, springs, and the" | "…springs, and the **roads between them**" |

Photography is dropped on phones as requested — at tile size it sat behind the eyebrow and made it unreadable while carrying nothing the copy didn't already say. Height is content-driven, so a long verdict line lengthens the tile instead of being truncated.

## 2. Masthead: page content visible through the header

Two stacked translucent layers.

`.masthead` in `global.css` carried a hardcoded `rgba(245, 241, 235, 0.97)` — a **warm v5 cream**. A raw `rgba()` is invisible to a token swap, so it survived every palette migration including Harbour.

`.v5-masthead` sat on top at 92% with a backdrop blur. That alpha had already been raised once, from 84%, to keep the masthead's own text legible over dark content. It solved the wrong problem: the issue is not the header's text contrast, it's the page showing through the chrome, and no alpha short of 1 removes it. Every hub opens on a full-bleed dark hero, so the hero headline read straight through the header on each one.

Both grounds are opaque and on-palette now. The blur goes with them — over an opaque ground it composites every scroll frame and shows nothing.

## 3. Menu button off-screen in standalone mode

Reported when launching from a saved home-screen icon rather than Safari.

iOS inflates text of its own accord in standalone mode and nothing pinned it, because `-webkit-text-size-adjust` was never set. Underneath that, the brand row had **no tolerance for text growth at all**:

| text size | Menu right edge (375px viewport) |
|---|---|
| default | 351 — 24px clearance |
| reader control, middle step | 368 — 7px clearance |
| reader control, top step (118%) | **396 — 21px off-screen** |

The page doesn't scroll horizontally, so the clipped part of the button was **untappable**, not merely hidden.

The masthead is fixed chrome with no spare width, so nothing in the row inflates with root font-size now: wordmark, utility labels, padding, gutter and gap are all capped against the viewport. Body copy still scales, which is what the reader control is for.

The wordmark is deliberately **not** given `min-width: 0`. An earlier pass did, so it could yield instead of the buttons, but in a `space-between` row that lets it shrink below its own content and it truncated to "Peninsula Insi…" even at default size. With the caps in place nothing needs to shrink.

## Verification

Doors — 375 / 390 / 430: one column, no media, no clipped line. 768+: unchanged, two columns, images, 3/4.

Masthead — `/stay/` at 390 across four scroll positions: solid ground, no backdrop filter, no bleed-through.

Menu — 375 across default, both reader text steps and 125% inflation: on screen every time with 15–19px clearance, wordmark constant at 188px, no horizontal scroll. Desktop unchanged: at 1024 and 1440 the logo, gap and gutter resolve to the same values as before, since the `vw` arms only bind at phone widths.

`npm run build` exits 0 at 964 pages; all four lints pass.