### PR TITLE
fix(design): remove the stray border around place tiles

### DIFF
--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -1480,9 +1480,19 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   grid-template-columns: repeat(2, 1fr);
   gap: 1.5rem;
 }
-/* P3-4: fully absorbed by .pi-card. The place tile previously carried no
-   ground and no hairline, which is exactly the "cards float without
-   definition" finding; it now takes the shared 3.45:1 rule. */
+/* The place tile is intentionally borderless: a photograph with a caption
+   beneath it, not a contained card.
+   P3-4 (2026-07-25) absorbed it into .pi-card to answer the "cards float
+   without definition" finding, but that only half-landed. .place-card__body
+   has no horizontal padding, so the new hairline ran flush into the name and
+   intro text, and on /explore/places/ the result read as a stray box around
+   every tile. Reverted to the pre-P3-4 rule. If this tile ever does want a
+   ground, the body padding has to come with it. */
+.place-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--tile-image-radius);
+}
 .place-card__image {
   display: block;
   aspect-ratio: 16 / 9;

--- a/next/src/styles/primitives.css
+++ b/next/src/styles/primitives.css
@@ -471,12 +471,15 @@
    --border hairline, which measures 3.45:1 on #FFFFFF.
    ========================================================= */
 
+/* .place-card is deliberately NOT in this group. See global.css: the place
+   tile is a photograph with a caption under it, not a contained card, and its
+   body carries no horizontal padding. Giving it the hairline ran the border
+   straight into the text. */
 .pi-card,
 .venue-card,
 .event-card,
 .itinerary-card,
 .tour-card,
-.place-card,
 .experience-card,
 .guide-card {
   position: relative;


### PR DESCRIPTION
The place tile is a photograph with a caption beneath it, not a contained card.

P3-4 (2026-07-25, `74e6b0ade4`) absorbed `.place-card` into the `.pi-card` primitive to answer the "cards float without definition" finding, which gave it a hairline, a white ground, and a clipped radius.

That only half-landed. `.place-card__body` still has `padding: 1.5rem 0 3rem` — **no horizontal padding** — so the new border ran flush into the name and intro text. On `/explore/places/`, where 37 tiles sit in a grid, it read as a stray box drawn around every one of them.

Reverted to the exact pre-P3-4 rule rather than inventing a new one:

```css
.place-card { position: relative; overflow: hidden; border-radius: var(--tile-image-radius); }
```

That keeps the rounded image, the hover-zoom clipping, and the positioning context the stretched title link and save actions depend on.

## Verified in the dev server

| | Result |
|---|---|
| `.place-card` | `0px none`, transparent background |
| radius / overflow / position | `16px` / `hidden` / `relative` intact |
| `.venue-card` + `.itinerary-card`, same pages | still bordered, untouched |
| Console errors | none |
| Production build | green, 886 pages |

## Scope

`PlaceCard` is shared across 8 templates, so all of them go borderless — consistent with how they looked before 25 July. Left a note in both files explaining why `.place-card` is not in the primitive group, so it doesn't get "fixed" back. If the tile ever does want a ground, the body padding has to come with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)