### PR TITLE
fix(mobile): map place sheet, expand control, and nested focus rings

### DIFF
--- a/next/src/components/v5/MapView.astro
+++ b/next/src/components/v5/MapView.astro
@@ -604,8 +604,12 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
     position: absolute;
     top: 0;
     left: 0;
-    right: 0;
-    height: 28px;
+    /* Clear of the 48px close button in the top-right corner. */
+    right: 56px;
+    /* 44px, not 28px. The visible grip stays a 4px bar; the button around
+       it has to be a real touch target or the sheet reads as unresponsive
+       because the tap simply misses. */
+    height: 44px;
     background: none;
     border: none;
     cursor: grab;
@@ -773,7 +777,8 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
       border-left: none;
       border-right: none;
       border-bottom: none;
-      padding-top: var(--space-6, 2rem);
+      /* 44px: the handle owns this strip, so content starts below it. */
+      padding-top: 2.75rem;
       padding-bottom: var(--space-4, 1rem);
       overflow-y: auto;
       overscroll-behavior: contain;
@@ -782,6 +787,25 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
     }
     .v5-mapview__peek--expanded {
       max-height: 82dvh;
+    }
+    /* Collapsed, the verdict is clamped so the expand control has something
+       to reveal. Without this the sheet already showed everything and
+       tapping the handle changed nothing visible, which reads as broken. */
+    .v5-mapview__peek .v5-mapview__peek-verdict {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      overflow: hidden;
+    }
+    .v5-mapview__peek--expanded .v5-mapview__peek-verdict {
+      -webkit-line-clamp: unset;
+      line-clamp: unset;
+      overflow: visible;
+    }
+    /* Genuinely nothing folded away: no control rather than a dead one. */
+    .v5-mapview__peek--nofold .v5-mapview__peek-handle {
+      display: none;
     }
     .v5-mapview__peek-handle {
       display: block;
@@ -1064,6 +1088,14 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
       /* The sheet scrolls, so a retained scrollTop from the previous place
          left the meta line clipped under the top padding. */
       peek.scrollTop = 0;
+      /* Hide the expand control when the verdict is not actually clamped,
+         so the handle never sits there doing nothing. Measured after paint
+         because the text has only just been written. */
+      requestAnimationFrame(() => {
+        const v = peek.querySelector<HTMLElement>('[data-peek-verdict]');
+        const folded = !!v && v.scrollHeight > v.clientHeight + 1;
+        peek.classList.toggle('v5-mapview__peek--nofold', !folded);
+      });
       items.forEach((x) => x.row.removeAttribute('data-selected'));
       it.row.setAttribute('data-selected', 'true');
       if (mapReady && cluster && it.marker) {

--- a/next/src/components/v5/MapView.astro
+++ b/next/src/components/v5/MapView.astro
@@ -755,21 +755,33 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
       top: auto;
       left: 0;
       right: 0;
-      bottom: 0;
+      /* Sit above V5BottomBar, which is fixed at bottom 0, 56px tall plus a
+         1px top border, at z-index 10000. The sheet is z-index 1200, so at
+         bottom: 0 its lowest 57px were painted UNDER the tab bar - which is
+         exactly where the View / Save / + Trip row lands, making the primary
+         actions unreachable rather than merely hidden. */
+      bottom: calc(57px + env(safe-area-inset-bottom));
       width: 100%;
-      height: 40dvh;
+      /* Content-driven, not a fixed 40dvh. The old fixed height did both
+         halves of the bug: too short for the content when collapsed, so the
+         actions fell into the covered zone, and at 90dvh expanded it left a
+         large dead region below a short card. Sizing to content and capping
+         means the sheet is only ever as tall as it needs to be. */
+      height: auto;
+      max-height: 46dvh;
       border-radius: var(--radius-m, 10px) var(--radius-m, 10px) 0 0;
       border-left: none;
       border-right: none;
       border-bottom: none;
       padding-top: var(--space-6, 2rem);
-      padding-bottom: calc(var(--space-3, 0.75rem) + env(safe-area-inset-bottom));
+      padding-bottom: var(--space-4, 1rem);
       overflow-y: auto;
+      overscroll-behavior: contain;
       z-index: 1200;
-      transition: height 0.25s var(--ease);
+      transition: max-height 0.25s var(--ease);
     }
     .v5-mapview__peek--expanded {
-      height: 90dvh;
+      max-height: 82dvh;
     }
     .v5-mapview__peek-handle {
       display: block;
@@ -1049,6 +1061,9 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
       peek.classList.remove('v5-mapview__peek--expanded');
       peek.querySelector('[data-peek-expand]')?.setAttribute('aria-expanded', 'false');
       peek.removeAttribute('hidden');
+      /* The sheet scrolls, so a retained scrollTop from the previous place
+         left the meta line clipped under the top padding. */
+      peek.scrollTop = 0;
       items.forEach((x) => x.row.removeAttribute('data-selected'));
       it.row.setAttribute('data-selected', 'true');
       if (mapReady && cluster && it.marker) {
@@ -1118,6 +1133,7 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
       if (!peek) return;
       const expanded = peek.classList.toggle('v5-mapview__peek--expanded');
       expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      if (!expanded) peek.scrollTop = 0;
     });
 
     // Swipe on the sheet handle: up expands, down collapses then closes.

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -4467,6 +4467,12 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   background: rgba(255, 255, 255, 0.12);
   border-color: rgba(185, 238, 225, 0.6);
 }
+/* The field wrapper carries the focus indicator (3.86:1 against its own
+   focused ground), so the global :focus-visible ring on the input inside
+   it only added a second nested box. */
+.insider-stripe__form .newsletter__field:focus-within .newsletter__input:focus-visible {
+  outline: none;
+}
 .insider-stripe__form .newsletter__input {
   flex: 1;
   padding: 1rem 1.15rem;

--- a/next/src/styles/search.css
+++ b/next/src/styles/search.css
@@ -151,7 +151,15 @@
 }
 .site-search-overlay__form:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(7, 158, 165, 0.18);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+/* The wrapper above IS the focus indicator: an accent border at 8.30:1 on
+   white plus a 3px ring. The global :focus-visible:focus-visible rule was
+   then drawing a SECOND outline around the input inside it, which is the
+   box-within-a-box. Suppressed here at (0,3,0) so it beats that (0,2,0)
+   rule. The input keeps a compliant indicator via the wrapper. */
+.site-search-overlay__form:focus-within .site-search-overlay__input:focus-visible {
+  outline: none;
 }
 .site-search-overlay__icon {
   display: inline-flex;
@@ -326,7 +334,11 @@ body.search-open { overflow: hidden; }
 }
 .search-page-v2__bar:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 4px rgba(7, 158, 165, 0.16);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+/* Same nested-indicator suppression as the overlay field above. */
+.search-page-v2__bar:focus-within .search-page-v2__input:focus-visible {
+  outline: none;
 }
 .search-page-v2__bar-icon {
   display: inline-flex;


### PR DESCRIPTION
Three defects reported from a phone.

## 1. The sheet hid its own actions behind the tab bar

| | position | height | z-index |
|---|---|---|---|
| peek sheet | `fixed`, `bottom: 0` | 40dvh = 325px | **1200** |
| `V5BottomBar` | `fixed`, `bottom: 0` | 56px + 1px | **10000** |

The lowest 57px painted **underneath** the tab bar — exactly where **View / Save / + Trip** sits. Not clipped, **unreachable**: visible, but the tap target behind a higher-stacked element.

Height was also fixed at `40dvh` / `90dvh`, wrong in both directions — too short collapsed (pushing the actions into the covered zone), and a large dead region expanded above a card needing ~260px. Now content-driven with a cap: `46dvh` / `82dvh`.

Also resets `scrollTop` on open and collapse. The sheet is `overflow-y: auto`, and a retained scroll position from the previously selected place left the meta line clipped under the top padding.

## 2. The slide-up handle did nothing

Two reasons.

It was a **28px tap target**, below the 44px minimum, with only a 4px visible grip inside it. Taps missed. Now 44px, inset on the right to stay clear of the 48px close button.

More fundamentally it had **nothing to reveal**. The verdict was never clamped, so the collapsed sheet already showed the whole card. Fix (1) made that strictly worse: with content-driven height, expanding a card that already fits is a true no-op.

The verdict now clamps to two lines collapsed and unclamps expanded, so the control has a real function — measured, the sheet goes **224 → 273px** and the verdict **49 → 99px**. Where a verdict genuinely fits in two lines there is still nothing to fold, so the handle **hides itself** rather than sitting there dead.

## 3. Search overlay drew a box inside a box

`.site-search-overlay__form` already carries the focus indicator via `:focus-within` — accent border at **8.30:1** plus a 3px ring. The global `:focus-visible:focus-visible` rule then drew a **second** outline around the input inside it.

That rule is deliberately doubled to (0,2,0) so it outranks stray `outline: none` suppressions, which is why the input's own suppression lost. Now suppressed at (0,3,0), scoped to inputs whose wrapper carries the indicator, so the global rule keeps protecting every other control.

Same pattern fixed on the search page bar and the newsletter field. Each wrapper indicator was checked rather than assumed: **8.30:1**, **8.30:1**, **3.86:1** — all clear 3:1, so every field keeps a compliant indicator, just one instead of two.

Also retargets two more hardcoded `rgba(7, 158, 165, …)` glows — the old v6 teal — onto the accent. Same class of leak as the warm cream found in the masthead: a raw `rgba()` is invisible to a token swap, so these survived the move to Harbour and glowed teal on a blue palette.

## Verification

Measured at 375×812 across twelve places: sheet clears the tab bar in both states, meta inside bounds, all twelve verdicts foldable with the handle shown, and the hide branch exercised directly with a one-line verdict (handle resolves to `display: none`). Search overlay verified with the input focused and matching `:focus-visible`.

All map changes sit inside the `max-width: 879px` block, so desktop is untouched. `npm run build` exits 0 at 964 pages.