### PR TITLE
Harden agent-facing event freshness

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,6 +10,10 @@ on:
       - 'next/package.json'
       - '.github/workflows/build-and-deploy.yml'
   schedule:
+    # The event feed and rolling weekend page are generated at build time.
+    # Rebuild daily just after midnight in Melbourne so yesterday's
+    # occurrences cannot remain published until the next editorial deploy.
+    - cron: '10 14 * * *'
     # Rebuild twice per Melbourne weekend day. UTC remains safely within the
     # weekend when DST shifts (08:00/14:00 AEST, 09:00/15:00 AEDT).
     - cron: '0 22 * * 5'
@@ -37,6 +41,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TZ: Australia/Sydney
 
     steps:
       - name: Checkout
@@ -63,6 +69,7 @@ jobs:
         run: |
           cd next
           npm run test:content-admission
+          npm run test:agent-readiness
           npm run validate:content
 
       - name: Build
@@ -70,8 +77,8 @@ jobs:
           cd next
           npm run build:search
         env:
-          PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
           PUBLIC_CONCIERGE_API_URL: https://peninsula-insider-platform-api.vercel.app
           # Set to 'off' to remove the temporary client-side password gate
           # and launch the site publicly.

--- a/next/package.json
+++ b/next/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npm run lint:seo-architecture && npm run lint:filter-chips",
-    "build:search": "npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npm run lint:filter-chips && npx pagefind --site dist",
+    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npm run lint:seo-architecture && npm run lint:filter-chips && npm run audit:agent-readiness",
+    "build:search": "npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && astro build && npm run lint:filter-chips && npx pagefind --site dist && npm run audit:agent-readiness",
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
@@ -27,6 +27,7 @@
     "entity-index:apply": "node scripts/refresh-entity-index.mjs --apply",
     "entity-index:report": "node scripts/refresh-entity-index.mjs --report",
     "search:audit": "node scripts/audit-search-links.mjs",
+    "audit:agent-readiness": "node scripts/audit-agent-readiness.mjs",
     "bf:lint": "node ../scripts/bf-import/verify-lint.mjs",
     "bf:lint:strict": "node ../scripts/bf-import/verify-lint.mjs --strict",
     "pdfs": "node scripts/render-pdfs.mjs",

--- a/next/package.json
+++ b/next/package.json
@@ -28,6 +28,7 @@
     "entity-index:report": "node scripts/refresh-entity-index.mjs --report",
     "search:audit": "node scripts/audit-search-links.mjs",
     "audit:agent-readiness": "node scripts/audit-agent-readiness.mjs",
+    "test:agent-readiness": "node --test scripts/test-agent-readiness.mjs",
     "bf:lint": "node ../scripts/bf-import/verify-lint.mjs",
     "bf:lint:strict": "node ../scripts/bf-import/verify-lint.mjs --strict",
     "pdfs": "node scripts/render-pdfs.mjs",

--- a/next/scripts/audit-agent-readiness.mjs
+++ b/next/scripts/audit-agent-readiness.mjs
@@ -5,6 +5,7 @@
  *
  * Usage:
  *   node scripts/audit-agent-readiness.mjs [--site dist] [--now YYYY-MM-DD]
+ *   node scripts/audit-agent-readiness.mjs [--site dist] [--instant ISO-8601]
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
@@ -28,7 +29,13 @@ const sydneyDate = (date = new Date()) => {
 };
 
 const siteDir = resolve(valueFor('--site', 'dist'));
-const nowArg = valueFor('--now', sydneyDate());
+const instantArg = valueFor('--instant', null);
+const instant = instantArg ? new Date(instantArg) : new Date();
+if (!Number.isFinite(instant.getTime())) {
+  console.error(`Agent-readiness audit: invalid --instant value: ${instantArg}`);
+  process.exit(1);
+}
+const nowArg = valueFor('--now', sydneyDate(instant));
 const today = new Date(`${nowArg}T00:00:00Z`);
 const failures = [];
 

--- a/next/scripts/audit-agent-readiness.mjs
+++ b/next/scripts/audit-agent-readiness.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+/**
+ * Post-build truth gate for the machine-readable and time-sensitive surfaces.
+ *
+ * Usage:
+ *   node scripts/audit-agent-readiness.mjs [--site dist] [--now YYYY-MM-DD]
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const args = process.argv.slice(2);
+const valueFor = (name, fallback) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const sydneyDate = (date = new Date()) => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Australia/Sydney',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const get = (type) => parts.find((part) => part.type === type)?.value;
+  return `${get('year')}-${get('month')}-${get('day')}`;
+};
+
+const siteDir = resolve(valueFor('--site', 'dist'));
+const nowArg = valueFor('--now', sydneyDate());
+const today = new Date(`${nowArg}T00:00:00Z`);
+const failures = [];
+
+const fail = (message) => failures.push(message);
+const read = (path) => readFileSync(path, 'utf8');
+const dateOnly = (value) => new Date(`${String(value).slice(0, 10)}T00:00:00Z`);
+
+if (!existsSync(siteDir)) {
+  console.error(`Agent-readiness audit: site directory not found: ${siteDir}`);
+  process.exit(1);
+}
+
+// The consolidated agent feed must describe only current/future occurrences.
+const upcomingPath = join(siteDir, 'whats-on', 'upcoming.json');
+if (!existsSync(upcomingPath)) {
+  fail('Missing /whats-on/upcoming.json');
+} else {
+  const feed = JSON.parse(read(upcomingPath));
+  if (feed.generated !== nowArg) {
+    fail(`/whats-on/upcoming.json generated=${feed.generated}; expected ${nowArg}`);
+  }
+  if (feed.count !== feed.events?.length) {
+    fail(`/whats-on/upcoming.json count=${feed.count}; events=${feed.events?.length ?? 'missing'}`);
+  }
+  const weekendCount = (feed.events ?? []).filter((event) => event.thisWeekend).length;
+  if (feed.thisWeekend?.count !== weekendCount) {
+    fail(`/whats-on/upcoming.json thisWeekend.count=${feed.thisWeekend?.count}; actual=${weekendCount}`);
+  }
+  for (const event of feed.events ?? []) {
+    const start = dateOnly(event.startDate);
+    const end = dateOnly(event.endDate ?? event.startDate);
+    if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime())) {
+      fail(`Invalid feed dates for ${event.url}`);
+      continue;
+    }
+    if (end < start) fail(`Feed endDate precedes startDate for ${event.url}`);
+    if (end < today) fail(`Expired occurrence in upcoming feed: ${event.url} (${event.endDate})`);
+  }
+}
+
+// The rolling weekend page declares the actual current window and whether it
+// is an edited dispatch or the registry fallback. Either mode must be current.
+const weekendPath = join(siteDir, 'whats-on', 'this-weekend', 'index.html');
+if (!existsSync(weekendPath)) {
+  fail('Missing /whats-on/this-weekend/');
+} else {
+  const html = read(weekendPath);
+  const marker = html.match(/<article[^>]+data-weekend-end="([^"]+)"[^>]+data-source-mode="([^"]+)"/);
+  if (!marker) {
+    fail('/whats-on/this-weekend/ is missing its freshness marker');
+  } else if (new Date(marker[1]) < today) {
+    fail(`/whats-on/this-weekend/ is stale (${marker[1]}, mode=${marker[2]})`);
+  }
+}
+
+const htmlFiles = [];
+const walk = (dir) => {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) walk(path);
+    else if (name.endsWith('.html')) htmlFiles.push(path);
+  }
+};
+walk(siteDir);
+
+// Event JSON-LD must be temporally coherent on every generated page.
+for (const path of htmlFiles) {
+  const html = read(path);
+  const scripts = html.matchAll(/<script[^>]+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi);
+  for (const match of scripts) {
+    let data;
+    try {
+      data = JSON.parse(match[1]);
+    } catch {
+      continue;
+    }
+    const visit = (node) => {
+      if (!node || typeof node !== 'object') return;
+      if (node['@type'] === 'Event' && node.startDate && node.endDate) {
+        const start = new Date(node.startDate);
+        const end = new Date(node.endDate);
+        if (Number.isFinite(start.getTime()) && Number.isFinite(end.getTime()) && end < start) {
+          fail(`Event schema endDate precedes startDate in ${relative(siteDir, path)}`);
+        }
+      }
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value)) value.forEach(visit);
+        else if (value && typeof value === 'object') visit(value);
+      }
+    };
+    visit(data);
+  }
+}
+
+// Sitemap URLs may not point at generated noindex/meta-refresh/canonical-loss
+// stubs. This keeps sitemap.xml and the derived llms indexes honest.
+const sitemapPath = join(siteDir, 'sitemap.xml');
+if (!existsSync(sitemapPath)) {
+  fail('Missing /sitemap.xml');
+} else {
+  const xml = read(sitemapPath);
+  const locs = [...xml.matchAll(/<loc>https:\/\/peninsulainsider\.com\.au([^<]*)<\/loc>/g)].map((m) => m[1] || '/');
+  if (new Set(locs).size !== locs.length) fail('Duplicate <loc> values in sitemap.xml');
+  for (const pathname of locs) {
+    const clean = decodeURIComponent(pathname.split(/[?#]/)[0]);
+    const local = clean === '/'
+      ? join(siteDir, 'index.html')
+      : join(siteDir, ...clean.split('/').filter(Boolean), 'index.html');
+    if (!existsSync(local)) {
+      fail(`Sitemap URL has no generated page: ${pathname}`);
+      continue;
+    }
+    const html = read(local);
+    if (/http-equiv=["']refresh["']/i.test(html) || /<meta[^>]+name=["']robots["'][^>]+noindex/i.test(html)) {
+      fail(`Sitemap includes redirect/noindex page: ${pathname}`);
+    }
+    const canonical = html.match(/<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)/i)?.[1];
+    if (canonical) {
+      const expected = `https://peninsulainsider.com.au${clean.endsWith('/') ? clean : `${clean}/`}`;
+      const normalized = canonical.endsWith('/') ? canonical : `${canonical}/`;
+      if (normalized !== expected) fail(`Sitemap canonical mismatch: ${pathname} -> ${canonical}`);
+    }
+  }
+}
+
+if (failures.length) {
+  console.error(`Agent-readiness audit failed (${failures.length}):`);
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Agent-readiness audit passed for ${nowArg} (${htmlFiles.length} HTML pages).`);

--- a/next/scripts/lint-filter-chips.mjs
+++ b/next/scripts/lint-filter-chips.mjs
@@ -18,8 +18,9 @@
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const DIST = new URL('../dist/', import.meta.url).pathname;
+const DIST = fileURLToPath(new URL('../dist/', import.meta.url));
 
 function htmlFiles(dir, out = []) {
   for (const name of readdirSync(dir)) {

--- a/next/scripts/test-agent-readiness.mjs
+++ b/next/scripts/test-agent-readiness.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const auditScript = fileURLToPath(new URL('./audit-agent-readiness.mjs', import.meta.url));
+const instant = '2026-08-14T14:10:00Z'; // 15 August in Australia/Sydney.
+
+function writeFixture(root, generated = '2026-08-15', endDate = '2026-08-15') {
+  const weekendDir = join(root, 'whats-on', 'this-weekend');
+  const feedDir = join(root, 'whats-on');
+  mkdirSync(weekendDir, { recursive: true });
+  writeFileSync(
+    join(feedDir, 'upcoming.json'),
+    JSON.stringify({
+      generated,
+      count: 1,
+      thisWeekend: { count: 1 },
+      events: [{
+        title: 'Fixture event',
+        url: 'https://peninsulainsider.com.au/whats-on/fixture/',
+        startDate: endDate,
+        endDate,
+        thisWeekend: true,
+      }],
+    }),
+  );
+  writeFileSync(
+    join(weekendDir, 'index.html'),
+    '<html><body><article data-weekend-end="2026-08-16T13:59:00.000Z" data-source-mode="registry-fallback"></article></body></html>',
+  );
+  writeFileSync(
+    join(root, 'index.html'),
+    '<html><head><link rel="canonical" href="https://peninsulainsider.com.au/" /></head><body></body></html>',
+  );
+  writeFileSync(
+    join(root, 'sitemap.xml'),
+    '<?xml version="1.0"?><urlset><url><loc>https://peninsulainsider.com.au/</loc></url></urlset>',
+  );
+}
+
+function runAudit(root) {
+  return spawnSync(
+    process.execPath,
+    [auditScript, '--site', root, '--instant', instant],
+    { encoding: 'utf8' },
+  );
+}
+
+test('derives the audit date in Australia/Sydney at the UTC date boundary', () => {
+  const root = mkdtempSync(join(tmpdir(), 'pi-agent-audit-'));
+  try {
+    writeFixture(root);
+    const result = runAudit(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /passed for 2026-08-15/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a previous-day feed and expired occurrence', () => {
+  const root = mkdtempSync(join(tmpdir(), 'pi-agent-audit-'));
+  try {
+    writeFixture(root, '2026-08-14', '2026-08-14');
+    const result = runAudit(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /expected 2026-08-15/);
+    assert.match(result.stderr, /Expired occurrence/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/next/scripts/validate-content.mjs
+++ b/next/scripts/validate-content.mjs
@@ -49,5 +49,10 @@ if (!existsSync(astro)) {
 
 // `sync` loads and validates content collections without failing on unrelated
 // page-level TypeScript diagnostics (which belong to the full build gate).
-const result = spawnSync(astro, ['sync'], { cwd: nextRoot, stdio: 'inherit' });
+const result = spawnSync(astro, ['sync'], {
+  cwd: nextRoot,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+if (result.error) console.error(`Content admission failed to start Astro: ${result.error.message}`);
 process.exit(result.status ?? 1);

--- a/next/src/components/NewsletterBlock.astro
+++ b/next/src/components/NewsletterBlock.astro
@@ -143,7 +143,6 @@ const showPreview = !hidePreview && resolvedHeadline && resolvedPicks.length > 0
         <a
           href={dispatchHref || '/whats-on/this-weekend/'}
           class="v2-newsletter__preview"
-          aria-label={`Read this issue: ${resolvedHeadline}`}
         >
           <div class="v2-np__head">
             <span class="v2-np__mark">Peninsula This Weekend</span>

--- a/next/src/components/TextScaleControl.astro
+++ b/next/src/components/TextScaleControl.astro
@@ -63,7 +63,7 @@
 <style is:global>
   .text-scale {
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
     gap: 0.15rem;
   }
 
@@ -71,7 +71,9 @@
     appearance: none;
     background: none;
     border: 0;
-    padding: 0.2rem 0.3rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    padding: 0.5rem;
     cursor: pointer;
     font-family: var(--font-ui);
     font-weight: 600;

--- a/next/src/content/articles/dog-friendly-wineries-mornington-peninsula.mdx
+++ b/next/src/content/articles/dog-friendly-wineries-mornington-peninsula.mdx
@@ -5,10 +5,10 @@ author: "editorial"
 houseByline: true
 publishedAt: 2026-04-22
 heroImage:
-  src: "/images/sourced/wine-stonier-cellar-door-01.webp"
-  alt: "Stonier Wines cellar door, Merricks - confirmed dog-friendly with lawn area"
-  credit: "Stonier Wines"
-  license: "venue-media-kit"
+  src: "/images/sourced/place-merricks-01.webp"
+  alt: "Vineyard landscape in Merricks on the Mornington Peninsula"
+  credit: "BrooksieG"
+  license: "wikimedia-cc-by"
 format: "service"
 tags: ["dog-friendly", "wineries", "cellar-door", "mornington-peninsula", "pets"]
 lastVerified: 2026-04-22

--- a/next/src/content/articles/mornington-peninsula-winery-guide.mdx
+++ b/next/src/content/articles/mornington-peninsula-winery-guide.mdx
@@ -5,10 +5,10 @@ author: "editorial"
 houseByline: true
 publishedAt: 2026-04-22
 heroImage:
-  src: "/images/sourced/wine-vineyard-01.webp"
-  alt: "Vineyard rows in autumn on the Mornington Peninsula, Red Hill South"
-  credit: "Visit Victoria"
-  license: "visit-victoria"
+  src: "/images/sourced/place-merricks-01.webp"
+  alt: "Vineyard landscape in Merricks on the Mornington Peninsula"
+  credit: "BrooksieG"
+  license: "wikimedia-cc-by"
 format: "hub-guide"
 tags: ["wine", "cellar-doors", "pinot-noir", "chardonnay", "dog-friendly", "winery-dining", "sub-regions"]
 lastVerified: 2026-04-22

--- a/next/src/lib/events.ts
+++ b/next/src/lib/events.ts
@@ -237,6 +237,15 @@ export function eventJsonLd(event: Event, siteUrl: string): Record<string, unkno
       const d = eventEndDate.toISOString().slice(0, 10);
       return `${d}T${data.endTime}:00+10:00`;
     }
+    // A same-day record with a start time but no explicit end time is a
+    // point-in-time event. Midnight on that date would precede startISO and
+    // emit invalid Event schema, so use the known instant for both bounds.
+    if (
+      data.startTime &&
+      eventEndDate.toISOString().slice(0, 10) === eventStartDate.toISOString().slice(0, 10)
+    ) {
+      return startISO;
+    }
     return eventEndDate.toISOString();
   })();
 
@@ -475,4 +484,3 @@ export function eventRecurrenceLabel(data: Event['data']): string {
       return data.recurrence;
   }
 }
-

--- a/next/src/lib/inline-edit/overrides.ts
+++ b/next/src/lib/inline-edit/overrides.ts
@@ -47,6 +47,7 @@ export interface CmsOverrides {
 
 const EMPTY: CmsOverrides = { text: {}, image: {} };
 const cache = new Map<string, Promise<CmsOverrides>>();
+const SKIP_LIVE_READS = process.env.PI_SKIP_CMS_LIVE_READS === '1';
 
 type BakedImageSlot = {
   src?: string | null;
@@ -87,6 +88,9 @@ async function fetchOverrides(
   entitySlug: string,
 ): Promise<CmsOverrides> {
   const baked = loadBakedImages(entityType, entitySlug);
+  // Deterministic local/CI verification can opt into the checked-in snapshot.
+  // Production builds leave this unset and continue to fetch published rows.
+  if (SKIP_LIVE_READS) return { text: {}, image: baked };
   const client = createCmsAnonClient();
   if (!client) return { text: {}, image: baked };
 

--- a/next/src/pages/sitemap.xml.ts
+++ b/next/src/pages/sitemap.xml.ts
@@ -75,6 +75,10 @@ const EXPERIENCE_STUB_SLUGS = new Set([
   'mornington-peninsula-walk',
 ]);
 
+const EAT_STUB_SLUGS = new Set([
+  'port-phillip-estate-restaurant',
+]);
+
 export const GET: APIRoute = async () => {
   const [
     venues,
@@ -116,7 +120,9 @@ export const GET: APIRoute = async () => {
   const stayTypes = ['hotel', 'villa', 'cottage', 'glamping', 'farm-stay', 'spa'];
   const wineTypes = ['winery', 'producer', 'brewery', 'distillery'];
 
-  const eatVenues = venues.filter((v) => eatTypes.includes(v.data.type) && notExcluded(v));
+  const eatVenues = venues.filter(
+    (v) => eatTypes.includes(v.data.type) && notExcluded(v) && !EAT_STUB_SLUGS.has(routeSlug(v)),
+  );
   const stayVenues = venues.filter((v) => stayTypes.includes(v.data.type) && notExcluded(v));
   const wineVenues = venues.filter((v) => wineTypes.includes(v.data.type) && notExcluded(v));
 
@@ -129,7 +135,7 @@ export const GET: APIRoute = async () => {
 
   // Section index pages. /spa/ and /walks/ are intentionally omitted:
   // /spa/ redirects to /explore/spas-and-wellness/ and /walks/ now
-  // canonicalises to /explore/best-walks/ (SEO plan §3.6 #12) - losers
+  // canonicalises to /explore/walks/ (SEO plan §3.6 #12) - losers
   // never enter. /golf/ removed 2026-05-05 (noindex stub -> /explore/golf/).
   // /events/ hub removed 2026-07-11: the /events/* signature-event tree is a
   // consolidation loser awaiting the §3.4 migration into /whats-on/*.
@@ -175,7 +181,7 @@ export const GET: APIRoute = async () => {
   // pages now canonicalise elsewhere or await redirect, and never enter).
   entries.push(url('/eat/best-restaurants', 0.9, 'weekly'));
   entries.push(url('/wine/best-cellar-doors', 0.9, 'weekly'));
-  entries.push(url('/explore/best-walks', 0.8, 'weekly'));
+  entries.push(url('/explore/walks', 0.8, 'weekly'));
   entries.push(url('/stay/best-accommodation', 0.8, 'weekly'));
 
   // SEO journal landing pages (hand-coded article pages that do not live in

--- a/next/src/pages/sitemap.xml.ts
+++ b/next/src/pages/sitemap.xml.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { routeSlug } from '../lib/editorial';
+import { loadLiveEvents } from './whats-on/_data';
 
 // SEOMIG rebuild 2026-07-11 (seo-migration-plan.md §4.1).
 // Inclusion contract - a URL enters the sitemap iff ALL of:
@@ -16,14 +17,12 @@ import { routeSlug } from '../lib/editorial';
 // double listing of /journal/free-things-to-do-mornington-peninsula/).
 
 const SITE_URL = 'https://peninsulainsider.com.au';
-const TODAY = new Date().toISOString().split('T')[0];
 
 function url(path: string, priority: number, changefreq: string, lastmod?: string): string {
   const loc = path === '/' ? path : (path.endsWith('/') ? path : path + '/');
   return `  <url>
     <loc>${SITE_URL}${loc}</loc>
-    <lastmod>${lastmod ?? TODAY}</lastmod>
-    <changefreq>${changefreq}</changefreq>
+${lastmod ? `    <lastmod>${lastmod}</lastmod>\n` : ''}    <changefreq>${changefreq}</changefreq>
     <priority>${priority.toFixed(1)}</priority>
   </url>`;
 }
@@ -68,6 +67,14 @@ const JOURNAL_STUB_OR_NOINDEX_SLUGS = new Set([
   'where-to-stay-mornington-peninsula',
 ]);
 
+// Experience records whose generated /explore/<slug>/ path is shadowed by
+// a hand-authored redirect/noindex page. Their canonical winners are emitted
+// elsewhere, so including these slugs would violate the sitemap contract.
+const EXPERIENCE_STUB_SLUGS = new Set([
+  'bushrangers-bay',
+  'mornington-peninsula-walk',
+]);
+
 export const GET: APIRoute = async () => {
   const [
     venues,
@@ -76,7 +83,6 @@ export const GET: APIRoute = async () => {
     regions,
     articles,
     itineraries,
-    events,
     tours,
     tourOperators,
     tourPackages,
@@ -92,7 +98,6 @@ export const GET: APIRoute = async () => {
     getCollection('regions'),
     getCollection('articles', ({ data }) => data.status === 'published'),
     getCollection('itineraries'),
-    getCollection('events'),
     getCollection('tours'),
     getCollection('tourOperators'),
     getCollection('tourPackages'),
@@ -235,7 +240,9 @@ export const GET: APIRoute = async () => {
   }
 
   // Experiences
-  for (const experience of experiences.filter(notExcluded)) {
+  for (const experience of experiences.filter(
+    (entry) => notExcluded(entry) && !EXPERIENCE_STUB_SLUGS.has(routeSlug(entry)),
+  )) {
     entries.push(url(`/explore/${routeSlug(experience)}`, 0.7, 'weekly', dateStr(experience.data.publishedAt)));
   }
 
@@ -359,16 +366,13 @@ export const GET: APIRoute = async () => {
     entries.push(url(`/whats-on/by-mood/${mood}`, 0.5, 'weekly'));
   }
 
-  // Event detail pages - current/future or recurring only (§4.1 rule 4:
-  // expired one-off events stay live for history but leave the sitemap).
+  // Event detail pages - only records with an occurrence from today onward.
+  // loadLiveEvents is recurrence-aware and rejects ended series, so a stale
+  // recurring label can no longer keep an expired URL in machine indexes.
   const today = new Date();
-  for (const event of events.filter(notExcluded)) {
-    const recurrence = event.data.recurrence ?? 'one-off';
-    const isRecurring = recurrence !== 'one-off';
-    const endish = event.data.endDate ?? event.data.startDate;
-    const stillCurrent = endish && endish.getTime() >= today.getTime() - 24 * 60 * 60 * 1000;
-    if (!isRecurring && !stillCurrent) continue;
-    entries.push(url(`/whats-on/${routeSlug(event)}`, 0.6, 'weekly', dateStr(event.data.publishedAt)));
+  const liveEvents = await loadLiveEvents(today);
+  for (const live of liveEvents) {
+    entries.push(url(live.href, 0.6, 'weekly', dateStr(live.event.data.publishedAt)));
   }
 
   // NOTE: /events/* signature pages, /picks/, /walks/*, /itinerary/, /plan/,

--- a/next/src/pages/whats-on/_data.ts
+++ b/next/src/pages/whats-on/_data.ts
@@ -164,6 +164,9 @@ export function ruleFor(event: EventEntry, now: Date): OccurrenceRule | null {
   const start: Date | undefined = data.startDate ? startOfDay(data.startDate) : undefined;
   const endRaw: Date | undefined = data.endDate ? startOfDay(data.endDate) : start;
   const next: Date | undefined = data.nextOccurrence ? startOfDay(data.nextOccurrence) : undefined;
+  // A computed occurrence before a future series start contradicts the
+  // record's own bounds. Ignore it instead of publishing the impossible date.
+  const validNext = next && (!start || next >= start) ? next : undefined;
   const recur: string = data.recurrence ?? 'one-off';
   const noteText = [data.recurrenceNote, data.title, data.summary].filter(Boolean).join(' ');
 
@@ -175,9 +178,12 @@ export function ruleFor(event: EventEntry, now: Date): OccurrenceRule | null {
       : addDays(today, FAR_HORIZON_DAYS);
 
   if (recur === 'weekly') {
-    const day = parseWeekday(noteText);
+    // Prefer explicit copy, but a weekly series' start date is also a valid
+    // weekday anchor. Falling back to a continuous range made Friday-only
+    // events appear on every day when the prose omitted the weekday.
+    const day = parseWeekday(noteText) ?? start?.getDay();
     if (day !== undefined) return { kind: 'weekly', start: seriesStart, end: seriesEnd, day };
-    if (next && next >= today) return { kind: 'range', start: next, end: next };
+    if (validNext && validNext >= today) return { kind: 'range', start: validNext, end: validNext };
     return start && endRaw ? { kind: 'range', start, end: endRaw } : null;
   }
 
@@ -187,8 +193,11 @@ export function ruleFor(event: EventEntry, now: Date): OccurrenceRule | null {
     if (day !== undefined && nth !== undefined) {
       return { kind: 'monthly', start: seriesStart, end: seriesEnd, day, nth };
     }
-    if (next && next >= today) return { kind: 'range', start: next, end: next };
-    return null;
+    // Do not invent a monthly cadence from a stale nextOccurrence. Without an
+    // explicit weekday + ordinal, expose only a dated future occurrence and
+    // let the record drop out once that date passes.
+    if (validNext && validNext >= today) return { kind: 'range', start: validNext, end: validNext };
+    return start && start >= today && endRaw ? { kind: 'range', start, end: endRaw } : null;
   }
 
   if (!start || !endRaw) return null;
@@ -196,9 +205,9 @@ export function ruleFor(event: EventEntry, now: Date): OccurrenceRule | null {
   // Annual / seasonal / one-off / ongoing: a plain date range. When the
   // listed dates are past but the cron has computed a fresh occurrence,
   // shift the same span onto it.
-  if (endRaw < today && next && next >= today) {
+  if (endRaw < today && validNext && validNext >= today) {
     const spanDays = Math.round((endRaw.getTime() - start.getTime()) / 86400000);
-    return { kind: 'range', start: next, end: addDays(next, Math.max(0, spanDays)) };
+    return { kind: 'range', start: validNext, end: addDays(validNext, Math.max(0, spanDays)) };
   }
   return { kind: 'range', start, end: endRaw };
 }
@@ -387,7 +396,7 @@ export interface Pick {
   dayLabel: string;
 }
 
-function firstDayInWindow(rule: OccurrenceRule, win: ScopeWindow): Date | null {
+export function firstDayInWindow(rule: OccurrenceRule, win: ScopeWindow): Date | null {
   const days =
     Math.round((startOfDay(win.end).getTime() - startOfDay(win.start).getTime()) / 86400000) + 1;
   for (let i = 0; i < days; i += 1) {

--- a/next/src/pages/whats-on/this-weekend/index.astro
+++ b/next/src/pages/whats-on/this-weekend/index.astro
@@ -16,7 +16,7 @@
  * Legacy /journal/peninsula-this-weekend-{slug}/ URLs redirect into the
  * dated archive (see src/pages/journal/[slug].astro).
  */
-import { getCollection, getEntry, render } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
@@ -37,6 +37,13 @@ import {
 import { isPeninsulaThisWeekend } from '../../../lib/peninsula-this-weekend';
 import { formatHeroCredit, routeSlug } from '../../../lib/editorial';
 import { resolveHero } from '../../../lib/inline-edit/resolve-hero';
+import {
+  loadLiveEvents,
+  occursInWindow,
+  startOfDay,
+  weekendWindow,
+  type ScopeWindow,
+} from '../_data';
 
 const allArticles = await getCollection('articles', ({ data }) => data.status === 'published');
 const ptwArticles = sortPtwLatestFirst(allArticles.filter(isPeninsulaThisWeekend));
@@ -49,10 +56,16 @@ if (!latest) {
 const { Content } = await render(latest);
 
 const canonical = 'https://peninsulainsider.com.au/whats-on/this-weekend/';
-const weekendLabel = ptwWeekendLabel(latest);
-const weekendEndIso = ptwWeekendEndIso(latest);
-const eventSchema = buildPtwEventSchema(latest, canonical);
-const dispatch = latest.data.dispatch;
+const now = new Date();
+const currentWeekend = weekendWindow(now);
+const latestWeekendEnd = new Date(ptwWeekendEndIso(latest));
+const hasCurrentDispatch = latestWeekendEnd >= startOfDay(now);
+const weekendLabel = hasCurrentDispatch ? ptwWeekendLabel(latest) : currentWeekend.label;
+const weekendEndIso = hasCurrentDispatch
+  ? ptwWeekendEndIso(latest)
+  : new Date(currentWeekend.end.getFullYear(), currentWeekend.end.getMonth(), currentWeekend.end.getDate(), 23, 59, 0).toISOString();
+const eventSchema = hasCurrentDispatch ? buildPtwEventSchema(latest, canonical) : null;
+const dispatch = hasCurrentDispatch ? latest.data.dispatch : null;
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },
@@ -60,9 +73,12 @@ const breadcrumbItems = [
   { label: 'This Weekend' },
 ];
 
-const latestHero = await resolveHero('article', routeSlug(latest), latest.data, 'hero');
-const heroStyle = latestHero.style;
-const ogImage = latestHero.src;
+const latestHero = hasCurrentDispatch
+  ? await resolveHero('article', routeSlug(latest), latest.data, 'hero')
+  : null;
+const fallbackHero = '/images/sourced/whats-on-winter-wine.webp';
+const heroStyle = latestHero?.style ?? `background-image: url('${fallbackHero}')`;
+const ogImage = latestHero?.src ?? fallbackHero;
 
 const breadcrumbSchema = {
   '@context': 'https://schema.org',
@@ -75,9 +91,47 @@ const breadcrumbSchema = {
   })),
 };
 
-// ItemList JSON-LD: machine-readable index of the weekend picks so AI
-// assistants and search rich results can extract the dispatch's curated
-// list cleanly without parsing prose.
+const archiveItems = ptwArticles
+  .slice(hasCurrentDispatch ? 1 : 0, hasCurrentDispatch ? 9 : 8)
+  .map((a) => ({
+    href: ptwArchivePath(a),
+    label: a.data.title,
+    dek: a.data.dek,
+    date: a.data.publishedAt,
+  }));
+
+// Cadence/refresh string: PTW publishes Sunday-ahead for the upcoming
+// weekend (publish + 6, publish + 7). The hero status pill shows when
+// this dispatch was last refreshed and what weekend it covers.
+const publishedFmt = latest.data.publishedAt.toLocaleDateString('en-AU', {
+  day: 'numeric',
+  month: 'short',
+});
+
+// Live events for this weekend, pulled from the events collection
+// where startDate or endDate falls within the dispatch's Fri-Sun window.
+// Lets us show "Also on this weekend" venue/event cards beneath the
+// editor's curated picks, without re-editing them by hand each week.
+const friday = hasCurrentDispatch ? ptwWeekendFriday(latest) : currentWeekend.start;
+const sunday = hasCurrentDispatch ? new Date(friday) : currentWeekend.end;
+if (hasCurrentDispatch) sunday.setUTCDate(friday.getUTCDate() + 2);
+sunday.setHours(23, 59, 0, 0);
+const activeWindow: ScopeWindow = { start: friday, end: sunday, label: weekendLabel };
+const dispatchPickEventSlugs = new Set(
+  [dispatch?.lead, dispatch?.saturday, dispatch?.sunday, dispatch?.rainyDay]
+    .map((p: any) => p?.eventRef)
+    .filter(Boolean),
+);
+const liveThisWeekend = (await loadLiveEvents(now))
+  .filter((live) => occursInWindow(live.rule, activeWindow))
+  .filter((live) => !dispatchPickEventSlugs.has(live.slug))
+  .sort((a, b) => b.appeal - a.appeal || a.title.localeCompare(b.title))
+  .map((live) => live.event)
+  .slice(0, 6);
+
+// Machine-readable list follows the current surface. When an edited weekly
+// dispatch has aged out, the rolling URL exposes only current registry events
+// and keeps the old edition in the archive instead of asserting stale picks.
 const itemListSchema = dispatch
   ? {
       '@context': 'https://schema.org',
@@ -101,69 +155,48 @@ const itemListSchema = dispatch
             : canonical,
         })),
     }
-  : null;
-
-const archiveItems = ptwArticles
-  .slice(1, 9)
-  .map((a) => ({
-    href: ptwArchivePath(a),
-    label: a.data.title,
-    dek: a.data.dek,
-    date: a.data.publishedAt,
-  }));
-
-// Cadence/refresh string: PTW publishes Sunday-ahead for the upcoming
-// weekend (publish + 6, publish + 7). The hero status pill shows when
-// this dispatch was last refreshed and what weekend it covers.
-const publishedFmt = latest.data.publishedAt.toLocaleDateString('en-AU', {
-  day: 'numeric',
-  month: 'short',
-});
-
-// Live events for this weekend, pulled from the events collection
-// where startDate or endDate falls within the dispatch's Fri-Sun window.
-// Lets us show "Also on this weekend" venue/event cards beneath the
-// editor's curated picks, without re-editing them by hand each week.
-const friday = ptwWeekendFriday(latest);
-const sunday = new Date(friday);
-sunday.setUTCDate(friday.getUTCDate() + 2);
-sunday.setUTCHours(23, 59, 0, 0);
-const allEvents = await getCollection('events', ({ data }) => data.status === 'published');
-const dispatchPickEventSlugs = new Set(
-  [dispatch?.lead, dispatch?.saturday, dispatch?.sunday, dispatch?.rainyDay]
-    .map((p: any) => p?.eventRef)
-    .filter(Boolean),
-);
-const liveThisWeekend = allEvents
-  .filter((e) => {
-    const start = e.data.startDate;
-    const end = e.data.endDate ?? e.data.startDate;
-    return start <= sunday && end >= friday;
-  })
-  .filter((e) => !dispatchPickEventSlugs.has(routeSlug(e)))
-  .sort((a, b) => (a.data.startDate?.getTime() ?? 0) - (b.data.startDate?.getTime() ?? 0))
-  .slice(0, 6);
+  : {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: `What's on this weekend, ${weekendLabel}`,
+      itemListOrder: 'https://schema.org/ItemListOrderAscending',
+      numberOfItems: liveThisWeekend.length,
+      itemListElement: liveThisWeekend.map((event, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: event.data.title,
+        url: `https://peninsulainsider.com.au/whats-on/${routeSlug(event)}/`,
+      })),
+    };
 export const prerender = true;
 ---
 
 <BaseLayout
-  title={`Peninsula This Weekend - ${weekendLabel} · Peninsula Insider`}
-  description={latest.data.dek}
+  title={hasCurrentDispatch
+    ? `Peninsula This Weekend - ${weekendLabel} · Peninsula Insider`
+    : `What's on this weekend - ${weekendLabel} · Peninsula Insider`}
+  description={hasCurrentDispatch
+    ? latest.data.dek
+    : `Current Mornington Peninsula events for ${weekendLabel}. The next edited Peninsula This Weekend dispatch is in preparation.`}
   section="whats-on"
   canonical={canonical}
   ogImage={ogImage}
   searchImage={ogImage}
   ogType="article"
-  publishedTime={latest.data.publishedAt.toISOString()}
-  modifiedTime={(latest.data.updatedAt ?? latest.data.publishedAt).toISOString()}
+  publishedTime={hasCurrentDispatch ? latest.data.publishedAt.toISOString() : undefined}
+  modifiedTime={hasCurrentDispatch ? (latest.data.updatedAt ?? latest.data.publishedAt).toISOString() : undefined}
 >
-  <script type="application/ld+json" set:html={JSON.stringify(eventSchema)} />
+  {eventSchema && <script type="application/ld+json" set:html={JSON.stringify(eventSchema)} />}
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   {itemListSchema && <script type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />}
 
   <Breadcrumbs items={breadcrumbItems} />
 
-  <article class="article ptw">
+  <article
+    class="article ptw"
+    data-weekend-end={weekendEndIso}
+    data-source-mode={hasCurrentDispatch ? 'editorial-dispatch' : 'registry-fallback'}
+  >
 
     <!-- ─── Hero ───────────────────────────────────────────────────── -->
     <header class="ptw-hero">
@@ -179,21 +212,31 @@ export const prerender = true;
                 moment the weekend closes. If the reader arrives after
                 Sunday night, say so honestly rather than presenting a past
                 weekend as current. */}
-            <p class="ptw-hero__stale" data-weekend-end={weekendEndIso} hidden>
-              This dispatch covered the weekend of {weekendLabel}. The next
-              edition lands Sunday. <a href="/whats-on/">Browse everything on
-              now instead</a>.
+            {hasCurrentDispatch && (
+              <p class="ptw-hero__stale" data-weekend-end={weekendEndIso} hidden>
+                This dispatch covered the weekend of {weekendLabel}. The next
+                edition is in preparation. <a href="/whats-on/">Browse everything on
+                now instead</a>.
+              </p>
+            )}
+            {hasCurrentDispatch && (
+              <script is:inline>
+                (function () {
+                  var el = document.querySelector('.ptw-hero__stale');
+                  if (!el) return;
+                  var end = new Date(el.getAttribute('data-weekend-end'));
+                  if (!isNaN(end) && Date.now() > end.getTime()) el.hidden = false;
+                })();
+              </script>
+            )}
+            <h1 class="ptw-hero__title">
+              {hasCurrentDispatch ? latest.data.title : 'What’s on this weekend'}
+            </h1>
+            <p class="ptw-hero__dek">
+              {hasCurrentDispatch
+                ? latest.data.dek
+                : `Current events across the Mornington Peninsula for ${weekendLabel}. Our next edited dispatch is in preparation; this list comes from the live events registry.`}
             </p>
-            <script is:inline>
-              (function () {
-                var el = document.querySelector('.ptw-hero__stale');
-                if (!el) return;
-                var end = new Date(el.getAttribute('data-weekend-end'));
-                if (!isNaN(end) && Date.now() > end.getTime()) el.hidden = false;
-              })();
-            </script>
-            <h1 class="ptw-hero__title">{latest.data.title}</h1>
-            <p class="ptw-hero__dek">{latest.data.dek}</p>
 
             {dispatch?.weather && (
               <div class="ptw-hero__weather">
@@ -202,29 +245,39 @@ export const prerender = true;
               </div>
             )}
 
-            <PiArticleActions
-              slug={latest.id}
-              section="whats-on"
-              title={latest.data.title}
-              dek={latest.data.dek}
-              imageUrl={latest.data.heroImage?.src}
-              href="/whats-on/this-weekend/"
-            />
+            {hasCurrentDispatch ? (
+              <>
+                <PiArticleActions
+                  slug={latest.id}
+                  section="whats-on"
+                  title={latest.data.title}
+                  dek={latest.data.dek}
+                  imageUrl={latest.data.heroImage?.src}
+                  href="/whats-on/this-weekend/"
+                />
 
-            <p class="ptw-hero__cadence">
-              <strong>Refreshed {publishedFmt}</strong> for the weekend of <strong>{weekendLabel}</strong>.
-              A new dispatch lands weekly for the weekend ahead.
-            </p>
+                <p class="ptw-hero__cadence">
+                  <strong>Refreshed {publishedFmt}</strong> for the weekend of <strong>{weekendLabel}</strong>.
+                  A new dispatch lands weekly for the weekend ahead.
+                </p>
+              </>
+            ) : (
+              <p class="ptw-hero__cadence">
+                <strong>Current window: {weekendLabel}.</strong> No expired dispatch is being presented as current.
+              </p>
+            )}
           </div>
 
           <figure class="ptw-hero__figure">
             <div
               class="ptw-hero__image"
               role="img"
-              aria-label={latest.data.heroImage.alt}
+              aria-label={hasCurrentDispatch
+                ? latest.data.heroImage.alt
+                : 'Mornington Peninsula wine-country events in winter'}
               style={heroStyle}
             ></div>
-            {latest.data.heroImage.credit && (
+            {hasCurrentDispatch && latest.data.heroImage.credit && (
               <figcaption class="ptw-hero__credit">{formatHeroCredit(latest.data.heroImage.credit)}</figcaption>
             )}
           </figure>
@@ -303,6 +356,27 @@ export const prerender = true;
         </section>
       )}
 
+      {!hasCurrentDispatch && (
+        <section class="ptw-current" aria-labelledby="ptw-current-title">
+          <div class="ptw-also__head">
+            <p class="ptw-also__eyebrow">Current registry</p>
+            <h2 id="ptw-current-title" class="ptw-also__title">Events running this weekend</h2>
+            <p class="ptw-also__sub">
+              These listings are date-checked at build time. The most recent edited dispatch is available in the archive below.
+            </p>
+          </div>
+          {liveThisWeekend.length > 0 ? (
+            <div class="event-grid">
+              {liveThisWeekend.map((event) => <EventCard event={event} />)}
+            </div>
+          ) : (
+            <p class="ptw-current__empty">
+              No verified listings are currently available for this weekend. <a href="/whats-on/">Browse the full events index</a>.
+            </p>
+          )}
+        </section>
+      )}
+
       {/* ─── Mid-page newsletter CTA ────────────────────────────────── */}
       <aside class="ptw-cta" aria-label="Newsletter signup">
         <p class="ptw-cta__eyebrow">Get the dispatch in your inbox</p>
@@ -314,12 +388,14 @@ export const prerender = true;
       </aside>
 
       {/* ─── Editor's long-form body (existing markdown) ────────────── */}
-      <div class="prose ptw-body">
-        <Content />
-      </div>
+      {hasCurrentDispatch && (
+        <div class="prose ptw-body">
+          <Content />
+        </div>
+      )}
 
       {/* ─── Also on this weekend (live events) ─────────────────────── */}
-      {liveThisWeekend.length > 0 && (
+      {hasCurrentDispatch && liveThisWeekend.length > 0 && (
         <section class="ptw-also" aria-labelledby="ptw-also-title">
           <div class="ptw-also__head">
             <p class="ptw-also__eyebrow">Also running</p>
@@ -337,11 +413,11 @@ export const prerender = true;
         </section>
       )}
 
-      {latest.data.clusterLinks && latest.data.clusterLinks.length > 0 && (
+      {hasCurrentDispatch && latest.data.clusterLinks && latest.data.clusterLinks.length > 0 && (
         <ClusterLinks links={latest.data.clusterLinks} heading="Explore this hub" />
       )}
 
-      {latest.data.faq && latest.data.faq.length > 0 && (
+      {hasCurrentDispatch && latest.data.faq && latest.data.faq.length > 0 && (
         <section class="article-faq" aria-labelledby="ptw-faq-title">
           <div class="article-faq__header">
             <p class="article-faq__eyebrow">Questions readers actually ask</p>

--- a/next/src/pages/whats-on/upcoming.json.ts
+++ b/next/src/pages/whats-on/upcoming.json.ts
@@ -1,7 +1,14 @@
 import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
-import { routeSlug } from '../../lib/editorial';
-import { upcomingWeekend, eventInWindow } from '../../lib/events';
+import {
+  addDays,
+  firstDayInWindow,
+  isoDate,
+  loadLiveEvents,
+  occursInWindow,
+  startOfDay,
+  weekendWindow,
+  type ScopeWindow,
+} from './_data';
 
 // Machine-readable "what's on" feed for AI assistants and agents. The site
 // already emits rich Event JSON-LD per page and llms.txt for site structure;
@@ -12,44 +19,43 @@ import { upcomingWeekend, eventInWindow } from '../../lib/events';
 
 const SITE = 'https://peninsulainsider.com.au';
 const WINDOW_DAYS = 90;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-const iso = (d: Date): string => d.toISOString().split('T')[0];
 
 export const GET: APIRoute = async () => {
   const now = new Date();
-  const horizon = new Date(now.getTime() + WINDOW_DAYS * DAY_MS);
-  const weekend = upcomingWeekend(now);
-
-  const events = await getCollection('events', ({ data }) => !data.sitemapExclude);
+  const today = startOfDay(now);
+  const window: ScopeWindow = {
+    start: today,
+    end: addDays(today, WINDOW_DAYS),
+    label: '',
+  };
+  const weekend = weekendWindow(now);
+  const events = await loadLiveEvents(now);
 
   const upcoming = events
-    .filter((e) => {
-      const start = e.data.startDate;
-      const end = e.data.endDate ?? e.data.startDate;
-      const recurring = e.data.recurrence && e.data.recurrence !== 'one-off';
-      if (recurring) return true; // recurring events remain valid
-      const stillCurrent = end && end.getTime() >= now.getTime() - DAY_MS;
-      const withinHorizon = start && start.getTime() <= horizon.getTime();
-      return Boolean(stillCurrent && withinHorizon);
-    })
-    .sort((a, b) => (a.data.startDate?.getTime() ?? 0) - (b.data.startDate?.getTime() ?? 0))
-    .map((e) => {
-      const slug = routeSlug(e);
+    .filter((live) => occursInWindow(live.rule, window))
+    .map((live) => {
+      const e = live.event;
+      const nextOccurrence = firstDayInWindow(live.rule, window);
+      if (!nextOccurrence) return null;
+      const occurrenceEnd = live.rule.kind === 'range'
+        ? new Date(Math.min(live.rule.end.getTime(), window.end.getTime()))
+        : nextOccurrence;
       return {
         title: e.data.title,
-        url: `${SITE}/whats-on/${slug}/`,
-        startDate: e.data.startDate ? iso(e.data.startDate) : null,
-        endDate: e.data.endDate ? iso(e.data.endDate) : null,
+        url: `${SITE}${live.href}`,
+        startDate: isoDate(nextOccurrence),
+        endDate: isoDate(occurrenceEnd),
         recurrence: e.data.recurrence ?? 'one-off',
         category: e.data.category ?? null,
         place: (e.data.place as { id?: string } | undefined)?.id ?? null,
         venue: (e.data.venue as { id?: string } | undefined)?.id ?? null,
         freePaid: e.data.freePaid ?? null,
         summary: e.data.summary ?? '',
-        thisWeekend: eventInWindow(e, weekend.start, weekend.end),
+        thisWeekend: occursInWindow(live.rule, weekend),
       };
-    });
+    })
+    .filter((event): event is NonNullable<typeof event> => event !== null)
+    .sort((a, b) => a.startDate.localeCompare(b.startDate) || a.title.localeCompare(b.title));
 
   const body = {
     '@context': 'https://schema.org',
@@ -59,12 +65,12 @@ export const GET: APIRoute = async () => {
       'Machine-readable feed of upcoming Mornington Peninsula events for AI ' +
       'assistants and agents. Forward-dated; regenerated on each build. See ' +
       `${SITE}/llms.txt for the full site map.`,
-    generated: iso(now),
+    generated: isoDate(now),
     site: SITE,
     windowDays: WINDOW_DAYS,
     thisWeekend: {
-      start: iso(weekend.start),
-      end: iso(weekend.end),
+      start: isoDate(weekend.start),
+      end: isoDate(weekend.end),
       label: weekend.label,
       count: upcoming.filter((x) => x.thisWeekend).length,
     },


### PR DESCRIPTION
## Summary

- keep the agent-facing event feed current across recurrences and overnight rebuilds
- add a Sydney-time daily production rebuild plus deterministic readiness regression tests
- remove redirect/noindex sitemap entries and repair missing article hero references
- preserve the existing content, SEO, and deployment gates while correcting public Supabase secret names

## Verification

- `npm run test:agent-readiness` (2/2)
- `npm run test:content-admission`
- `npm run validate:content`
- `node --test src/lib/v5-store.test.mjs` (8/8)
- `node scripts/test-facets.mjs`
- `node scripts/test-event-access.mjs` (4/4)
- `node scripts/test-whatson-empty-state.mjs` (3/3)
- production-equivalent `npm run build:search` with `TZ=Australia/Sydney` (950 pages, 953 HTML audited, 754 indexed)
- generated feed: 2026-08-14, 30 events, 17 this weekend, 0 expired

## Known follow-up

- dependency audit remains at the pre-existing 24 advisories; the complete fix requires a separately tested major Astro/Puppeteer migration
- Astro type check retains pre-existing errors and is not a release gate; the production build is green
