### PR TITLE
fix(whats-on): date picker rendered off-screen, and a season word that ignored the range

### DIFF
--- a/next/src/components/v5/whatson/WhatsOnScopeBar.astro
+++ b/next/src/components/v5/whatson/WhatsOnScopeBar.astro
@@ -97,6 +97,11 @@ const { weekendStartISO, weekendLabel, nextWeekendLabel, holidays, todayISO } = 
 <style>
   .wo-scope {
     margin: var(--space-4, 1rem) 0 0;
+    /* Anchor the Pick dates panel to the whole bar, not to the summary it
+       hangs off. Hung off the summary it overflowed in both directions: past
+       the left edge on phones and 138px past the right at tablet widths. The
+       bar spans the container, so a panel pinned to it cannot leave the page. */
+    position: relative;
   }
   .wo-scope__row {
     display: flex;
@@ -150,7 +155,7 @@ const { weekendStartISO, weekendLabel, nextWeekendLabel, holidays, todayISO } = 
 
   /* Pick dates disclosure */
   .wo-scope__custom {
-    position: relative;
+    position: static;
   }
   .wo-scope__btn--summary {
     list-style: none;
@@ -172,7 +177,8 @@ const { weekendStartISO, weekendLabel, nextWeekendLabel, holidays, todayISO } = 
     position: absolute;
     z-index: 30;
     top: calc(100% + var(--space-2, 0.5rem));
-    left: 0;
+    left: auto;
+    right: 0;
     display: flex;
     flex-wrap: wrap;
     align-items: flex-end;
@@ -182,7 +188,8 @@ const { weekendStartISO, weekendLabel, nextWeekendLabel, holidays, todayISO } = 
     border: 1px solid var(--border);
     border-radius: var(--radius-m, 10px);
     box-shadow: var(--elev-2);
-    min-width: min(320px, 82vw);
+    min-width: min(320px, 100%);
+    max-width: 100%;
   }
   .wo-scope__field {
     display: flex;
@@ -231,9 +238,19 @@ const { weekendStartISO, weekendLabel, nextWeekendLabel, holidays, todayISO } = 
       flex-direction: row;
       align-items: center;
     }
+    /* Phones: fill the bar and stack the submit button under the fields
+       rather than squeezing three controls onto one line. */
     .wo-scope__form {
-      left: auto;
-      right: 0;
+      left: 0;
+    }
+    .wo-scope__field {
+      flex: 1 1 9rem;
+    }
+    .wo-scope__field input {
+      width: 100%;
+    }
+    .wo-scope__apply {
+      flex: 1 0 100%;
     }
   }
 </style>

--- a/next/src/pages/whats-on/index.astro
+++ b/next/src/pages/whats-on/index.astro
@@ -147,7 +147,7 @@ const pageDescription = `What is actually worth it on the Mornington Peninsula t
       <p class="wo-head__eyebrow"><span class="wo-head__live" aria-hidden="true"></span>What's On · live now</p>
       <h1 class="wo-head__title" data-wo-heading>What's on this weekend</h1>
       <p class="wo-head__context">
-        <span data-wo-range>{weekend.label}</span> · {season} on the Peninsula
+        <span data-wo-range>{weekend.label}</span> · <span data-wo-season>{season}</span> on the Peninsula
       </p>
       <p class="wo-head__rule">We list what's worth the drive, not everything on.</p>
     </div>
@@ -325,6 +325,7 @@ const pageDescription = `What is actually worth it on the Mornington Peninsula t
   const scopeNav = document.querySelector<HTMLElement>('[data-wo-scope]');
   const headingEl = document.querySelector<HTMLElement>('[data-wo-heading]');
   const rangeEl = document.querySelector<HTMLElement>('[data-wo-range]');
+  const seasonEl = document.querySelector<HTMLElement>('[data-wo-season]');
   const statusEl = document.getElementById('pi-results-status');
   const monthBtn = document.querySelector<HTMLButtonElement>('[data-wo-month]');
   const custom = document.querySelector<HTMLDetailsElement>('[data-wo-custom]');
@@ -334,6 +335,7 @@ const pageDescription = `What is actually worth it on the Mornington Peninsula t
   if (daysEl && scopeNav && rowTpl) {
     const defaultHTML = daysEl.innerHTML;
     const defaultRange = rangeEl?.textContent ?? '';
+    const defaultSeason = seasonEl?.textContent ?? '';
     if (monthBtn) monthBtn.hidden = false;
 
     // ── date helpers (mirror _data.ts, runtime clock) ──────────────────
@@ -496,9 +498,21 @@ const pageDescription = `What is actually worth it on the Mornington Peninsula t
       history.replaceState(null, '', url.pathname + url.search + url.hash);
     };
 
-    const setHeading = (headline: string, label: string) => {
+    // The season word belongs to the range on screen, not to today. Picking
+    // the September school holidays in July left the line reading
+    // "Sat 19 September to Sun 4 October · winter on the Peninsula".
+    const auSeason = (d: Date) => {
+      const m = d.getMonth();
+      if (m === 11 || m <= 1) return 'summer';
+      if (m <= 4) return 'autumn';
+      if (m <= 7) return 'winter';
+      return 'spring';
+    };
+
+    const setHeading = (headline: string, label: string, start?: Date) => {
       if (headingEl) headingEl.textContent = headline;
       if (rangeEl) rangeEl.textContent = label;
+      if (seasonEl) seasonEl.textContent = start ? auSeason(start) : defaultSeason;
     };
 
     const applyDefault = () => {
@@ -520,7 +534,7 @@ const pageDescription = `What is actually worth it on the Mornington Peninsula t
     ) => {
       setPressed(scope);
       const label = rangeLabel(start, end);
-      setHeading(headline, label);
+      setHeading(headline, label, start);
       syncUrl(param);
       try {
         const entries = await loadFeed();


### PR DESCRIPTION
Two defects on the What's On scope bar, both visible in one screenshot.

## 1. The Pick dates panel opened off the side of the screen

`.wo-scope__form` is absolutely positioned against `.wo-scope__custom`, the Pick dates `<details>`. That control is roughly 107px wide and sits mid-row, but the panel has `min-width: min(320px, 82vw)`. On phones the mobile rule right-aligns it to that control:

| | value at 390px |
|---|---|
| Pick dates control, right edge | 269 |
| panel width | 320 |
| **panel left edge** | **-51** |

The body clips horizontally rather than scrolling, so the From field and part of **Show these dates** were not merely off-view, they were **unreachable**.

Fixing only the phone case turned up the same anchoring failing the other way at tablet widths. Base rule is `left: 0`, and in a single-row layout the control sits far right:

| width | panel | viewport | overflow |
|---|---|---|---|
| **768** | 586 to **906** | 768 | **138px past the right edge** |

One anchor, two opposite failures. The panel now anchors to `.wo-scope`, which spans the container, so it cannot leave the page in either direction. On phones it fills the bar and the submit button takes its own row rather than squeezing three controls onto one line.

## 2. The season word described today, not the range

The line is `<span data-wo-range>` followed by the season word rendered **outside** the span the client updates. Scope changes rewrote the dates and left the season alone, so in July the September school holidays read:

> Sat 19 September – Sun 4 October · **winter** on the Peninsula

The word now derives from the start of the range on screen, falling back to the server-rendered value on the default scope.

## Verification

Panel open, every element checked against the viewport:

| width | panel left | panel right | elements crossing the viewport |
|---|---|---|---|
| 320 | 16 | 304 | 0 |
| 375 | 16 | 359 | 0 |
| 390 | 16 | 374 | 0 |
| 430 | 16 | 414 | 0 |
| 600 | 24 | 576 | 0 |
| **768** | 224 | 737 | **0** (was 1) |
| 1024 | 470 | 983 | 0 |
| 1440 | 709 | 1222 | 0 |

Season word across scopes:

| scope | range | season |
|---|---|---|
| this weekend | Fri 24 to Sun 26 July | winter |
| next weekend | Fri 31 July to Sun 2 August | winter |
| school holidays | Sat 19 Sept to Sun 4 Oct | **spring** (was winter) |
| custom | Fri 8 to Sun 10 January 2027 | **summer** |
| back to default | Fri 24 to Sun 26 July | winter |

No console errors through the full scope cycle. `npm run build` exits 0 at 931 pages; house-style and the other build lints pass, and `astro check` reports no errors in either touched file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9vsVtarRqLg1ugjohpZwV)_