### PR TITLE
Verify agent readiness after every deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -95,6 +95,13 @@ jobs:
             --sitemap next/dist/sitemap.xml \
             --out-dir next/dist
 
+      - name: Write deployment provenance
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          BUILD_RUN_ID: ${{ github.run_id }}
+        run: |
+          node --input-type=module -e "import { writeFileSync } from 'node:fs'; writeFileSync('next/dist/deployment.json', JSON.stringify({ sourceSha: process.env.SOURCE_SHA, runId: process.env.BUILD_RUN_ID, generatedAt: new Date().toISOString() }, null, 2) + '\n')"
+
       - name: Prune internal surfaces from deploy output (T-006)
         # v5 hygiene (2026-07-11, T-006): the editorial admin surface
         # (next/src/pages/admin + public/admin/media-registry.json) must not

--- a/.github/workflows/content-gate.yml
+++ b/.github/workflows/content-gate.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           cd next
           npm run test:content-admission
+          npm run test:agent-readiness
 
       - name: Content admission gate
         # Placeholder markers + real Astro collection-schema validation

--- a/.github/workflows/live-agent-readiness.yml
+++ b/.github/workflows/live-agent-readiness.yml
@@ -1,0 +1,56 @@
+name: Live Agent Readiness — Peninsula Insider
+
+on:
+  workflow_run:
+    workflows: ['Build and Deploy — Peninsula Insider']
+    types: [completed]
+  schedule:
+    # Independent daily proof 30 minutes after the 14:10 UTC rebuild.
+    # That is 00:40 AEST / 01:40 AEDT, after the local date has rolled over.
+    - cron: '40 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: live-agent-readiness
+  cancel-in-progress: true
+
+jobs:
+  verify-live-agent-readiness:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      TZ: Australia/Sydney
+      EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+
+    steps:
+      - name: Checkout current source of truth
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '22'
+
+      - name: Verify deployed provenance and agent-facing surfaces
+        run: node next/scripts/audit-live-agent-readiness.mjs
+
+      - name: Alert on stale, incomplete, or unsafe live output
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PI_REPO_ROOT: ${{ github.workspace }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 engine/alert.py \
+            --title "Live agent-readiness gate failed (run #${{ github.run_number }})" \
+            --body "The deployed site did not match the expected source commit or failed a semantic agent-readiness check. Run: ${RUN_URL}" \
+            --dedup live-agent-readiness --severity fatal

--- a/next/package.json
+++ b/next/package.json
@@ -28,7 +28,7 @@
     "entity-index:report": "node scripts/refresh-entity-index.mjs --report",
     "search:audit": "node scripts/audit-search-links.mjs",
     "audit:agent-readiness": "node scripts/audit-agent-readiness.mjs",
-    "test:agent-readiness": "node --test scripts/test-agent-readiness.mjs",
+    "test:agent-readiness": "node --test scripts/test-agent-readiness.mjs scripts/test-live-agent-readiness.mjs",
     "bf:lint": "node ../scripts/bf-import/verify-lint.mjs",
     "bf:lint:strict": "node ../scripts/bf-import/verify-lint.mjs --strict",
     "pdfs": "node scripts/render-pdfs.mjs",

--- a/next/scripts/audit-live-agent-readiness.mjs
+++ b/next/scripts/audit-live-agent-readiness.mjs
@@ -1,0 +1,185 @@
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const SYDNEY_TZ = 'Australia/Sydney';
+const DEFAULT_BASE = 'https://peninsulainsider.com.au';
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isIsoDate(value) {
+  if (!ISO_DATE.test(value || '')) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+export function sydneyDate(instant = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: SYDNEY_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(instant);
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function validateLivePayloads(payloads, { expectedDate, expectedSha } = {}) {
+  const failures = [];
+  const feed = payloads.feed;
+  const events = Array.isArray(feed?.events) ? feed.events : [];
+  const weekendEvents = events.filter((event) => event?.thisWeekend === true);
+
+  if (feed?.generated !== expectedDate) {
+    failures.push(`feed generated ${JSON.stringify(feed?.generated)}; expected ${expectedDate}`);
+  }
+  if (!Number.isInteger(feed?.count) || feed.count !== events.length) {
+    failures.push(`feed count ${JSON.stringify(feed?.count)} does not match ${events.length} events`);
+  }
+  if (!Number.isInteger(feed?.thisWeekend?.count) || feed.thisWeekend.count !== weekendEvents.length) {
+    failures.push(
+      `weekend count ${JSON.stringify(feed?.thisWeekend?.count)} does not match ${weekendEvents.length} flagged events`,
+    );
+  }
+
+  const weekendStart = feed?.thisWeekend?.start;
+  const weekendEnd = feed?.thisWeekend?.end;
+  if (!isIsoDate(weekendStart) || !isIsoDate(weekendEnd) || weekendStart > weekendEnd) {
+    failures.push('weekend window is missing, malformed, or reversed');
+  }
+
+  for (const event of events) {
+    const startDate = event?.startDate;
+    const lastDate = event?.endDate || event?.startDate;
+    if (!isIsoDate(startDate) || !isIsoDate(lastDate) || startDate > lastDate) {
+      failures.push(`${event?.url || event?.title || 'event'} has malformed or reversed dates`);
+    } else if (lastDate < expectedDate) {
+      failures.push(`${event?.url || event?.title || 'event'} has expired or invalid date ${JSON.stringify(lastDate)}`);
+    }
+    if (typeof event?.url !== 'string' || !event.url.startsWith(`${DEFAULT_BASE}/`)) {
+      failures.push(`${event?.title || 'event'} has a missing or non-canonical URL`);
+    }
+    if (event?.thisWeekend === true && (lastDate < weekendStart || startDate > weekendEnd)) {
+      failures.push(`${event.url || event.title || 'event'} is flagged this weekend but falls outside the weekend window`);
+    }
+  }
+
+  if (!/<link\b(?=[^>]*\brel=["']canonical["'])(?=[^>]*\bhref=["']https:\/\/peninsulainsider\.com\.au\/["'])[^>]*>/i.test(payloads.root)) {
+    failures.push('homepage canonical URL is missing or unexpected');
+  }
+  if (!payloads.weekend.includes(feed?.thisWeekend?.label || '__missing_weekend_label__')) {
+    failures.push('weekend page does not expose the feed weekend label');
+  }
+  if (!payloads.llms.includes('https://peninsulainsider.com.au/whats-on/')) {
+    failures.push('llms.txt does not link to the What’s On surface');
+  }
+  if (!payloads.llmsFull.includes('https://peninsulainsider.com.au/')) {
+    failures.push('llms-full.txt does not identify the canonical site');
+  }
+  if (!payloads.sitemap.includes('<loc>https://peninsulainsider.com.au/')) {
+    failures.push('sitemap does not contain canonical Peninsula Insider URLs');
+  }
+  for (const excluded of ['/explore/best-walks/', '/eat/port-phillip-estate-restaurant/']) {
+    if (payloads.sitemap.includes(excluded)) failures.push(`sitemap contains redirect/noindex URL ${excluded}`);
+  }
+  if (expectedSha && payloads.deployment?.sourceSha !== expectedSha) {
+    failures.push(
+      `live deployment source ${JSON.stringify(payloads.deployment?.sourceSha)}; expected ${expectedSha}`,
+    );
+  }
+
+  return failures;
+}
+
+function parseArgs(argv) {
+  const args = {
+    base: DEFAULT_BASE,
+    expectedDate: sydneyDate(),
+    expectedSha: process.env.EXPECTED_SHA || '',
+    attempts: 12,
+    delayMs: 15_000,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index + 1];
+    if (argv[index] === '--base') args.base = value;
+    if (argv[index] === '--expected-date') args.expectedDate = value;
+    if (argv[index] === '--expected-sha') args.expectedSha = value;
+    if (argv[index] === '--attempts') args.attempts = Number.parseInt(value, 10);
+    if (argv[index] === '--delay-ms') args.delayMs = Number.parseInt(value, 10);
+  }
+  args.base = args.base.replace(/\/$/, '');
+  if (!isIsoDate(args.expectedDate)) throw new Error('expected date must be a valid YYYY-MM-DD date');
+  if (!Number.isInteger(args.attempts) || args.attempts < 1) throw new Error('attempts must be a positive integer');
+  if (!Number.isInteger(args.delayMs) || args.delayMs < 0) throw new Error('delay-ms must be non-negative');
+  return args;
+}
+
+async function fetchResource(base, path, expectedStatus = 200) {
+  const separator = path.includes('?') ? '&' : '?';
+  const url = `${base}${path}${separator}pi_smoke=${Date.now()}`;
+  const response = await fetch(url, {
+    redirect: 'follow',
+    headers: { 'cache-control': 'no-cache', 'user-agent': 'PI-live-agent-readiness/1.0' },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (response.status !== expectedStatus) throw new Error(`${path} returned HTTP ${response.status}; expected ${expectedStatus}`);
+  return response.text();
+}
+
+async function auditOnce(args) {
+  const [root, feedText, weekend, llms, llmsFull, sitemap, deploymentText, admin404, unknown404] = await Promise.all([
+    fetchResource(args.base, '/'),
+    fetchResource(args.base, '/whats-on/upcoming.json'),
+    fetchResource(args.base, '/whats-on/this-weekend/'),
+    fetchResource(args.base, '/llms.txt'),
+    fetchResource(args.base, '/llms-full.txt'),
+    fetchResource(args.base, '/sitemap.xml'),
+    fetchResource(args.base, '/deployment.json'),
+    fetchResource(args.base, '/admin/', 404),
+    fetchResource(args.base, '/__pi-agent-readiness-not-found__/', 404),
+  ]);
+  void admin404;
+  void unknown404;
+
+  let feed;
+  let deployment;
+  try {
+    feed = JSON.parse(feedText);
+  } catch (error) {
+    throw new Error(`upcoming feed is not valid JSON: ${error.message}`);
+  }
+  try {
+    deployment = JSON.parse(deploymentText);
+  } catch (error) {
+    throw new Error(`deployment provenance is not valid JSON: ${error.message}`);
+  }
+
+  return validateLivePayloads(
+    { root, feed, weekend, llms, llmsFull, sitemap, deployment },
+    { expectedDate: args.expectedDate, expectedSha: args.expectedSha },
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let failures = [];
+  for (let attempt = 1; attempt <= args.attempts; attempt += 1) {
+    try {
+      failures = await auditOnce(args);
+    } catch (error) {
+      failures = [error.message];
+    }
+    if (failures.length === 0) {
+      console.log(
+        `Live agent-readiness passed for ${args.expectedDate}${args.expectedSha ? ` at ${args.expectedSha}` : ''}.`,
+      );
+      return;
+    }
+    console.error(`Live agent-readiness attempt ${attempt}/${args.attempts} failed:`);
+    failures.forEach((failure) => console.error(`- ${failure}`));
+    if (attempt < args.attempts) await new Promise((resolve) => setTimeout(resolve, args.delayMs));
+  }
+  process.exitCode = 2;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/next/scripts/test-live-agent-readiness.mjs
+++ b/next/scripts/test-live-agent-readiness.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import test from 'node:test';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { sydneyDate, validateLivePayloads } from './audit-live-agent-readiness.mjs';
+
+const expectedSha = 'a'.repeat(40);
+const execFileAsync = promisify(execFile);
+
+function fixture(overrides = {}) {
+  return {
+    root: '<link rel="canonical" href="https://peninsulainsider.com.au/" />',
+    feed: {
+      generated: '2026-08-15',
+      count: 1,
+      thisWeekend: {
+        start: '2026-08-15',
+        end: '2026-08-16',
+        count: 1,
+        label: 'Sat 15 – Sun 16 August',
+      },
+      events: [{
+        title: 'Market',
+        url: 'https://peninsulainsider.com.au/whats-on/market/',
+        startDate: '2026-08-15',
+        thisWeekend: true,
+      }],
+    },
+    weekend: '<h1>This weekend</h1><p>Sat 15 – Sun 16 August</p>',
+    llms: 'https://peninsulainsider.com.au/whats-on/',
+    llmsFull: 'https://peninsulainsider.com.au/',
+    sitemap: '<loc>https://peninsulainsider.com.au/</loc>',
+    deployment: { sourceSha: expectedSha },
+    ...overrides,
+  };
+}
+
+test('derives the Sydney date across the UTC date boundary', () => {
+  assert.equal(sydneyDate(new Date('2026-08-14T14:10:00Z')), '2026-08-15');
+});
+
+test('accepts a current, internally consistent live surface', () => {
+  assert.deepEqual(
+    validateLivePayloads(fixture(), { expectedDate: '2026-08-15', expectedSha }),
+    [],
+  );
+});
+
+test('scheduled checks may validate semantic freshness without an expected deployment SHA', () => {
+  assert.deepEqual(validateLivePayloads(fixture(), { expectedDate: '2026-08-15' }), []);
+});
+
+test('rejects stale events, stale provenance, and redirect sitemap entries', () => {
+  const payloads = fixture();
+  payloads.feed.events[0].startDate = '2026-08-14';
+  payloads.deployment.sourceSha = 'b'.repeat(40);
+  payloads.sitemap += '<loc>https://peninsulainsider.com.au/explore/best-walks/</loc>';
+  const failures = validateLivePayloads(payloads, { expectedDate: '2026-08-15', expectedSha });
+  assert.ok(failures.some((failure) => failure.includes('expired')));
+  assert.ok(failures.some((failure) => failure.includes('live deployment source')));
+  assert.ok(failures.some((failure) => failure.includes('redirect/noindex')));
+});
+
+test('rejects malformed, reversed, and incorrectly flagged event dates', () => {
+  const payloads = fixture();
+  payloads.feed.events[0].startDate = 'banana';
+  payloads.feed.events[0].endDate = '2026-08-14';
+  const failures = validateLivePayloads(payloads, { expectedDate: '2026-08-15', expectedSha });
+  assert.ok(failures.some((failure) => failure.includes('malformed or reversed')));
+});
+
+test('rejects impossible calendar dates and valid-format reversed ranges', () => {
+  const impossible = fixture();
+  impossible.feed.events[0].startDate = '2026-99-99';
+  assert.ok(
+    validateLivePayloads(impossible, { expectedDate: '2026-08-15', expectedSha })
+      .some((failure) => failure.includes('malformed or reversed')),
+  );
+
+  const reversed = fixture();
+  reversed.feed.events[0].startDate = '2026-08-16';
+  reversed.feed.events[0].endDate = '2026-08-15';
+  assert.ok(
+    validateLivePayloads(reversed, { expectedDate: '2026-08-15', expectedSha })
+      .some((failure) => failure.includes('malformed or reversed')),
+  );
+});
+
+test('rejects an event flagged for a weekend it does not intersect', () => {
+  const payloads = fixture();
+  payloads.feed.events[0].startDate = '2026-08-17';
+  const failures = validateLivePayloads(payloads, { expectedDate: '2026-08-15', expectedSha });
+  assert.ok(failures.some((failure) => failure.includes('outside the weekend window')));
+});
+
+test('command-line audit verifies HTTP status, provenance, and semantic payloads', async (context) => {
+  const payloads = fixture();
+  const routes = new Map([
+    ['/', ['text/html', payloads.root]],
+    ['/whats-on/upcoming.json', ['application/json', JSON.stringify(payloads.feed)]],
+    ['/whats-on/this-weekend/', ['text/html', payloads.weekend]],
+    ['/llms.txt', ['text/plain', payloads.llms]],
+    ['/llms-full.txt', ['text/plain', payloads.llmsFull]],
+    ['/sitemap.xml', ['application/xml', payloads.sitemap]],
+    ['/deployment.json', ['application/json', JSON.stringify(payloads.deployment)]],
+  ]);
+  const server = createServer((request, response) => {
+    const path = new URL(request.url, 'http://localhost').pathname;
+    const route = routes.get(path);
+    if (!route) {
+      response.writeHead(404, { 'content-type': 'text/plain' });
+      response.end('not found');
+      return;
+    }
+    response.writeHead(200, { 'content-type': route[0] });
+    response.end(route[1]);
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  context.after(() => server.close());
+
+  const address = server.address();
+  const script = fileURLToPath(new URL('./audit-live-agent-readiness.mjs', import.meta.url));
+  const { stdout } = await execFileAsync(process.execPath, [
+    script,
+    '--base',
+    `http://127.0.0.1:${address.port}`,
+    '--expected-date',
+    '2026-08-15',
+    '--expected-sha',
+    expectedSha,
+    '--attempts',
+    '1',
+  ]);
+  assert.match(stdout, /Live agent-readiness passed/);
+});


### PR DESCRIPTION
## Summary

- publish a small deployment provenance record that links live output to the exact source commit and build run
- run a bounded semantic smoke test after every successful production build and daily after the Sydney date rollover
- verify HTTP status, feed freshness, event dates, weekend consistency, canonical discovery surfaces, sitemap exclusions, private-route pruning, and live source provenance
- execute the readiness regression suite in branch CI

## Verification

- `npm run test:agent-readiness` (9/9)
- `npm run test:content-admission`
- `npm run validate:content`
- workflow YAML parse for build, content gate, and live readiness workflows
- current production correctly fails the new probe only because `/deployment.json` is not published until this change deploys

## Rollback

Revert this commit. The live probe and public provenance file are additive and do not alter site rendering or content selection.
