### PR TITLE
fix(ci): remove nonexistent semrush-api-client pip dependency

### DIFF
--- a/.github/workflows/weekly-content.yml
+++ b/.github/workflows/weekly-content.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install engine dependencies
         run: |
-          pip install anthropic requests python-dateutil semrush-api-client
+          pip install anthropic requests python-dateutil
 
       - name: Configure git identity
         run: |


### PR DESCRIPTION
## Root cause

The Weekly Content Engine has failed on every scheduled run for at least 3 weeks (26 Jul, 2 Aug, 9 Aug — see #287) with:

```
ERROR: Could not find a version that satisfies the requirement semrush-api-client (from versions: none)
ERROR: No matching distribution found for semrush-api-client
Process completed with exit code 1.
```

`semrush-api-client` is not a real PyPI package. It's requested in the `Install engine dependencies` step of `.github/workflows/weekly-content.yml` but never imported anywhere — `engine/signal_engine.py`'s `run_semrush_signal()` pulls SEO signals via `pplx_sdk`/direct API calls, not this SDK.

## Fix

Drop the bogus dependency from the pip install line. No behavior change to the signal engine itself.

Closes #287 once a scheduled/dispatched run confirms green.