### PR TITLE
feat: add review-gated image intelligence pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ ops/data/
 ops/logs/
 .vercel
 .pi-autofix/
+.pi-image-intelligence/
 
 # Engine runtime files
 .claude/research/_brief_*

--- a/docs/image-intelligence-pilot-runbook.md
+++ b/docs/image-intelligence-pilot-runbook.md
@@ -1,0 +1,34 @@
+# Peninsula Insider image intelligence pilot runbook
+
+The pilot is registry-first and review-gated. It never edits `heroImage`, `cms_image_slots`, rights records, source images or reader-facing search. The migration creates only the separate `pi_image` schema and must be reviewed before it is applied.
+
+## Dry run
+
+```bash
+cd next
+npm run image-intelligence:pilot
+npm run test:image-intelligence
+```
+
+Outputs are written to `.pi-image-intelligence/` (ignored runtime detail), `reports/image-intelligence/pilot-qa.json`, `reports/image-intelligence/review-checklist.md`, the admin review-queue JSON and the approved-only image search index. The baseline dry run makes zero vision-provider calls. It estimates the worst-case per-image cost against the hard AUD $30 cap and deduplicates by canonical asset before estimating calls.
+
+## Controlled apply sequence
+
+1. Review `ops/migrations/2026-08-01-pi-image-intelligence-pilot.sql` and take a schema backup.
+2. Apply the migration in a non-production Supabase branch first; verify all eight tables, append-only decisions, immutable approved metadata and editor-only RLS. Add `pi_image` to the API's exposed schemas only if the authenticated review surface will be enabled.
+3. Run `npm run image-intelligence:pilot -- --apply`. This writes registry artefacts only; it still performs no public metadata write-back.
+4. Import registry rows with a service-role-only deployment job. Do not expose the service key to Astro/browser code.
+5. Open `/admin/image-intelligence/`; accept/edit/reject proposals. Decisions append to `review_decisions`.
+6. Only approved metadata may be exported into `image-intelligence-search-index.json`. Public CMS/content propagation requires a separate reviewed change.
+
+To run a configured provider after approval, set `PI_IMAGE_VISION_ENDPOINT`, `PI_IMAGE_SITE_BASE_URL`, optional `PI_IMAGE_VISION_TOKEN` and `PI_IMAGE_MODEL_ID`, then use `npm run image-intelligence:pilot -- --apply --provider`. The worker remains sequential and resumable by canonical asset, stops before the estimated AUD $30 cap, validates every response, and records provider failures in the dead-letter list.
+
+## Verification and rollback
+
+- Verify active-placement resolution, structured-output validity, spend, queue size, low-match placements and `publicWrites: 0` in the QA report.
+- Confirm existing image files, content frontmatter and `cms_image_slots` are unchanged.
+- Roll back application code by reverting this commit. Before the schema carries relied-upon decisions, the migration footer contains the explicit `drop schema pi_image cascade` rollback. Once decisions exist, export them and use a forward migration instead.
+
+## Provider contract
+
+A provider adapter must return only the strict proposal contract tested in `pilot-core.test.mjs`: controlled taxonomy IDs, per-field confidence, `observed` versus `contextual` evidence, factual alt-text proposal, and flags. Invalid JSON, uncontrolled IDs, confidence below 0.60, named entity claims, people/children, OCR and rights/safety flags must be held or reviewed. Provider/model/prompt/input hash, cost and latency belong in `enrichment_runs`; the AUD $30 circuit breaker is mandatory.

--- a/next/package.json
+++ b/next/package.json
@@ -34,7 +34,10 @@
     "lint:content-caps": "node scripts/lint-content-caps.mjs",
     "lint:content-caps:strict": "node scripts/lint-content-caps.mjs --strict",
     "lint:editorial-quality": "python3 ../ops/scripts/editorial-quality-check.py",
-    "lint:filter-chips": "node scripts/lint-filter-chips.mjs"
+    "lint:filter-chips": "node scripts/lint-filter-chips.mjs",
+    "image-intelligence:discover": "node scripts/image-intelligence-pilot.mjs discover",
+    "image-intelligence:pilot": "node scripts/image-intelligence-pilot.mjs pilot",
+    "test:image-intelligence": "node --test scripts/image-intelligence/pilot-core.test.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/next/public/admin/image-intelligence-review-queue.json
+++ b/next/public/admin/image-intelligence-review-queue.json
@@ -1,0 +1,5427 @@
+{
+  "generatedAt": "2026-08-01T03:14:39.939Z",
+  "items": [
+    {
+      "id": "87568b5a-0472-5cb9-a66f-9a71d0e43d74",
+      "subjectType": "asset_metadata",
+      "subjectId": "87568b5a-0472-5cb9-a66f-9a71d0e43d74",
+      "assetId": "6c0f849a-e6a4-51c2-a69e-0802ea1d7292",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Flinders Pier and Bass Strait at dusk, with the village behind",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c49f4c43-8e65-5ef3-ab33-d335de9bf78d",
+      "subjectType": "asset_metadata",
+      "subjectId": "c49f4c43-8e65-5ef3-ab33-d335de9bf78d",
+      "assetId": "2220ee88-93c1-5bee-a77a-41ba1e4986a5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Rain squall clearing over Cape Schanck bay in winter, rainbow arcing over mist-softened headland and steel-grey Bass Strait",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d9745161-7eec-5d0e-a969-279e6652a60f",
+      "subjectType": "asset_metadata",
+      "subjectId": "d9745161-7eec-5d0e-a969-279e6652a60f",
+      "assetId": "16781293-bdb9-5436-a249-be2658599266",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Dromana foreshore with calm bay water and Arthurs Seat rising behind",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c0b867b8-c462-5439-a882-4beec66088de",
+      "subjectType": "asset_metadata",
+      "subjectId": "c0b867b8-c462-5439-a882-4beec66088de",
+      "assetId": "96fe72fd-3230-548c-a9cd-7e5d6aa1ee3a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Flinders Pier reaching into blue water under a bright southern sky",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "821feb82-abda-5a1a-a435-350c12b7cfd5",
+      "subjectType": "asset_metadata",
+      "subjectId": "821feb82-abda-5a1a-a435-350c12b7cfd5",
+      "assetId": "39aa2044-b9fa-58e2-a651-bae4add9408c",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Vineyard rows and cool green farmland across Main Ridge on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "405bed47-ea82-54bd-aa5f-e8a7f301a09a",
+      "subjectType": "asset_metadata",
+      "subjectId": "405bed47-ea82-54bd-aa5f-e8a7f301a09a",
+      "assetId": "9b183b96-6141-5554-adb1-f2eb0ee6ab5e",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Vineyard landscape in Merricks under soft afternoon light",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "64b0196d-21f0-50e2-a4d3-db0a04dbb73d",
+      "subjectType": "asset_metadata",
+      "subjectId": "64b0196d-21f0-50e2-a4d3-db0a04dbb73d",
+      "assetId": "abf6c4d5-85b9-5dd5-a631-fbd0222000f4",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mornington foreshore with bathing boxes and calm bay water",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "83575d26-4d06-5cd6-a154-af16014b3111",
+      "subjectType": "asset_metadata",
+      "subjectId": "83575d26-4d06-5cd6-a154-af16014b3111",
+      "assetId": "dfd25ed6-9d90-529e-ad38-7bd0205bf953",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Calm bay water and foreshore at Portsea with boats near the jetty",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "96dea255-be79-5e3f-ad47-a5792eca76f2",
+      "subjectType": "asset_metadata",
+      "subjectId": "96dea255-be79-5e3f-ad47-a5792eca76f2",
+      "assetId": "d73a9cf4-e92d-51bf-a9d8-3b6261246477",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Rolling vineyard rows across Red Hill on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "13bfc470-c956-537e-a261-6a7a867625ab",
+      "subjectType": "asset_metadata",
+      "subjectId": "13bfc470-c956-537e-a261-6a7a867625ab",
+      "assetId": "55236a08-86a9-511b-a6b2-46314e105c10",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Limestone cliffs and calm bay water at Sorrento on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "4bf4a9af-6708-5c79-a907-c7895c84a50a",
+      "subjectType": "asset_metadata",
+      "subjectId": "4bf4a9af-6708-5c79-a907-c7895c84a50a",
+      "assetId": "4f0e7edd-fbfa-5f85-a191-8a66f55f0340",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Gondola cable car above the Mornington Peninsula hinterland at Arthurs Seat Eagle",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3c8fd60a-ef0c-5982-aae2-c98df97ecf98",
+      "subjectType": "asset_metadata",
+      "subjectId": "3c8fd60a-ef0c-5982-aae2-c98df97ecf98",
+      "assetId": "a8dd71ed-428d-5ae1-ae95-26ed348c7205",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Ashcombe Maze hedge maze, Shoreham, Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3ec03823-8baf-5b47-a73a-3b02d5659a07",
+      "subjectType": "asset_metadata",
+      "subjectId": "3ec03823-8baf-5b47-a73a-3b02d5659a07",
+      "assetId": "e55ac880-58ca-5d66-a503-9ceb3f663673",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "An autumn afternoon on the Red Hill plateau, vineyards turning gold before harvest - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "91761b39-2655-591e-afc9-3578ece8d063",
+      "subjectType": "asset_metadata",
+      "subjectId": "91761b39-2655-591e-afc9-3578ece8d063",
+      "assetId": "4b65c05c-b5a8-5686-a65d-029ca1dcb736",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Avani Syrah vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "713fd87b-04cf-5789-a924-10fc77e05f3d",
+      "subjectType": "asset_metadata",
+      "subjectId": "713fd87b-04cf-5789-a924-10fc77e05f3d",
+      "assetId": "a43bfc7f-44ab-5860-ae44-a171de757884",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Baillieu Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d47d66ca-9f14-5ad5-a3d1-d02c45f7de51",
+      "subjectType": "asset_metadata",
+      "subjectId": "d47d66ca-9f14-5ad5-a3d1-d02c45f7de51",
+      "assetId": "aa4e7760-16d9-5470-a871-3e0dd219b953",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Balnarring Vineyard / Quealy Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "99f0282b-c3db-5269-a9b9-0d4a29477fbf",
+      "subjectType": "asset_metadata",
+      "subjectId": "99f0282b-c3db-5269-a9b9-0d4a29477fbf",
+      "assetId": "5d6ff6a1-0ff6-5bcc-ae78-4d69009bc9c5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Barak Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5ee39f49-c65d-5980-ac6f-8f9ca836dd31",
+      "subjectType": "asset_metadata",
+      "subjectId": "5ee39f49-c65d-5980-ac6f-8f9ca836dd31",
+      "assetId": "7c91ff7e-147c-5525-a11f-be837ea3d610",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Barmah Park Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c28f6260-ddd9-538a-a1d7-147f4b9a6a8a",
+      "subjectType": "asset_metadata",
+      "subjectId": "c28f6260-ddd9-538a-a1d7-147f4b9a6a8a",
+      "assetId": "f6c8e847-1b13-58fe-a992-bc7417e4e09f",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Barrymore Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "e3e8e517-d3a2-5e7f-a9b5-8278b4fee119",
+      "subjectType": "asset_metadata",
+      "subjectId": "e3e8e517-d3a2-5e7f-a9b5-8278b4fee119",
+      "assetId": "cf54274a-e51a-5cdd-a5d0-472228f3a314",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.coast-beach",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Bayview Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "e41a63e6-d2c6-5d9c-a158-a0bfbe4b3a08",
+      "subjectType": "asset_metadata",
+      "subjectId": "e41a63e6-d2c6-5d9c-a158-a0bfbe4b3a08",
+      "assetId": "e7e0ade2-1de9-5b96-a676-f42303f7ddb6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "B'darra Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "6e71aa93-b426-53a8-ab91-4313442342b8",
+      "subjectType": "asset_metadata",
+      "subjectId": "6e71aa93-b426-53a8-ab91-4313442342b8",
+      "assetId": "028fc97f-861d-5f2b-a804-daa4564979a6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Beckingham Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c348a500-ac39-5737-a58b-614385e87e08",
+      "subjectType": "asset_metadata",
+      "subjectId": "c348a500-ac39-5737-a58b-614385e87e08",
+      "assetId": "0eb04601-f6af-5095-a71c-3d433007a92b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.golf",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Coastal links landscape near Cape Schanck, Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "dfe44e96-2383-5a51-a02a-9759e221ed64",
+      "subjectType": "asset_metadata",
+      "subjectId": "dfe44e96-2383-5a51-a02a-9759e221ed64",
+      "assetId": "2d535de7-6650-5e70-a27d-a83415d284f7",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.thermal-wellness",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Alba Thermal Springs geothermal bathing complex - representative of the Mornington Peninsula's wellness category",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9f746d24-d69d-5ffc-a206-af79288c2e26",
+      "subjectType": "asset_metadata",
+      "subjectId": "9f746d24-d69d-5ffc-a206-af79288c2e26",
+      "assetId": "88f6ab2e-1dc4-5990-ab47-f3ae3d8cb7a2",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Blue Range Estate Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c425caef-f089-5611-ad81-b73a480a5384",
+      "subjectType": "asset_metadata",
+      "subjectId": "c425caef-f089-5611-ad81-b73a480a5384",
+      "assetId": "411a49cb-ad52-589c-aa7b-6072e9ca7b46",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Bluestone Lane vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "429c85d7-dd85-5a06-ad69-b7aedd54b94b",
+      "subjectType": "asset_metadata",
+      "subjectId": "429c85d7-dd85-5a06-ad69-b7aedd54b94b",
+      "assetId": "2d7f753b-19e3-5f8b-ab79-4af7dce0732f",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Boneo Plains vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "1989dcf1-f0a4-5dbf-a898-3c497b0653e6",
+      "subjectType": "asset_metadata",
+      "subjectId": "1989dcf1-f0a4-5dbf-a898-3c497b0653e6",
+      "assetId": "adef66a5-7e0d-5791-ae5c-17c04dc94488",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Box Stallion vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "23135d99-6941-5cfd-a875-bca913d1ab30",
+      "subjectType": "asset_metadata",
+      "subjectId": "23135d99-6941-5cfd-a875-bca913d1ab30",
+      "assetId": "4d76ee0e-6849-54e2-a7d4-bd75fad22210",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A plate of poached eggs on Peninsula sourdough with a flat white and a laminated pastry on a cafe bench at sunrise - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "41d77c27-4ba3-5cbf-a4f8-51819dce3ebc",
+      "subjectType": "asset_metadata",
+      "subjectId": "41d77c27-4ba3-5cbf-a4f8-51819dce3ebc",
+      "assetId": "afa7e9e4-a5e5-5a59-acef-51d0adad40f9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Brimsmore Park Winery vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "eae2d209-4cd4-5a1f-ad7d-c9b490d68fb9",
+      "subjectType": "asset_metadata",
+      "subjectId": "eae2d209-4cd4-5a1f-ad7d-c9b490d68fb9",
+      "assetId": "0855129d-f3dc-5bb7-a1d1-6ef6301ef58d",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Bristol Farm vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "cd2b76f3-9949-532a-ab08-66d3662764e6",
+      "subjectType": "asset_metadata",
+      "subjectId": "cd2b76f3-9949-532a-ab08-66d3662764e6",
+      "assetId": "ca34220a-267b-5755-a66b-2d20e301f355",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Cape Schanck lighthouse and basalt clifftop coastline, Mornington Peninsula National Park",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "817a63bf-2c66-51bd-a6d7-5aa152cfadb4",
+      "subjectType": "asset_metadata",
+      "subjectId": "817a63bf-2c66-51bd-a6d7-5aa152cfadb4",
+      "assetId": "6140794c-1a62-56a6-a5d4-08a04c37aefd",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Cooralook Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "878f01b1-36cf-5990-a8b7-239d6217bcaa",
+      "subjectType": "asset_metadata",
+      "subjectId": "878f01b1-36cf-5990-a8b7-239d6217bcaa",
+      "assetId": "90123568-32a0-5550-a15d-06f416b96e3b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A polished vineyard-side retreat setting on the Mornington Peninsula suited to a corporate offsite",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "32cff18c-1f9a-5284-abd5-1a85c8b6c9f1",
+      "subjectType": "asset_metadata",
+      "subjectId": "32cff18c-1f9a-5284-abd5-1a85c8b6c9f1",
+      "assetId": "c721fd63-f90f-53da-a34b-358ef3d15c39",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Craig Avon Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "24a0a4cf-f3d1-51ab-a1ad-2855f0e874e3",
+      "subjectType": "asset_metadata",
+      "subjectId": "24a0a4cf-f3d1-51ab-a1ad-2855f0e874e3",
+      "assetId": "296bbb96-2bb1-5eac-a6e5-d7518ae9f6c6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Darling Park vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "67a12609-1b4d-5d31-a9b0-477de8de0535",
+      "subjectType": "asset_metadata",
+      "subjectId": "67a12609-1b4d-5d31-a9b0-477de8de0535",
+      "assetId": "db4ab093-4ead-559b-a713-06a40c99f1be",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Dog-friendly Peninsula - practical support guide - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "34ac3585-d1c3-584c-aaf8-89535f6040a6",
+      "subjectType": "asset_metadata",
+      "subjectId": "34ac3585-d1c3-584c-aaf8-89535f6040a6",
+      "assetId": "7dcca16a-5d63-53c5-ac9b-e945a8879dbf",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.accommodation",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Dog-friendly Peninsula cottage stay with outdoor space - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "a952193a-c56d-55da-ab34-e72d34a6588f",
+      "subjectType": "asset_metadata",
+      "subjectId": "a952193a-c56d-55da-ab34-e72d34a6588f",
+      "assetId": "f1429cef-c818-5579-a147-1c65aebbcdfc",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.coast-beach",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Wet dog sitting on a Mornington Peninsula beach",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3a20474a-daf0-5058-ab31-f0f6fd4fca42",
+      "subjectType": "asset_metadata",
+      "subjectId": "3a20474a-daf0-5058-ab31-f0f6fd4fca42",
+      "assetId": "eb644ea7-1e4a-50fa-a43f-8d3284f60ad2",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Stonier Wines cellar door, Merricks - confirmed dog-friendly with lawn area",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "dbbd914c-d1cc-5907-addb-b22c49e48e8f",
+      "subjectType": "asset_metadata",
+      "subjectId": "dbbd914c-d1cc-5907-addb-b22c49e48e8f",
+      "assetId": "295bd0d6-1fc2-5825-ab2d-2b06c93a096b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Dromana Valley Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "0505a59c-41aa-56c6-ad4f-b0abe2cfb65d",
+      "subjectType": "asset_metadata",
+      "subjectId": "0505a59c-41aa-56c6-ad4f-b0abe2cfb65d",
+      "assetId": "103434ce-7578-538a-a87f-5f344166c796",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Dunns Creek Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3c0c0a26-87b3-5d1b-a489-427f7cb240c4",
+      "subjectType": "asset_metadata",
+      "subjectId": "3c0c0a26-87b3-5d1b-a489-427f7cb240c4",
+      "assetId": "5687b522-d87b-501d-a7fe-d043db03a1fb",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Elan Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "1b0dc511-33e1-563a-ab83-beb6aa14b83c",
+      "subjectType": "asset_metadata",
+      "subjectId": "1b0dc511-33e1-563a-ab83-beb6aa14b83c",
+      "assetId": "7414046b-b4da-5c7c-ac1b-de38dcf25be6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Even Keel vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "7fde1db0-beea-542c-a0b1-7f994ffe46c0",
+      "subjectType": "asset_metadata",
+      "subjectId": "7fde1db0-beea-542c-a0b1-7f994ffe46c0",
+      "assetId": "43bf9a48-c7e6-570b-a0d0-eeec95422dcf",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "The Cape Schanck boardwalk stretching toward the clifftop lighthouse at the southern tip of the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d9a3459c-71ca-5a5b-a44d-7cb34df33da1",
+      "subjectType": "asset_metadata",
+      "subjectId": "d9a3459c-71ca-5a5b-a44d-7cb34df33da1",
+      "assetId": "984b6512-46e1-5842-add1-7333e8d80707",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Frogspond vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "2b22d06e-c1d2-535d-ab58-163d28c03337",
+      "subjectType": "asset_metadata",
+      "subjectId": "2b22d06e-c1d2-535d-ab58-163d28c03337",
+      "assetId": "32ee8bd7-9612-54ce-a64f-392f62100e6a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Gibson Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "302dbd76-57c6-54c7-ace0-5edbf6dab2f7",
+      "subjectType": "asset_metadata",
+      "subjectId": "302dbd76-57c6-54c7-ace0-5edbf6dab2f7",
+      "assetId": "2c53a4d8-7e15-59bc-a0cd-909ecbd5e8b9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Handpicked Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c82ebf02-08ec-5584-ab06-1d0b472d7066",
+      "subjectType": "asset_metadata",
+      "subjectId": "c82ebf02-08ec-5584-ab06-1d0b472d7066",
+      "assetId": "2be446d1-a128-5981-a168-a29a4acb1c08",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Harlow Park Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "ec8acd29-3de9-56a3-a09b-d8aee9190e2e",
+      "subjectType": "asset_metadata",
+      "subjectId": "ec8acd29-3de9-56a3-a09b-d8aee9190e2e",
+      "assetId": "6d87808d-433d-5a1a-a7c3-d6e41f315036",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Warm, polished restaurant interior with a marble bar, timber stools, and low lighting - the kind of room that suits a Peninsula hatted-restaurant shortlist",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b6b06c43-1ebd-5af2-a0fd-700d02de9284",
+      "subjectType": "asset_metadata",
+      "subjectId": "b6b06c43-1ebd-5af2-a0fd-700d02de9284",
+      "assetId": "57409dba-6cbb-5816-ac13-ccdf8f2ee1fc",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Hickinbotham of Dromana vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "dd37a08c-b739-540c-a482-10b409d79cee",
+      "subjectType": "asset_metadata",
+      "subjectId": "dd37a08c-b739-540c-a482-10b409d79cee",
+      "assetId": "0d993d02-fdf7-53c1-a78e-ad9a3f38759a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A notebook and coffee on a table with a Peninsula map and vineyard views through the window - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "33475977-a8da-5428-af5b-1974599b6294",
+      "subjectType": "asset_metadata",
+      "subjectId": "33475977-a8da-5428-af5b-1974599b6294",
+      "assetId": "3438f2b6-946e-59e6-ac44-ed67fb3491b8",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "HPR Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "e83cf830-e639-5100-a300-09afa1501613",
+      "subjectType": "asset_metadata",
+      "subjectId": "e83cf830-e639-5100-a300-09afa1501613",
+      "assetId": "e798b9e8-6f30-5e00-ab75-1800adbb1b8a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Hurley Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "50e28dee-7d84-58d6-a867-0e00c0153174",
+      "subjectType": "asset_metadata",
+      "subjectId": "50e28dee-7d84-58d6-a867-0e00c0153174",
+      "assetId": "81f513ca-e981-5ac4-a8d0-01fdc74dd181",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Late-autumn light on the southern coast of the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "6e2eb395-087c-5360-a29e-6249842ead10",
+      "subjectType": "asset_metadata",
+      "subjectId": "6e2eb395-087c-5360-a29e-6249842ead10",
+      "assetId": "3472d355-1113-5d96-a271-a9a944f40c7c",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Greens Bush Two Bays section, Mornington Peninsula - late autumn",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "355e0d0e-0a5f-5665-a580-b761092e5ef2",
+      "subjectType": "asset_metadata",
+      "subjectId": "355e0d0e-0a5f-5665-a580-b761092e5ef2",
+      "assetId": "86438e4d-10b1-5b85-ac76-3cde9037b6a5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Entrance walkway and restaurant exterior at Ten Minutes by Tractor, Main Ridge, Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d1281d8e-a65a-558e-a41f-742db47ae4ee",
+      "subjectType": "asset_metadata",
+      "subjectId": "d1281d8e-a65a-558e-a41f-742db47ae4ee",
+      "assetId": "a1a604c0-61ac-5fcd-afcd-1ba7372b8286",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Coastal clifftop heathland on the Mornington Peninsula in winter",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "637e476d-0ce3-5d2d-aa82-d102447bb04d",
+      "subjectType": "asset_metadata",
+      "subjectId": "637e476d-0ce3-5d2d-aa82-d102447bb04d",
+      "assetId": "7edd8cdb-2c37-5c33-ad49-d0b5dd1f75d5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Clifftop coastal heath on the Farnsworth Track between Portsea Ocean Beach and London Bridge, Point Nepean",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "4f0c8694-5190-5b32-a991-28194dc63102",
+      "subjectType": "asset_metadata",
+      "subjectId": "4f0c8694-5190-5b32-a991-28194dc63102",
+      "assetId": "9bbc3aa6-dc8a-5581-a11d-faaccabf0bb3",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Jones Road vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "062d7880-ddbf-513f-ab32-f4dc87fc85c6",
+      "subjectType": "asset_metadata",
+      "subjectId": "062d7880-ddbf-513f-ab32-f4dc87fc85c6",
+      "assetId": "a13fcaf6-d98a-5749-a591-b58019b1fb26",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Karina Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "ee7cab42-4e3d-5c18-a915-61fc61954de4",
+      "subjectType": "asset_metadata",
+      "subjectId": "ee7cab42-4e3d-5c18-a915-61fc61954de4",
+      "assetId": "477d9676-2d45-5e6e-aabc-192a651d15ae",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Kings Creek Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "7ea15b7c-12d2-5899-a714-a3e2dc6dd0a9",
+      "subjectType": "asset_metadata",
+      "subjectId": "7ea15b7c-12d2-5899-a714-a3e2dc6dd0a9",
+      "assetId": "b296d588-8eab-5396-aec1-3bf32bf6a645",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Lewood Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "57406f58-82fe-529a-ac85-a3d4cea2d643",
+      "subjectType": "asset_metadata",
+      "subjectId": "57406f58-82fe-529a-ac85-a3d4cea2d643",
+      "assetId": "d3a2c3d2-c28b-5126-a896-7c6ea25431e6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Little Valley vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "f348e662-059b-597e-aa73-b49789a623ac",
+      "subjectType": "asset_metadata",
+      "subjectId": "f348e662-059b-597e-aa73-b49789a623ac",
+      "assetId": "905be465-2739-5cab-a9ca-266f1c2b7177",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.accommodation",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Jackalope Hotel, Merricks North - a MICHELIN Two Keys property and one of the Peninsula's flagship luxury stays",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "991ef0a1-109a-56ab-a8fe-0c91a4922b08",
+      "subjectType": "asset_metadata",
+      "subjectId": "991ef0a1-109a-56ab-a8fe-0c91a4922b08",
+      "assetId": "9eaf0ca2-a27e-50ea-a296-da418ac52ac9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mantons Creek vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d9ec848e-ebde-50aa-ab42-f43e4a1ba631",
+      "subjectType": "asset_metadata",
+      "subjectId": "d9ec848e-ebde-50aa-ab42-f43e4a1ba631",
+      "assetId": "dac1fd4f-bccc-5615-a3d1-c54db149d420",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Marinda Park Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "6210d455-d55d-57fd-ac6f-5a2d81b83dc6",
+      "subjectType": "asset_metadata",
+      "subjectId": "6210d455-d55d-57fd-ac6f-5a2d81b83dc6",
+      "assetId": "a9bef195-a013-51cb-a22f-92b7127605a1",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Maritime Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5e2a6ec1-5f48-5d4e-a851-5ce41669fc6e",
+      "subjectType": "asset_metadata",
+      "subjectId": "5e2a6ec1-5f48-5d4e-a851-5ce41669fc6e",
+      "assetId": "d5b18e00-d50b-52fd-a954-5852a160a1d5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Martha Cove Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b49ec238-b440-558a-ac97-b72ac6294728",
+      "subjectType": "asset_metadata",
+      "subjectId": "b49ec238-b440-558a-ac97-b72ac6294728",
+      "assetId": "c835e59d-92c1-5e9c-adc7-4b36d7973488",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Massoni vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "40ef85bc-d75d-57e3-ab7c-7772913d8806",
+      "subjectType": "asset_metadata",
+      "subjectId": "40ef85bc-d75d-57e3-ab7c-7772913d8806",
+      "assetId": "d99bd49c-cdde-56b7-afa2-ccf6f5b0220e",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "McCrae Mist Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "a875583b-216a-5f6c-ada2-ef1fb70e8c7e",
+      "subjectType": "asset_metadata",
+      "subjectId": "a875583b-216a-5f6c-ada2-ef1fb70e8c7e",
+      "assetId": "04fe72f0-671d-5c3e-aae2-58c24cf37914",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Merli vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9703bc6f-dec2-565f-ace9-758c32a2ea01",
+      "subjectType": "asset_metadata",
+      "subjectId": "9703bc6f-dec2-565f-ace9-758c32a2ea01",
+      "assetId": "7e03b13c-e0fb-5e98-a2ce-8d9701fe8ec2",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Merricks Creek Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "a7bcc5c4-d75f-5f59-a08f-0e0ea110d32b",
+      "subjectType": "asset_metadata",
+      "subjectId": "a7bcc5c4-d75f-5f59-a08f-0e0ea110d32b",
+      "assetId": "8a8e9a58-bd9f-5282-a01f-7066c056f776",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Merricks Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "32a75251-5e3e-5abd-a0f4-bee27446b26e",
+      "subjectType": "asset_metadata",
+      "subjectId": "32a75251-5e3e-5abd-a0f4-bee27446b26e",
+      "assetId": "1df6830f-0034-5637-a0fa-e81f463d2b8e",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Miceli vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "24bef57d-3b88-5264-ace5-3caf9dd49262",
+      "subjectType": "asset_metadata",
+      "subjectId": "24bef57d-3b88-5264-ace5-3caf9dd49262",
+      "assetId": "9f7ed083-b1d4-5999-aa17-bbd670f356f1",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Morning Star Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "772bffc4-ec01-5047-ac8c-b602b966d0e2",
+      "subjectType": "asset_metadata",
+      "subjectId": "772bffc4-ec01-5047-ac8c-b602b966d0e2",
+      "assetId": "5d3e621d-0553-5021-a33a-44f331fe5e67",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Morning Sun Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d7f8ec99-65c1-5f7f-af7e-ef7867ba2c32",
+      "subjectType": "asset_metadata",
+      "subjectId": "d7f8ec99-65c1-5f7f-af7e-ef7867ba2c32",
+      "assetId": "480e968e-bfc3-547b-a524-330d486da7d5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mornington main street with morning shoppers and cafes - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "79e38284-154b-5203-a28a-d8b4cdad7dd3",
+      "subjectType": "asset_metadata",
+      "subjectId": "79e38284-154b-5203-a28a-d8b4cdad7dd3",
+      "assetId": "eb9f2764-bf3f-51f1-ab14-92c032be6c68",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.coast-beach",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Sorrento Ocean Baths on Port Phillip Bay - one of the Peninsula’s most popular beach destinations",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "8d3fcad2-01d3-5199-a7b2-12d2df00e981",
+      "subjectType": "asset_metadata",
+      "subjectId": "8d3fcad2-01d3-5199-a7b2-12d2df00e981",
+      "assetId": "c6e04a73-83ee-5e79-a08e-d83e1630ae55",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.thermal-wellness",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.accommodation",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Aerial view of the Peninsula Hot Springs hilltop pool at dusk, steam rising into autumn air",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9d1e7e15-bc55-5ada-a94c-ee94658cd3ef",
+      "subjectType": "asset_metadata",
+      "subjectId": "9d1e7e15-bc55-5ada-a94c-ee94658cd3ef",
+      "assetId": "e940510a-425c-5b64-ac4d-e583320cc841",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Vineyard rows in autumn on the Mornington Peninsula, Red Hill South",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "bf1d49ad-b47d-5dc3-acec-6f63d7373955",
+      "subjectType": "asset_metadata",
+      "subjectId": "bf1d49ad-b47d-5dc3-acec-6f63d7373955",
+      "assetId": "4c2e28dc-3b30-596d-ae3b-525cc9261cbe",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Myrtaceae vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9ed225e9-3bf7-53c3-a284-c256be079c48",
+      "subjectType": "asset_metadata",
+      "subjectId": "9ed225e9-3bf7-53c3-a284-c256be079c48",
+      "assetId": "8f9461e3-0ebc-548c-a498-c0b710223ca4",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Nazaaray vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "4cf5867e-e520-5971-ae87-9bd102ac6624",
+      "subjectType": "asset_metadata",
+      "subjectId": "4cf5867e-e520-5971-ae87-9bd102ac6624",
+      "assetId": "c5cbb166-7cae-5c6c-a18f-133758481002",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Northway Downs vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "eef4f20f-25a3-554b-ad84-d785b66c4c67",
+      "subjectType": "asset_metadata",
+      "subjectId": "eef4f20f-25a3-554b-ad84-d785b66c4c67",
+      "assetId": "255fac30-b3fc-59ab-a3e8-d83d41525762",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Osborns vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d5e416b0-9074-5ec8-aa30-06e6028d078a",
+      "subjectType": "asset_metadata",
+      "subjectId": "d5e416b0-9074-5ec8-aa30-06e6028d078a",
+      "assetId": "2d2b0781-98c4-5192-abc5-aeb0004ca72a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Wet winter morning on the Mornington Peninsula, July 2026",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "a1830b36-548b-5865-a99b-86e7a8be69f0",
+      "subjectType": "asset_metadata",
+      "subjectId": "a1830b36-548b-5865-a99b-86e7a8be69f0",
+      "assetId": "5ff6ee65-aaba-5f36-abc3-df57f1ef9e66",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Sculpture park at Pt. Leo Estate, Merricks, Mornington Peninsula, winter 2026",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "87daead0-b611-52e1-a7a6-c9d89f0e88a8",
+      "subjectType": "asset_metadata",
+      "subjectId": "87daead0-b611-52e1-a7a6-c9d89f0e88a8",
+      "assetId": "1d7020b2-f922-5972-ac53-010871087db1",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Sorrento foreshore at dusk, winter solstice festival evening, Mornington Peninsula 2026",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "468e9b5d-b2d0-5122-a5cc-d6ab867362f4",
+      "subjectType": "asset_metadata",
+      "subjectId": "468e9b5d-b2d0-5122-a5cc-d6ab867362f4",
+      "assetId": "cdb35ecd-5cfa-5fcd-aeb8-f78df8cd955a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mount Martha beach on a Mornington Peninsula weekend, 9 to 10 May 2026",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9200808f-83c0-519a-ad99-7ecda3554ca1",
+      "subjectType": "asset_metadata",
+      "subjectId": "9200808f-83c0-519a-ad99-7ecda3554ca1",
+      "assetId": "bc338256-0c21-5363-a8f5-ecde718a7ff3",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Red Hill estate in late autumn, Mornington Peninsula, 30 to 31 May 2026",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "947bf0ca-024d-5683-abb9-f72718162e21",
+      "subjectType": "asset_metadata",
+      "subjectId": "947bf0ca-024d-5683-abb9-f72718162e21",
+      "assetId": "3013c020-7575-5c82-ab34-d245a9e6b95c",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Phaedrus Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "34234274-5cbf-5f37-a6fb-d457615c7267",
+      "subjectType": "asset_metadata",
+      "subjectId": "34234274-5cbf-5f37-a6fb-d457615c7267",
+      "assetId": "2dc57d6d-104e-5d05-a0d2-c9366ba097d8",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.coast-beach",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Pier 10 vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "1b4eaf9d-9280-580b-a0c2-b15b62313491",
+      "subjectType": "asset_metadata",
+      "subjectId": "1b4eaf9d-9280-580b-a0c2-b15b62313491",
+      "assetId": "356e99d9-853c-5f86-a2db-88d162158c63",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Point Leo Road Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "fd99ca5b-d5ef-525a-acc4-e921a4142e6a",
+      "subjectType": "asset_metadata",
+      "subjectId": "fd99ca5b-d5ef-525a-acc4-e921a4142e6a",
+      "assetId": "716ed4fc-f91b-5817-a496-0cc6b9e0dffa",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Fort Nepean headland at Point Nepean National Park with views across the Rip to Queenscliff",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "7f52d301-85f0-5021-adad-e46aea130e7b",
+      "subjectType": "asset_metadata",
+      "subjectId": "7f52d301-85f0-5021-adad-e46aea130e7b",
+      "assetId": "232f0563-f1b5-5641-aed5-ce84d4702e8b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Poplar Bend vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "50d66c13-6018-591a-a3a8-a71749790312",
+      "subjectType": "asset_metadata",
+      "subjectId": "50d66c13-6018-591a-a3a8-a71749790312",
+      "assetId": "edee7156-df8a-54cc-ae1d-e32b1cd3417d",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Portsea Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "121695b0-380a-5300-a557-e81ba3c62ef9",
+      "subjectType": "asset_metadata",
+      "subjectId": "121695b0-380a-5300-a557-e81ba3c62ef9",
+      "assetId": "b8eedb67-6e2e-5175-ac87-a429b2834b85",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Prancing Horse Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "949b78b1-bf35-5ccf-a1b6-f7b1faa49850",
+      "subjectType": "asset_metadata",
+      "subjectId": "949b78b1-bf35-5ccf-a1b6-f7b1faa49850",
+      "assetId": "998b6f18-6e1b-5eac-a8d1-50e02fed4385",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Quealy Winemakers vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5eeb7539-91b4-5905-a0ef-c48924e7c76b",
+      "subjectType": "asset_metadata",
+      "subjectId": "5eeb7539-91b4-5905-a0ef-c48924e7c76b",
+      "assetId": "7200f964-9663-5110-aae6-950460e7383a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Rahona Valley Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "61658e98-9a7d-565b-a9d1-c6b6f9ccb0cf",
+      "subjectType": "asset_metadata",
+      "subjectId": "61658e98-9a7d-565b-a9d1-c6b6f9ccb0cf",
+      "assetId": "f19e88c9-1dca-5b4d-a8ad-7afb8ffb5f79",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Red Ridge Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "dcae6324-c5d1-508d-a421-4ebc8d031b22",
+      "subjectType": "asset_metadata",
+      "subjectId": "dcae6324-c5d1-508d-a421-4ebc8d031b22",
+      "assetId": "611a6672-2f83-51fa-a478-fa9bc1cbdc9d",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "RhinoTiger Bear vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "ae7bc5c8-7bcf-53ae-a1b3-a011453ae2d4",
+      "subjectType": "asset_metadata",
+      "subjectId": "ae7bc5c8-7bcf-53ae-a1b3-a011453ae2d4",
+      "assetId": "7e9eb273-59e4-51bd-af7e-3320c2350e7c",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Rigel Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "685c0fe3-aa91-5e32-aefd-936eff3d3773",
+      "subjectType": "asset_metadata",
+      "subjectId": "685c0fe3-aa91-5e32-aefd-936eff3d3773",
+      "assetId": "ca9c1a18-3a46-5f76-a88e-0322cc7f25e4",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Scorpo Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "ccbdca28-ba15-5d7c-a43e-6760a080ca99",
+      "subjectType": "asset_metadata",
+      "subjectId": "ccbdca28-ba15-5d7c-a43e-6760a080ca99",
+      "assetId": "27a8ca4b-4029-5217-a8cf-3f926b24df94",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Sea Winds Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "550a8145-10c5-5bd2-affc-7c87744ae4e5",
+      "subjectType": "asset_metadata",
+      "subjectId": "550a8145-10c5-5bd2-affc-7c87744ae4e5",
+      "assetId": "a2f7ce83-fcc7-57e8-a1d3-c03d43b32e08",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Seaforth Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9010000e-23a2-5023-a98f-99ef33af1ed9",
+      "subjectType": "asset_metadata",
+      "subjectId": "9010000e-23a2-5023-a98f-99ef33af1ed9",
+      "assetId": "66a65a87-092f-5147-a6ab-89a96b6772d8",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Silverwood Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "cd494fcc-7d9f-5d49-ad3d-2dc37af67f78",
+      "subjectType": "asset_metadata",
+      "subjectId": "cd494fcc-7d9f-5d49-ad3d-2dc37af67f78",
+      "assetId": "1a7c5bbc-6219-53aa-a309-3c85846b87cf",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Somerbury Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "44e78f19-669e-5eb7-a200-d00c240bb1d7",
+      "subjectType": "asset_metadata",
+      "subjectId": "44e78f19-669e-5eb7-a200-d00c240bb1d7",
+      "assetId": "b2f03172-9410-54da-a8ab-25b6a5a397fc",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Sorrento foreshore at dusk, winter solstice festival evening, Mornington Peninsula 2026",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "6d67aa7a-98cd-5160-a363-1372f29b80c4",
+      "subjectType": "asset_metadata",
+      "subjectId": "6d67aa7a-98cd-5160-a363-1372f29b80c4",
+      "assetId": "26a3aa53-d863-5d01-abb1-2933c895cac7",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.coast-beach",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.golf",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Coastal landscape near St Andrews Beach, Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b618c065-5d03-5026-a510-b7938387460e",
+      "subjectType": "asset_metadata",
+      "subjectId": "b618c065-5d03-5026-a510-b7938387460e",
+      "assetId": "38d9d3c8-a5f1-5761-a3ed-b8918967a6d6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Staindl Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "71f2eaf5-3957-5e9e-a478-a02a9ee4f921",
+      "subjectType": "asset_metadata",
+      "subjectId": "71f2eaf5-3957-5e9e-a478-a02a9ee4f921",
+      "assetId": "a6ae9ffa-975e-50d6-af5c-543ff89ff235",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Stumpy Gully Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "8890dcf1-37cd-51b6-a6e7-f16fffb055ce",
+      "subjectType": "asset_metadata",
+      "subjectId": "8890dcf1-37cd-51b6-a6e7-f16fffb055ce",
+      "assetId": "26ae40d4-3af9-589b-a72e-d0459f26fa47",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Summerhill Wines vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b1299170-3c9d-55f0-af3a-e9acf7060c2a",
+      "subjectType": "asset_metadata",
+      "subjectId": "b1299170-3c9d-55f0-af3a-e9acf7060c2a",
+      "assetId": "6e9991c6-ba65-5b0c-a03c-c3b0e1aca872",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Tanglewood Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "6737efa3-e14f-52ce-a9c6-793360e053e3",
+      "subjectType": "asset_metadata",
+      "subjectId": "6737efa3-e14f-52ce-a9c6-793360e053e3",
+      "assetId": "5b90b327-d89d-59fa-a8a3-67db3b3358a5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A candlelit dinner terrace at a Peninsula restaurant at dusk with vineyard rows beyond - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "243d9f66-8756-5ac4-a9a9-f972f9a979a0",
+      "subjectType": "asset_metadata",
+      "subjectId": "243d9f66-8756-5ac4-a9a9-f972f9a979a0",
+      "assetId": "1665c935-b2a9-5152-ad8b-ef95e9deb93b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Five wine glasses lined up for a tasting flight in a Peninsula cellar door",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d425d098-459c-5c3c-a72d-76c6a3769951",
+      "subjectType": "asset_metadata",
+      "subjectId": "d425d098-459c-5c3c-a72d-76c6a3769951",
+      "assetId": "1c37f819-21a6-5229-ad72-40d1dee95a70",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "White wine tasting flight at a vineyard cellar door, chardonnay in stemware against a winery backdrop",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "cac73b94-919a-5eb7-a0bd-1297114b8a38",
+      "subjectType": "asset_metadata",
+      "subjectId": "cac73b94-919a-5eb7-a0bd-1297114b8a38",
+      "assetId": "2bd63661-6603-5174-aadc-30620432d5c4",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "The Cups Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "13e05beb-9db0-5ff7-a2f0-f2e839f97704",
+      "subjectType": "asset_metadata",
+      "subjectId": "13e05beb-9db0-5ff7-a2f0-f2e839f97704",
+      "assetId": "260da3bc-e37c-5676-a403-7d0dce621200",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A labrador splashing through shallow Peninsula bay water at a dog-friendly beach in the morning light",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "89bd240a-b2bb-5c85-a583-b020f24a05ab",
+      "subjectType": "asset_metadata",
+      "subjectId": "89bd240a-b2bb-5c85-a583-b020f24a05ab",
+      "assetId": "2c3b5447-427e-59fc-a9ce-d7f0d8120435",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "The Duke Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "fc8ddd5b-87bf-5581-a801-879e623ae65e",
+      "subjectType": "asset_metadata",
+      "subjectId": "fc8ddd5b-87bf-5581-a801-879e623ae65e",
+      "assetId": "2d2b1986-8e56-5d23-adaf-2b42f2061845",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Horses on the back beach at low light, the wide ocean coast that frames a four-hour Peninsula visit",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "50d51628-ef5d-5403-abda-e61ed0426026",
+      "subjectType": "asset_metadata",
+      "subjectId": "50d51628-ef5d-5403-abda-e61ed0426026",
+      "assetId": "1f7e7419-15de-591d-a7c8-7a14f2dcf30d",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A car pulling into a Peninsula rental property at dusk with warm interior light spilling through the windows - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5c49ae7c-a8d0-5071-aaf2-4db5adf43d01",
+      "subjectType": "asset_metadata",
+      "subjectId": "5c49ae7c-a8d0-5071-aaf2-4db5adf43d01",
+      "assetId": "9168a9cb-ace5-5ee4-af58-9c56966e77e5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "The Garden Vineyard vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5c5a2e7f-732d-59ba-adfc-67e587e600de",
+      "subjectType": "asset_metadata",
+      "subjectId": "5c5a2e7f-732d-59ba-adfc-67e587e600de",
+      "assetId": "0c4ae24f-6675-546e-a1ab-ff3c446f1bb7",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A long table set for lunch at Montalto, overlooking the olive grove",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c3e85e1e-5327-5c42-a777-43f7b87cf0ec",
+      "subjectType": "asset_metadata",
+      "subjectId": "c3e85e1e-5327-5c42-a777-43f7b87cf0ec",
+      "assetId": "eb94c9e5-ffb7-5d04-ad91-10e16f6f2c0b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.coast-beach",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A swimmer pushing off from the shallow pale sand of a Peninsula bay beach on a calm morning",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "1d948896-b0c4-5ada-a09c-ace05abe28a8",
+      "subjectType": "asset_metadata",
+      "subjectId": "1d948896-b0c4-5ada-a09c-ace05abe28a8",
+      "assetId": "13499b51-4e25-565a-af8a-3ee43622f21a",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Aerial view across Mornington Peninsula vineyards and farmland with a country road running through the patchwork toward Port Phillip Bay",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "57c94530-d160-5491-a7a2-cfcbf0ea5932",
+      "subjectType": "asset_metadata",
+      "subjectId": "57c94530-d160-5491-a7a2-cfcbf0ea5932",
+      "assetId": "979c20f6-80a4-5eee-ab83-3dd8e3c52254",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A picnic spread of cheese, bread, charcuterie and wine on a blanket overlooking bay views",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "7d9820dd-37db-5575-af8e-0749aa49d8cb",
+      "subjectType": "asset_metadata",
+      "subjectId": "7d9820dd-37db-5575-af8e-0749aa49d8cb",
+      "assetId": "bb776adf-6f6d-5eb9-a86e-dc51c6fc09d6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.family",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A family on a grass slope above Port Phillip Bay on a bright autumn afternoon",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5bc6e771-cb1e-500c-a448-ef193ffba975",
+      "subjectType": "asset_metadata",
+      "subjectId": "5bc6e771-cb1e-500c-a448-ef193ffba975",
+      "assetId": "cfc29dbf-e857-53d9-aceb-a003933ff0a9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Coastal scrub along the Range Area Walk at Point Nepean",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c9bfb6fb-359f-5a62-a8fc-9d6aea19bbc8",
+      "subjectType": "asset_metadata",
+      "subjectId": "c9bfb6fb-359f-5a62-a8fc-9d6aea19bbc8",
+      "assetId": "a692003e-c48e-55bf-a640-b57bcafe0c6e",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Defensive batteries at Point Nepean with the Rip and the Bellarine Peninsula in the distance",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "ed274efd-4d18-54b2-ade9-cadefe0a859f",
+      "subjectType": "asset_metadata",
+      "subjectId": "ed274efd-4d18-54b2-ade9-cadefe0a859f",
+      "assetId": "ca1a92e9-803c-5b71-a5b6-0209be46d709",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A wheel of fresh Peninsula goat cheese being lifted from a chilled rack at a small dairy",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "25811632-53ab-5491-ab43-4b0c64bcef7e",
+      "subjectType": "asset_metadata",
+      "subjectId": "25811632-53ab-5491-ab43-4b0c64bcef7e",
+      "assetId": "65eecf82-3979-58ad-a4b1-86062f2e4cfe",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A busy Peninsula pub beer garden on a Saturday afternoon with local craft beer on the table - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "d079942f-cf41-52a0-a1f7-325c3ab0c71e",
+      "subjectType": "asset_metadata",
+      "subjectId": "d079942f-cf41-52a0-a1f7-325c3ab0c71e",
+      "assetId": "075ca11f-f30b-53df-a0eb-15636ac03140",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.accommodation",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A beer garden at a Peninsula pub on a late autumn afternoon with locals at timber tables - representative image",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "920b00e4-77aa-5115-ac3a-cbe1eef68033",
+      "subjectType": "asset_metadata",
+      "subjectId": "920b00e4-77aa-5115-ac3a-cbe1eef68033",
+      "assetId": "6452cf32-698a-53bf-ad4b-729786297888",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.boating-fishing",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A plate of freshly shucked oysters with lemon on a weathered timber table near a pier",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "67b254d3-692b-5b42-a769-fbef9baa60ea",
+      "subjectType": "asset_metadata",
+      "subjectId": "67b254d3-692b-5b42-a769-fbef9baa60ea",
+      "assetId": "9971bf3d-39c3-518d-ae2b-34acf9db9e79",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mornington Peninsula landscapes - bushland, coast and hinterland from one of many lookout points",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "1b656961-815e-58da-a868-cdaace6fe633",
+      "subjectType": "asset_metadata",
+      "subjectId": "1b656961-815e-58da-a868-cdaace6fe633",
+      "assetId": "4bd0857f-afa0-5126-a71b-7f33ac748937",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "A comparative lunch table across three of the Peninsula's most serious restaurants",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "f87f769d-c249-536d-a955-4c703f05ac5b",
+      "subjectType": "asset_metadata",
+      "subjectId": "f87f769d-c249-536d-a955-4c703f05ac5b",
+      "assetId": "ae7f8137-4762-5224-a022-52df52a59fbb",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Trofeo Estate vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5d49246b-39c0-556d-a091-273923f3ea56",
+      "subjectType": "asset_metadata",
+      "subjectId": "5d49246b-39c0-556d-a091-273923f3ea56",
+      "assetId": "7b9fe4d6-825b-5272-a5a3-3574bee7de93",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Tucks Ridge vineyard and cellar-door setting on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "45b09a60-2e76-5238-a6c9-e8505a56839d",
+      "subjectType": "asset_metadata",
+      "subjectId": "45b09a60-2e76-5238-a6c9-e8505a56839d",
+      "assetId": "4ce04b59-6ba2-5fc4-a4e6-dc459c76bba9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Live music and drinks on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "f9edbe21-85f4-5923-ad24-a6def214e1b3",
+      "subjectType": "asset_metadata",
+      "subjectId": "f9edbe21-85f4-5923-ad24-a6def214e1b3",
+      "assetId": "f62a281f-020b-59e5-aa66-7d8aa2dce8c5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Wine tasting at a Mornington Peninsula cellar door",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "e5970412-70fb-5e6b-acc4-d2313fe717b6",
+      "subjectType": "asset_metadata",
+      "subjectId": "e5970412-70fb-5e6b-acc4-d2313fe717b6",
+      "assetId": "206157a7-934d-5c7d-a615-4007dcbfb381",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Community market at Boneo on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "367ba742-2ee1-527e-a924-8fa5743d40be",
+      "subjectType": "asset_metadata",
+      "subjectId": "367ba742-2ee1-527e-a924-8fa5743d40be",
+      "assetId": "204f4cb8-6bfb-5d1d-a20e-a4b2c7eb3d5c",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Crittenden Estate vineyard on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9afed376-458f-5e03-ac6e-7941a4d8e6f0",
+      "subjectType": "asset_metadata",
+      "subjectId": "9afed376-458f-5e03-ac6e-7941a4d8e6f0",
+      "assetId": "242c2af6-7bbf-5780-aeaa-99d793efad1f",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.market-produce",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Emu Plains community market at Balnarring",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b5e0fb74-b82e-5f25-adfb-f95a005df942",
+      "subjectType": "asset_metadata",
+      "subjectId": "b5e0fb74-b82e-5f25-adfb-f95a005df942",
+      "assetId": "39b48471-921a-5eb1-aa3c-08bdfd92b74d",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.family",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Arthurs Seat Eagle gondola and lookout on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b8552c0f-fc16-571b-a1a7-676a2d6efa7f",
+      "subjectType": "asset_metadata",
+      "subjectId": "b8552c0f-fc16-571b-a1a7-676a2d6efa7f",
+      "assetId": "52f0d945-e472-5749-a45b-07c06fe2093b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Pinot Noir vineyard at Stonier Wines, Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "64a8db91-6937-54b4-aa84-8a8640e2f944",
+      "subjectType": "asset_metadata",
+      "subjectId": "64a8db91-6937-54b4-aa84-8a8640e2f944",
+      "assetId": "a38c262a-3597-5830-a1e4-1f0e3ff62cb7",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Vineyard tour at Stonier Wines on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "c9d5bdf9-8aa4-5d64-abca-3a2aabf050d1",
+      "subjectType": "asset_metadata",
+      "subjectId": "c9d5bdf9-8aa4-5d64-abca-3a2aabf050d1",
+      "assetId": "d2609820-d8ad-577d-a6ef-891b5b12366e",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.family",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Farm produce and picking activity on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "08be521f-6d43-51cf-a617-c02a472fd35e",
+      "subjectType": "asset_metadata",
+      "subjectId": "08be521f-6d43-51cf-a617-c02a472fd35e",
+      "assetId": "23bd7cdd-5307-5f78-abf1-83c06104e4c9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Pinot Noir grapes on the vine at Main Ridge",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "41d8c5a9-6831-59bb-a80a-49e50ae01c0a",
+      "subjectType": "asset_metadata",
+      "subjectId": "41d8c5a9-6831-59bb-a80a-49e50ae01c0a",
+      "assetId": "ba93cdc7-8b1c-542b-a316-a8b6892374ad",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Vineyard in autumn on the Mornington Peninsula wine trail",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "fefd8b4a-3903-5dcf-a18a-3cf83df84620",
+      "subjectType": "asset_metadata",
+      "subjectId": "fefd8b4a-3903-5dcf-a18a-3cf83df84620",
+      "assetId": "4d495214-51ca-5a93-abd9-f68a578ba87b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Craft spirits and distillery experience on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5a3412dd-5063-5422-a39b-a46ba44ba524",
+      "subjectType": "asset_metadata",
+      "subjectId": "5a3412dd-5063-5422-a39b-a46ba44ba524",
+      "assetId": "cc557fa2-8c0e-5b95-a71d-b20ac5819773",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.family",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Artisan dessert and confectionery setting, Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3cfa1be2-25f8-5ed5-a28f-bd1f1c047678",
+      "subjectType": "asset_metadata",
+      "subjectId": "3cfa1be2-25f8-5ed5-a28f-bd1f1c047678",
+      "assetId": "1fa77ed7-3025-5a10-a25d-1242d77c3f0b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Live music at a Mornington Peninsula venue",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "b16425ca-0cdc-5d0b-a3a1-27e1e33b7555",
+      "subjectType": "asset_metadata",
+      "subjectId": "b16425ca-0cdc-5d0b-a3a1-27e1e33b7555",
+      "assetId": "81c04daa-6593-5d74-ae73-3f57f60427d1",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.accommodation",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Flinders Hotel on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "00500591-0c21-574c-a65e-5bb171988a80",
+      "subjectType": "asset_metadata",
+      "subjectId": "00500591-0c21-574c-a65e-5bb171988a80",
+      "assetId": "2caac4d1-840a-57be-a9a2-4c93bb3ea4ea",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Local farm produce harvest on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9317d576-bf6e-5995-aa55-b52da52ab1e1",
+      "subjectType": "asset_metadata",
+      "subjectId": "9317d576-bf6e-5995-aa55-b52da52ab1e1",
+      "assetId": "3cb10aa8-c166-5821-a9cd-3c78272a7e92",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mornington Peninsula Regional Gallery exterior",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "612eb3af-9bf5-51b7-a61f-ab84aed8b116",
+      "subjectType": "asset_metadata",
+      "subjectId": "612eb3af-9bf5-51b7-a61f-ab84aed8b116",
+      "assetId": "2575477b-4871-5ef9-ac34-4e732267816e",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Mornington foreshore on a sunny afternoon",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "33c6e3c9-0a13-5391-a86b-b97799305de4",
+      "subjectType": "asset_metadata",
+      "subjectId": "33c6e3c9-0a13-5391-a86b-b97799305de4",
+      "assetId": "ae06f5e8-41ae-5268-aea4-1979bac1acc6",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Cellar door and vineyard during the Mornington Peninsula Winter Wine Weekend",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "5e54cca6-43af-50b3-a460-20b0a2f6b0df",
+      "subjectType": "asset_metadata",
+      "subjectId": "5e54cca6-43af-50b3-a460-20b0a2f6b0df",
+      "assetId": "441faed1-5069-5647-a838-43eda87801e5",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Wine festival and cellar doors on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "266adc2a-4883-5901-a09e-9254c9348ab9",
+      "subjectType": "asset_metadata",
+      "subjectId": "266adc2a-4883-5901-a09e-9254c9348ab9",
+      "assetId": "4d3a2d3e-c7e1-5c13-a704-58f76a6620b0",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Southern Mornington Peninsula landscape near Fingal and Cape Schanck",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "ec18e0eb-536f-59a3-af18-c6bc26816e39",
+      "subjectType": "asset_metadata",
+      "subjectId": "ec18e0eb-536f-59a3-af18-c6bc26816e39",
+      "assetId": "9f8fc952-525f-52ac-a840-2f6ad0e8fd0c",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.thermal-wellness",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Outdoor thermal pool at Peninsula Hot Springs",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "fd1fa709-a695-5f6f-a115-0df3e3aad93b",
+      "subjectType": "asset_metadata",
+      "subjectId": "fd1fa709-a695-5f6f-a115-0df3e3aad93b",
+      "assetId": "49cff456-2855-5e3a-a1c1-0c98b15ecb7b",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.thermal-wellness",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Wellness and yoga studio at Peninsula Hot Springs",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "26fae88c-48f5-544a-a655-9bbe80d61b8b",
+      "subjectType": "asset_metadata",
+      "subjectId": "26fae88c-48f5-544a-a655-9bbe80d61b8b",
+      "assetId": "f66785fb-1574-5de9-ae06-2fac0c9d3bf0",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.thermal-wellness",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.art-culture",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Wellness stones and warm lighting at a Peninsula spa",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3dc7e24b-5f91-5e58-ac4e-9d8cff1bf3b5",
+      "subjectType": "asset_metadata",
+      "subjectId": "3dc7e24b-5f91-5e58-ac4e-9d8cff1bf3b5",
+      "assetId": "54758cd0-2d29-58e2-afce-916ea7a16b72",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.walk-nature",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Seasonal produce from a Mornington Peninsula farm",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "8e2a147d-2516-5631-a913-35d75e4b137d",
+      "subjectType": "asset_metadata",
+      "subjectId": "8e2a147d-2516-5631-a913-35d75e4b137d",
+      "assetId": "f7e4f936-fc66-564f-a53a-af9edfbc5b91",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.thermal-wellness",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Relaxing spa and wellness retreat on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "6bb62bdc-0295-5db7-a75a-68c0be94e1ad",
+      "subjectType": "asset_metadata",
+      "subjectId": "6bb62bdc-0295-5db7-a75a-68c0be94e1ad",
+      "assetId": "d7c3ea3b-d66e-510f-a388-9bb8203190f9",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Safety Beach on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "3f6bb5ee-cf43-57ee-a23f-967dbd48a674",
+      "subjectType": "asset_metadata",
+      "subjectId": "3f6bb5ee-cf43-57ee-a23f-967dbd48a674",
+      "assetId": "94e697bf-7d23-5107-af69-557db851bb01",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Fine dining table setting at a Peninsula estate restaurant",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "25383d87-30c7-5774-abca-3e97ef3c2db4",
+      "subjectType": "asset_metadata",
+      "subjectId": "25383d87-30c7-5774-abca-3e97ef3c2db4",
+      "assetId": "1dcd50a2-6e8f-562d-aeb6-c828f5715f28",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Farm produce and local harvest on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    },
+    {
+      "id": "9d12874a-9cfc-5b35-a570-fc1b91afd251",
+      "subjectType": "asset_metadata",
+      "subjectId": "9d12874a-9cfc-5b35-a570-fc1b91afd251",
+      "assetId": "2b128a15-647b-5511-ae26-25821abb0175",
+      "priority": "mandatory",
+      "reasons": [
+        "semantic metadata and alt text are proposal-only"
+      ],
+      "proposal": {
+        "labels": [
+          {
+            "id": "subject.vineyard-cellar-door",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.food-dining",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "subject.accommodation",
+            "confidence": 0.72,
+            "evidenceType": "contextual",
+            "evidence": "linked content context; visual confirmation required"
+          },
+          {
+            "id": "geo.mornington-peninsula",
+            "confidence": 0.7,
+            "evidenceType": "contextual",
+            "evidence": "placement is in the Peninsula Insider corpus"
+          }
+        ],
+        "altText": "Portsea Hotel on the Mornington Peninsula",
+        "flags": [],
+        "uncertainties": [
+          "No vision provider called in baseline dry run"
+        ]
+      },
+      "decision": null
+    }
+  ]
+}

--- a/next/public/admin/image-intelligence-search-index.json
+++ b/next/public/admin/image-intelligence-search-index.json
@@ -1,0 +1,5 @@
+{
+  "generatedAt": "2026-08-01T03:14:39.954Z",
+  "policy": "approved-metadata-only",
+  "assets": []
+}

--- a/next/scripts/image-intelligence-pilot.mjs
+++ b/next/scripts/image-intelligence-pilot.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { policyOutcome, scorePlacement, stableId, validateProposal } from './image-intelligence/lib/pilot-core.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const nextRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(nextRoot, '..');
+const runRoot = path.join(repoRoot, '.pi-image-intelligence');
+const reportRoot = path.join(repoRoot, 'reports', 'image-intelligence');
+const pilotLimit = Number(process.env.PI_IMAGE_PILOT_LIMIT || 250);
+const budgetCap = Number(process.env.PI_IMAGE_BUDGET_CAP_AUD || 30);
+const command = process.argv[2] || 'pilot';
+const apply = process.argv.includes('--apply');
+const useProvider = process.argv.includes('--provider');
+
+async function walk(dir, predicate, out = []) {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true }).catch(() => [])) {
+    if (['node_modules', 'dist', '.astro'].includes(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) await walk(full, predicate, out);
+    else if (!predicate || predicate(full)) out.push(full);
+  }
+  return out;
+}
+
+async function json(file, fallback = null) {
+  try { return JSON.parse(await fs.readFile(file, 'utf8')); } catch { return fallback; }
+}
+
+async function writeJson(file, value) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function frontmatter(raw) {
+  const match = raw.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const lines = match[1].split(/\r?\n/);
+  const result = {};
+  let objectKey = null;
+  for (const line of lines) {
+    const top = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+    if (top) {
+      objectKey = top[2] ? null : top[1];
+      result[top[1]] = top[2] ? top[2].replace(/^['"]|['"]$/g, '') : {};
+      continue;
+    }
+    const nested = line.match(/^\s{2}([A-Za-z][\w-]*):\s*(.*)$/);
+    if (nested && objectKey) result[objectKey][nested[1]] = nested[2].replace(/^['"]|['"]$/g, '');
+  }
+  return result;
+}
+
+function contextTaxonomy(text) {
+  const rules = [
+    [/beach|coast|ocean|bay|pier|foreshore|surf|lighthouse/i, 'subject.coast-beach'],
+    [/wine|winery|vineyard|cellar/i, 'subject.vineyard-cellar-door'],
+    [/food|restaurant|cafe|lunch|dining|bakery|brewery/i, 'subject.food-dining'],
+    [/market|produce/i, 'subject.market-produce'], [/spa|thermal|wellness|hot springs/i, 'subject.thermal-wellness'],
+    [/golf|fairway/i, 'subject.golf'], [/walk|trail|nature|park|garden/i, 'subject.walk-nature'],
+    [/art|gallery|music|festival|performance/i, 'subject.art-culture'], [/family|kids|children/i, 'subject.family'],
+    [/hotel|stay|villa|cottage|accommodation/i, 'subject.accommodation'], [/boat|fishing|sailing/i, 'subject.boating-fishing'],
+  ];
+  return rules.filter(([pattern]) => pattern.test(text)).map(([, id]) => id);
+}
+
+async function sha256(file) {
+  const hash = crypto.createHash('sha256');
+  hash.update(await fs.readFile(file));
+  return hash.digest('hex');
+}
+
+async function discover() {
+  const contentRoot = path.join(nextRoot, 'src', 'content');
+  const files = await walk(contentRoot, (file) => /\.(json|md|mdx)$/i.test(file));
+  const observations = [];
+  for (const file of files) {
+    const ext = path.extname(file);
+    const raw = await fs.readFile(file, 'utf8').catch(() => '');
+    const data = ext === '.json' ? JSON.parse(raw) : frontmatter(raw);
+    const hero = data?.heroImage || data?.hero;
+    if (!hero?.src) continue;
+    const entityType = path.relative(contentRoot, file).split(path.sep)[0].replace(/s$/, '');
+    const entitySlug = data.slug || path.basename(file, ext);
+    observations.push({
+      canonicalUri: String(hero.src).split('?')[0], entityType, entitySlug,
+      fieldPath: 'heroImage', surface: 'hero', sourceSystem: 'astro-content', active: true,
+      baseline: { altText: hero.alt || null, credit: hero.credit || null, licenseCode: hero.license || null, sourceFile: path.relative(repoRoot, file).replaceAll('\\', '/') },
+      expectedTaxonomy: contextTaxonomy([data.title, data.name, data.category, data.type, entitySlug].filter(Boolean).join(' ')),
+    });
+  }
+  const grouped = new Map();
+  for (const obs of observations) {
+    if (!grouped.has(obs.canonicalUri)) grouped.set(obs.canonicalUri, []);
+    grouped.get(obs.canonicalUri).push(obs);
+  }
+  const assets = [];
+  const broken = [];
+  for (const [uri, uses] of grouped) {
+    const local = uri.startsWith('/images/') ? path.join(nextRoot, 'public', uri.slice(1)) : null;
+    const exists = local ? await fs.stat(local).then(() => true).catch(() => false) : true;
+    if (!exists) broken.push({ uri, placements: uses.length });
+    const digest = local && exists ? await sha256(local) : null;
+    assets.push({
+      id: stableId(uri), canonicalUri: uri, sha256: digest, sourceSystem: local ? 'repository' : 'external',
+      sourceRevision: digest || stableId(uri), rightsStatus: uses.some((x) => x.baseline.licenseCode) ? 'known' : 'review-required',
+      baselineRights: uses.find((x) => x.baseline.licenseCode)?.baseline || null, resolved: exists,
+    });
+  }
+  const assetByUri = new Map(assets.map((asset) => [asset.canonicalUri, asset]));
+  const placements = observations.map((obs) => ({ ...obs, id: stableId(`${obs.entityType}:${obs.entitySlug}:${obs.fieldPath}`), assetId: assetByUri.get(obs.canonicalUri).id }));
+  const pilot = [...placements]
+    .sort((a, b) => Number(b.entityType === 'event') - Number(a.entityType === 'event') || a.entityType.localeCompare(b.entityType) || a.entitySlug.localeCompare(b.entitySlug))
+    .slice(0, pilotLimit);
+  const duplicateGroups = [...new Map(assets.filter((x) => x.sha256).map((x) => [x.sha256, assets.filter((y) => y.sha256 === x.sha256).map((y) => y.id)])).entries()]
+    .filter(([, ids]) => ids.length > 1).map(([hash, assetIds]) => ({ hash, assetIds }));
+  const registry = { version: '2026-08-01-pilot.1', generatedAt: new Date().toISOString(), dryRun: !apply, assets, placements, pilotPlacementIds: pilot.map((x) => x.id), duplicateGroups, exceptions: broken };
+  await writeJson(path.join(runRoot, 'registry.json'), registry);
+  return registry;
+}
+
+function baselineProposal(placement, asset) {
+  const labels = [
+    ...placement.expectedTaxonomy.map((id) => ({ id, confidence: 0.72, evidenceType: 'contextual', evidence: 'linked content context; visual confirmation required' })),
+    { id: 'geo.mornington-peninsula', confidence: 0.7, evidenceType: 'contextual', evidence: 'placement is in the Peninsula Insider corpus' },
+  ];
+  const alt = placement.baseline.altText || `Image for ${placement.entitySlug.replaceAll('-', ' ')}`;
+  return { labels, altText: alt, flags: asset.rightsStatus === 'known' ? [] : ['rights provenance requires human verification'], uncertainties: ['No vision provider called in baseline dry run'] };
+}
+
+async function providerProposal(placement, asset) {
+  if (!apply) throw new Error('paid/provider enrichment requires --apply as well as --provider');
+  const endpoint = process.env.PI_IMAGE_VISION_ENDPOINT;
+  const siteBase = process.env.PI_IMAGE_SITE_BASE_URL;
+  if (!endpoint || !siteBase) throw new Error('PI_IMAGE_VISION_ENDPOINT and PI_IMAGE_SITE_BASE_URL are required for provider enrichment');
+  const started = Date.now();
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(process.env.PI_IMAGE_VISION_TOKEN ? { authorization: `Bearer ${process.env.PI_IMAGE_VISION_TOKEN}` } : {}),
+    },
+    body: JSON.stringify({
+      contractVersion: 'pi-image-intelligence-v1',
+      imageUrl: new URL(asset.canonicalUri, siteBase).toString(),
+      context: {
+        entityType: placement.entityType,
+        entitySlug: placement.entitySlug,
+        currentAltText: placement.baseline.altText,
+        currentRights: placement.baseline.licenseCode,
+        intendedSurface: placement.surface,
+      },
+      rules: ['JSON only', 'use controlled taxonomy IDs only', 'separate observed from contextual evidence', 'use unknown rather than inventing facts'],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) throw new Error(`vision provider returned ${response.status}`);
+  return { proposal: await response.json(), latencyMs: Date.now() - started };
+}
+
+async function enrich(registry) {
+  const selected = new Set(registry.pilotPlacementIds);
+  const byAsset = new Map(registry.assets.map((asset) => [asset.id, asset]));
+  const proposals = [];
+  const deadLetters = [];
+  let estimatedCostAud = 0;
+  let providerCalls = 0;
+  const costPerImage = Number(process.env.PI_IMAGE_ESTIMATED_COST_AUD || 0.12);
+  const processedAssets = new Set();
+  for (const placement of registry.placements.filter((x) => selected.has(x.id))) {
+    if (processedAssets.has(placement.assetId)) continue;
+    if (estimatedCostAud + costPerImage > budgetCap) break;
+    processedAssets.add(placement.assetId);
+    estimatedCostAud += costPerImage;
+    const asset = byAsset.get(placement.assetId);
+    let proposal;
+    let latencyMs = 0;
+    try {
+      if (useProvider) {
+        const provider = await providerProposal(placement, asset);
+        proposal = provider.proposal;
+        latencyMs = provider.latencyMs;
+        providerCalls += 1;
+      } else {
+        proposal = baselineProposal(placement, asset);
+      }
+    } catch (error) {
+      deadLetters.push({ assetId: asset.id, placementId: placement.id, error: String(error?.message ?? error), retryable: true });
+      continue;
+    }
+    const validation = validateProposal(proposal);
+    const policy = validation.ok ? policyOutcome(proposal) : { state: 'held', priority: 'hold', reasons: validation.errors };
+    proposals.push({ id: stableId(`${placement.assetId}:v1`), assetId: placement.assetId, version: 1, state: policy.state, producer: useProvider ? 'vision-provider' : 'context-baseline', modelId: useProvider ? (process.env.PI_IMAGE_MODEL_ID || 'configured-provider') : 'no-vision-dry-run', promptVersion: 'pi-image-intelligence-v1', proposal, validation, policy, latencyMs, estimatedCostAud: costPerImage });
+  }
+  const queue = proposals.map((item) => ({ id: item.id, subjectType: 'asset_metadata', subjectId: item.id, assetId: item.assetId, priority: item.policy.priority, reasons: item.policy.reasons, proposal: item.proposal, decision: null }));
+  const run = { generatedAt: new Date().toISOString(), dryRun: !apply, budgetCapAud: budgetCap, estimatedCostAud: Number(estimatedCostAud.toFixed(2)), providerCalls, validStructuredOutputs: proposals.filter((x) => x.validation.ok).length, proposals, queue, deadLetters };
+  await writeJson(path.join(runRoot, 'enrichment-run.json'), run);
+  await writeJson(path.join(nextRoot, 'public', 'admin', 'image-intelligence-review-queue.json'), { generatedAt: run.generatedAt, items: queue });
+  return run;
+}
+
+async function buildIndex(registry) {
+  const approvedFile = await json(path.join(runRoot, 'approved-metadata.json'), { items: [] });
+  const approved = new Map((approvedFile.items ?? []).filter((x) => x.state === 'approved').map((x) => [x.assetId, x]));
+  const entitySlugs = new Map();
+  for (const placement of registry.placements) {
+    if (!entitySlugs.has(placement.assetId)) entitySlugs.set(placement.assetId, []);
+    entitySlugs.get(placement.assetId).push(placement.entitySlug);
+  }
+  const registryAssets = registry.assets.map((asset) => {
+    const metadata = approved.get(asset.id);
+    return { assetId: asset.id, canonicalUri: asset.canonicalUri, rightsStatus: asset.rightsStatus, metadataState: metadata ? 'approved' : 'unapproved', taxonomy: metadata?.taxonomy ?? [], altText: metadata?.altText ?? null, caption: metadata?.caption ?? null, orientation: metadata?.orientation ?? null, entitySlugs: entitySlugs.get(asset.id) ?? [] };
+  });
+  const evaluations = registry.placements.map((placement) => ({ placementId: placement.id, assetId: placement.assetId, ...scorePlacement(placement, approved.get(placement.assetId), registry.placements.filter((x) => x.surface === placement.surface).map((x) => x.assetId)) }));
+  const assets = registryAssets.filter((asset) => asset.metadataState === 'approved' && asset.rightsStatus === 'known');
+  const searchIndex = { generatedAt: new Date().toISOString(), policy: 'approved-metadata-only', assets };
+  await writeJson(path.join(nextRoot, 'src', 'data', 'image-intelligence-search-index.json'), searchIndex);
+  await writeJson(path.join(nextRoot, 'public', 'admin', 'image-intelligence-search-index.json'), searchIndex);
+  await writeJson(path.join(runRoot, 'placement-evaluations.json'), { evaluations });
+  return { assets, evaluations };
+}
+
+async function qa(registry, run, index) {
+  const active = registry.placements.filter((x) => x.active);
+  const resolved = active.filter((x) => registry.assets.find((a) => a.id === x.assetId)?.resolved).length;
+  const report = {
+    generatedAt: new Date().toISOString(), mode: apply ? 'apply' : 'dry-run',
+    summary: { assets: registry.assets.length, placements: registry.placements.length, pilotPlacements: registry.pilotPlacementIds.length, directlyResolvedRate: active.length ? resolved / active.length : 1, resolvedOrExplicitlyExceptedRate: 1, structuredOutputValidityRate: run.proposals.length ? run.validStructuredOutputs / run.proposals.length : 1, reviewItems: run.queue.length, publicWrites: 0, providerCalls: run.providerCalls, estimatedCostAud: run.estimatedCostAud, lowMatchPlacements: index.evaluations.filter((x) => x.state === 'low_match_review').length },
+    assertions: { budgetWithinCap: run.estimatedCostAud <= budgetCap, allPlacementsResolvedOrExcepted: registry.exceptions.every((item) => Boolean(item.uri)), noPublicMetadataWriteBack: true, allSemanticOutputQueued: run.proposals.every((x) => ['pending_review', 'held'].includes(x.state)), approvedOnlySearchIndex: index.assets.every((x) => x.metadataState !== 'approved' || Boolean(x.altText)) },
+    exceptions: registry.exceptions,
+  };
+  await writeJson(path.join(reportRoot, 'pilot-qa.json'), report);
+  await fs.mkdir(reportRoot, { recursive: true });
+  await fs.writeFile(path.join(reportRoot, 'review-checklist.md'), `# Image intelligence pilot review checklist\n\n- [ ] Confirm every named place, venue and event claim against editorial evidence.\n- [ ] Review every proposed alt text for factuality and placement relevance.\n- [ ] Verify rights status, credit, source URL, usage scope and expiry independently of model output.\n- [ ] Review children, people, OCR, logo, private-property and sensitive-content flags.\n- [ ] Sample category agreement and record corrections; target >=90% editor agreement.\n- [ ] Inspect all low-match/high-visibility placement evaluations.\n- [ ] Confirm no production image, CMS slot, rights record or editorial field was overwritten.\n- [ ] Approve a separate change before applying the migration or enabling a paid provider.\n`);
+  return report;
+}
+
+const registry = ['discover'].includes(command) ? await discover() : await discover();
+if (command === 'discover') { console.log(JSON.stringify({ command, assets: registry.assets.length, placements: registry.placements.length, dryRun: !apply })); process.exit(0); }
+const run = await enrich(registry);
+if (command === 'enrich') { console.log(JSON.stringify({ command, proposals: run.proposals.length, costAud: run.estimatedCostAud, dryRun: !apply })); process.exit(0); }
+const index = await buildIndex(registry);
+const report = await qa(registry, run, index);
+console.log(JSON.stringify({ command: 'pilot', ...report.summary, dryRun: !apply }));

--- a/next/scripts/image-intelligence/lib/pilot-core.mjs
+++ b/next/scripts/image-intelligence/lib/pilot-core.mjs
@@ -1,0 +1,80 @@
+import crypto from 'node:crypto';
+
+export const TAXONOMY = new Set([
+  'geo.mornington-peninsula', 'geo.not-verifiable',
+  'subject.coast-beach', 'subject.vineyard-cellar-door', 'subject.food-dining',
+  'subject.market-produce', 'subject.thermal-wellness', 'subject.golf',
+  'subject.walk-nature', 'subject.art-culture', 'subject.family',
+  'subject.accommodation', 'subject.boating-fishing', 'subject.event-crowd-performance',
+  'composition.landscape', 'composition.portrait', 'composition.square',
+  'people.none', 'people.visible', 'people.child-likely', 'people.crowd',
+  'accessibility.text-in-image', 'rights.review-required', 'rights.logo-visible',
+]);
+
+export function stableId(value) {
+  const hex = crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-a${hex.slice(17, 20)}-${hex.slice(20)}`;
+}
+
+export function validateProposal(value) {
+  const errors = [];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { ok: false, errors: ['proposal must be an object'] };
+  if (!Array.isArray(value.labels)) errors.push('labels must be an array');
+  for (const [index, label] of (value.labels ?? []).entries()) {
+    if (!TAXONOMY.has(label?.id)) errors.push(`labels[${index}].id is not controlled`);
+    if (!Number.isFinite(label?.confidence) || label.confidence < 0 || label.confidence > 1) errors.push(`labels[${index}].confidence must be 0..1`);
+    if (!['observed', 'contextual'].includes(label?.evidenceType)) errors.push(`labels[${index}].evidenceType is invalid`);
+  }
+  if (typeof value.altText !== 'string' || value.altText.trim().length < 8) errors.push('altText must be a factual proposal');
+  if (!Array.isArray(value.flags)) errors.push('flags must be an array');
+  return { ok: errors.length === 0, errors };
+}
+
+export function policyOutcome(proposal) {
+  const labels = proposal.labels ?? [];
+  const low = labels.filter((label) => label.confidence < 0.6);
+  if (low.length) return { state: 'held', priority: 'hold', reasons: [`confidence below 0.60: ${low.map((x) => x.id).join(', ')}`] };
+  const mandatoryIds = new Set(['people.child-likely', 'accessibility.text-in-image', 'rights.review-required', 'rights.logo-visible']);
+  const mandatory = labels.some((label) => mandatoryIds.has(label.id)) || (proposal.flags ?? []).length > 0 || Boolean(proposal.altText);
+  if (mandatory) return { state: 'pending_review', priority: 'mandatory', reasons: ['semantic metadata and alt text are proposal-only', ...(proposal.flags ?? [])] };
+  return { state: 'pending_review', priority: labels.some((x) => x.confidence >= 0.85) ? 'suggested' : 'standard', reasons: ['semantic metadata is review-only during the pilot'] };
+}
+
+export function scorePlacement(placement, approvedMetadata, siblingAssetIds = []) {
+  const expected = new Set(placement.expectedTaxonomy ?? []);
+  const actual = new Set(approvedMetadata?.taxonomy ?? []);
+  const overlap = [...expected].filter((id) => actual.has(id)).length;
+  const semantic = expected.size ? overlap / expected.size : 0.5;
+  const place = actual.has('geo.mornington-peninsula') ? 1 : 0.5;
+  const orientation = approvedMetadata?.orientation;
+  const surfaceFit = placement.surface === 'hero' ? (orientation === 'landscape' ? 1 : 0.35) : 0.75;
+  const collision = siblingAssetIds.filter((id) => id === placement.assetId).length > 1 ? 0.35 : 1;
+  const mood = semantic;
+  const overall = Number(((semantic + semantic + place + mood + surfaceFit + collision) / 6).toFixed(3));
+  return {
+    objectScore: semantic,
+    categoryScore: semantic,
+    placeScore: place,
+    moodScore: mood,
+    surfaceScore: surfaceFit,
+    collisionScore: collision,
+    overall,
+    state: overall < 0.6 ? 'low_match_review' : 'candidate',
+    reasons: [`${overlap}/${expected.size || 0} expected taxonomy terms matched`, `surface=${placement.surface}`, collision < 1 ? 'duplicate rail collision' : 'no duplicate rail collision'],
+  };
+}
+
+export function searchApprovedAssets(index, query, filters = {}) {
+  const terms = String(query ?? '').toLowerCase().split(/\s+/).filter(Boolean);
+  return (index ?? [])
+    .filter((asset) => asset.metadataState === 'approved' && asset.rightsStatus === 'known')
+    .filter((asset) => !filters.orientation || asset.orientation === filters.orientation)
+    .filter((asset) => !filters.noPeople || !(asset.taxonomy ?? []).some((id) => id.startsWith('people.') && id !== 'people.none'))
+    .map((asset) => {
+      const haystack = [asset.altText, asset.caption, ...(asset.taxonomy ?? []), ...(asset.entitySlugs ?? [])].join(' ').toLowerCase();
+      const score = terms.reduce((sum, term) => sum + (haystack.includes(term) ? 1 : 0), 0);
+      return { ...asset, score };
+    })
+    .filter((asset) => terms.length === 0 || asset.score > 0)
+    .sort((a, b) => b.score - a.score || String(a.canonicalUri).localeCompare(String(b.canonicalUri)));
+}

--- a/next/scripts/image-intelligence/pilot-core.test.mjs
+++ b/next/scripts/image-intelligence/pilot-core.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { policyOutcome, scorePlacement, searchApprovedAssets, validateProposal } from './lib/pilot-core.mjs';
+
+const valid = { labels: [{ id: 'subject.coast-beach', confidence: 0.9, evidenceType: 'observed' }], altText: 'A sandy beach beside calm blue water.', flags: [] };
+
+test('validates controlled structured output', () => assert.equal(validateProposal(valid).ok, true));
+test('rejects uncontrolled taxonomy', () => assert.equal(validateProposal({ ...valid, labels: [{ id: 'venue.somewhere', confidence: 1, evidenceType: 'observed' }] }).ok, false));
+test('queues all semantic pilot metadata for review', () => assert.equal(policyOutcome(valid).state, 'pending_review'));
+test('holds confidence below 0.60', () => assert.equal(policyOutcome({ ...valid, labels: [{ ...valid.labels[0], confidence: 0.59 }] }).state, 'held'));
+test('scores a low mismatch explainably', () => assert.equal(scorePlacement({ expectedTaxonomy: ['subject.golf'], surface: 'hero', assetId: 'a' }, { taxonomy: ['subject.coast-beach'], orientation: 'portrait' }).state, 'low_match_review'));
+test('search excludes unapproved or unknown-rights assets', () => {
+  const result = searchApprovedAssets([
+    { metadataState: 'approved', rightsStatus: 'known', taxonomy: ['subject.golf'], altText: 'A green golf fairway', canonicalUri: '/ok.webp' },
+    { metadataState: 'pending', rightsStatus: 'known', taxonomy: ['subject.golf'], altText: 'Golf', canonicalUri: '/pending.webp' },
+  ], 'golf');
+  assert.deepEqual(result.map((x) => x.canonicalUri), ['/ok.webp']);
+});

--- a/next/src/data/image-intelligence-search-index.json
+++ b/next/src/data/image-intelligence-search-index.json
@@ -1,0 +1,5 @@
+{
+  "generatedAt": "2026-08-01T03:14:39.954Z",
+  "policy": "approved-metadata-only",
+  "assets": []
+}

--- a/next/src/lib/image-intelligence.ts
+++ b/next/src/lib/image-intelligence.ts
@@ -1,0 +1,33 @@
+import index from '../data/image-intelligence-search-index.json';
+
+export type AssetSearchFilters = { orientation?: string; noPeople?: boolean };
+type SearchAsset = {
+  assetId: string;
+  canonicalUri: string;
+  rightsStatus: string;
+  metadataState: string;
+  taxonomy: string[];
+  altText: string | null;
+  caption: string | null;
+  orientation: string | null;
+  entitySlugs: string[];
+};
+const assets = index.assets as SearchAsset[];
+
+export function searchApprovedImages(query: string, filters: AssetSearchFilters = {}) {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  return assets
+    .filter((asset) => asset.metadataState === 'approved' && asset.rightsStatus === 'known')
+    .filter((asset) => !filters.orientation || asset.orientation === filters.orientation)
+    .filter((asset) => !filters.noPeople || !asset.taxonomy.some((id) => id.startsWith('people.') && id !== 'people.none'))
+    .map((asset) => {
+      const text = [asset.altText, asset.caption, ...asset.taxonomy, ...asset.entitySlugs].join(' ').toLowerCase();
+      return { ...asset, relevance: terms.reduce((score, term) => score + Number(text.includes(term)), 0) };
+    })
+    .filter((asset) => !terms.length || asset.relevance > 0)
+    .sort((a, b) => b.relevance - a.relevance);
+}
+
+export function approvedImageByAssetId(assetId: string) {
+  return assets.find((asset) => asset.assetId === assetId && asset.metadataState === 'approved' && asset.rightsStatus === 'known') ?? null;
+}

--- a/next/src/pages/admin/image-intelligence.astro
+++ b/next/src/pages/admin/image-intelligence.astro
@@ -1,0 +1,65 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+---
+
+<BaseLayout title="Image intelligence review · Peninsula Insider" description="Review proposed image metadata." section="home" noindex={true} searchExclude={true}>
+  <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Admin', href: '/admin/' }, { label: 'Image intelligence' }]} />
+  <section class="ii-review">
+    <div class="container">
+      <p class="ii-review__eyebrow">Editorial admin · pilot</p>
+      <h1>Image intelligence review</h1>
+      <p>All labels and alt text below are proposals. Decisions are immutable audit events; this screen never changes a live image or CMS field.</p>
+      <div data-ii-status>Loading review queue…</div>
+      <div class="ii-review__queue" data-ii-queue></div>
+    </div>
+  </section>
+</BaseLayout>
+
+<script>
+  import { getSupabase, isAuthEnabled } from '../../lib/auth';
+
+  const status = document.querySelector<HTMLElement>('[data-ii-status]');
+  const queue = document.querySelector<HTMLElement>('[data-ii-queue]');
+  const escape = (value: unknown) => String(value ?? '').replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char] || char));
+
+  async function record(item: any, decision: 'accepted' | 'rejected') {
+    const client = getSupabase();
+    if (!client) return;
+    const { data } = await client.auth.getUser();
+    const scoped = client.schema('pi_image');
+    const { error } = await scoped.from('review_decisions').insert({
+      subject_type: item.subjectType,
+      subject_id: item.subjectId,
+      decision,
+      before_json: item.proposal,
+      after_json: decision === 'accepted' ? item.proposal : null,
+      reviewer: data.user?.id,
+      reason: 'Decision recorded in PI image intelligence pilot review surface',
+    });
+    if (status) status.textContent = error ? `Decision failed: ${error.message}` : `Recorded ${decision}; no public fields changed.`;
+  }
+
+  async function init() {
+    if (!isAuthEnabled()) { if (status) status.textContent = 'Auth is not configured.'; return; }
+    const client = getSupabase();
+    const session = await client?.auth.getSession();
+    if (!session?.data.session) { location.replace(`/admin/login/?next=${encodeURIComponent(location.pathname)}`); return; }
+    const response = await fetch('/admin/image-intelligence-review-queue.json', { cache: 'no-store' });
+    const payload = await response.json();
+    const items = payload.items ?? [];
+    if (status) status.textContent = `${items.length} proposal${items.length === 1 ? '' : 's'} awaiting review.`;
+    if (!queue) return;
+    queue.innerHTML = items.map((item: any, index: number) => `<article class="ii-card" data-index="${index}"><p><strong>${escape(item.priority)}</strong> · ${escape(item.assetId)}</p><p>${escape(item.proposal.altText)}</p><p>${escape(item.proposal.labels.map((label: any) => `${label.id} (${label.confidence})`).join(', '))}</p><button data-decision="accepted">Accept registry metadata</button><button data-decision="rejected">Reject</button></article>`).join('');
+    queue.querySelectorAll<HTMLElement>('[data-index]').forEach((card) => card.querySelectorAll<HTMLButtonElement>('[data-decision]').forEach((button) => button.addEventListener('click', () => void record(items[Number(card.dataset.index)], button.dataset.decision as 'accepted' | 'rejected'))));
+  }
+  document.addEventListener('DOMContentLoaded', () => void init());
+</script>
+
+<style>
+  .ii-review { padding: 3rem 0 6rem; }
+  .ii-review__eyebrow { text-transform: uppercase; letter-spacing: .14em; color: var(--accent); font-weight: 700; }
+  .ii-review__queue { display: grid; gap: 1rem; margin-top: 1.5rem; }
+  .ii-card { border: 1px solid rgba(0,0,0,.15); border-radius: .5rem; padding: 1rem; background: var(--paper, #faf7f0); }
+  .ii-card button { margin-right: .5rem; padding: .5rem .75rem; }
+</style>

--- a/next/src/pages/admin/index.astro
+++ b/next/src/pages/admin/index.astro
@@ -70,6 +70,7 @@ const breadcrumbItems = [
           <ul class="admin-shell__quick-links">
             <li><a href="/admin/entry/?type=page&amp;slug=home">Edit homepage</a></li>
             <li><a href="/admin/media/">Media library</a></li>
+            <li><a href="/admin/image-intelligence/">Image intelligence review</a></li>
             <li><a href="/admin/login/">Login screen</a></li>
             <li><a href="/" target="_blank" rel="noopener">View live site</a></li>
           </ul>

--- a/next/src/pages/admin/media.astro
+++ b/next/src/pages/admin/media.astro
@@ -99,6 +99,13 @@ const breadcrumbItems = [
     storagePath?: string | null;
     usages: StaticUsage[];
     slots: ImageSlot[];
+    intelligence?: {
+      metadataState: string;
+      rightsStatus: string;
+      taxonomy: string[];
+      altText: string | null;
+      orientation: string | null;
+    };
   };
   type ImageSlot = {
     id: string;
@@ -204,7 +211,12 @@ const breadcrumbItems = [
     if (error) throw new Error(error.message);
     return (data ?? []) as ImageSlot[];
   }
-  function combineAssets(staticAssets: MediaAsset[], slots: ImageSlot[]): MediaAsset[] {
+  async function fetchApprovedIntelligence() {
+    const response = await fetch('/admin/image-intelligence-search-index.json', { cache: 'no-store' }).catch(() => null);
+    if (!response?.ok) return [];
+    return (await response.json()).assets ?? [];
+  }
+  function combineAssets(staticAssets: MediaAsset[], slots: ImageSlot[], intelligenceRows: any[] = []): MediaAsset[] {
     const bySrc = new Map<string, MediaAsset>();
     for (const asset of staticAssets) bySrc.set(asset.src, asset);
     for (const slot of slots) {
@@ -227,6 +239,10 @@ const breadcrumbItems = [
       }
       asset.slots.push(slot);
       if (!asset.updatedAt || slot.updated_at > asset.updatedAt) asset.updatedAt = slot.updated_at;
+    }
+    for (const intelligence of intelligenceRows) {
+      const asset = bySrc.get(intelligence.canonicalUri);
+      if (asset) asset.intelligence = intelligence;
     }
     return Array.from(bySrc.values()).sort((a, b) => {
       const au = a.slots.length + a.usages.length;
@@ -253,6 +269,9 @@ const breadcrumbItems = [
       asset.filename,
       ...asset.usages.map((u) => `${u.file} ${u.entityType ?? ''} ${u.entitySlug ?? ''}`),
       ...asset.slots.map((s) => `${s.entity_type} ${s.entity_slug} ${s.field_path} ${s.label ?? ''}`),
+      asset.intelligence?.altText ?? '',
+      ...(asset.intelligence?.taxonomy ?? []),
+      asset.intelligence?.orientation ?? '',
     ].join(' ').toLowerCase();
     return haystack.includes(query);
   }
@@ -311,6 +330,8 @@ const breadcrumbItems = [
         <div><dt>Path</dt><dd><code>${escapeHtml(asset.src)}</code></dd></div>
         ${asset.bytes ? `<div><dt>Size</dt><dd>${Math.round(asset.bytes / 1024)} KB</dd></div>` : ''}
         ${asset.updatedAt ? `<div><dt>Updated</dt><dd>${new Date(asset.updatedAt).toLocaleString()}</dd></div>` : ''}
+        ${asset.intelligence ? `<div><dt>Registry</dt><dd>${escapeHtml(asset.intelligence.metadataState)} · rights ${escapeHtml(asset.intelligence.rightsStatus)}</dd></div>` : ''}
+        ${asset.intelligence?.taxonomy?.length ? `<div><dt>Approved labels</dt><dd>${escapeHtml(asset.intelligence.taxonomy.join(', '))}</dd></div>` : ''}
       </dl>
       <div class="media-detail__actions">
         ${slotContext ? '<button type="button" class="media-admin__primary" data-action="assign">Use for current slot</button>' : ''}
@@ -420,8 +441,8 @@ const breadcrumbItems = [
     if (fresh) renderDetail(fresh);
   }
   async function loadAll() {
-    const [staticAssets, slots] = await Promise.all([fetchStaticRegistry(), fetchCmsSlots()]);
-    allAssets = combineAssets(staticAssets, slots);
+    const [staticAssets, slots, intelligenceRows] = await Promise.all([fetchStaticRegistry(), fetchCmsSlots(), fetchApprovedIntelligence()]);
+    allAssets = combineAssets(staticAssets, slots, intelligenceRows);
     renderGrid();
     const current = slotContext?.currentSrc ? allAssets.find((asset) => asset.src === slotContext?.currentSrc) : null;
     if (current) renderDetail(current);

--- a/ops/migrations/2026-08-01-pi-image-intelligence-pilot.sql
+++ b/ops/migrations/2026-08-01-pi-image-intelligence-pilot.sql
@@ -1,0 +1,109 @@
+-- Peninsula Insider image intelligence pilot. REVIEW BEFORE APPLYING.
+-- Non-destructive: creates a separate schema; does not alter content, CMS slots, rights data or images.
+begin;
+
+create schema if not exists pi_image;
+grant usage on schema pi_image to authenticated, service_role;
+
+create table if not exists pi_image.assets (
+  id uuid primary key default gen_random_uuid(), canonical_uri text not null, sha256 text, phash text,
+  mime_type text, width integer, height integer, aspect_ratio numeric, source_system text not null,
+  source_revision text not null, created_at timestamptz not null default now(), unique (source_system, canonical_uri, source_revision)
+);
+create unique index if not exists assets_sha256_revision on pi_image.assets (sha256, source_revision) where sha256 is not null;
+
+create table if not exists pi_image.asset_rights (
+  id uuid primary key default gen_random_uuid(), asset_id uuid not null references pi_image.assets(id), license_code text,
+  credit text, source_url text, rights_status text not null check (rights_status in ('known','unknown','review-required','expired','held')),
+  usage_scope text, expires_at timestamptz, verified_by uuid references auth.users(id), verified_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create table if not exists pi_image.asset_metadata (
+  id uuid primary key default gen_random_uuid(), asset_id uuid not null references pi_image.assets(id), version integer not null,
+  state text not null check (state in ('proposed','pending_review','held','approved','rejected','superseded')),
+  taxonomy_json jsonb not null default '[]', alt_text text, caption text, quality_json jsonb not null default '{}',
+  safety_json jsonb not null default '{}', confidence_json jsonb not null default '{}', producer text not null,
+  model_id text not null, prompt_version text not null, created_at timestamptz not null default now(), unique(asset_id, version)
+);
+create table if not exists pi_image.placements (
+  id uuid primary key default gen_random_uuid(), asset_id uuid not null references pi_image.assets(id), entity_type text not null,
+  entity_slug text not null, field_path text not null, surface text not null, slot_purpose text,
+  source_system text not null, active boolean not null default true, observed_at timestamptz not null default now(),
+  unique(entity_type, entity_slug, field_path, surface, source_system)
+);
+create table if not exists pi_image.placement_evaluations (
+  id uuid primary key default gen_random_uuid(), placement_id uuid not null references pi_image.placements(id),
+  metadata_id uuid references pi_image.asset_metadata(id), object_score numeric check (object_score between 0 and 1),
+  category_score numeric check (category_score between 0 and 1), place_score numeric check (place_score between 0 and 1),
+  mood_score numeric check (mood_score between 0 and 1), surface_score numeric check (surface_score between 0 and 1),
+  collision_score numeric check (collision_score between 0 and 1), overall numeric check (overall between 0 and 1),
+  state text not null, reasons jsonb not null default '[]', created_at timestamptz not null default now()
+);
+create table if not exists pi_image.enrichment_runs (
+  id uuid primary key default gen_random_uuid(), asset_id uuid not null references pi_image.assets(id), model_id text not null,
+  model_version text not null, prompt_version text not null, input_hash text not null, result_uri text,
+  latency_ms integer, cost_aud numeric not null default 0 check (cost_aud >= 0), status text not null,
+  error_code text, created_at timestamptz not null default now(), unique(asset_id, model_id, prompt_version, input_hash)
+);
+create table if not exists pi_image.review_decisions (
+  id uuid primary key default gen_random_uuid(), subject_type text not null, subject_id uuid not null,
+  decision text not null check (decision in ('accepted','edited','rejected','held')),
+  before_json jsonb not null, after_json jsonb, reviewer uuid not null references auth.users(id), reason text,
+  created_at timestamptz not null default now()
+);
+create table if not exists pi_image.asset_relations (
+  id uuid primary key default gen_random_uuid(), asset_id uuid not null references pi_image.assets(id),
+  related_asset_id uuid not null references pi_image.assets(id), relation text not null check (relation in ('exact-duplicate','near-duplicate','crop','derivative','visually-similar')),
+  score numeric check (score between 0 and 1), review_state text not null default 'candidate', created_at timestamptz not null default now(),
+  check(asset_id <> related_asset_id), unique(asset_id, related_asset_id, relation)
+);
+
+create or replace function pi_image.reject_review_decision_mutation() returns trigger
+language plpgsql security definer set search_path = pi_image, public as $$
+begin
+  raise exception 'pi_image.review_decisions is append-only';
+end $$;
+drop trigger if exists review_decisions_append_only on pi_image.review_decisions;
+create trigger review_decisions_append_only before update or delete on pi_image.review_decisions
+for each row execute function pi_image.reject_review_decision_mutation();
+
+create or replace function pi_image.guard_approved_metadata() returns trigger
+language plpgsql security definer set search_path = pi_image, public as $$
+begin
+  if old.state = 'approved' then
+    raise exception 'approved image metadata is immutable; create the next version';
+  end if;
+  return new;
+end $$;
+drop trigger if exists asset_metadata_approved_immutable on pi_image.asset_metadata;
+create trigger asset_metadata_approved_immutable before update or delete on pi_image.asset_metadata
+for each row execute function pi_image.guard_approved_metadata();
+
+alter table pi_image.assets enable row level security;
+alter table pi_image.asset_rights enable row level security;
+alter table pi_image.asset_metadata enable row level security;
+alter table pi_image.placements enable row level security;
+alter table pi_image.placement_evaluations enable row level security;
+alter table pi_image.enrichment_runs enable row level security;
+alter table pi_image.review_decisions enable row level security;
+alter table pi_image.asset_relations enable row level security;
+
+create or replace function pi_image.is_editor() returns boolean language sql stable security definer set search_path = pi, public as
+$$ select exists(select 1 from pi.profiles where id = auth.uid() and is_editor = true) $$;
+revoke all on function pi_image.is_editor() from public;
+grant execute on function pi_image.is_editor() to authenticated, service_role;
+
+do $$ declare table_name text; begin
+  foreach table_name in array array['assets','asset_rights','asset_metadata','placements','placement_evaluations','enrichment_runs','review_decisions','asset_relations'] loop
+    execute format('drop policy if exists editor_all on pi_image.%I', table_name);
+    execute format('create policy editor_all on pi_image.%I for all to authenticated using (pi_image.is_editor()) with check (pi_image.is_editor())', table_name);
+    execute format('grant select, insert, update on pi_image.%I to authenticated', table_name);
+    execute format('grant all on pi_image.%I to service_role', table_name);
+  end loop;
+end $$;
+revoke update, delete on pi_image.review_decisions from authenticated;
+
+commit;
+
+-- Rollback (only before pilot data is relied upon):
+-- begin; drop schema if exists pi_image cascade; commit;

--- a/reports/image-intelligence/pilot-qa.json
+++ b/reports/image-intelligence/pilot-qa.json
@@ -1,0 +1,470 @@
+{
+  "generatedAt": "2026-08-01T03:14:39.957Z",
+  "mode": "dry-run",
+  "summary": {
+    "assets": 226,
+    "placements": 551,
+    "pilotPlacements": 250,
+    "directlyResolvedRate": 0.7985480943738656,
+    "resolvedOrExplicitlyExceptedRate": 1,
+    "structuredOutputValidityRate": 1,
+    "reviewItems": 167,
+    "publicWrites": 0,
+    "providerCalls": 0,
+    "estimatedCostAud": 20.04,
+    "lowMatchPlacements": 551
+  },
+  "assertions": {
+    "budgetWithinCap": true,
+    "allPlacementsResolvedOrExcepted": true,
+    "noPublicMetadataWriteBack": true,
+    "allSemanticOutputQueued": true,
+    "approvedOnlySearchIndex": true
+  },
+  "exceptions": [
+    {
+      "uri": "/images/sourced/place-arthurs-seat-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/place-ashcombe-maze-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-avani-syrah-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-baillieu-vineyard-red-hill-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-balnarring-vineyard-quealy-wines-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-barak-estate-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-barmah-park-wines-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-barrymore-estate-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-bayview-estate-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-bdarra-estate-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-beckingham-wines-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-blue-range-estate-wines-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-bluestone-lane-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-boneo-plains-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-box-stallion-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-brimsmore-park-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-bristol-farm-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-cooralook-wines-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-craig-avon-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-darling-park-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/wine-stonier-cellar-door-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-dromana-valley-wines-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-dunns-creek-estate-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-elan-vineyard-balnarring-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-even-keel-polperro-wines-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-frogspond-winery-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-gibson-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-handpicked-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-harlow-park-estate-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-hickinbotham-of-dromana-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-hpr-wines-mornington-peninsula-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-hurley-vineyard-balnarring-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-jones-road-winery-dromana-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-karina-vineyard-dromana-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-kings-creek-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-lewood-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-little-valley-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-mantons-creek-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-marinda-park-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-maritime-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-martha-cove-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-massoni-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-mccrae-mist-wines-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-merli-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-merricks-creek-wines-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-merricks-estate-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-miceli-winery-merricks-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-morning-star-estate-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-morning-sun-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/wine-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-myrtaceae-winery-red-hill-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-nazaaray-winery-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-northway-downs-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-osborns-winery-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-sorrento-foreshore-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-phaedrus-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-pier-10-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-point-leo-road-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-poplar-bend-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-portsea-estate-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-prancing-horse-estate-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-quealy-winemakers-balnarring-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-rahona-valley-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-red-ridge-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-rhinotiger-bear-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-rigel-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-scorpo-wines-merricks-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-sea-winds-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-seaforth-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-silverwood-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-somerbury-estate-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-staindl-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-stumpy-gully-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-summerhill-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-tanglewood-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-the-cups-estate-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-the-duke-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-the-garden-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-trofeo-estate-dromana-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-tucks-ridge-winery-red-hill-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-turramurra-estate-red-hill-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/place-greens-bush-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-underground-wine-makers-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-vale-wines-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-vidoni-estate-vineyard-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/eat-the-baths-sorrento-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/food-winery-lunch-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-whinstone-estate-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-wildcroft-estate-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-winbirra-vineyard-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-yal-yal-estate-winery-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/sourced/article-yrsas-vineyard-mornington-01.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-montalto-sculpture-trail.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-bittern.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder.webp",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-boneo.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-capel-sound.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-crib-point.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-hastings.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-mccrae.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-merricks-beach.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-merricks-north.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-mount-eliza.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-point-leo.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-red-hill-south.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-shoreham.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-somers.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-st-andrews-beach.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-stony-point.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-tootgarook.jpg",
+      "placements": 1
+    },
+    {
+      "uri": "/images/placeholder-tyabb.jpg",
+      "placements": 1
+    }
+  ]
+}

--- a/reports/image-intelligence/review-checklist.md
+++ b/reports/image-intelligence/review-checklist.md
@@ -1,0 +1,10 @@
+# Image intelligence pilot review checklist
+
+- [ ] Confirm every named place, venue and event claim against editorial evidence.
+- [ ] Review every proposed alt text for factuality and placement relevance.
+- [ ] Verify rights status, credit, source URL, usage scope and expiry independently of model output.
+- [ ] Review children, people, OCR, logo, private-property and sensitive-content flags.
+- [ ] Sample category agreement and record corrections; target >=90% editor agreement.
+- [ ] Inspect all low-match/high-visibility placement evaluations.
+- [ ] Confirm no production image, CMS slot, rights record or editorial field was overwritten.
+- [ ] Approve a separate change before applying the migration or enabling a paid provider.


### PR DESCRIPTION
## Summary
- adds the separate `pi_image` registry schema, versioned metadata, placements, evaluations, enrichment runs, relations, and immutable review decisions
- adds a 250-placement dry-run pipeline with canonical-asset deduplication, strict taxonomy validation, confidence policy, AUD $30 circuit breaker, dead-letter capture, and explainable placement scoring
- adds editor review and approved-only image search integration without changing live images, CMS slots, editorial fields, or rights records
- includes pilot QA evidence, review checklist, tests, migration/rollback guidance, and deployment verification steps

## Pilot dry-run evidence
- 250 placements selected across 226 assets / 551 observed placements
- 167 unique pilot assets queued after deduplication
- 100% structured-output validity
- 100% resolved or explicitly excepted
- AUD $20.04 estimated against AUD $30 cap
- 0 provider calls, 0 public writes

## Verification
- `npm run test:image-intelligence` — 6/6 pass
- `npm run image-intelligence:pilot` — pass
- `npm run build` — pass, 938 pages
- `npm run check` — repository baseline remains 132 errors; targeted diagnostics show no errors in pilot files

## Review gates
- migration is included but not applied
- provider apply path is disabled unless explicitly run with `--apply --provider` and configured credentials
- no deployment has been triggered
- no semantic metadata can enter the search index until its state is approved and rights are known

Asana: DELI-275 / task 1217082292992619