### PR TITLE
feat(foundry): add sealed URL capture kernel

### DIFF
--- a/.github/workflows/content-foundry-ci.yml
+++ b/.github/workflows/content-foundry-ci.yml
@@ -30,6 +30,7 @@ jobs:
           cache: npm
           cache-dependency-path: studio-peninsula-insider/package-lock.json
       - run: npm ci
+      - run: npm run check:capture-boundary
       - run: npm run typecheck
       - run: npm test
       - run: npm run build

--- a/docs/architecture-decisions/content-foundry-capture-kernel.md
+++ b/docs/architecture-decisions/content-foundry-capture-kernel.md
@@ -1,0 +1,38 @@
+# Content Foundry sealed capture kernel
+
+Date: 2026-08-21
+Status: implemented behind a default-off flag; no caller exposed
+Tracks: DELI-693, GitHub issue #324, stacked base `ebe0702bd369641f3235dc7c54955c678b54eb8e`
+
+## Decision
+
+Real URL ingestion must pass through one sealed `CaptureKernel`. The kernel is backend-only, has no Express route, UI action or provider adapter, and remains disabled unless `FOUNDRY_REAL_URLS_ENABLED=1`. The local Compose runtime explicitly sets the flag to `0`.
+
+The kernel owns URL policy, DNS validation, the pinned HTTPS connection, redirect handling, byte and time bounds, immutable storage and inert extraction. CI rejects direct HTTP clients or socket-opening imports outside the single pinned transport module.
+
+## Network boundary
+
+- Parse with WHATWG URL and allow only HTTPS on port 443.
+- Reject credentials, malformed hostnames and special-use suffixes including `.localhost`, `.local`, `.internal`, `.home.arpa`, `.onion`, `.test`, `.example` and `.invalid`.
+- Resolve both A and AAAA answers. Every answer must be public unicast; one private, loopback, link-local, CGNAT, metadata, multicast, reserved or IPv4-mapped IPv6 answer rejects the hop.
+- Pin one member of the validated set into the TLS connection. The connected `remoteAddress` must equal that pin and remain a member of the validated set.
+- Follow redirects manually, at most five. Reapply URL, DNS, pin and remote-address checks on every hop; an HTTPS downgrade fails closed.
+- Bound header bytes and count, wire and decoded body bytes, DNS/header/body/total time and concurrent captures.
+
+All query values may be used only in memory for the outbound request. Persisted attempt, source and redirect URLs replace every query value with `[redacted]`; request headers with credential or cookie value are never persisted. A SHA-256 request fingerprint binds the exact canonical request to its idempotency key without storing the URL value, and reuse with a different request fails closed. Failure records use controlled messages rather than raw transport errors.
+
+## Immutable records
+
+`CaptureAttempt`, `SourceRevision` and `ExtractionRevision` are independently schema-versioned contracts with enforced attempt/source/extraction cross-links. They are committed together in one immutable `pi.capture-manifest.v1`. Attempt event histories enforce legal transitions through capture, extraction, held, no-story and failure outcomes. Idempotency keys are stored only as SHA-256 hashes.
+
+Blobs are addressed by SHA-256 under a root-contained path. Writes use `wx`, file `fsync`, supported-platform parent-directory `fsync`, and exact-byte verification when an address already exists. Manifest commit uses a same-directory private temporary file, file `fsync`, atomic rename and parent-directory `fsync`; the rebuildable idempotency index is written only after the manifest. A crash before manifest commit leaves only reusable blobs. A crash after manifest commit is recovered from the deterministic attempt ID and recreates the missing index. Replaying an idempotency key returns one attempt; a new key produces new immutable revisions while identical source and extracted blobs are reused.
+
+## Extraction and evidence
+
+Only `text/html` and `text/plain` with UTF-8 or US-ASCII enter extraction. Gzip, deflate and Brotli are decoded under separate wire and decoded limits. DNS, headers, body idle time, total capture time and concurrency are independently bounded; the total deadline wraps extraction, blob writes and manifest persistence as well as network work. `parse5` parses HTML without script execution or subresource fetching; script, style, template, SVG and similar non-story nodes are excluded. Prompt-like text in ordinary content remains inert evidence text.
+
+Every extracted block has a stable locator and hash. A capture evidence locator names both the source and extraction revision and resolves only when its excerpt and hash reproduce from that immutable revision.
+
+## Gates retained
+
+This decision grants no production deployment, team-network exposure, credentials, provider spend, CMS or Git mutation, publication, email/social distribution or publication-ledger authority. PI public artifacts still prohibit prices and em dashes, and Workbench review remains distinct from source verification and publication.

--- a/studio-peninsula-insider/Dockerfile
+++ b/studio-peninsula-insider/Dockerfile
@@ -5,11 +5,14 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 COPY --from=pi_fonts . /pi-fonts-source/
-RUN PI_FONT_SOURCE=/pi-fonts-source npm run build
+RUN npm run check:capture-boundary \
+    && npm test \
+    && PI_FONT_SOURCE=/pi-fonts-source npm run build
 
 FROM node:22.23.2-bookworm-slim AS runtime
 
 ENV NODE_ENV=development \
+    FOUNDRY_REAL_URLS_ENABLED=0 \
     FOUNDRY_HOST=0.0.0.0 \
     FOUNDRY_PORT=4310 \
     FOUNDRY_STATIC_DIR=/app/dist \

--- a/studio-peninsula-insider/README.md
+++ b/studio-peninsula-insider/README.md
@@ -8,6 +8,8 @@ Private, fixture-only Content Foundry shell for DELI-693.
 
 The shell performs no model calls, Git writes, CMS writes, publication or external distribution. Its atomic file-backed store is a single-process development/test adapter behind the durable run contract; startup fails closed in production. PostgreSQL, authentication and private storage remain explicit later gates.
 
+The next URL-ingestion foundation is present only as a sealed backend kernel. `FOUNDRY_REAL_URLS_ENABLED` defaults to `0`, Compose pins it to `0`, and no route, UI or provider invokes it. Enabling the flag alone exposes nothing. A later reviewed change must add the private caller after the capture boundary and threat model are accepted.
+
 ## Run locally
 
 ```powershell
@@ -38,6 +40,7 @@ docker compose down
 npm run typecheck
 npm test
 npm run build
+npm run check:capture-boundary
 ```
 
 Runtime state is written under `.foundry-data/` and is ignored by the repository-wide `node_modules/` rule plus the Studio-specific ignore entry added with this module.

--- a/studio-peninsula-insider/compose.yaml
+++ b/studio-peninsula-insider/compose.yaml
@@ -10,6 +10,8 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    environment:
+      FOUNDRY_REAL_URLS_ENABLED: "0"
     ports:
       - "127.0.0.1:4310:4310"
     volumes:

--- a/studio-peninsula-insider/package-lock.json
+++ b/studio-peninsula-insider/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "express": "^4.21.1",
         "helmet": "^8.1.0",
+        "ipaddr.js": "^2.5.0",
+        "parse5": "^8.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "zod": "^4.3.6"
@@ -2341,6 +2343,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2847,12 +2861,12 @@
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3351,6 +3365,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3431,6 +3457,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/studio-peninsula-insider/package.json
+++ b/studio-peninsula-insider/package.json
@@ -13,6 +13,7 @@
     "build": "npm run typecheck && npm run build:client && npm run build:server",
     "build:client": "node scripts/copy-fonts.mjs && vite build",
     "build:server": "tsc -p tsconfig.server.build.json",
+    "check:capture-boundary": "node scripts/check-capture-boundary.mjs",
     "start": "node .server-build/server/index.js",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.server.json",
     "test": "vitest run"
@@ -20,6 +21,8 @@
   "dependencies": {
     "express": "^4.21.1",
     "helmet": "^8.1.0",
+    "ipaddr.js": "^2.5.0",
+    "parse5": "^8.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zod": "^4.3.6"

--- a/studio-peninsula-insider/scripts/check-capture-boundary.mjs
+++ b/studio-peninsula-insider/scripts/check-capture-boundary.mjs
@@ -1,0 +1,56 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const allowedSocketModule = 'server/capture/transport.ts';
+const allowedTransportCaller = 'server/capture/kernel.ts';
+const allowedAddressParser = 'server/capture/policy.ts';
+const violations = [];
+
+async function walk(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolute = join(directory, entry.name);
+    if (entry.isDirectory()) await walk(absolute);
+    if (!entry.isFile() || !['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'].includes(extname(entry.name))) continue;
+    const path = relative(root, absolute).replaceAll('\\', '/');
+    const source = await readFile(absolute, 'utf8');
+    if (/\bfetch\s*\(\s*(?!['"`]\/api\/)/.test(source)) {
+      violations.push(`${path}: external or dynamic direct fetch is forbidden`);
+    }
+    const networkImport = /(?:from\s+|import\s*\(|require\s*\()\s*['"](?:node:)?(?:http|https|http2|net|tls|dgram|dns(?:\/promises)?)['"]/m.test(source);
+    const addressParserOnly = path === allowedAddressParser
+      && /import\s*{\s*isIP\s*}\s*from\s*['"]node:net['"]/.test(source)
+      && !/\b(?:connect|createConnection|createServer)\s*\(/.test(source);
+    if (path !== allowedSocketModule && networkImport && !addressParserOnly) {
+      violations.push(`${path}: outbound socket APIs are reserved for ${allowedSocketModule}`);
+    }
+    if (path !== allowedTransportCaller && /from\s+['"][^'"]*(?:capture\/transport|\.\/transport)(?:\.js)?['"]/.test(source)) {
+      violations.push(`${path}: the pinned transport may be called only by ${allowedTransportCaller}`);
+    }
+    if (![allowedTransportCaller, allowedSocketModule, allowedAddressParser, 'server/capture/transport-contract.ts'].includes(path)
+      && /from\s+['"][^'"]*(?:capture\/policy|\.\/policy)(?:\.js)?['"]/.test(source)) {
+      violations.push(`${path}: DNS and address policy may be called only inside the sealed kernel boundary`);
+    }
+    if (/(?:from\s+|import\s*\(|require\s*\()\s*['"](?:axios|got|node-fetch|undici)['"]/.test(source)) {
+      violations.push(`${path}: direct HTTP client dependency is forbidden`);
+    }
+    if (/(?:from\s+|import\s*\(|require\s*\()\s*['"](?:node:)?child_process['"]|\b(?:exec|execFile|spawn|fork)\s*\(/.test(source)) {
+      violations.push(`${path}: subprocess network bypass surfaces are forbidden`);
+    }
+    if (/\b(?:WebSocket|EventSource)\s*\(|navigator\.sendBeacon\s*\(/.test(source)) {
+      violations.push(`${path}: alternate browser network surfaces are forbidden`);
+    }
+  }
+}
+
+await walk(join(root, 'server'));
+await walk(join(root, 'src'));
+
+if (violations.length > 0) {
+  process.stderr.write(`${violations.join('\n')}\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write('Capture boundary verified: outbound resolution and HTTPS remain inside the sealed kernel modules.\n');
+}

--- a/studio-peninsula-insider/server/capture/blob-store.ts
+++ b/studio-peninsula-insider/server/capture/blob-store.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+import { ImmutableFileStore, ImmutableStorageError } from './filesystem.js';
+
+const SHA256 = /^[a-f0-9]{64}$/;
+
+export function sha256(content: string | Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+export class ContentAddressedBlobStore {
+  private readonly files: ImmutableFileStore;
+  private readonly inFlight = new Map<string, Promise<{ readonly hash: string; readonly created: boolean }>>();
+
+  constructor(root: string) {
+    this.files = new ImmutableFileStore(root);
+  }
+
+  private segments(hash: string): readonly string[] {
+    if (!SHA256.test(hash)) {
+      throw new ImmutableStorageError('Blob hash must be a lowercase SHA-256 digest');
+    }
+    return ['blobs', 'sha256', hash.slice(0, 2), hash];
+  }
+
+  async put(content: Uint8Array): Promise<{ readonly hash: string; readonly created: boolean }> {
+    const hash = sha256(content);
+    const active = this.inFlight.get(hash);
+    if (active) {
+      await active;
+      return Object.freeze({ hash, created: false });
+    }
+    const operation = (async () => {
+      const result = await this.files.writeOnce(this.segments(hash), content);
+      const persisted = await this.files.read(this.segments(hash));
+      if (sha256(persisted) !== hash) {
+        throw new ImmutableStorageError('Existing blob content does not match its address');
+      }
+      return Object.freeze({ hash, created: result === 'created' });
+    })();
+    this.inFlight.set(hash, operation);
+    try {
+      return await operation;
+    } finally {
+      this.inFlight.delete(hash);
+    }
+  }
+
+  async get(hash: string): Promise<Buffer> {
+    const content = await this.files.read(this.segments(hash));
+    if (sha256(content) !== hash) {
+      throw new ImmutableStorageError('Stored blob failed content-address verification');
+    }
+    return content;
+  }
+}

--- a/studio-peninsula-insider/server/capture/body.ts
+++ b/studio-peninsula-insider/server/capture/body.ts
@@ -1,0 +1,102 @@
+import { Readable, type Transform } from 'node:stream';
+import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
+import type { TransportResponse } from './transport-contract.js';
+
+export interface BodyLimits {
+  readonly maxWireBytes: number;
+  readonly maxDecodedBytes: number;
+  readonly bodyIdleTimeoutMs: number;
+}
+
+export class BodyReadError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = 'BodyReadError';
+  }
+}
+
+function decoderFor(encoding: 'identity' | 'gzip' | 'deflate' | 'br'): Transform | undefined {
+  if (encoding === 'gzip') return createGunzip();
+  if (encoding === 'deflate') return createInflate();
+  if (encoding === 'br') return createBrotliDecompress();
+  return undefined;
+}
+
+async function nextWithIdleTimeout<T>(
+  promise: Promise<IteratorResult<T>>,
+  timeoutMs: number,
+  abort: () => void,
+): Promise<IteratorResult<T>> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          abort();
+          reject(new BodyReadError('body_timeout', 'Response body exceeded the idle timeout'));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export async function readBoundedBody(
+  response: TransportResponse,
+  encoding: 'identity' | 'gzip' | 'deflate' | 'br',
+  limits: BodyLimits,
+  signal: AbortSignal,
+): Promise<{ readonly wire: Buffer; readonly decoded: Buffer }> {
+  const contentLength = response.headers['content-length'];
+  if (contentLength && /^\d+$/.test(contentLength) && Number(contentLength) > limits.maxWireBytes) {
+    response.abort();
+    throw new BodyReadError('wire_oversize', 'Content-Length exceeds the wire-byte limit');
+  }
+
+  const wireChunks: Buffer[] = [];
+  let wireBytes = 0;
+  const boundedWire = async function* () {
+    for await (const value of response.body) {
+      signal.throwIfAborted();
+      const chunk = Buffer.from(value);
+      wireBytes += chunk.length;
+      if (wireBytes > limits.maxWireBytes) {
+        throw new BodyReadError('wire_oversize', 'Response exceeded the wire-byte limit');
+      }
+      wireChunks.push(chunk);
+      yield chunk;
+    }
+  };
+
+  const source = Readable.from(boundedWire());
+  const decoder = decoderFor(encoding);
+  const decodedStream = decoder ? source.pipe(decoder) : source;
+  const decodedChunks: Buffer[] = [];
+  let decodedBytes = 0;
+  const iterator = decodedStream[Symbol.asyncIterator]();
+
+  try {
+    while (true) {
+      signal.throwIfAborted();
+      const next = await nextWithIdleTimeout(iterator.next(), limits.bodyIdleTimeoutMs, response.abort);
+      if (next.done) break;
+      const chunk = Buffer.from(next.value);
+      decodedBytes += chunk.length;
+      if (decodedBytes > limits.maxDecodedBytes) {
+        throw new BodyReadError('decoded_oversize', 'Response exceeded the decoded-byte limit');
+      }
+      decodedChunks.push(chunk);
+    }
+  } catch (error) {
+    response.abort();
+    source.destroy();
+    decoder?.destroy();
+    if (error instanceof BodyReadError) throw error;
+    if (signal.aborted) throw new BodyReadError('capture_timeout', 'Capture exceeded its total timeout');
+    throw new BodyReadError('invalid_compression', 'Response body could not be decoded');
+  }
+
+  return Object.freeze({ wire: Buffer.concat(wireChunks), decoded: Buffer.concat(decodedChunks) });
+}

--- a/studio-peninsula-insider/server/capture/extractor.ts
+++ b/studio-peninsula-insider/server/capture/extractor.ts
@@ -1,0 +1,122 @@
+import { parse } from 'parse5';
+import {
+  CaptureEvidenceLocatorSchema,
+  ExtractionRevisionSchema,
+  type CaptureEvidenceLocator,
+  type ExtractionRevision,
+} from '../../shared/capture-contracts.js';
+import { sha256 } from './blob-store.js';
+
+interface HtmlNode {
+  readonly nodeName?: string;
+  readonly value?: string;
+  readonly childNodes?: readonly HtmlNode[];
+}
+
+const BLOCK_ELEMENTS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'blockquote', 'dt', 'dd', 'pre', 'figcaption', 'td', 'th']);
+const EXCLUDED_ELEMENTS = new Set(['script', 'style', 'noscript', 'template', 'svg', 'canvas']);
+
+export class ExtractionError extends Error {}
+
+function normalizedText(value: string): string {
+  return value.replace(/\u00a0/g, ' ').replace(/[\t\r\n ]+/g, ' ').trim();
+}
+
+function collectText(node: HtmlNode): string {
+  if (node.nodeName && EXCLUDED_ELEMENTS.has(node.nodeName)) return '';
+  if (node.nodeName === '#text') return node.value ?? '';
+  return (node.childNodes ?? []).map(collectText).join(' ');
+}
+
+function htmlBlocks(content: string): string[] {
+  const document = parse(content) as unknown as HtmlNode;
+  const blocks: string[] = [];
+  const visit = (node: HtmlNode): void => {
+    if (node.nodeName && EXCLUDED_ELEMENTS.has(node.nodeName)) return;
+    if (node.nodeName && BLOCK_ELEMENTS.has(node.nodeName)) {
+      const text = normalizedText(collectText(node));
+      if (text) blocks.push(text);
+      return;
+    }
+    (node.childNodes ?? []).forEach(visit);
+  };
+  visit(document);
+  if (blocks.length > 0) return blocks;
+  const fallback = normalizedText(collectText(document));
+  return fallback ? [fallback] : [];
+}
+
+function plainTextBlocks(content: string): string[] {
+  return content
+    .split(/(?:\r?\n){2,}/)
+    .map(normalizedText)
+    .filter(Boolean);
+}
+
+export function decodeText(content: Uint8Array, charset: 'utf-8' | 'us-ascii'): string {
+  if (charset === 'us-ascii' && content.some((byte) => byte > 0x7f)) {
+    throw new ExtractionError('US-ASCII response contained non-ASCII bytes');
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(content);
+  } catch {
+    throw new ExtractionError(`Response body is not valid ${charset}`);
+  }
+}
+
+export function extractBlocks(content: string, mediaType: 'text/html' | 'text/plain') {
+  const texts = mediaType === 'text/html' ? htmlBlocks(content) : plainTextBlocks(content);
+  return texts.map((text, index) => Object.freeze({
+    locator: `block:${String(index + 1).padStart(6, '0')}`,
+    text,
+    textHash: sha256(text),
+  }));
+}
+
+export function buildExtractionRevision(input: {
+  readonly id: string;
+  readonly attemptId: string;
+  readonly sourceRevisionId: string;
+  readonly extractedAt: string;
+  readonly sourceContentBlobHash: string;
+  readonly extractedTextBlobHash: string;
+  readonly blocks: ReturnType<typeof extractBlocks>;
+}): ExtractionRevision {
+  return ExtractionRevisionSchema.parse({
+    schemaVersion: 'pi.extraction-revision.v1',
+    ...input,
+    extractorVersion: 'pi.parse5-text.v1',
+  });
+}
+
+export function createEvidenceLocator(
+  revision: ExtractionRevision,
+  locator: string,
+): CaptureEvidenceLocator {
+  const block = revision.blocks.find((candidate) => candidate.locator === locator);
+  if (!block) throw new ExtractionError(`Extraction locator does not exist: ${locator}`);
+  return CaptureEvidenceLocatorSchema.parse({
+    sourceRevisionId: revision.sourceRevisionId,
+    extractionRevisionId: revision.id,
+    locatorType: 'extracted_block',
+    locator,
+    excerpt: block.text,
+    excerptHash: block.textHash,
+  });
+}
+
+export function resolveEvidenceLocator(
+  revision: ExtractionRevision,
+  input: CaptureEvidenceLocator,
+): string {
+  const locator = CaptureEvidenceLocatorSchema.parse(input);
+  const immutableRevision = ExtractionRevisionSchema.parse(revision);
+  if (locator.extractionRevisionId !== immutableRevision.id || locator.sourceRevisionId !== immutableRevision.sourceRevisionId) {
+    throw new ExtractionError('Evidence locator points to a different immutable extraction revision');
+  }
+  const block = immutableRevision.blocks.find((candidate) => candidate.locator === locator.locator);
+  if (!block || block.text !== locator.excerpt || sha256(block.text) !== locator.excerptHash || block.textHash !== locator.excerptHash) {
+    throw new ExtractionError('Evidence excerpt cannot be reproduced from the immutable extraction revision');
+  }
+  return block.text;
+}

--- a/studio-peninsula-insider/server/capture/filesystem.ts
+++ b/studio-peninsula-insider/server/capture/filesystem.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from 'node:crypto';
+import { lstat, mkdir, open, readFile, realpath, rm } from 'node:fs/promises';
+import { rename } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+
+export class ImmutableStorageError extends Error {}
+
+function assertSegment(segment: string): void {
+  if (!segment || segment === '.' || segment === '..' || segment.includes('/') || segment.includes('\\')) {
+    throw new ImmutableStorageError('Immutable storage path contains an invalid segment');
+  }
+}
+
+function assertContained(root: string, candidate: string): void {
+  const pathFromRoot = relative(root, candidate);
+  if (pathFromRoot.startsWith('..') || isAbsolute(pathFromRoot)) {
+    throw new ImmutableStorageError('Immutable storage path escaped its configured root');
+  }
+}
+
+export class ImmutableFileStore {
+  readonly root: string;
+
+  constructor(root: string) {
+    this.root = resolve(root);
+  }
+
+  private pathFor(segments: readonly string[]): string {
+    segments.forEach(assertSegment);
+    const candidate = resolve(this.root, ...segments);
+    assertContained(this.root, candidate);
+    return candidate;
+  }
+
+  private async prepare(segments: readonly string[]): Promise<string> {
+    const candidate = this.pathFor(segments);
+    await mkdir(this.root, { recursive: true });
+    await mkdir(dirname(candidate), { recursive: true });
+    const [realRoot, realParent] = await Promise.all([realpath(this.root), realpath(dirname(candidate))]);
+    assertContained(realRoot, realParent);
+    return candidate;
+  }
+
+  private async syncParent(candidate: string): Promise<void> {
+    let directoryHandle;
+    try {
+      directoryHandle = await open(dirname(candidate), 'r');
+      await directoryHandle.sync();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!['EACCES', 'EINVAL', 'EISDIR', 'ENOTSUP', 'EPERM'].includes(code ?? '')) throw error;
+    } finally {
+      await directoryHandle?.close().catch(() => undefined);
+    }
+  }
+
+  private async validatedRegularFile(candidate: string): Promise<string> {
+    const metadata = await lstat(candidate);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
+      throw new ImmutableStorageError('Immutable record is not a private regular file');
+    }
+    const [realRoot, realCandidate] = await Promise.all([realpath(this.root), realpath(candidate)]);
+    assertContained(realRoot, realCandidate);
+    return realCandidate;
+  }
+
+  async writeOnce(segments: readonly string[], content: Uint8Array): Promise<'created' | 'existing'> {
+    const candidate = await this.prepare(segments);
+    let handle;
+    try {
+      handle = await open(candidate, 'wx', 0o600);
+      await handle.writeFile(content);
+      await handle.sync();
+      await handle.close();
+      await this.syncParent(candidate);
+      return 'created';
+    } catch (error) {
+      const createdByThisCall = Boolean(handle);
+      await handle?.close().catch(() => undefined);
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        if (createdByThisCall) await rm(candidate, { force: true }).catch(() => undefined);
+        throw error;
+      }
+      const existing = await readFile(await this.validatedRegularFile(candidate));
+      if (!existing.equals(Buffer.from(content))) {
+        throw new ImmutableStorageError('Immutable record already exists with different content');
+      }
+      return 'existing';
+    }
+  }
+
+  async writeOnceAtomic(segments: readonly string[], content: Uint8Array): Promise<'created' | 'existing'> {
+    const candidate = await this.prepare(segments);
+    const temporary = join(dirname(candidate), `.${basename(candidate)}.${process.pid}.${randomUUID()}.tmp`);
+    let handle;
+    try {
+      handle = await open(temporary, 'wx', 0o600);
+      await handle.writeFile(content);
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      try {
+        const existing = await readFile(await this.validatedRegularFile(candidate));
+        if (!existing.equals(Buffer.from(content))) {
+          throw new ImmutableStorageError('Immutable record already exists with different content');
+        }
+        await rm(temporary, { force: true });
+        return 'existing';
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      await rename(temporary, candidate);
+      await this.syncParent(candidate);
+      return 'created';
+    } catch (error) {
+      await handle?.close().catch(() => undefined);
+      await rm(temporary, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async read(segments: readonly string[]): Promise<Buffer> {
+    const candidate = this.pathFor(segments);
+    return readFile(await this.validatedRegularFile(candidate));
+  }
+
+  async readOptional(segments: readonly string[]): Promise<Buffer | undefined> {
+    try {
+      return await this.read(segments);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+  }
+}

--- a/studio-peninsula-insider/server/capture/kernel.ts
+++ b/studio-peninsula-insider/server/capture/kernel.ts
@@ -1,0 +1,534 @@
+import { randomUUID } from 'node:crypto';
+import {
+  CaptureAttemptSchema,
+  CaptureRecordSchema,
+  SourceRevisionSchema,
+  type CaptureRecord,
+  type CaptureStateEvent,
+  type SourceRevision,
+} from '../../shared/capture-contracts.js';
+import { ContentAddressedBlobStore, sha256 } from './blob-store.js';
+import { BodyReadError, readBoundedBody } from './body.js';
+import { buildExtractionRevision, decodeText, extractBlocks, ExtractionError } from './extractor.js';
+import {
+  canonicalizeCaptureUrl,
+  CapturePolicyError,
+  NodeDnsResolver,
+  redactCaptureUrl,
+  resolveAndValidate,
+  sameIpAddress,
+  type DnsResolver,
+} from './policy.js';
+import { FileCaptureRepository } from './repository.js';
+import type { CaptureTransport, TransportResponse } from './transport-contract.js';
+import { createPinnedHttpsTransport } from './transport.js';
+
+export interface CaptureLimits {
+  readonly maxRedirects: number;
+  readonly maxHeaderBytes: number;
+  readonly maxHeaderCount: number;
+  readonly maxWireBytes: number;
+  readonly maxDecodedBytes: number;
+  readonly bodyIdleTimeoutMs: number;
+  readonly dnsTimeoutMs: number;
+  readonly headerTimeoutMs: number;
+  readonly totalTimeoutMs: number;
+  readonly maxConcurrency: number;
+}
+
+export const DEFAULT_CAPTURE_LIMITS: CaptureLimits = Object.freeze({
+  maxRedirects: 5,
+  maxHeaderBytes: 32 * 1024,
+  maxHeaderCount: 100,
+  maxWireBytes: 2 * 1024 * 1024,
+  maxDecodedBytes: 4 * 1024 * 1024,
+  bodyIdleTimeoutMs: 5_000,
+  dnsTimeoutMs: 3_000,
+  headerTimeoutMs: 8_000,
+  totalTimeoutMs: 15_000,
+  maxConcurrency: 2,
+});
+
+export interface CaptureBlobStore {
+  put(content: Uint8Array): Promise<{ readonly hash: string; readonly created: boolean }>;
+}
+
+export interface CaptureRepository {
+  getByIdempotencyKey(key: string): Promise<CaptureRecord | undefined>;
+  save(record: CaptureRecord): Promise<CaptureRecord>;
+}
+
+export interface CaptureExtractor {
+  extract(
+    content: Uint8Array,
+    mediaType: 'text/html' | 'text/plain',
+    charset: 'utf-8' | 'us-ascii',
+    signal: AbortSignal,
+  ): Promise<{ readonly blocks: ReturnType<typeof extractBlocks>; readonly extractedText: string }>;
+}
+
+export interface CaptureKernelDependencies {
+  readonly enabled: boolean;
+  readonly resolver: DnsResolver;
+  readonly transport: CaptureTransport;
+  readonly blobs: CaptureBlobStore;
+  readonly repository: CaptureRepository;
+  readonly extractor?: CaptureExtractor;
+  readonly now?: () => Date;
+  readonly idFactory?: () => string;
+  readonly limits?: Partial<CaptureLimits>;
+}
+
+export interface CaptureInput {
+  readonly url: string;
+  readonly idempotencyKey: string;
+}
+
+export class CaptureDisabledError extends Error {}
+export class CaptureIdempotencyConflictError extends Error {}
+
+class CaptureStageError extends Error {
+  constructor(
+    readonly stage: 'policy' | 'dns' | 'transport' | 'body' | 'extraction' | 'storage',
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+class CaptureHeldError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+class Semaphore {
+  private active = 0;
+  private readonly waiting: Array<() => void> = [];
+
+  constructor(private readonly maximum: number) {}
+
+  async use<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.active >= this.maximum) await new Promise<void>((resolve) => this.waiting.push(resolve));
+    this.active += 1;
+    try {
+      return await operation();
+    } finally {
+      this.active -= 1;
+      this.waiting.shift()?.();
+    }
+  }
+}
+
+function after<T>(promise: Promise<T>, timeoutMs: number, timeout: () => Error): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  return Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) => { timer = setTimeout(() => reject(timeout()), timeoutMs); }),
+  ]).finally(() => { if (timer) clearTimeout(timer); });
+}
+
+function parseContentType(value: string | undefined): {
+  mediaType: 'text/html' | 'text/plain';
+  charset: 'utf-8' | 'us-ascii';
+} {
+  if (!value) throw new CaptureHeldError('missing_media_type', 'Response did not declare a supported media type');
+  const [rawMediaType, ...parameters] = value.split(';').map((part) => part.trim().toLowerCase());
+  if (rawMediaType !== 'text/html' && rawMediaType !== 'text/plain') {
+    throw new CaptureHeldError('unsupported_media_type', 'Response media type is not safe for text extraction');
+  }
+  const charsetParameters = parameters.filter((parameter) => parameter.startsWith('charset='));
+  if (charsetParameters.length > 1) throw new CaptureHeldError('invalid_charset', 'Response declared multiple charsets');
+  const rawCharset = charsetParameters[0]?.slice('charset='.length).replace(/^['"]|['"]$/g, '') ?? 'utf-8';
+  const charset = rawCharset === 'utf8' ? 'utf-8' : rawCharset;
+  if (charset !== 'utf-8' && charset !== 'us-ascii') {
+    throw new CaptureHeldError('unsupported_charset', 'Response charset is not supported by the inert extractor');
+  }
+  return { mediaType: rawMediaType, charset };
+}
+
+function parseContentEncoding(value: string | undefined): 'identity' | 'gzip' | 'deflate' | 'br' {
+  const encoding = (value ?? 'identity').trim().toLowerCase();
+  if (!['identity', 'gzip', 'deflate', 'br'].includes(encoding) || encoding.includes(',')) {
+    throw new CaptureStageError('body', 'unsupported_content_encoding', 'Response content encoding is unsupported');
+  }
+  return encoding as 'identity' | 'gzip' | 'deflate' | 'br';
+}
+
+function safeHeaders(headers: Readonly<Record<string, string>>): Readonly<Record<string, string>> {
+  const allowed = ['content-type', 'content-encoding', 'content-length', 'last-modified'];
+  return Object.freeze(Object.fromEntries(allowed.flatMap((name) => headers[name] ? [[name, headers[name]]] : [])));
+}
+
+function event(state: CaptureStateEvent['state'], at: string, detail?: string): CaptureStateEvent {
+  return Object.freeze({ state, at, ...(detail ? { detail } : {}) });
+}
+
+function failureFor(error: unknown): CaptureStageError {
+  if (error instanceof CaptureStageError) return error;
+  if (error instanceof BodyReadError) return new CaptureStageError('body', error.code, error.message);
+  if (error instanceof ExtractionError) return new CaptureStageError('extraction', 'invalid_text', error.message);
+  if (error instanceof CapturePolicyError) return new CaptureStageError('policy', error.code, error.message);
+  if ((error as Error).name === 'AbortError') return new CaptureStageError('transport', 'capture_timeout', 'Capture exceeded its total timeout');
+  return new CaptureStageError('storage', 'capture_failed', 'Capture failed without persisting external error details');
+}
+
+function isRedirect(status: number): boolean {
+  return [301, 302, 303, 307, 308].includes(status);
+}
+
+function ensureHeaderBounds(response: TransportResponse, limits: CaptureLimits): void {
+  if (response.headerBytes > limits.maxHeaderBytes || response.headerCount > limits.maxHeaderCount) {
+    response.abort();
+    throw new CaptureStageError('transport', 'headers_oversize', 'Response headers exceeded configured limits');
+  }
+}
+
+export function realUrlCaptureEnabled(environment: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = environment.FOUNDRY_REAL_URLS_ENABLED ?? '0';
+  if (raw !== '0' && raw !== '1') throw new Error('FOUNDRY_REAL_URLS_ENABLED must be 0 or 1');
+  return raw === '1';
+}
+
+export class CaptureKernel {
+  private readonly limits: CaptureLimits;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+  private readonly extractor: CaptureExtractor;
+  private readonly semaphore: Semaphore;
+  private readonly inFlight = new Map<string, { readonly requestFingerprint: string; readonly promise: Promise<CaptureRecord> }>();
+
+  constructor(private readonly dependencies: CaptureKernelDependencies) {
+    this.limits = Object.freeze({ ...DEFAULT_CAPTURE_LIMITS, ...dependencies.limits });
+    if (!Number.isInteger(this.limits.maxConcurrency) || this.limits.maxConcurrency < 1) {
+      throw new Error('Capture maxConcurrency must be a positive integer');
+    }
+    this.now = dependencies.now ?? (() => new Date());
+    this.idFactory = dependencies.idFactory ?? randomUUID;
+    this.extractor = dependencies.extractor ?? {
+      extract: async (content, mediaType, charset, signal) => {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        signal.throwIfAborted();
+        const text = decodeText(content, charset);
+        const blocks = extractBlocks(text, mediaType);
+        signal.throwIfAborted();
+        return { blocks, extractedText: blocks.map((block) => block.text).join('\n\n') };
+      },
+    };
+    this.semaphore = new Semaphore(this.limits.maxConcurrency);
+  }
+
+  async capture(input: CaptureInput): Promise<CaptureRecord> {
+    if (!this.dependencies.enabled) throw new CaptureDisabledError('Real URL capture is disabled');
+    if (!input.idempotencyKey.trim() || input.idempotencyKey.length > 256) throw new Error('A bounded idempotency key is required');
+    const canonicalUrl = canonicalizeCaptureUrl(input.url);
+    const requestFingerprint = sha256(canonicalUrl.href);
+    const safeRequestedUrl = redactCaptureUrl(canonicalUrl);
+    const keyHash = sha256(input.idempotencyKey);
+    const deadlineAt = Date.now() + this.limits.totalTimeoutMs;
+    const active = this.inFlight.get(keyHash);
+    if (active) {
+      if (active.requestFingerprint !== requestFingerprint) {
+        throw new CaptureIdempotencyConflictError('Idempotency key is already bound to a different capture URL');
+      }
+      return active.promise;
+    }
+    const operation = this.semaphore.use(async () => {
+      const remaining = deadlineAt - Date.now();
+      if (remaining <= 0) throw new CaptureStageError('storage', 'capture_timeout', 'Capture exceeded its total timeout');
+      const existing = await after(
+        this.dependencies.repository.getByIdempotencyKey(input.idempotencyKey),
+        remaining,
+        () => new CaptureStageError('storage', 'capture_timeout', 'Capture exceeded its total timeout'),
+      );
+      if (existing) {
+        if (existing.attempt.requestFingerprint !== requestFingerprint) {
+          throw new CaptureIdempotencyConflictError('Idempotency key is already bound to a different capture URL');
+        }
+        return existing;
+      }
+      return this.captureOnce(canonicalUrl, safeRequestedUrl, requestFingerprint, keyHash, deadlineAt);
+    });
+    this.inFlight.set(keyHash, { requestFingerprint, promise: operation });
+    try {
+      return await operation;
+    } finally {
+      this.inFlight.delete(keyHash);
+    }
+  }
+
+  private async captureOnce(
+    initialUrl: URL,
+    safeRequestedUrl: string,
+    requestFingerprint: string,
+    keyHash: string,
+    deadlineAt: number,
+  ): Promise<CaptureRecord> {
+    const createdAt = this.now().toISOString();
+    const attemptId = `capture-${keyHash.slice(0, 24)}`;
+    const events: CaptureStateEvent[] = [event('queued', createdAt)];
+    let sourceRevision: SourceRevision | undefined;
+    const controller = new AbortController();
+    const totalTimer = setTimeout(() => controller.abort(), Math.max(1, deadlineAt - Date.now()));
+    const totalFailure = (stage: CaptureStageError['stage']) => new CaptureStageError(stage, 'capture_timeout', 'Capture exceeded its total timeout');
+    const assertWithinDeadline = (stage: CaptureStageError['stage']): void => {
+      if (Date.now() >= deadlineAt || controller.signal.aborted) {
+        controller.abort();
+        throw totalFailure(stage);
+      }
+    };
+    const waitFor = <T>(
+      promise: Promise<T>,
+      stage: CaptureStageError['stage'],
+      stageTimeoutMs = Number.POSITIVE_INFINITY,
+      stageTimeout?: () => CaptureStageError,
+      abort?: () => void,
+    ): Promise<T> => {
+      const remaining = deadlineAt - Date.now();
+      if (remaining <= 0 || controller.signal.aborted) {
+        controller.abort();
+        abort?.();
+        return Promise.reject(totalFailure(stage));
+      }
+      const totalWins = remaining <= stageTimeoutMs;
+      return after(promise, Math.max(1, Math.min(remaining, stageTimeoutMs)), () => {
+        if (totalWins || !stageTimeout) controller.abort();
+        abort?.();
+        return totalWins || !stageTimeout ? totalFailure(stage) : stageTimeout();
+      });
+    };
+    const persist = (record: CaptureRecord): Promise<CaptureRecord> => {
+      assertWithinDeadline('storage');
+      return waitFor(this.dependencies.repository.save(record), 'storage');
+    };
+
+    try {
+      let currentUrl = initialUrl;
+      events.push(event('capturing', this.now().toISOString()));
+      const redirects: Array<{
+        url: string;
+        status: number;
+        location: string;
+        resolvedAddresses: string[];
+        selectedAddress: string;
+        remoteAddress: string;
+      }> = [];
+
+      for (let redirectCount = 0; ; redirectCount += 1) {
+        assertWithinDeadline('dns');
+        let answers;
+        const dnsController = new AbortController();
+        const abortDns = () => dnsController.abort();
+        controller.signal.addEventListener('abort', abortDns, { once: true });
+        try {
+          answers = await waitFor(
+            resolveAndValidate(currentUrl, this.dependencies.resolver, dnsController.signal),
+            'dns',
+            this.limits.dnsTimeoutMs,
+            () => new CaptureStageError('dns', 'dns_timeout', 'DNS resolution exceeded its timeout'),
+            abortDns,
+          );
+        } catch (error) {
+          if (error instanceof CaptureStageError) throw error;
+          if (error instanceof CapturePolicyError) throw new CaptureStageError('dns', error.code, error.message);
+          throw new CaptureStageError('dns', 'dns_failed', 'DNS resolution failed closed');
+        } finally {
+          controller.signal.removeEventListener('abort', abortDns);
+        }
+        const selected = answers[0];
+        assertWithinDeadline('transport');
+        let response: TransportResponse;
+        const transportController = new AbortController();
+        const abortTransport = () => transportController.abort();
+        controller.signal.addEventListener('abort', abortTransport, { once: true });
+        try {
+          response = await waitFor(
+            this.dependencies.transport.request({
+              url: currentUrl,
+              pinnedAddress: selected,
+              maxHeaderBytes: this.limits.maxHeaderBytes,
+              signal: transportController.signal,
+            }),
+            'transport',
+            this.limits.headerTimeoutMs,
+            () => new CaptureStageError('transport', 'header_timeout', 'Response headers exceeded their timeout'),
+            abortTransport,
+          );
+        } catch (error) {
+          if (error instanceof CaptureStageError) throw error;
+          throw new CaptureStageError('transport', 'transport_failed', 'HTTPS transport failed closed');
+        } finally {
+          controller.signal.removeEventListener('abort', abortTransport);
+        }
+        ensureHeaderBounds(response, this.limits);
+        if (!answers.some((answer) => sameIpAddress(answer.address, response.remoteAddress)) || !sameIpAddress(selected.address, response.remoteAddress)) {
+          response.abort();
+          throw new CaptureStageError('transport', 'remote_address_mismatch', 'Connected address did not match the validated DNS pin');
+        }
+
+        if (isRedirect(response.status)) {
+          const location = response.headers.location;
+          response.abort();
+          if (!location) throw new CaptureStageError('transport', 'redirect_missing_location', 'Redirect response omitted Location');
+          if (redirectCount >= this.limits.maxRedirects) throw new CaptureStageError('transport', 'redirect_limit', 'Redirect chain exceeded its configured limit');
+          let nextUrl: URL;
+          try {
+            nextUrl = canonicalizeCaptureUrl(location, currentUrl);
+          } catch (error) {
+            const policy = failureFor(error);
+            throw new CaptureStageError('policy', `redirect_${policy.code}`, policy.message);
+          }
+          redirects.push({
+            url: redactCaptureUrl(currentUrl),
+            status: response.status,
+            location: redactCaptureUrl(nextUrl),
+            resolvedAddresses: answers.map((answer) => answer.address),
+            selectedAddress: selected.address,
+            remoteAddress: response.remoteAddress,
+          });
+          currentUrl = nextUrl;
+          continue;
+        }
+
+        if (response.status < 200 || response.status > 299) {
+          response.abort();
+          throw new CaptureStageError('transport', 'http_status', `Capture returned HTTP status ${response.status}`);
+        }
+        let mediaType: 'text/html' | 'text/plain';
+        let charset: 'utf-8' | 'us-ascii';
+        let contentEncoding: 'identity' | 'gzip' | 'deflate' | 'br';
+        try {
+          ({ mediaType, charset } = parseContentType(response.headers['content-type']));
+          contentEncoding = parseContentEncoding(response.headers['content-encoding']);
+        } catch (error) {
+          response.abort();
+          throw error;
+        }
+        assertWithinDeadline('body');
+        const body = await waitFor(
+          readBoundedBody(response, contentEncoding, this.limits, controller.signal),
+          'body',
+          Number.POSITIVE_INFINITY,
+          undefined,
+          response.abort,
+        );
+        assertWithinDeadline('storage');
+        const [wireBlob, contentBlob] = await waitFor(Promise.all([
+          this.dependencies.blobs.put(body.wire),
+          this.dependencies.blobs.put(body.decoded),
+        ]), 'storage');
+        const sourceRevisionId = `source-${sha256(this.idFactory()).slice(0, 24)}`;
+        sourceRevision = SourceRevisionSchema.parse({
+          schemaVersion: 'pi.source-revision.v1',
+          id: sourceRevisionId,
+          attemptId,
+          requestedUrl: safeRequestedUrl,
+          canonicalUrl: redactCaptureUrl(currentUrl),
+          capturedAt: this.now().toISOString(),
+          status: response.status,
+          mediaType,
+          charset,
+          contentEncoding,
+          headers: safeHeaders(response.headers),
+          redirects,
+          resolvedAddresses: answers.map((answer) => answer.address),
+          selectedAddress: selected.address,
+          remoteAddress: response.remoteAddress,
+          wireBlobHash: wireBlob.hash,
+          contentBlobHash: contentBlob.hash,
+          wireBytes: body.wire.length,
+          decodedBytes: body.decoded.length,
+        });
+        events.push(event('captured', this.now().toISOString()));
+        events.push(event('extracting', this.now().toISOString()));
+
+        assertWithinDeadline('extraction');
+        const { blocks, extractedText } = await waitFor(
+          this.extractor.extract(body.decoded, mediaType, charset, controller.signal),
+          'extraction',
+        );
+        assertWithinDeadline('extraction');
+        assertWithinDeadline('storage');
+        const extractedBlob = await waitFor(this.dependencies.blobs.put(Buffer.from(extractedText, 'utf8')), 'storage');
+        const extractionRevisionId = `extract-${sha256(this.idFactory()).slice(0, 24)}`;
+        const extractionRevision = buildExtractionRevision({
+          id: extractionRevisionId,
+          attemptId,
+          sourceRevisionId,
+          extractedAt: this.now().toISOString(),
+          sourceContentBlobHash: contentBlob.hash,
+          extractedTextBlobHash: extractedBlob.hash,
+          blocks,
+        });
+        const finalState = blocks.length === 0 ? 'no_story' : 'extracted';
+        events.push(event(finalState, this.now().toISOString(), blocks.length === 0 ? 'No extractable story text was found.' : undefined));
+        return persist(CaptureRecordSchema.parse({
+          schemaVersion: 'pi.capture-manifest.v1',
+          attempt: CaptureAttemptSchema.parse({
+            schemaVersion: 'pi.capture-attempt.v1',
+            id: attemptId,
+            idempotencyKeyHash: keyHash,
+            requestFingerprint,
+            requestedUrl: safeRequestedUrl,
+            createdAt,
+            completedAt: this.now().toISOString(),
+            state: finalState,
+            events,
+            sourceRevisionId,
+            extractionRevisionId,
+            outcomeReason: blocks.length === 0 ? { code: 'no_extractable_text', detail: 'No extractable story text was found.' } : undefined,
+          }),
+          sourceRevision,
+          extractionRevision,
+        }));
+      }
+    } catch (error) {
+      const completedAt = this.now().toISOString();
+      if (['extracted', 'no_story', 'held', 'failed'].includes(events.at(-1)?.state ?? '')) throw error;
+      if (error instanceof CaptureHeldError) {
+        if (events.at(-1)?.state !== 'capturing' && events.at(-1)?.state !== 'captured' && events.at(-1)?.state !== 'extracting') {
+          events.push(event('capturing', completedAt));
+        }
+        events.push(event('held', completedAt, error.message));
+        return persist(CaptureRecordSchema.parse({
+          schemaVersion: 'pi.capture-manifest.v1',
+          attempt: {
+            schemaVersion: 'pi.capture-attempt.v1', id: attemptId, idempotencyKeyHash: keyHash,
+            requestFingerprint,
+            requestedUrl: safeRequestedUrl, createdAt, completedAt, state: 'held', events,
+            sourceRevisionId: sourceRevision?.id,
+            outcomeReason: { code: error.code, detail: error.message },
+          },
+          sourceRevision,
+        }));
+      }
+      const failure = failureFor(error);
+      if (events.at(-1)?.state === 'queued') events.push(event('capturing', completedAt));
+      events.push(event('failed', completedAt, failure.code));
+      return persist(CaptureRecordSchema.parse({
+        schemaVersion: 'pi.capture-manifest.v1',
+        attempt: {
+          schemaVersion: 'pi.capture-attempt.v1', id: attemptId, idempotencyKeyHash: keyHash,
+          requestFingerprint,
+          requestedUrl: safeRequestedUrl, createdAt, completedAt, state: 'failed', events,
+          sourceRevisionId: sourceRevision?.id,
+          failure: { stage: failure.stage, code: failure.code, message: failure.message },
+        },
+        sourceRevision,
+      }));
+    } finally {
+      clearTimeout(totalTimer);
+    }
+  }
+}
+
+export function createCaptureKernel(root: string, environment: NodeJS.ProcessEnv = process.env): CaptureKernel {
+  return new CaptureKernel({
+    enabled: realUrlCaptureEnabled(environment),
+    resolver: new NodeDnsResolver(),
+    transport: createPinnedHttpsTransport(),
+    blobs: new ContentAddressedBlobStore(root),
+    repository: new FileCaptureRepository(root),
+  });
+}

--- a/studio-peninsula-insider/server/capture/policy.ts
+++ b/studio-peninsula-insider/server/capture/policy.ts
@@ -1,0 +1,150 @@
+import { resolve4, resolve6 } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import { domainToUnicode } from 'node:url';
+import ipaddr from 'ipaddr.js';
+
+export interface ResolvedAddress {
+  readonly address: string;
+  readonly family: 4 | 6;
+}
+
+export interface DnsResolver {
+  resolve(hostname: string, signal: AbortSignal): Promise<readonly ResolvedAddress[]>;
+}
+
+export class CapturePolicyError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = 'CapturePolicyError';
+  }
+}
+
+const BLOCKED_HOST_SUFFIXES = ['localhost', 'local', 'internal', 'home.arpa', 'onion', 'test', 'example', 'invalid'];
+
+function isNoData(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'ENODATA' || code === 'ENOTFOUND';
+}
+
+export class NodeDnsResolver implements DnsResolver {
+  async resolve(hostname: string, signal: AbortSignal): Promise<readonly ResolvedAddress[]> {
+    signal.throwIfAborted();
+    const [v4, v6] = await Promise.all([
+      resolve4(hostname).catch((error: unknown) => {
+        if (isNoData(error)) return [];
+        throw error;
+      }),
+      resolve6(hostname).catch((error: unknown) => {
+        if (isNoData(error)) return [];
+        throw error;
+      }),
+    ]);
+    signal.throwIfAborted();
+    return [
+      ...v4.map((address): ResolvedAddress => ({ address, family: 4 })),
+      ...v6.map((address): ResolvedAddress => ({ address, family: 6 })),
+    ];
+  }
+}
+
+export function canonicalizeCaptureUrl(input: string, base?: URL): URL {
+  let url: URL;
+  try {
+    url = base ? new URL(input, base) : new URL(input);
+  } catch {
+    throw new CapturePolicyError('invalid_url', 'Capture URL is invalid');
+  }
+  if (url.protocol !== 'https:') {
+    throw new CapturePolicyError('https_required', 'Capture URLs must use HTTPS');
+  }
+  if (url.port && url.port !== '443') {
+    throw new CapturePolicyError('port_blocked', 'Capture URLs may use only port 443');
+  }
+  if (url.username || url.password) {
+    throw new CapturePolicyError('credentials_blocked', 'Capture URLs may not contain credentials');
+  }
+  if (!url.hostname) {
+    throw new CapturePolicyError('hostname_required', 'Capture URL requires a hostname');
+  }
+  const literal = unbracket(url.hostname);
+  if (!isIP(literal)) {
+    const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+    if (!hostname || !domainToUnicode(hostname) || hostname.split('.').some((label) => !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label))) {
+      throw new CapturePolicyError('invalid_hostname', 'Capture hostname is not a valid DNS name');
+    }
+    if (BLOCKED_HOST_SUFFIXES.some((suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`))) {
+      throw new CapturePolicyError('special_use_hostname', `Capture hostname uses blocked suffix .${hostname.split('.').at(-1)}`);
+    }
+    url.hostname = hostname;
+  }
+  url.port = '';
+  url.hash = '';
+  return url;
+}
+
+export function redactCaptureUrl(url: URL): string {
+  const redacted = new URL(url.href);
+  for (const name of [...new Set(redacted.searchParams.keys())]) {
+    redacted.searchParams.set(name, '[redacted]');
+  }
+  return redacted.href;
+}
+
+function unbracket(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
+export function normalizeIpAddress(address: string): string {
+  let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    parsed = ipaddr.parse(unbracket(address));
+  } catch {
+    throw new CapturePolicyError('invalid_ip', `DNS returned an invalid address: ${address}`);
+  }
+  return parsed.toNormalizedString();
+}
+
+export function isPublicAddress(address: string): boolean {
+  try {
+    const parsed = ipaddr.parse(unbracket(address));
+    if (parsed.kind() === 'ipv6' && (parsed as ipaddr.IPv6).isIPv4MappedAddress()) return false;
+    return parsed.range() === 'unicast';
+  } catch {
+    return false;
+  }
+}
+
+export function sameIpAddress(left: string, right: string): boolean {
+  try {
+    return normalizeIpAddress(left) === normalizeIpAddress(right);
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveAndValidate(
+  url: URL,
+  resolver: DnsResolver,
+  signal: AbortSignal,
+): Promise<readonly ResolvedAddress[]> {
+  const hostname = unbracket(url.hostname);
+  const literalFamily = isIP(hostname);
+  const answers = literalFamily
+    ? [{ address: hostname, family: literalFamily as 4 | 6 }]
+    : await resolver.resolve(hostname, signal);
+
+  if (answers.length === 0) {
+    throw new CapturePolicyError('dns_empty', 'DNS returned no A or AAAA answers');
+  }
+  const normalized = answers.map((answer): ResolvedAddress => ({
+    address: normalizeIpAddress(answer.address),
+    family: answer.family,
+  }));
+  const blocked = normalized.filter((answer) => !isPublicAddress(answer.address));
+  if (blocked.length > 0) {
+    throw new CapturePolicyError('non_public_address', `DNS included blocked address ${blocked[0].address}`);
+  }
+
+  const unique = new Map(normalized.map((answer) => [`${answer.family}:${answer.address}`, answer]));
+  return [...unique.values()].sort((left, right) => left.family - right.family || left.address.localeCompare(right.address));
+}

--- a/studio-peninsula-insider/server/capture/repository.ts
+++ b/studio-peninsula-insider/server/capture/repository.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import {
+  CaptureRecordSchema,
+  type CaptureRecord,
+} from '../../shared/capture-contracts.js';
+import { sha256 } from './blob-store.js';
+import { ImmutableFileStore } from './filesystem.js';
+
+const IdSchema = z.string().regex(/^[a-z][a-z0-9-]{7,127}$/);
+const IdempotencyIndexSchema = z.object({
+  schemaVersion: z.literal('pi.capture-idempotency.v1'),
+  idempotencyKeyHash: z.string().regex(/^[a-f0-9]{64}$/),
+  attemptId: IdSchema,
+}).readonly();
+
+function jsonBytes(value: unknown): Buffer {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export class FileCaptureRepository {
+  private readonly files: ImmutableFileStore;
+
+  constructor(root: string) {
+    this.files = new ImmutableFileStore(root);
+  }
+
+  private async writeJson(segments: readonly string[], value: unknown): Promise<void> {
+    await this.files.writeOnceAtomic(segments, jsonBytes(value));
+  }
+
+  async save(recordInput: CaptureRecord): Promise<CaptureRecord> {
+    const record = CaptureRecordSchema.parse(recordInput);
+    await this.files.writeOnceAtomic(['capture', 'manifests', `${record.attempt.id}.json`], jsonBytes(record));
+    await this.writeJson(['capture', 'idempotency', `${record.attempt.idempotencyKeyHash}.json`], {
+      schemaVersion: 'pi.capture-idempotency.v1',
+      idempotencyKeyHash: record.attempt.idempotencyKeyHash,
+      attemptId: record.attempt.id,
+    });
+    return record;
+  }
+
+  async getByIdempotencyKey(key: string): Promise<CaptureRecord | undefined> {
+    const keyHash = sha256(key);
+    const rawIndex = await this.files.readOptional(['capture', 'idempotency', `${keyHash}.json`]);
+    if (rawIndex) {
+      const index = IdempotencyIndexSchema.parse(JSON.parse(rawIndex.toString('utf8')));
+      if (index.idempotencyKeyHash !== keyHash) throw new Error('Capture idempotency index hash mismatch');
+      return this.get(index.attemptId);
+    }
+    const attemptId = `capture-${keyHash.slice(0, 24)}`;
+    const recovered = await this.get(attemptId);
+    if (!recovered) return undefined;
+    if (recovered.attempt.idempotencyKeyHash !== keyHash) throw new Error('Recovered capture manifest hash mismatch');
+    await this.writeJson(['capture', 'idempotency', `${keyHash}.json`], {
+      schemaVersion: 'pi.capture-idempotency.v1',
+      idempotencyKeyHash: keyHash,
+      attemptId,
+    });
+    return recovered;
+  }
+
+  async get(attemptIdInput: string): Promise<CaptureRecord | undefined> {
+    const attemptId = IdSchema.parse(attemptIdInput);
+    const rawManifest = await this.files.readOptional(['capture', 'manifests', `${attemptId}.json`]);
+    return rawManifest ? CaptureRecordSchema.parse(JSON.parse(rawManifest.toString('utf8'))) : undefined;
+  }
+}

--- a/studio-peninsula-insider/server/capture/transport-contract.ts
+++ b/studio-peninsula-insider/server/capture/transport-contract.ts
@@ -1,0 +1,22 @@
+import type { ResolvedAddress } from './policy.js';
+
+export interface TransportRequest {
+  readonly url: URL;
+  readonly pinnedAddress: ResolvedAddress;
+  readonly maxHeaderBytes: number;
+  readonly signal: AbortSignal;
+}
+
+export interface TransportResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly headerBytes: number;
+  readonly headerCount: number;
+  readonly remoteAddress: string;
+  readonly body: AsyncIterable<Uint8Array>;
+  abort(): void;
+}
+
+export interface CaptureTransport {
+  request(input: TransportRequest): Promise<TransportResponse>;
+}

--- a/studio-peninsula-insider/server/capture/transport.ts
+++ b/studio-peninsula-insider/server/capture/transport.ts
@@ -1,0 +1,59 @@
+import { request as httpsRequest } from 'node:https';
+import type { LookupFunction } from 'node:net';
+import { sameIpAddress } from './policy.js';
+import type { CaptureTransport, TransportRequest, TransportResponse } from './transport-contract.js';
+
+function normalizeHeaders(rawHeaders: readonly string[]): Readonly<Record<string, string>> {
+  const headers: Record<string, string> = {};
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index].toLowerCase();
+    const value = rawHeaders[index + 1] ?? '';
+    headers[name] = headers[name] ? `${headers[name]}, ${value}` : value;
+  }
+  return Object.freeze(headers);
+}
+
+class PinnedHttpsTransport implements CaptureTransport {
+  request(input: TransportRequest): Promise<TransportResponse> {
+    return new Promise((resolve, reject) => {
+      const lookup: LookupFunction = (_hostname, _options, callback) => {
+        callback(null, input.pinnedAddress.address, input.pinnedAddress.family);
+      };
+      const request = httpsRequest(input.url, {
+        method: 'GET',
+        agent: false,
+        lookup,
+        maxHeaderSize: input.maxHeaderBytes,
+        signal: input.signal,
+        headers: {
+          accept: 'text/html, text/plain;q=0.9',
+          'accept-encoding': 'gzip, deflate, br',
+          'user-agent': 'PeninsulaInsider-CaptureKernel/0.1',
+        },
+      }, (response) => {
+        const remoteAddress = response.socket.remoteAddress;
+        if (!remoteAddress || !sameIpAddress(remoteAddress, input.pinnedAddress.address)) {
+          response.destroy();
+          reject(new Error('Connected remote address did not match the DNS-pinned address'));
+          return;
+        }
+        const headerBytes = response.rawHeaders.reduce((total, value) => total + Buffer.byteLength(value) + 2, 0);
+        resolve(Object.freeze({
+          status: response.statusCode ?? 0,
+          headers: normalizeHeaders(response.rawHeaders),
+          headerBytes,
+          headerCount: response.rawHeaders.length / 2,
+          remoteAddress,
+          body: response,
+          abort: () => response.destroy(),
+        }));
+      });
+      request.once('error', reject);
+      request.end();
+    });
+  }
+}
+
+export function createPinnedHttpsTransport(): CaptureTransport {
+  return new PinnedHttpsTransport();
+}

--- a/studio-peninsula-insider/shared/capture-contracts.ts
+++ b/studio-peninsula-insider/shared/capture-contracts.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const ImmutableIdSchema = z.string().regex(/^[a-z][a-z0-9-]{7,127}$/);
+const IpAddressSchema = z.union([z.ipv4(), z.ipv6()]);
+
+export const CaptureStateSchema = z.enum([
+  'queued',
+  'capturing',
+  'captured',
+  'extracting',
+  'extracted',
+  'held',
+  'no_story',
+  'failed',
+]);
+
+export const CaptureStateEventSchema = z.object({
+  state: CaptureStateSchema,
+  at: z.string().datetime(),
+  detail: z.string().max(500).optional(),
+}).readonly();
+
+const ALLOWED_TRANSITIONS: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  queued: ['capturing'],
+  capturing: ['captured', 'held', 'failed'],
+  captured: ['extracting', 'held', 'failed'],
+  extracting: ['extracted', 'held', 'no_story', 'failed'],
+  extracted: [],
+  held: [],
+  no_story: [],
+  failed: [],
+});
+
+export const CaptureAttemptSchema = z.object({
+  schemaVersion: z.literal('pi.capture-attempt.v1'),
+  id: ImmutableIdSchema,
+  idempotencyKeyHash: Sha256Schema,
+  requestFingerprint: Sha256Schema,
+  requestedUrl: z.string().url(),
+  createdAt: z.string().datetime(),
+  completedAt: z.string().datetime(),
+  state: CaptureStateSchema,
+  events: z.array(CaptureStateEventSchema).min(2),
+  sourceRevisionId: ImmutableIdSchema.optional(),
+  extractionRevisionId: ImmutableIdSchema.optional(),
+  outcomeReason: z.object({
+    code: z.string().min(1).max(80),
+    detail: z.string().min(1).max(500),
+  }).readonly().optional(),
+  failure: z.object({
+    stage: z.enum(['policy', 'dns', 'transport', 'body', 'extraction', 'storage']),
+    code: z.string().min(1).max(80),
+    message: z.string().min(1).max(500),
+  }).readonly().optional(),
+}).superRefine((attempt, context) => {
+  if (attempt.events[0]?.state !== 'queued') {
+    context.addIssue({ code: 'custom', path: ['events', 0], message: 'Capture attempts must begin queued' });
+  }
+  for (let index = 1; index < attempt.events.length; index += 1) {
+    const previous = attempt.events[index - 1].state;
+    const current = attempt.events[index].state;
+    if (!ALLOWED_TRANSITIONS[previous]?.includes(current)) {
+      context.addIssue({ code: 'custom', path: ['events', index], message: `Invalid capture transition ${previous} -> ${current}` });
+    }
+  }
+  if (attempt.events.at(-1)?.state !== attempt.state) {
+    context.addIssue({ code: 'custom', path: ['state'], message: 'Final event must match attempt state' });
+  }
+  if (attempt.state === 'extracted' && (!attempt.sourceRevisionId || !attempt.extractionRevisionId)) {
+    context.addIssue({ code: 'custom', path: ['state'], message: 'Extracted attempts require both immutable revisions' });
+  }
+  if (attempt.state === 'failed' && !attempt.failure) {
+    context.addIssue({ code: 'custom', path: ['failure'], message: 'Failed attempts require failure details' });
+  }
+  if (attempt.state !== 'failed' && attempt.failure) {
+    context.addIssue({ code: 'custom', path: ['failure'], message: 'Only failed attempts may carry failure details' });
+  }
+  if (['held', 'no_story'].includes(attempt.state) !== Boolean(attempt.outcomeReason)) {
+    context.addIssue({ code: 'custom', path: ['outcomeReason'], message: 'Held and no-story outcomes require one structured reason' });
+  }
+}).readonly();
+
+export const RedirectHopSchema = z.object({
+  url: z.string().url(),
+  status: z.number().int().min(300).max(399),
+  location: z.string().min(1),
+  resolvedAddresses: z.array(IpAddressSchema).min(1),
+  selectedAddress: IpAddressSchema,
+  remoteAddress: IpAddressSchema,
+}).readonly();
+
+export const SourceRevisionSchema = z.object({
+  schemaVersion: z.literal('pi.source-revision.v1'),
+  id: ImmutableIdSchema,
+  attemptId: ImmutableIdSchema,
+  requestedUrl: z.string().url(),
+  canonicalUrl: z.string().url(),
+  capturedAt: z.string().datetime(),
+  status: z.number().int().min(200).max(299),
+  mediaType: z.enum(['text/html', 'text/plain']),
+  charset: z.enum(['utf-8', 'us-ascii']),
+  contentEncoding: z.enum(['identity', 'gzip', 'deflate', 'br']),
+  headers: z.record(z.string(), z.string()),
+  redirects: z.array(RedirectHopSchema),
+  resolvedAddresses: z.array(IpAddressSchema).min(1),
+  selectedAddress: IpAddressSchema,
+  remoteAddress: IpAddressSchema,
+  wireBlobHash: Sha256Schema,
+  contentBlobHash: Sha256Schema,
+  wireBytes: z.number().int().nonnegative(),
+  decodedBytes: z.number().int().nonnegative(),
+}).readonly();
+
+export const ExtractedBlockSchema = z.object({
+  locator: z.string().regex(/^block:\d{6}$/),
+  text: z.string().min(1),
+  textHash: Sha256Schema,
+}).readonly();
+
+export const ExtractionRevisionSchema = z.object({
+  schemaVersion: z.literal('pi.extraction-revision.v1'),
+  id: ImmutableIdSchema,
+  attemptId: ImmutableIdSchema,
+  sourceRevisionId: ImmutableIdSchema,
+  extractedAt: z.string().datetime(),
+  extractorVersion: z.literal('pi.parse5-text.v1'),
+  sourceContentBlobHash: Sha256Schema,
+  extractedTextBlobHash: Sha256Schema,
+  blocks: z.array(ExtractedBlockSchema),
+}).readonly();
+
+export const CaptureEvidenceLocatorSchema = z.object({
+  sourceRevisionId: ImmutableIdSchema,
+  extractionRevisionId: ImmutableIdSchema,
+  locatorType: z.literal('extracted_block'),
+  locator: z.string().regex(/^block:\d{6}$/),
+  excerpt: z.string().min(1),
+  excerptHash: Sha256Schema,
+}).readonly();
+
+export const CaptureRecordSchema = z.object({
+  schemaVersion: z.literal('pi.capture-manifest.v1'),
+  attempt: CaptureAttemptSchema,
+  sourceRevision: SourceRevisionSchema.optional(),
+  extractionRevision: ExtractionRevisionSchema.optional(),
+}).superRefine((record, context) => {
+  if (record.attempt.sourceRevisionId !== record.sourceRevision?.id) {
+    context.addIssue({ code: 'custom', path: ['sourceRevision'], message: 'Source revision does not match attempt' });
+  }
+  if (record.attempt.extractionRevisionId !== record.extractionRevision?.id) {
+    context.addIssue({ code: 'custom', path: ['extractionRevision'], message: 'Extraction revision does not match attempt' });
+  }
+  if (record.sourceRevision && record.sourceRevision.attemptId !== record.attempt.id) {
+    context.addIssue({ code: 'custom', path: ['sourceRevision', 'attemptId'], message: 'Source revision belongs to a different attempt' });
+  }
+  if (record.sourceRevision && record.sourceRevision.requestedUrl !== record.attempt.requestedUrl) {
+    context.addIssue({ code: 'custom', path: ['sourceRevision', 'requestedUrl'], message: 'Source revision request does not match attempt' });
+  }
+  if (record.extractionRevision && record.extractionRevision.attemptId !== record.attempt.id) {
+    context.addIssue({ code: 'custom', path: ['extractionRevision', 'attemptId'], message: 'Extraction revision belongs to a different attempt' });
+  }
+  if (record.extractionRevision && record.extractionRevision.sourceRevisionId !== record.sourceRevision?.id) {
+    context.addIssue({ code: 'custom', path: ['extractionRevision', 'sourceRevisionId'], message: 'Extraction revision belongs to a different source revision' });
+  }
+  if (record.extractionRevision && record.extractionRevision.sourceContentBlobHash !== record.sourceRevision?.contentBlobHash) {
+    context.addIssue({ code: 'custom', path: ['extractionRevision', 'sourceContentBlobHash'], message: 'Extraction revision content does not match its source blob' });
+  }
+}).readonly();
+
+export type CaptureState = z.infer<typeof CaptureStateSchema>;
+export type CaptureStateEvent = z.infer<typeof CaptureStateEventSchema>;
+export type CaptureAttempt = z.infer<typeof CaptureAttemptSchema>;
+export type SourceRevision = z.infer<typeof SourceRevisionSchema>;
+export type ExtractionRevision = z.infer<typeof ExtractionRevisionSchema>;
+export type CaptureEvidenceLocator = z.infer<typeof CaptureEvidenceLocatorSchema>;
+export type CaptureRecord = z.infer<typeof CaptureRecordSchema>;

--- a/studio-peninsula-insider/tests/capture-kernel.test.ts
+++ b/studio-peninsula-insider/tests/capture-kernel.test.ts
@@ -1,0 +1,419 @@
+import { gzipSync } from 'node:zlib';
+import { link, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CaptureAttemptSchema, CaptureRecordSchema, type CaptureRecord } from '../shared/capture-contracts.js';
+import { ContentAddressedBlobStore, sha256 } from '../server/capture/blob-store.js';
+import { ImmutableFileStore } from '../server/capture/filesystem.js';
+import { createEvidenceLocator, resolveEvidenceLocator } from '../server/capture/extractor.js';
+import { CaptureDisabledError, CaptureIdempotencyConflictError, CaptureKernel, realUrlCaptureEnabled } from '../server/capture/kernel.js';
+import { canonicalizeCaptureUrl, isPublicAddress, type DnsResolver, type ResolvedAddress } from '../server/capture/policy.js';
+import { FileCaptureRepository } from '../server/capture/repository.js';
+import type { CaptureTransport, TransportRequest, TransportResponse } from '../server/capture/transport-contract.js';
+
+const temporaryDirectories: string[] = [];
+const PUBLIC_V4: ResolvedAddress = { address: '93.184.216.34', family: 4 };
+
+function bytes(value: string | Uint8Array): Uint8Array {
+  return typeof value === 'string' ? Buffer.from(value, 'utf8') : value;
+}
+
+function fakeResponse(input: {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string | Uint8Array;
+  chunks?: Array<{ value: string | Uint8Array; delayMs?: number }>;
+  remoteAddress?: string;
+  headerBytes?: number;
+  headerCount?: number;
+} = {}): TransportResponse & { readonly wasAborted: () => boolean } {
+  let aborted = false;
+  const headers = Object.freeze(input.headers ?? { 'content-type': 'text/html; charset=utf-8' });
+  const chunks = input.chunks ?? [{ value: input.body ?? '<p>Safe local fixture</p>' }];
+  return Object.freeze({
+    status: input.status ?? 200,
+    headers,
+    headerBytes: input.headerBytes ?? Object.entries(headers).reduce((total, [name, value]) => total + name.length + value.length + 4, 0),
+    headerCount: input.headerCount ?? Object.keys(headers).length,
+    remoteAddress: input.remoteAddress ?? PUBLIC_V4.address,
+    body: {
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of chunks) {
+          if (chunk.delayMs) await new Promise((resolve) => setTimeout(resolve, chunk.delayMs));
+          if (aborted) return;
+          yield bytes(chunk.value);
+        }
+      },
+    },
+    abort: () => { aborted = true; },
+    wasAborted: () => aborted,
+  });
+}
+
+class FakeTransport implements CaptureTransport {
+  readonly requests: TransportRequest[] = [];
+  constructor(private readonly handler: (input: TransportRequest, index: number) => Promise<TransportResponse> | TransportResponse) {}
+  async request(input: TransportRequest): Promise<TransportResponse> {
+    this.requests.push(input);
+    return this.handler(input, this.requests.length - 1);
+  }
+}
+
+function resolverFor(handler: (hostname: string) => readonly ResolvedAddress[] = () => [PUBLIC_V4]): DnsResolver {
+  return { resolve: async (hostname, signal) => { signal.throwIfAborted(); return handler(hostname); } };
+}
+
+async function harness(input: {
+  resolver?: DnsResolver;
+  transport?: CaptureTransport;
+  enabled?: boolean;
+  limits?: ConstructorParameters<typeof CaptureKernel>[0]['limits'];
+} = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'pi-capture-'));
+  temporaryDirectories.push(root);
+  const blobs = new ContentAddressedBlobStore(root);
+  const repository = new FileCaptureRepository(root);
+  const transport = input.transport ?? new FakeTransport(() => fakeResponse());
+  const kernel = new CaptureKernel({
+    enabled: input.enabled ?? true,
+    resolver: input.resolver ?? resolverFor(),
+    transport,
+    blobs,
+    repository,
+    now: () => new Date('2026-08-21T07:00:00.000Z'),
+    limits: input.limits,
+  });
+  return { root, blobs, repository, transport, kernel };
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe('sealed CaptureKernel policy', () => {
+  it('defaults the real-URL flag off and rejects malformed flag values', async () => {
+    expect(realUrlCaptureEnabled({})).toBe(false);
+    expect(realUrlCaptureEnabled({ FOUNDRY_REAL_URLS_ENABLED: '1' })).toBe(true);
+    expect(() => realUrlCaptureEnabled({ FOUNDRY_REAL_URLS_ENABLED: 'yes' })).toThrow(/must be 0 or 1/);
+    const { kernel } = await harness({ enabled: false });
+    await expect(kernel.capture({ url: 'https://public.example.org/', idempotencyKey: 'disabled' })).rejects.toBeInstanceOf(CaptureDisabledError);
+  });
+
+  it('allows only public IP space and rejects literal, mapped and metadata ranges', () => {
+    for (const address of [
+      '0.0.0.0', '10.0.0.1', '100.64.0.1', '127.0.0.1', '169.254.169.254', '172.16.0.1',
+      '192.168.0.1', '224.0.0.1', '::', '::1', 'fe80::1', 'fc00::1', '::ffff:127.0.0.1', '::ffff:93.184.216.34',
+    ]) expect(isPublicAddress(address), address).toBe(false);
+    expect(isPublicAddress(PUBLIC_V4.address)).toBe(true);
+    expect(isPublicAddress('2606:4700:4700::1111')).toBe(true);
+  });
+
+  it('rejects unsafe schemes, ports, credentials, special-use hosts and malformed IDNs before transport', () => {
+    for (const url of [
+      'http://public.example.org/', 'https://public.example.org:444/', 'https://user:pass@public.example.org/',
+      'https://localhost/', 'https://service.local/', 'https://service.internal/', 'https://router.home.arpa/',
+      'https://hidden.onion/', 'https://fixture.test/', 'https://reserved.example/', 'https://reserved.invalid/', 'https://xn--/',
+    ]) expect(() => canonicalizeCaptureUrl(url), url).toThrow();
+  });
+
+  it('fails closed when any A or AAAA answer or literal target is non-public', async () => {
+    const transport = new FakeTransport(() => fakeResponse());
+    const { kernel } = await harness({
+      resolver: resolverFor(() => [PUBLIC_V4, { address: '10.0.0.7', family: 4 }, { address: '2606:4700:4700::1111', family: 6 }]),
+      transport,
+    });
+    const record = await kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'mixed-dns' });
+    expect(record.attempt.state).toBe('failed');
+    expect(record.attempt.failure).toMatchObject({ stage: 'dns', code: 'non_public_address' });
+    expect(transport.requests).toHaveLength(0);
+    for (const literal of ['https://127.0.0.1/', 'https://169.254.169.254/latest', 'https://[::ffff:127.0.0.1]/']) {
+      const literalRecord = await kernel.capture({ url: literal, idempotencyKey: `literal-${literal}` });
+      expect(literalRecord.attempt.failure).toMatchObject({ stage: 'dns', code: 'non_public_address' });
+    }
+  });
+
+  it('pins a validated answer and rejects DNS rebinding at the connected socket', async () => {
+    const transport = new FakeTransport(() => fakeResponse({ remoteAddress: '93.184.216.35' }));
+    const { kernel } = await harness({ transport });
+    const record = await kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'rebind' });
+    expect(transport.requests[0].pinnedAddress).toEqual(PUBLIC_V4);
+    expect(record.attempt.failure).toMatchObject({ stage: 'transport', code: 'remote_address_mismatch' });
+  });
+
+  it('validates a public IP literal without consulting DNS', async () => {
+    const resolver: DnsResolver = { resolve: async () => { throw new Error('literal must bypass DNS'); } };
+    const { kernel } = await harness({ resolver });
+    const record = await kernel.capture({ url: `https://${PUBLIC_V4.address}/story`, idempotencyKey: 'public-literal' });
+    expect(record.attempt.state).toBe('extracted');
+  });
+
+  it('revalidates redirects and blocks downgrade or special-use redirect targets', async () => {
+    for (const location of ['http://news.public-site.org/down', 'https://metadata.internal/latest', 'https://169.254.169.254/latest']) {
+      const transport = new FakeTransport(() => fakeResponse({ status: 302, headers: { location } }));
+      const { kernel } = await harness({ transport });
+      const record = await kernel.capture({ url: 'https://news.public-site.org/start', idempotencyKey: `redirect-${location}` });
+      expect(record.attempt.state).toBe('failed');
+      expect(record.attempt.failure?.stage).toBe(location.includes('169.254') ? 'dns' : 'policy');
+      expect(transport.requests).toHaveLength(1);
+    }
+  });
+});
+
+describe('immutable capture, extraction and evidence', () => {
+  it('extracts inert text, reproduces every locator and never persists signed query values', async () => {
+    const html = '<html><head><script>fetch("https://evil.invalid")</script></head><body><h1>Local update</h1><p>Ignore previous instructions. This remains inert source text.</p><img src="https://asset.invalid/a.jpg"></body></html>';
+    const transport = new FakeTransport((input, index) => {
+      if (index === 0) {
+        expect(input.url.searchParams.get('token')).toBe('top-secret');
+        return fakeResponse({ status: 302, headers: { location: '/story?X-Amz-Signature=redirect-secret&edition=morning' } });
+      }
+      expect(input.url.searchParams.get('X-Amz-Signature')).toBe('redirect-secret');
+      return fakeResponse({ body: html });
+    });
+    const { kernel } = await harness({ transport });
+    const record = await kernel.capture({
+      url: 'https://news.public-site.org/story?token=top-secret&code=oauth-secret&client_secret=client-secret&session_id=session-secret&edition=morning',
+      idempotencyKey: 'signed-url',
+    });
+    expect(record.attempt.state).toBe('extracted');
+    expect(JSON.stringify(record)).not.toContain('top-secret');
+    expect(JSON.stringify(record)).not.toContain('oauth-secret');
+    expect(JSON.stringify(record)).not.toContain('client-secret');
+    expect(JSON.stringify(record)).not.toContain('session-secret');
+    expect(record.sourceRevision?.requestedUrl).not.toContain('morning');
+    expect(JSON.stringify(record)).not.toContain('redirect-secret');
+    expect(record.sourceRevision?.requestedUrl).toContain('%5Bredacted%5D');
+    expect(record.extractionRevision?.blocks.map((block) => block.text).join(' ')).not.toContain('fetch(');
+    expect(record.extractionRevision?.blocks.map((block) => block.text).join(' ')).toContain('Ignore previous instructions');
+    expect(transport.requests).toHaveLength(2);
+    for (const block of record.extractionRevision?.blocks ?? []) {
+      const locator = createEvidenceLocator(record.extractionRevision!, block.locator);
+      expect(resolveEvidenceLocator(record.extractionRevision!, locator)).toBe(block.text);
+    }
+  });
+
+  it('replays one attempt and creates new revisions that reuse identical blobs for a new key', async () => {
+    const transport = new FakeTransport(() => fakeResponse({ body: '<p>Same source bytes</p>' }));
+    const { kernel } = await harness({ transport });
+    const first = await kernel.capture({ url: 'https://news.public-site.org/story', idempotencyKey: 'key-one' });
+    const replay = await kernel.capture({ url: 'https://news.public-site.org/story', idempotencyKey: 'key-one' });
+    const second = await kernel.capture({ url: 'https://news.public-site.org/story', idempotencyKey: 'key-two' });
+    expect(replay.attempt.id).toBe(first.attempt.id);
+    expect(second.attempt.id).not.toBe(first.attempt.id);
+    expect(second.sourceRevision?.id).not.toBe(first.sourceRevision?.id);
+    expect(second.sourceRevision?.wireBlobHash).toBe(first.sourceRevision?.wireBlobHash);
+    expect(second.sourceRevision?.contentBlobHash).toBe(first.sourceRevision?.contentBlobHash);
+    expect(second.extractionRevision?.extractedTextBlobHash).toBe(first.extractionRevision?.extractedTextBlobHash);
+    expect(transport.requests).toHaveLength(2);
+  });
+
+  it('binds each idempotency key to the exact request fingerprint', async () => {
+    const { kernel } = await harness();
+    await kernel.capture({ url: 'https://news.public-site.org/one?token=first', idempotencyKey: 'bound-key' });
+    await expect(kernel.capture({ url: 'https://news.public-site.org/two?token=second', idempotencyKey: 'bound-key' }))
+      .rejects.toBeInstanceOf(CaptureIdempotencyConflictError);
+  });
+
+  it('persists stage-valid extracted, held, no-story and failed attempts', async () => {
+    const extracted = await (await harness()).kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'state-extracted' });
+    const held = await (await harness({ transport: new FakeTransport(() => fakeResponse({ headers: { 'content-type': 'application/pdf' } })) })).kernel
+      .capture({ url: 'https://news.public-site.org/', idempotencyKey: 'state-held' });
+    const noStory = await (await harness({ transport: new FakeTransport(() => fakeResponse({ body: '<script>nothing()</script>' })) })).kernel
+      .capture({ url: 'https://news.public-site.org/', idempotencyKey: 'state-no-story' });
+    const failed = await (await harness({ resolver: resolverFor(() => [{ address: '127.0.0.1', family: 4 }]) })).kernel
+      .capture({ url: 'https://news.public-site.org/', idempotencyKey: 'state-failed' });
+    expect([extracted.attempt.state, held.attempt.state, noStory.attempt.state, failed.attempt.state]).toEqual(['extracted', 'held', 'no_story', 'failed']);
+    expect(() => CaptureAttemptSchema.parse({ ...extracted.attempt, state: 'held' })).toThrow(/Final event/);
+  });
+
+  it('keeps blobs append-only, verifies existing hashes and rejects path escape', async () => {
+    const { root, blobs } = await harness();
+    const content = Buffer.from('immutable');
+    const first = await blobs.put(content);
+    const replay = await blobs.put(content);
+    expect(first.created).toBe(true);
+    expect(replay.created).toBe(false);
+    await expect(blobs.get('../../escape')).rejects.toThrow(/SHA-256/);
+    const blobPath = join(root, 'blobs', 'sha256', first.hash.slice(0, 2), first.hash);
+    await writeFile(blobPath, 'corrupt', 'utf8');
+    await expect(blobs.get(first.hash)).rejects.toThrow(/verification/);
+  });
+
+  it('recovers an atomic manifest when its rebuildable idempotency index is missing', async () => {
+    const { root, kernel } = await harness();
+    const input = { url: 'https://news.public-site.org/recovery', idempotencyKey: 'manifest-recovery' };
+    const first = await kernel.capture(input);
+    const indexPath = join(root, 'capture', 'idempotency', `${sha256(input.idempotencyKey)}.json`);
+    await rm(indexPath);
+    const transport = new FakeTransport(() => { throw new Error('recovery must not recapture'); });
+    const recoveredKernel = new CaptureKernel({
+      enabled: true,
+      resolver: resolverFor(),
+      transport,
+      blobs: new ContentAddressedBlobStore(root),
+      repository: new FileCaptureRepository(root),
+      now: () => new Date('2026-08-21T08:00:00.000Z'),
+    });
+    const recovered = await recoveredKernel.capture(input);
+    expect(recovered.attempt.id).toBe(first.attempt.id);
+    expect(transport.requests).toHaveLength(0);
+    expect(JSON.parse(await readFile(indexPath, 'utf8')).attemptId).toBe(first.attempt.id);
+  });
+
+  it('exercises traversal, symlink or junction, hardlink and file-type containment', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pi-immutable-root-'));
+    const outside = await mkdtemp(join(tmpdir(), 'pi-immutable-outside-'));
+    temporaryDirectories.push(root, outside);
+    const files = new ImmutableFileStore(root);
+    await expect(files.writeOnce(['..', 'escape'], Buffer.from('no'))).rejects.toThrow(/invalid segment/);
+
+    await mkdir(join(root, 'records'), { recursive: true });
+    await writeFile(join(outside, 'secret.txt'), 'secret', 'utf8');
+    await link(join(outside, 'secret.txt'), join(root, 'records', 'hardlink.txt'));
+    await expect(files.read(['records', 'hardlink.txt'])).rejects.toThrow(/private regular file/);
+
+    await mkdir(join(root, 'records', 'directory.json'));
+    await expect(files.read(['records', 'directory.json'])).rejects.toThrow(/private regular file/);
+
+    if (process.platform !== 'win32') {
+      await symlink(join(outside, 'secret.txt'), join(root, 'records', 'symlink.txt'), 'file');
+      await expect(files.read(['records', 'symlink.txt'])).rejects.toThrow(/private regular file/);
+    }
+    await symlink(outside, join(root, 'junction'), process.platform === 'win32' ? 'junction' : 'dir');
+    await expect(files.writeOnce(['junction', 'escaped.txt'], Buffer.from('no'))).rejects.toThrow(/escaped/);
+  });
+
+  it('rejects cross-linked immutable provenance from unrelated attempts or sources', async () => {
+    const { kernel } = await harness();
+    const record = await kernel.capture({ url: 'https://news.public-site.org/cross-link', idempotencyKey: 'cross-link' });
+    expect(() => CaptureRecordSchema.parse({
+      ...record,
+      sourceRevision: { ...record.sourceRevision!, attemptId: 'capture-aaaaaaaaaaaaaaaaaaaaaaaa' },
+    })).toThrow(/different attempt/);
+    expect(() => CaptureRecordSchema.parse({
+      ...record,
+      extractionRevision: { ...record.extractionRevision!, sourceRevisionId: 'source-aaaaaaaaaaaaaaaaaaaaaaaa' },
+    })).toThrow(/different source revision/);
+    expect(() => CaptureRecordSchema.parse({
+      ...record,
+      extractionRevision: { ...record.extractionRevision!, sourceContentBlobHash: 'a'.repeat(64) },
+    })).toThrow(/does not match its source blob/);
+  });
+});
+
+describe('bounded deterministic transport processing', () => {
+  it('fails closed on wire oversize, compressed expansion, slow bodies and malformed compression', async () => {
+    const cases: Array<{ name: string; response: TransportResponse; limits: ConstructorParameters<typeof CaptureKernel>[0]['limits']; code: string }> = [
+      { name: 'wire', response: fakeResponse({ body: 'x'.repeat(32) }), limits: { maxWireBytes: 8 }, code: 'wire_oversize' },
+      { name: 'decoded', response: fakeResponse({ headers: { 'content-type': 'text/plain', 'content-encoding': 'gzip' }, body: gzipSync('x'.repeat(1_000)) }), limits: { maxDecodedBytes: 64 }, code: 'decoded_oversize' },
+      { name: 'slow', response: fakeResponse({ chunks: [{ value: 'late', delayMs: 30 }] }), limits: { bodyIdleTimeoutMs: 5 }, code: 'body_timeout' },
+      { name: 'compression', response: fakeResponse({ headers: { 'content-type': 'text/plain', 'content-encoding': 'gzip' }, body: 'not-gzip' }), limits: {}, code: 'invalid_compression' },
+    ];
+    for (const scenario of cases) {
+      const { kernel } = await harness({ transport: new FakeTransport(() => scenario.response), limits: scenario.limits });
+      const record = await kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: `bounded-${scenario.name}` });
+      expect(record.attempt.failure?.code, scenario.name).toBe(scenario.code);
+    }
+  });
+
+  it('holds invalid media or charset and fails invalid text without extracting it', async () => {
+    const cases = [
+      { key: 'media', response: fakeResponse({ headers: { 'content-type': 'image/png' } }), state: 'held', code: undefined },
+      { key: 'charset', response: fakeResponse({ headers: { 'content-type': 'text/html; charset=shift_jis' } }), state: 'held', code: undefined },
+      { key: 'utf8', response: fakeResponse({ body: Uint8Array.from([0xc3, 0x28]) }), state: 'failed', code: 'invalid_text' },
+    ];
+    for (const scenario of cases) {
+      const response = scenario.response;
+      const { kernel } = await harness({ transport: new FakeTransport(() => response) });
+      const record = await kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: scenario.key });
+      expect(record.attempt.state).toBe(scenario.state);
+      expect(record.attempt.failure?.code).toBe(scenario.code);
+      expect(response.wasAborted()).toBe(scenario.state === 'held');
+    }
+  });
+
+  it('aborts unsupported content encodings and bounds extraction, blob and manifest waits by the total deadline', async () => {
+    const unsupported = fakeResponse({ headers: { 'content-type': 'text/plain', 'content-encoding': 'compress' } });
+    const unsupportedHarness = await harness({ transport: new FakeTransport(() => unsupported) });
+    const unsupportedRecord = await unsupportedHarness.kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'unsupported-encoding' });
+    expect(unsupportedRecord.attempt.failure?.code).toBe('unsupported_content_encoding');
+    expect(unsupported.wasAborted()).toBe(true);
+
+    const root = await mkdtemp(join(tmpdir(), 'pi-capture-timeout-'));
+    temporaryDirectories.push(root);
+    const hanging = <T>() => new Promise<T>(() => undefined);
+    const base = {
+      enabled: true,
+      resolver: resolverFor(),
+      transport: new FakeTransport(() => fakeResponse()),
+      repository: new FileCaptureRepository(root),
+      blobs: new ContentAddressedBlobStore(root),
+      now: () => new Date('2026-08-21T09:00:00.000Z'),
+      limits: { totalTimeoutMs: 15 },
+    };
+    const extractionKernel = new CaptureKernel({ ...base, extractor: { extract: () => hanging() } });
+    await expect(extractionKernel.capture({ url: 'https://news.public-site.org/extract', idempotencyKey: 'timeout-extract' })).rejects.toThrow(/total timeout/);
+
+    const blobKernel = new CaptureKernel({ ...base, blobs: { put: () => hanging() } });
+    await expect(blobKernel.capture({ url: 'https://news.public-site.org/blob', idempotencyKey: 'timeout-blob' })).rejects.toThrow(/total timeout/);
+
+    const manifestKernel = new CaptureKernel({
+      ...base,
+      repository: { getByIdempotencyKey: async () => undefined, save: () => hanging() },
+    });
+    await expect(manifestKernel.capture({ url: 'https://news.public-site.org/manifest', idempotencyKey: 'timeout-manifest' })).rejects.toThrow(/total timeout/);
+
+    const lookupKernel = new CaptureKernel({
+      ...base,
+      repository: { getByIdempotencyKey: () => hanging(), save: async (record) => record },
+    });
+    await expect(lookupKernel.capture({ url: 'https://news.public-site.org/lookup', idempotencyKey: 'timeout-lookup' })).rejects.toThrow(/total timeout/);
+  });
+
+  it('bounds headers, redirects and concurrent captures', async () => {
+    const headers = await harness({ transport: new FakeTransport(() => fakeResponse({ headerCount: 101 })) });
+    expect((await headers.kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'headers' })).attempt.failure?.code).toBe('headers_oversize');
+    const headerBytes = await harness({ transport: new FakeTransport(() => fakeResponse({ headerBytes: 40_000 })) });
+    expect((await headerBytes.kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'header-bytes' })).attempt.failure?.code).toBe('headers_oversize');
+
+    const redirectTransport = new FakeTransport((_input, index) => fakeResponse({ status: 302, headers: { location: `/hop-${index + 1}` } }));
+    const redirectHarness = await harness({ transport: redirectTransport });
+    expect((await redirectHarness.kernel.capture({ url: 'https://news.public-site.org/start', idempotencyKey: 'redirect-limit' })).attempt.failure?.code).toBe('redirect_limit');
+    expect(redirectTransport.requests).toHaveLength(6);
+
+    let active = 0;
+    let maximumActive = 0;
+    const concurrencyTransport = new FakeTransport(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return fakeResponse();
+    });
+    const concurrency = await harness({ transport: concurrencyTransport, limits: { maxConcurrency: 1 } });
+    await Promise.all([
+      concurrency.kernel.capture({ url: 'https://news.public-site.org/a', idempotencyKey: 'concurrency-a' }),
+      concurrency.kernel.capture({ url: 'https://news.public-site.org/b', idempotencyKey: 'concurrency-b' }),
+    ]);
+    expect(maximumActive).toBe(1);
+  });
+
+  it('enforces deterministic DNS and response-header timeouts', async () => {
+    const slowResolver: DnsResolver = {
+      resolve: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        return [PUBLIC_V4];
+      },
+    };
+    const dns = await harness({ resolver: slowResolver, limits: { dnsTimeoutMs: 5 } });
+    expect((await dns.kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'dns-timeout' })).attempt.failure?.code).toBe('dns_timeout');
+
+    const slowHeaders = new FakeTransport(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return fakeResponse();
+    });
+    const headers = await harness({ transport: slowHeaders, limits: { headerTimeoutMs: 5 } });
+    expect((await headers.kernel.capture({ url: 'https://news.public-site.org/', idempotencyKey: 'header-timeout' })).attempt.failure?.code).toBe('header_timeout');
+  });
+});


### PR DESCRIPTION
Closes #324

## Outcome
Adds the sealed, immutable SSRF-safe CaptureKernel on top of feature/content-foundry-workbench.

- Real URL capture stays disabled by default with FOUNDRY_REAL_URLS_ENABLED=0.
- No real-URL route, UI, provider caller, production mutation, publication path, or public-network test was added.
- DNS and transport are injected for deterministic tests; every A/AAAA answer is classified, one validated address is pinned, and remoteAddress is verified.
- Redirects, headers, wire/decoded bytes, concurrency, media/charset/encoding, and total deadlines are bounded.
- Blobs and the atomic attempt/source/extraction manifest are immutable, fsynced, content-addressed, cross-linked, and crash-recoverable.
- Persisted URLs redact every query value while a separate request fingerprint binds idempotency to the exact request.
- Filesystem reads reject traversal, links, hardlinks, non-regular files, and containment escapes.
- A path-scoped boundary check keeps outbound DNS/HTTPS inside the sealed kernel modules.

## Verification
- npm run check:capture-boundary
- npm run typecheck
- npm test: 30/30 passed (existing 10 plus 20 capture-kernel tests)
- npm run build
- npm audit --audit-level=moderate: 0 vulnerabilities
- docker compose config --quiet
- Node 22.23.2 Docker build: boundary, 30 tests, typecheck and build passed
- Hardened container smoke: healthy; /api/health and / returned 200; node user; read-only rootfs; cap-drop ALL; flag 0
- Independent adversarial rereview: PASS across query secrecy, crash recovery, encoding abort, total timeout coverage, provenance cross-links, filesystem escapes, boundary enforcement, and idempotency conflicts

## Stack and gates
- Base: feature/content-foundry-workbench (draft PR #323)
- Exact stacked base commit: ebe0702bd369641f3235dc7c54955c678b54eb8e
- Publication, credentials, spend, real-network capture, and merge remain human-gated.