### PR TITLE
fix(hero): stop the section hero overflowing the viewport on phones

### DIFF
--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -775,6 +775,13 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 }
 .section-hero__visual {
   position: relative;
+  /* width:100% is load-bearing. With no width set, aspect-ratio and
+     min-height together resolve the box from its HEIGHT: at the mobile
+     16/9 override that made the width 220 * 16/9 = 391px inside a 343px
+     grid track, so the journal hero ran 32px past the viewport and was
+     clipped by the body's overflow-x. Sizing from the container instead
+     makes the ratio describe the height, which is the intent. */
+  width: 100%;
   border-radius: var(--radius-m);
   overflow: hidden;
   aspect-ratio: 4 / 3;


### PR DESCRIPTION
The Journal hero image was cut off at the right edge on mobile.

## Root cause

`.section-hero__visual` sets `aspect-ratio` and `min-height` but **no width**. With no width constraint the browser resolves the box from its *height*:

```
mobile override:  aspect-ratio: 16 / 9
base rule:        min-height: 220px
                  220 × 16 / 9 = 391.11px
```

391px inside a 343px grid track — 32px past a 375px viewport. Since the body sets `overflow-x: hidden` it clipped rather than scrolled, which is why it read as a chopped image rather than a scrollable one.

The base `4/3` ratio gives 293px and fits, so only phones showed it.

`width: 100%` makes the box size from its container, so the aspect-ratio describes the height — which was the intent.

## Swept the other hubs while confirming

| page | overflowing elements at 375px | verdict |
|---|---|---|
| `/journal/` | 0 | fixed |
| `/eat/` | 3 | filter chips, inside a scroller |
| `/wine/` | 4 | filter chips, inside a scroller |
| `/explore/` | 25 cards | card shelf, inside a scroller |
| `/stay/`, `/whats-on/` | 0 | clean |

Everything remaining is inside a horizontal scroller and *meant* to extend past the viewport. No page has document-level horizontal scroll (`scrollWidth === clientWidth` throughout). This hero was the only genuine clip.

## Verification

Journal hero measures **343×220 at 375px** and **437×328 at 1440px**, with zero overflowing elements at either width. `npm run build` exits 0 at 964 pages; lints pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9vsVtarRqLg1ugjohpZwV)_