### PR TITLE
fix(filters): dead chips on Explore, and a filter sheet offering the whole taxonomy

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build",
-    "build:search": "npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npx pagefind --site dist",
+    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npm run lint:filter-chips",
+    "build:search": "npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npm run lint:filter-chips && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
@@ -33,7 +33,8 @@
     "lint:house-style": "node scripts/lint-house-style.mjs",
     "lint:content-caps": "node scripts/lint-content-caps.mjs",
     "lint:content-caps:strict": "node scripts/lint-content-caps.mjs --strict",
-    "lint:editorial-quality": "python3 ../ops/scripts/editorial-quality-check.py"
+    "lint:editorial-quality": "python3 ../ops/scripts/editorial-quality-check.py",
+    "lint:filter-chips": "node scripts/lint-filter-chips.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/next/scripts/lint-filter-chips.mjs
+++ b/next/scripts/lint-filter-chips.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * lint-filter-chips - fails the build when a filter chip cannot match anything.
+ *
+ * FilterBar renders its chips from CHIP_PRESETS[surface] in lib/facets.ts.
+ * That list is authored by hand; the items it filters come from content. When
+ * the two drift, the chip still renders, still highlights when tapped, still
+ * writes its param to the URL, and returns zero results every time. Nothing
+ * else in the pipeline notices: the build passes, the page is valid HTML, and
+ * the failure only shows up when someone taps it.
+ *
+ * That is how /explore/ shipped Markets and Springs & spa chips against a
+ * directory containing no market and no spa. Both had content; it lived in a
+ * collection the page did not read.
+ *
+ * This runs on the built output rather than on source so it checks what
+ * actually shipped, and needs no map of which page reads which collection.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const DIST = new URL('../dist/', import.meta.url).pathname;
+
+function htmlFiles(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) htmlFiles(full, out);
+    else if (name.endsWith('.html')) out.push(full);
+  }
+  return out;
+}
+
+/** Decode the numeric and named entities Astro emits inside attributes. */
+function decodeAttr(value) {
+  return value
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function attr(tag, name) {
+  const m = tag.match(new RegExp(`\\s${name}="([^"]*)"`));
+  return m ? decodeAttr(m[1]) : null;
+}
+
+let pagesChecked = 0;
+const failures = [];
+
+for (const file of htmlFiles(DIST)) {
+  const html = readFileSync(file, 'utf8');
+  if (!html.includes('data-filter-chip')) continue;
+  pagesChecked += 1;
+
+  // Every value present on the page, per facet key.
+  const available = new Map();
+  for (const m of html.matchAll(/\sdata-facets="([^"]*)"/g)) {
+    let facets;
+    try {
+      facets = JSON.parse(decodeAttr(m[1]));
+    } catch {
+      continue;
+    }
+    if (!facets || typeof facets !== 'object') continue;
+    for (const [key, values] of Object.entries(facets)) {
+      if (!Array.isArray(values)) continue;
+      if (!available.has(key)) available.set(key, new Set());
+      for (const v of values) available.get(key).add(v);
+    }
+  }
+
+  for (const m of html.matchAll(/<button[^>]*\sdata-filter-chip[^>]*>/g)) {
+    const tag = m[0];
+    const key = attr(tag, 'data-key');
+    const value = attr(tag, 'data-value');
+    if (!key || !value) continue;
+    if (available.get(key)?.has(value)) continue;
+    failures.push({
+      page: '/' + relative(DIST, file).replace(/index\.html$/, ''),
+      key,
+      value,
+      items: [...available.values()].reduce((n, s) => n + (s.size ? 1 : 0), 0),
+    });
+  }
+}
+
+if (failures.length) {
+  console.error(`\nlint-filter-chips: ${failures.length} chip(s) match nothing on their own page.\n`);
+  for (const f of failures) {
+    console.error(`  ${f.page}  ${f.key}=${f.value}`);
+  }
+  console.error(
+    '\nEither the page is not sourcing that content, or the chip should be ' +
+      'removed from CHIP_PRESETS in src/lib/facets.ts. A chip that always ' +
+      'returns zero results is a dead control.\n',
+  );
+  process.exit(1);
+}
+
+console.log(`lint-filter-chips: OK (${pagesChecked} filterable page(s), no dead chips).`);

--- a/next/src/components/v5/FilterSheet.astro
+++ b/next/src/components/v5/FilterSheet.astro
@@ -270,6 +270,7 @@ const groups = facets
     toggleValue,
     commit,
     countMatches,
+    getAvailableValues,
     isEmptyState,
     type FilterState,
     type FilterKey,
@@ -288,6 +289,27 @@ const groups = facets
     let staged: FilterState = {};
     let invoker: HTMLElement | null = null;
     let open = false;
+
+    /**
+     * Drop options this page cannot satisfy. The sheet markup is the whole
+     * shared taxonomy; only some of it applies to any one surface. An option
+     * that can only ever return zero results is not a filter, it is a dead
+     * control, so it is removed rather than shown disabled. A group left with
+     * nothing goes too.
+     */
+    function pruneToAvailable() {
+      const available = getAvailableValues();
+      sheet.querySelectorAll<HTMLElement>('[data-sheet-option]').forEach((btn) => {
+        const key = btn.dataset.key as FilterKey;
+        const value = btn.dataset.value || '';
+        const live = !!available[key] && available[key].has(value);
+        btn.toggleAttribute('hidden', !live);
+      });
+      sheet.querySelectorAll<HTMLElement>('.v5-sheet__group').forEach((group) => {
+        const anyLive = !!group.querySelector('[data-sheet-option]:not([hidden])');
+        group.toggleAttribute('hidden', !anyLive);
+      });
+    }
 
     function paintOptions() {
       sheet.querySelectorAll<HTMLButtonElement>('[data-sheet-option]').forEach((btn) => {
@@ -308,6 +330,8 @@ const groups = facets
       open = true;
       invoker = from;
       staged = getState();
+      // Recomputed per open: the vocabulary follows whatever is on the page.
+      pruneToAvailable();
       paintOptions();
       paintCount();
       sheet.removeAttribute('hidden');

--- a/next/src/lib/v5-filter-state.ts
+++ b/next/src/lib/v5-filter-state.ts
@@ -217,6 +217,30 @@ export function countMatches(state: FilterState, root?: ParentNode): number {
   );
 }
 
+/**
+ * Every facet value actually present on this page, per key.
+ *
+ * The shared FilterSheet renders the whole global taxonomy because it has no
+ * knowledge of the surface it sits on. Without this, roughly two thirds of the
+ * options on any given page match nothing: /wine/ offered Sorrento and Portsea
+ * with no cellar door in either, /stay/ offered "Restaurant", and every
+ * surface offered every date scope. Deriving the vocabulary from the rendered
+ * items keeps the sheet honest as content changes, with no per-page config to
+ * fall out of date.
+ */
+export function getAvailableValues(root?: ParentNode): Record<FilterKey, Set<string>> {
+  const out = {} as Record<FilterKey, Set<string>>;
+  for (const key of FILTER_KEYS) out[key] = new Set<string>();
+  if (!hasDom()) return out;
+  for (const item of collectItems(root || document)) {
+    for (const key of FILTER_KEYS) {
+      const values = item.facets[key];
+      if (values) for (const v of values) out[key].add(v);
+    }
+  }
+  return out;
+}
+
 let announceTimer: ReturnType<typeof setTimeout> | undefined;
 
 /** Politely announce to the shared #pi-results-status live region. */

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -25,7 +25,7 @@ import FilterBar from '../../components/v5/FilterBar.astro';
 import EmptyState from '../../components/v5/EmptyState.astro';
 import { getFacets, type FacetKey } from '../../lib/facets';
 import { resolveHero } from '../../lib/inline-edit/resolve-hero';
-import { routeSlug, currentSeason, seasonBlurb, placeLabel, titleize } from '../../lib/editorial';
+import { routeSlug, currentSeason, seasonBlurb, placeLabel, titleize, venueHrefPrefix } from '../../lib/editorial';
 import { buildCollectionPageSchema, buildFaqSchema, buildBreadcrumbSchema } from '../../lib/schema';
 
 // ── Copy helpers ──────────────────────────────────────────────────────────────
@@ -58,6 +58,7 @@ const TYPE_LABEL: Record<string, string> = {
   park: 'Park',
   tour: 'Tour',
   market: 'Market',
+  spa: 'Springs & spa',
   wellness: 'Wellness',
 };
 
@@ -93,6 +94,39 @@ const rows: Row[] = experiences.map((e) => {
   };
 });
 
+// Markets and day spas are Explore subjects whose records live in the venues
+// collection, so their detail pages route to /eat/ and /stay/ via
+// venueHrefPrefix. The directory is the one place every Explore subject is
+// listed, and CHIP_PRESETS.explore offers Markets and Springs & spa chips, so
+// sourcing them here is what makes those two chips match anything at all.
+const EXPLORE_VENUE_TYPES = ['market', 'spa'];
+const exploreVenues = (await getCollection('venues')).filter((v) =>
+  EXPLORE_VENUE_TYPES.includes(v.data.type),
+);
+
+const venueRows: Row[] = exploreVenues.map((v) => {
+  const slug = routeSlug(v);
+  return {
+    slug,
+    name: v.data.name,
+    href: `${venueHrefPrefix(v.data.type)}/${slug}/`,
+    facets: getFacets('venue', v.data),
+    verdict: clipLine(v.data.signature ?? v.data.whyWeGo ?? v.data.editorNote, 25),
+    meta: [
+      TYPE_LABEL[v.data.type] ?? titleize(v.data.type ?? ''),
+      placeLabel(v.data.place),
+    ].filter((m): m is string => Boolean(m)).slice(0, 3),
+    data: v.data,
+  };
+});
+
+// Shelves stay experience-only, keeping the "at most one shelf plus one
+// directory row" rule. The directory carries the whole Explore corpus, so
+// every count and every filter result is drawn from this list.
+const directoryRows: Row[] = [...rows, ...venueRows].sort((a, b) =>
+  a.name.localeCompare(b.name),
+);
+
 const season = currentSeason();
 const blurb = seasonBlurb[season];
 
@@ -103,7 +137,10 @@ const matches = (r: Row, preset: FilterPreset) =>
   Object.entries(preset).every(([key, vals]) =>
     (r.facets[key as FacetKey] ?? []).some((v) => (vals as string[]).includes(v)),
   );
-const countLive = (preset: FilterPreset) => rows.filter((r) => matches(r, preset)).length;
+// Counted over the directory, not the shelf pool: "All N" has to equal what
+// the filter will actually show once applied.
+const countLive = (preset: FilterPreset) =>
+  directoryRows.filter((r) => matches(r, preset)).length;
 
 // Shelf assembly: an experience appears in at most ONE shelf (plus its single
 // directory row), enforcing the corpus <=2x-per-entry acceptance (spec 30).
@@ -423,20 +460,20 @@ export const prerender = true;
   <section class="x-directory" id="directory" aria-labelledby="directory-heading">
     <div class="container">
       <p class="x-eyebrow">The full list</p>
-      <h2 class="x-directory__heading" id="directory-heading">All {rows.length} experiences</h2>
+      <h2 class="x-directory__heading" id="directory-heading">All {directoryRows.length} experiences</h2>
       <p class="x-directory__intro">
-        One list, one render: every walk, beach, course, gallery, and lookout we cover.
-        Narrow it from the filter bar above.
+        One list, one render: every walk, beach, course, gallery, lookout, market, and
+        day spa we cover. Narrow it from the filter bar above.
       </p>
-      <CardGrid label={`All ${rows.length} experiences`} layout="rows">
-        {rows.map((r, i) => (
+      <CardGrid label={`All ${directoryRows.length} experiences`} layout="rows">
+        {directoryRows.map((r, i) => (
           <li data-facets={JSON.stringify(r.facets)} data-title={r.name} class="x-directory__row">
             <Card
               as="div"
               variant="compact-row"
               title={r.name}
               href={r.href}
-              entityType="experience"
+              entityType={EXPLORE_VENUE_TYPES.includes(r.data.type) ? 'venue' : 'experience'}
               entitySlug={r.slug}
               verdict={r.verdict}
               meta={r.meta}

--- a/next/src/pages/explore/markets.astro
+++ b/next/src/pages/explore/markets.astro
@@ -11,7 +11,7 @@ import {
   buildFaqSchema,
   buildBreadcrumbSchema,
 } from '../../lib/schema';
-import { routeSlug } from '../../lib/editorial';
+import { routeSlug, titleize } from '../../lib/editorial';
 import { resolveHero } from '../../lib/inline-edit/resolve-hero';
 import { editableImage } from '../../lib/inline-edit/attrs';
 
@@ -45,27 +45,49 @@ const heroPlaceRedHill = await resolvePlaceHero('red-hill', '/images/sourced/pla
 const heroPlaceBalnarring = await resolvePlaceHero('balnarring', '/images/sourced/place-balnarring-01.webp');
 
 // ── Load markets in editorial order ───────────────────────────────────────────
-const allExperiences = await getCollection('experiences');
-const marketOrder = [
-  'red-hill-market',
-  'balnarring-farmers-market',
-  'mornington-main-street-market',
-  'rye-beachside-market',
-  'mount-eliza-farmers-market',
+// Markets are records in the venues collection, not experiences. This page
+// used to read them from experiences, which matched nothing, so the guide
+// rendered with no market cards and no link to a single market page.
+//
+// The Explore route slug and the venue slug differ for Balnarring, so the
+// pairing is stated rather than inferred from either name.
+const MARKET_ROUTES: { route: string; venue: string }[] = [
+  { route: 'red-hill-market', venue: 'red-hill-market' },
+  { route: 'balnarring-farmers-market', venue: 'balnarring-market' },
+  { route: 'mornington-main-street-market', venue: 'mornington-main-street-market' },
+  { route: 'rye-beachside-market', venue: 'rye-beachside-market' },
+  { route: 'mount-eliza-farmers-market', venue: 'mount-eliza-farmers-market' },
 ];
-const allMarkets = allExperiences.filter((e) => e.data.type === 'market');
-const markets = marketOrder
-  .map((slug) => allMarkets.find((m) => (m.data.slug ?? m.id) === slug))
-  .filter(Boolean) as typeof allMarkets;
+
+const marketVenues = await getCollection('venues', ({ data }) => data.type === 'market');
+const missingMarkets = MARKET_ROUTES.filter(
+  ({ venue }) => !marketVenues.some((v) => (v.data.slug ?? v.id) === venue),
+);
+if (missingMarkets.length) {
+  // Fail the build rather than ship a market guide with missing markets.
+  throw new Error(
+    `explore/markets: no venue record for ${missingMarkets.map((m) => m.venue).join(', ')}. ` +
+      'Update MARKET_ROUTES or restore the venue file.',
+  );
+}
+
+// Cards are keyed by Explore route slug: marketMeta, the hero map and the
+// detail href are all route-keyed. venueSlug carries the CMS identity.
+const markets = MARKET_ROUTES.map(({ route, venue }) => {
+  const entry = marketVenues.find((v) => (v.data.slug ?? v.id) === venue)!;
+  return { id: route, venueSlug: venue, data: { ...entry.data, slug: route } };
+});
 
 // Resolve CMS hero overrides for the market cards so an editor's replacement
-// (saved to experience/<slug>/heroImage) survives rebuilds instead of
-// reverting to the content file.
+// (saved to venue/<slug>/heroImage) survives rebuilds instead of reverting to
+// the content file. Keyed by route slug to match the render below.
 const marketHeroBySlug = new Map<string, Awaited<ReturnType<typeof resolveHero>>>();
 await Promise.all(
   markets.map(async (market) => {
-    const s = market.data.slug ?? market.id;
-    marketHeroBySlug.set(s, await resolveHero('experience', s, market.data));
+    marketHeroBySlug.set(
+      market.id,
+      await resolveHero('venue', market.venueSlug, market.data),
+    );
   }),
 );
 
@@ -173,13 +195,14 @@ const itemListSchema = buildItemListSchema({
   name: 'Mornington Peninsula Markets',
   description: 'Five Mornington Peninsula markets ranked by editorial value.',
   listPath: '/explore/markets',
-  items: [
-    { name: 'Red Hill Community Market', path: '/explore/red-hill-market', itemType: 'TouristAttraction', addressLocality: 'Red Hill' },
-    { name: 'Balnarring Farmers Market', path: '/explore/balnarring-farmers-market', itemType: 'TouristAttraction', addressLocality: 'Balnarring' },
-    { name: 'Mornington Main Street Market', path: '/explore/mornington-main-street-market', itemType: 'TouristAttraction', addressLocality: 'Mornington' },
-    { name: 'Rye Beachside Market', path: '/explore/rye-beachside-market', itemType: 'TouristAttraction', addressLocality: 'Rye' },
-    { name: 'Mount Eliza Farmers Market', path: '/explore/mount-eliza-farmers-market', itemType: 'TouristAttraction', addressLocality: 'Mount Eliza' },
-  ],
+  // Derived from the same records the cards render, so the names and the
+  // canonical paths cannot drift from what the page actually links to.
+  items: markets.map((m) => ({
+    name: m.data.name,
+    path: `/eat/${m.venueSlug}`,
+    itemType: 'TouristAttraction' as const,
+    addressLocality: m.data.address?.split(',')[1]?.trim() ?? titleize(String(m.data.place ?? '')),
+  })),
 });
 const faqSchema = buildFaqSchema([
   {
@@ -319,7 +342,8 @@ export const prerender = true;
           const slug = d.slug ?? market.id;
           const meta = marketMeta[slug];
           if (!meta) return null;
-          const detailHref = `/explore/${slug}/`;
+          // /explore/<slug>/ is a redirect stub; the venue page is canonical.
+          const detailHref = `/eat/${market.venueSlug}/`;
           const locality = d.address?.split(',')[1]?.trim() ?? '';
           return (
             <article class="market-card">
@@ -329,7 +353,7 @@ export const prerender = true;
                 style={marketHeroBySlug.get(slug)?.style ?? `background-image: url('${d.heroImage.src}')`}
                 role="img"
                 aria-label={marketHeroBySlug.get(slug)?.alt ?? d.heroImage.alt}
-                {...editableImage({ entityType: 'experience', entitySlug: slug, fieldPath: 'heroImage', label: `${d.name} hero`, purpose: 'hero' })}
+                {...editableImage({ entityType: 'venue', entitySlug: market.venueSlug, fieldPath: 'heroImage', label: `${d.name} hero`, purpose: 'hero' })}
               ></div>
               <div class="market-card__body">
                 <div class="market-card__badges">


### PR DESCRIPTION
Reported from a phone: the Markets chip on `/explore/` does nothing. It turned out to be one instance of a class.

## The mechanism was fine

Tapping **Markets** sets `aria-pressed="true"`, writes `?cat=market`, updates the counter to "Showing 0 of 44", and reveals the zero-state. Every moving part works. The chip filters for a value that does not exist on the page.

| `cat` values present on `/explore/` | count |
|---|---|
| beach, walk | 10 each |
| golf | 11 |
| attraction | 4 |
| gallery, tour | 3 each |
| lookout | 2 |
| park | 1 |
| **market** | **0** |
| **spa** | **0** |

Markets and day spas are records in the **venues** collection, not experiences. `/explore/` rendered only the 44 experiences, so both chips were dead controls. `TYPE_LABEL` in the page already carried `market:` and `wellness:` entries, so the intent was there; the data was never sourced.

The directory now includes the 6 market and 5 spa venues, each linked to its canonical detail page (`/eat/` and `/stay/` respectively, via `venueHrefPrefix`). Shelves stay experience-only, preserving the "at most one shelf plus one directory row" rule, and `countLive` moves to the directory so "All N" equals what the filter actually shows.

## The markets guide linked to no markets

`/explore/markets/` filtered experiences by `type === 'market'` and matched nothing, so the card loop rendered zero times. Every market name on the page was hardcoded prose. **The page contained no link to any market page at all.**

It now reads the venue records. Four follow-ons:

- The Explore route slug and venue slug differ for Balnarring (`balnarring-farmers-market` vs `balnarring-market`), so the pairing is stated rather than inferred.
- The ItemList schema was a parallel hardcoded list; it is now derived from the same records, so names and paths cannot drift from what the page links.
- Cards and schema pointed at the `/explore/:slug/` routes, which are **648-byte redirect stubs** canonicalising to `/eat/:slug/`. Both now link the canonical page directly.
- A missing venue record now **throws at build time** rather than silently rendering an empty guide.

## The sheet was the same bug at scale

`FilterSheet` renders `FACET_OPTIONS` in full because it has no knowledge of the surface it sits on. Measured against each page's actual items:

| page | options | matching nothing |
|---|---|---|
| `/eat/` | 110 | **68** |
| `/stay/` | 110 | **69** |
| `/wine/` | 110 | **72** |
| `/explore/` | 110 | **68** |

`/wine/` offered Sorrento and Portsea with no cellar door in either. `/stay/` offered "Restaurant". Every surface offered every date scope. Roughly two thirds of every filter sheet was inert.

Options are now pruned to values present in the rendered items, recomputed each time the sheet opens. Derived from the DOM rather than per-page config, so it stays correct as content changes. A group left with nothing hides too. An option that can only ever return zero is not a filter, so it is removed rather than shown disabled.

| page | options visible after |
|---|---|
| `/eat/` | 42 |
| `/stay/` | 41 |
| `/wine/` | 38 |
| `/explore/` | 49 |

## Guard

`lint:filter-chips` fails the build when a preset chip matches nothing on its own page. It reads the **built output**, not source, so it checks what actually shipped and needs no map of which page reads which collection. Run against the pre-fix build it reports exactly the two chips that were reported:

```
lint-filter-chips: 2 chip(s) match nothing on their own page.
  /explore/  cat=market
  /explore/  cat=spa
```

## Verification

Every preset chip on every filter surface, at 390px:

| page | chips | all matching |
|---|---|---|
| `/eat/` | 5 | yes (1 to 35) |
| `/stay/` | 5 | yes (6 to 41) |
| `/wine/` | 5 | yes (8 to 52) |
| `/explore/` | 6 | yes, incl. **market 6**, **spa 5** |

`/explore/` goes 44 to 55 items; `party=family` 21 to 27 and `mood=rainy-day` 2 to 4 gain from the new rows. Sheets opened on all four surfaces: **zero** dead options visible. Markets hub renders 5 cards linking to 5 canonical pages. `npm run build` exits 0 at 931 pages; house-style, no-pricing, region-images, surfaces, nav-budget and CSS budget all pass, and `astro check` reports no new errors in the touched files.