### PR TITLE
Standardize agent-facing structured data

### DIFF
--- a/next/scripts/audit-agent-readiness.mjs
+++ b/next/scripts/audit-agent-readiness.mjs
@@ -60,6 +60,24 @@ if (!existsSync(upcomingPath)) {
   if (feed.count !== feed.events?.length) {
     fail(`/whats-on/upcoming.json count=${feed.count}; events=${feed.events?.length ?? 'missing'}`);
   }
+  if (feed.numberOfItems !== feed.events?.length || feed.itemListElement?.length !== feed.events?.length) {
+    fail(
+      `/whats-on/upcoming.json ItemList counts do not match events=${feed.events?.length ?? 'missing'}`,
+    );
+  }
+  for (const [index, event] of (feed.events ?? []).entries()) {
+    const listItem = feed.itemListElement?.[index];
+    if (
+      listItem?.['@type'] !== 'ListItem' ||
+      listItem?.position !== index + 1 ||
+      listItem?.item?.['@type'] !== 'Event' ||
+      listItem?.item?.url !== event.url ||
+      listItem?.item?.startDate !== event.startDate ||
+      listItem?.item?.endDate !== event.endDate
+    ) {
+      fail(`/whats-on/upcoming.json ItemList entry ${index + 1} disagrees with events payload`);
+    }
+  }
   const weekendCount = (feed.events ?? []).filter((event) => event.thisWeekend).length;
   if (feed.thisWeekend?.count !== weekendCount) {
     fail(`/whats-on/upcoming.json thisWeekend.count=${feed.thisWeekend?.count}; actual=${weekendCount}`);
@@ -106,6 +124,7 @@ walk(siteDir);
 for (const path of htmlFiles) {
   const html = read(path);
   const scripts = html.matchAll(/<script[^>]+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi);
+  let breadcrumbLists = 0;
   for (const match of scripts) {
     let data;
     try {
@@ -115,6 +134,7 @@ for (const path of htmlFiles) {
     }
     const visit = (node) => {
       if (!node || typeof node !== 'object') return;
+      if (node['@type'] === 'BreadcrumbList') breadcrumbLists += 1;
       if (node['@type'] === 'Event' && node.startDate && node.endDate) {
         const start = new Date(node.startDate);
         const end = new Date(node.endDate);
@@ -128,6 +148,9 @@ for (const path of htmlFiles) {
       }
     };
     visit(data);
+  }
+  if (breadcrumbLists > 1) {
+    fail(`Duplicate BreadcrumbList schemas in ${relative(siteDir, path)} (${breadcrumbLists})`);
   }
 }
 

--- a/next/scripts/audit-live-agent-readiness.mjs
+++ b/next/scripts/audit-live-agent-readiness.mjs
@@ -34,6 +34,22 @@ export function validateLivePayloads(payloads, { expectedDate, expectedSha } = {
   if (!Number.isInteger(feed?.count) || feed.count !== events.length) {
     failures.push(`feed count ${JSON.stringify(feed?.count)} does not match ${events.length} events`);
   }
+  if (feed?.numberOfItems !== events.length || feed?.itemListElement?.length !== events.length) {
+    failures.push('schema.org ItemList counts do not match the stable events payload');
+  }
+  for (const [index, event] of events.entries()) {
+    const listItem = feed?.itemListElement?.[index];
+    if (
+      listItem?.['@type'] !== 'ListItem' ||
+      listItem?.position !== index + 1 ||
+      listItem?.item?.['@type'] !== 'Event' ||
+      listItem?.item?.url !== event?.url ||
+      listItem?.item?.startDate !== event?.startDate ||
+      listItem?.item?.endDate !== event?.endDate
+    ) {
+      failures.push(`schema.org ItemList entry ${index + 1} disagrees with the stable events payload`);
+    }
+  }
   if (!Number.isInteger(feed?.thisWeekend?.count) || feed.thisWeekend.count !== weekendEvents.length) {
     failures.push(
       `weekend count ${JSON.stringify(feed?.thisWeekend?.count)} does not match ${weekendEvents.length} flagged events`,

--- a/next/scripts/test-agent-readiness.mjs
+++ b/next/scripts/test-agent-readiness.mjs
@@ -18,7 +18,18 @@ function writeFixture(root, generated = '2026-08-15', endDate = '2026-08-15') {
     JSON.stringify({
       generated,
       count: 1,
+      numberOfItems: 1,
       thisWeekend: { count: 1 },
+      itemListElement: [{
+        '@type': 'ListItem',
+        position: 1,
+        item: {
+          '@type': 'Event',
+          url: 'https://peninsulainsider.com.au/whats-on/fixture/',
+          startDate: endDate,
+          endDate,
+        },
+      }],
       events: [{
         title: 'Fixture event',
         url: 'https://peninsulainsider.com.au/whats-on/fixture/',

--- a/next/scripts/test-live-agent-readiness.mjs
+++ b/next/scripts/test-live-agent-readiness.mjs
@@ -11,23 +11,34 @@ const expectedSha = 'a'.repeat(40);
 const execFileAsync = promisify(execFile);
 
 function fixture(overrides = {}) {
+  const event = {
+    title: 'Market',
+    url: 'https://peninsulainsider.com.au/whats-on/market/',
+    startDate: '2026-08-15',
+    thisWeekend: true,
+  };
   return {
     root: '<link rel="canonical" href="https://peninsulainsider.com.au/" />',
     feed: {
       generated: '2026-08-15',
       count: 1,
+      numberOfItems: 1,
       thisWeekend: {
         start: '2026-08-15',
         end: '2026-08-16',
         count: 1,
         label: 'Sat 15 – Sun 16 August',
       },
-      events: [{
-        title: 'Market',
-        url: 'https://peninsulainsider.com.au/whats-on/market/',
-        startDate: '2026-08-15',
-        thisWeekend: true,
+      itemListElement: [{
+        '@type': 'ListItem',
+        position: 1,
+        item: {
+          '@type': 'Event',
+          url: event.url,
+          startDate: event.startDate,
+        },
       }],
+      events: [event],
     },
     weekend: '<h1>This weekend</h1><p>Sat 15 – Sun 16 August</p>',
     llms: 'https://peninsulainsider.com.au/whats-on/',

--- a/next/src/components/Breadcrumbs.astro
+++ b/next/src/components/Breadcrumbs.astro
@@ -1,20 +1,14 @@
 ---
 /**
- * Breadcrumbs - visible navigation + BreadcrumbList JSON-LD.
+ * Breadcrumbs - visible semantic navigation.
  *
- * Single source of truth for breadcrumbs on Peninsula Insider. Emits both:
- *   1. Visible <nav> element (styled as before)
- *   2. BreadcrumbList schema.org JSON-LD (for SERP rich results)
- *
- * Pages should not emit a separate BreadcrumbList JSON-LD - this component
- * handles it. Pass the same `items` array you'd use for the visible nav.
+ * Page templates that have a curated BreadcrumbList own that JSON-LD. Keeping
+ * this reusable visual component schema-free prevents site-wide duplicates
+ * while preserving semantic nav for every page.
  *
  * Each item:
- *   - `label` - visible text + schema `name`
- *   - `href` - optional. Omit on the final (current) item. Relative paths are
- *               resolved against SITE_URL; absolute URLs (http(s)://) pass through.
- *               For the final item, if `href` is omitted, the current page URL
- *               is used in the schema (visible rendering shows it as non-link text).
+ *   - `label` - visible text
+ *   - `href` - optional. Omit on the final (current) item.
  */
 
 export interface Crumb {
@@ -28,33 +22,7 @@ export interface Props {
 
 const { items } = Astro.props;
 
-const SITE_URL = 'https://peninsulainsider.com.au';
-
-// Derive current canonical URL for the final breadcrumb item when href is not supplied.
-const rawPathname = Astro.url.pathname.replace(/^\/V2/, '') || '/';
-const normalizedPath = rawPathname !== '/' ? rawPathname.replace(/\/$/, '') : rawPathname;
-const currentUrl = `${SITE_URL}${normalizedPath}`;
-
-function absolutize(href: string | undefined, fallback: string): string {
-  if (!href) return fallback;
-  if (href.startsWith('http://') || href.startsWith('https://')) return href;
-  if (href === '/') return SITE_URL;
-  return `${SITE_URL}${href.startsWith('/') ? href : '/' + href}`;
-}
-
-const breadcrumbSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
-  itemListElement: items.map((item, index) => ({
-    '@type': 'ListItem',
-    position: index + 1,
-    name: item.label,
-    item: absolutize(item.href, currentUrl),
-  })),
-};
 ---
-
-<script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <div class="container">

--- a/next/src/components/v5/chrome/V5Breadcrumbs.astro
+++ b/next/src/components/v5/chrome/V5Breadcrumbs.astro
@@ -6,13 +6,14 @@
  *
  * Auto-derives the trail from the URL path so no page file needs
  * editing; the final crumb prefers the page <title> (suffix stripped)
- * over a title-cased slug. Emits BreadcrumbList JSON-LD.
+ * over a title-cased slug. Page templates own BreadcrumbList JSON-LD so the
+ * global visual trail cannot create duplicate structured data.
  *
  * Coexistence with page-authored <Breadcrumbs>: pages that already
  * render their own trail inside <main> keep it (their labels are
  * richer). This component defers to them: a :has() rule hides the
- * auto trail visually, and a tiny script removes the auto nav and its
- * JSON-LD from the DOM so assistive tech and crawlers see one trail.
+ * auto trail visually, and a tiny script removes the auto nav from the DOM
+ * so assistive tech sees one trail.
  *
  * v6 token pass (P3-6, 2026-07-25): no buttons here, so nothing moves
  * to .pi-btn. Two contrast corrections only - the separator glyph and
@@ -25,8 +26,6 @@ export interface Props {
 }
 
 const { pageTitle } = Astro.props;
-
-const SITE_URL = 'https://peninsulainsider.com.au';
 
 const rawPathname = Astro.url.pathname.replace(/^\/V2/, '') || '/';
 const segments = rawPathname.split('/').filter(Boolean);
@@ -126,21 +125,6 @@ const crumbs: Crumb[] = show
     ]
   : [];
 
-const normalizedPath = rawPathname !== '/' ? rawPathname.replace(/\/$/, '') : rawPathname;
-const currentUrl = `${SITE_URL}${normalizedPath}`;
-
-const breadcrumbSchema = show
-  ? {
-      '@context': 'https://schema.org',
-      '@type': 'BreadcrumbList',
-      itemListElement: crumbs.map((item, index) => ({
-        '@type': 'ListItem',
-        position: index + 1,
-        name: item.label,
-        item: item.href ? `${SITE_URL}${item.href === '/' ? '' : item.href}` || SITE_URL : currentUrl,
-      })),
-    }
-  : null;
 ---
 
 {show && (
@@ -161,21 +145,15 @@ const breadcrumbSchema = show
   </nav>
 )}
 
-{show && breadcrumbSchema && (
-  <script type="application/ld+json" id="v5BreadcrumbsLd" set:html={JSON.stringify(breadcrumbSchema)} />
-)}
-
 <script is:inline>
     // Defer to a page-authored trail: if the page renders its own
     // <Breadcrumbs> (which carries better labels and its own JSON-LD),
-    // remove the auto trail and its schema so exactly one remains.
+    // remove the auto visual trail.
     (function () {
       function dedupeV5Crumbs() {
         var auto = document.getElementById('v5Breadcrumbs');
         if (!auto) return;
         if (document.querySelector('main .breadcrumbs')) {
-          var ld = document.getElementById('v5BreadcrumbsLd');
-          if (ld) ld.remove();
           auto.remove();
         }
       }

--- a/next/src/pages/boating/hire/index.astro
+++ b/next/src/pages/boating/hire/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import SectionHero from '../../../components/SectionHero.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../../lib/schema';
+import { buildBfHubSchema } from '../../../lib/schema';
 import { formatVerifiedStamp } from '../../../lib/bf';
 
 const lastVerifiedISO = '2026-04-30';
@@ -38,11 +38,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Boating', url: 'https://peninsulainsider.com.au/boating/' },
-  { name: 'Boat hire', url: 'https://peninsulainsider.com.au/boating/hire/' },
-]);
 export const prerender = true;
 ---
 
@@ -54,7 +49,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/boating/index.astro
+++ b/next/src/pages/boating/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import SectionHero from '../../components/SectionHero.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../lib/schema';
+import { buildBfHubSchema } from '../../lib/schema';
 import { BF_EXTERNAL, formatVerifiedStamp } from '../../lib/bf';
 
 // Source: peninsula_insider_boating_fishing_v1/content-bf/hub_boating_index.md
@@ -50,10 +50,6 @@ const hubSchema = buildBfHubSchema({
   ],
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Boating', url: 'https://peninsulainsider.com.au/boating/' },
-]);
 export const prerender = true;
 ---
 
@@ -65,7 +61,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/boating/ramps/index.astro
+++ b/next/src/pages/boating/ramps/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import SectionHero from '../../../components/SectionHero.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../../lib/schema';
+import { buildBfHubSchema } from '../../../lib/schema';
 import { REGION_LABEL, formatVerifiedStamp, BF_EXTERNAL } from '../../../lib/bf';
 
 const lastVerifiedISO = '2026-04-30';
@@ -42,11 +42,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Boating', url: 'https://peninsulainsider.com.au/boating/' },
-  { name: 'Boat ramps', url: 'https://peninsulainsider.com.au/boating/ramps/' },
-]);
 export const prerender = true;
 ---
 
@@ -58,7 +53,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/fishing/charters/index.astro
+++ b/next/src/pages/fishing/charters/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import SectionHero from '../../../components/SectionHero.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../../lib/schema';
+import { buildBfHubSchema } from '../../../lib/schema';
 import { formatVerifiedStamp, BF_CHARTERS_P5 } from '../../../lib/bf';
 
 const lastVerifiedISO = '2026-04-30';
@@ -45,11 +45,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Fishing', url: 'https://peninsulainsider.com.au/fishing/' },
-  { name: 'Charters', url: 'https://peninsulainsider.com.au/fishing/charters/' },
-]);
 export const prerender = true;
 ---
 
@@ -61,7 +56,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/fishing/index.astro
+++ b/next/src/pages/fishing/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import SectionHero from '../../components/SectionHero.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../lib/schema';
+import { buildBfHubSchema } from '../../lib/schema';
 import { BF_EXTERNAL, formatVerifiedStamp } from '../../lib/bf';
 
 // Source: peninsula_insider_boating_fishing_v1/content-bf/hub_fishing_index.md
@@ -43,10 +43,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Fishing', url: 'https://peninsulainsider.com.au/fishing/' },
-]);
 
 // Editorial seasonality calendar, derived from the pack hub draft. Not
 // schema-emitted; this is the in-page summary table.
@@ -75,7 +71,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/fishing/locations/index.astro
+++ b/next/src/pages/fishing/locations/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import SectionHero from '../../../components/SectionHero.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../../lib/schema';
+import { buildBfHubSchema } from '../../../lib/schema';
 import { REGION_LABEL, formatVerifiedStamp } from '../../../lib/bf';
 
 const lastVerifiedISO = '2026-04-30';
@@ -44,11 +44,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Fishing', url: 'https://peninsulainsider.com.au/fishing/' },
-  { name: 'Locations', url: 'https://peninsulainsider.com.au/fishing/locations/' },
-]);
 export const prerender = true;
 ---
 
@@ -60,7 +55,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/fishing/species/index.astro
+++ b/next/src/pages/fishing/species/index.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import SectionHero from '../../../components/SectionHero.astro';
 import NewsletterBlock from '../../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../../lib/schema';
+import { buildBfHubSchema } from '../../../lib/schema';
 import { BF_EXTERNAL, BF_SPECIES_ORDER, REGION_LABEL, formatVerifiedStamp } from '../../../lib/bf';
 
 const lastVerifiedISO = '2026-04-30';
@@ -44,11 +44,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Fishing', url: 'https://peninsulainsider.com.au/fishing/' },
-  { name: 'Species', url: 'https://peninsulainsider.com.au/fishing/species/' },
-]);
 export const prerender = true;
 ---
 
@@ -60,7 +55,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/tour/fishing-tours.astro
+++ b/next/src/pages/tour/fishing-tours.astro
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import SectionHero from '../../components/SectionHero.astro';
 import NewsletterBlock from '../../components/NewsletterBlock.astro';
 import BfAnalytics from '../../components/BfAnalytics.astro';
-import { buildBfHubSchema, buildBreadcrumbSchema } from '../../lib/schema';
+import { buildBfHubSchema } from '../../lib/schema';
 import { formatVerifiedStamp } from '../../lib/bf';
 
 // /tour/ ↔ /fishing/charters/ bidirectional rail. This page is the "I want
@@ -52,11 +52,6 @@ const hubSchema = buildBfHubSchema({
   })),
 });
 
-const breadcrumbSchema = buildBreadcrumbSchema([
-  { name: 'Home', url: 'https://peninsulainsider.com.au/' },
-  { name: 'Tours', url: 'https://peninsulainsider.com.au/tour/' },
-  { name: 'Fishing tours', url: `https://peninsulainsider.com.au${path}` },
-]);
 export const prerender = true;
 ---
 
@@ -68,7 +63,6 @@ export const prerender = true;
   modifiedTime={lastVerifiedISO}
 >
   <script type="application/ld+json" set:html={JSON.stringify(hubSchema)} />
-  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   <BfAnalytics />
 
   <Breadcrumbs items={breadcrumbItems} />

--- a/next/src/pages/whats-on/upcoming.json.ts
+++ b/next/src/pages/whats-on/upcoming.json.ts
@@ -74,6 +74,20 @@ export const GET: APIRoute = async () => {
       label: weekend.label,
       count: upcoming.filter((x) => x.thisWeekend).length,
     },
+    numberOfItems: upcoming.length,
+    itemListElement: upcoming.map((event, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'Event',
+        name: event.title,
+        url: event.url,
+        startDate: event.startDate,
+        endDate: event.endDate,
+        description: event.summary,
+        eventStatus: 'https://schema.org/EventScheduled',
+      },
+    })),
     count: upcoming.length,
     events: upcoming,
   };


### PR DESCRIPTION
## Summary

- remove duplicate global and hub-owned BreadcrumbList JSON-LD while preserving semantic visual navigation
- enforce at most one BreadcrumbList per generated page
- make `/whats-on/upcoming.json` a standards-compliant schema.org ItemList
- preserve the existing stable `events` payload and assert both representations remain identical

## Verification

- `npm run test:agent-readiness` (10/10)
- content admission and schema validation passed
- production-equivalent `npm run build:search`: 950 pages built, 953 HTML audited, 754 indexed
- zero duplicate BreadcrumbList schemas in the full snapshot
- feed: 30 events, 30 ItemList entries, first standard item is an Event

## Rollback

Revert this commit. Visible breadcrumb navigation and the legacy event payload are unchanged.
