### PR TITLE
fix(mobile): trip stop rows overflowed the gutter and clipped Remove

### DIFF
--- a/next/src/pages/me/trip.astro
+++ b/next/src/pages/me/trip.astro
@@ -929,6 +929,12 @@ export const prerender = true;
     gap: var(--space-5, 1.5rem);
   }
 
+  /* Grid items default to min-width: auto, so day groups and stop rows refuse
+     to shrink below their content width and overflow the page gutters. */
+  .trip-page .trip-day {
+    min-width: 0;
+  }
+
   .trip-page .trip-day__head {
     display: flex;
     align-items: baseline;
@@ -978,6 +984,7 @@ export const prerender = true;
     align-items: center;
     gap: var(--space-3, 0.75rem);
     padding: var(--space-3, 0.75rem);
+    min-width: 0;
     background: var(--bg, #fff);
     border: 1px solid var(--border);
     border-radius: var(--radius-m, 10px);
@@ -1152,6 +1159,19 @@ export const prerender = true;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  /* Below this width the media tile, title and both 48px targets cannot share a
+     single line without crushing the title, so the actions take their own row. */
+  @media (max-width: 32.49em) {
+    .trip-page .trip-stop {
+      flex-wrap: wrap;
+    }
+
+    .trip-page .trip-stop__actions {
+      flex: 1 0 100%;
+      justify-content: flex-end;
+    }
   }
 
   @media print {


### PR DESCRIPTION
Reported from a phone: on `/me/trip/` the **Move** button sat half off-screen and **Remove** was cut off entirely.

## Root cause

`.trip-list` and `.trip-day__list` are both `display: grid`. Grid items default to `min-width: auto`, so neither the day group nor the stop row would shrink below its own content width.

| element | width | right edge | container right edge |
|---|---|---|---|
| `.trip-list` | 327 | 351 | 351 |
| `.trip-day` | **371** | **395** | 351 |
| `.trip-stop` | **371** | **395** | 351 |
| `.trip-stop__actions` | 140 | **382** | 351 |

44px past its own parent at a 375px viewport. The body sets `overflow-x: hidden`, so it clipped rather than scrolled, which is why Remove was not merely off-screen but **untappable**.

Adding `min-width: 0` stops the overflow but is not on its own a fix: the row then honours the container by crushing the title instead, down to ~75px and a five-line wrap. The 64px media tile, the title and two 48px targets genuinely do not fit on one line at phone widths.

So below `32.49em` the actions take their own right-aligned row. The media tile and title stay side by side above it, which keeps the desktop rhythm rather than stacking everything.

## Choosing the breakpoint

Not the site's usual `35.94em` phone breakpoint. The threshold was picked from where the title stops having room:

| viewport | title width, single row | title lines |
|---|---|---|
| 375 | 75 | 5 |
| 480 | 178 | 3 |
| **520** | **220** | 2 |
| 600 | 298 | 2 |

520px (`32.49em`) is where a two-line title fits, so that is where the wrap ends. Worth flagging as a judgement call: matching `35.94em` for consistency is a one-value change.

## Verification

Measured across eight widths, checking every element against the viewport:

| width | row / container | actions right edge | overflowing elements |
|---|---|---|---|
| 320 | 272 / 272 | 283 (in) | 0 |
| 375 | 327 / 327 | 338 (in) | 0 |
| 390 | 342 / 342 | 353 (in) | 0 |
| 414 | 366 / 366 | 377 (in) | 0 |
| 480 | 432 / 432 | 443 (in) | 0 |
| 600 | 552 / 552 | 563 (in) | 0 |
| 768 | 720 / 720 | 731 (in) | 0 |
| 1440 | 852 / 852 | 1133 (in) | 0 |

Both 48px targets fully visible at every width, and `scrollWidth === clientWidth` throughout.

600px and above are unchanged: the single-row layout measures identically child by child, since the two `min-width: 0` additions are non-binding once the content fits. Desktop screenshot confirms no visual change.

Card height at 375 also drops **228px to 152px**, the title now getting 225px and two lines instead of 75px and five.

`npm run build` exits 0 at 931 pages; lints and the CSS budget check pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9vsVtarRqLg1ugjohpZwV)_