### PR TITLE
feat(foundry): add generic article artifact packs

### DIFF
--- a/docs/architecture-decisions/content-foundry-artifact-pack-contract.md
+++ b/docs/architecture-decisions/content-foundry-artifact-pack-contract.md
@@ -1,0 +1,36 @@
+# Content Foundry artifact-pack contract
+
+Date: 2026-08-21
+
+Status: implemented locally for review
+
+Issue: #326
+
+## Decision
+
+The Foundry run contract is versioned as `pi.foundry-run.v2`. A run now locks one `RecipeDefinition`, immutable `ClaimSetVersion`, selected angle version and `ArtifactPack`.
+
+An artifact pack records completed, failed and omitted derivatives independently. A required derivative failure blocks the run. An optional derivative failure makes the pack partial but does not invalidate completed artifacts.
+
+Each completed artifact is a discriminated `ArtifactVersion`. It records a payload hash, claim usage by factual segment, claim-set and angle dependencies, direct artifact dependencies, any media-rights snapshot and typed gate results.
+
+Reviews are per artifact and grant `draft_handoff_only` authority. Freshness is derived again on every read and export from the current claim-set, angle, transitive artifact and exact media-rights snapshots. Editing an artifact stales its own current review and all transitive dependent reviews, while unrelated derivatives remain current. Run-level `accepted` remains only as a compatibility projection for the single quick-note artifact and never means publication approval.
+
+Non-quick artifact edits replace the payload, factual segment list and claim-usage map atomically. Each locator must resolve against the edited payload and its stored segment hash must match. Article paragraphs use explicit `$.body::paragraph[n]` locators, so appended, removed or changed paragraphs cannot inherit obsolete lineage.
+
+## Article and Ask mapping
+
+The deterministic `url_article_v1` recipe creates:
+
+- an article body draft;
+- article metadata;
+- an Ask response using `answer`, `recommendations`, `follow_on` and `provenance_footer`;
+- optional internal-link and SEO metadata proposals.
+
+Article metadata mirrors the current Astro article fields, including optional cluster links. Because Astro requires a hero image, a text-only pack remains reviewable with `astroPatchReady=false`. Readiness is server-derived: changing a hero invalidates the previous media-rights snapshot and a client cannot assert clearance. Patch export becomes available only when the exact hero placement matches a separately rights-cleared snapshot and both the body and metadata have current accepted draft-handoff reviews.
+
+Ask recommendations cannot carry `price_band`. The public payload gates reject dollar pricing, price language and em dashes. Unsupported, expired, unevidenced and restricted claims cannot pass the supported-claims gate.
+
+## Compatibility
+
+The v0.1 quick-note fields remain as API projections. The file adapter recognises persisted v0.1 run snapshots and deterministically migrates them in memory to the v2 pack contract on every restart. No network, provider, Git apply, CMS, publication or distribution authority is introduced.

--- a/studio-peninsula-insider/README.md
+++ b/studio-peninsula-insider/README.md
@@ -12,9 +12,19 @@ The v0.2 fixture path adds reusable artifact packs:
 
 `frozen URL fixture -> locked claim set -> Article + Ask pack -> per-artifact draft-handoff review -> downloadable article patch when media rights are cleared`
 
+The v0.3 fixture path adds the governed newsletter and social recipes:
+
+`current article + locked claim set -> stable 11-position Insider Note + separate subject set + LinkedIn/Instagram drafts -> independent reviews -> downloadable draft handoffs`
+
 The shell performs no model calls, Git writes, CMS writes, publication or external distribution. Its atomic file-backed store is a single-process development/test adapter behind the durable run contract; startup fails closed in production. PostgreSQL, authentication and private storage remain explicit later gates.
 
 `url_article_v1` can produce article body, article metadata, Ask answer, internal-link plan and SEO metadata proposal artifacts. Text-only packs remain valid and reviewable. Astro patch export stays unavailable until a separately rights-cleared hero placement exists. Reviews approve draft handoff only and never grant publication authority.
+
+`newsletter_social_v1` preserves the full `insider_note.position.01.masthead` through `insider_note.position.11.footer` union. Optional positions are explicitly omitted instead of padded. Weather and reader replies require authoritative lineage, reader privacy is first-name-only, secondary picks contain exactly two items when present, and poll content remains an editorial-supplied Beehiiv-native decision. Locked copy, CTA limits, venue spelling, email UTMs, nested claim lineage, no-price and no-em-dash rules are deterministic gates.
+
+Subject and preview candidates are a separate artifact with three mutually distinct pairs and no selected value. Only James can select a subject, send an email or publish a social post. Instagram caption, first-comment, carousel and media-brief drafts remain separate artifacts; cadence and hashtag placement stay unresolved. A media brief cannot be accepted or handed off unless rights explicitly clear the exact Instagram placement and any recognisable people.
+
+Every declared artifact can be reviewed independently. A reviewed artifact can be downloaded from its own `reviewed_draft_handoff` adapter as inert JSON containing payload and claim lineage. No handoff grants publication or scheduling authority.
 
 ## Run locally
 

--- a/studio-peninsula-insider/README.md
+++ b/studio-peninsula-insider/README.md
@@ -4,9 +4,17 @@ Private, fixture-only Content Foundry shell for DELI-693.
 
 ## Current vertical slice
 
+The v0.1 path remains available:
+
 `frozen URL fixture -> evidence ledger -> quick-note draft -> human review -> downloadable patch`
 
+The v0.2 fixture path adds reusable artifact packs:
+
+`frozen URL fixture -> locked claim set -> Article + Ask pack -> per-artifact draft-handoff review -> downloadable article patch when media rights are cleared`
+
 The shell performs no model calls, Git writes, CMS writes, publication or external distribution. Its atomic file-backed store is a single-process development/test adapter behind the durable run contract; startup fails closed in production. PostgreSQL, authentication and private storage remain explicit later gates.
+
+`url_article_v1` can produce article body, article metadata, Ask answer, internal-link plan and SEO metadata proposal artifacts. Text-only packs remain valid and reviewable. Astro patch export stays unavailable until a separately rights-cleared hero placement exists. Reviews approve draft handoff only and never grant publication authority.
 
 ## Run locally
 

--- a/studio-peninsula-insider/server/app.ts
+++ b/studio-peninsula-insider/server/app.ts
@@ -1,14 +1,15 @@
 import express from 'express';
 import helmet from 'helmet';
 import { z } from 'zod';
-import { ArtifactEditSchema, ReviewDecisionSchema } from '../shared/contracts.js';
-import { buildPatch, FIXTURE_ID, runFixture } from './fixture-runner.js';
+import { ArtifactEditSchema, ArtifactUpdateSchema, ReviewDecisionSchema } from '../shared/contracts.js';
+import { buildPatch, FIXTURE_ID, runFixture, runUrlArticleFixture, URL_ARTICLE_FIXTURE_ID } from './fixture-runner.js';
 import { FileFoundryStore, VersionConflictError } from './store.js';
 
 const CreateRunSchema = z.object({
-  fixtureId: z.literal(FIXTURE_ID),
+  fixtureId: z.enum([FIXTURE_ID, URL_ARTICLE_FIXTURE_ID]),
   actor: z.string().min(1).default('local-editor'),
   idempotencyKey: z.string().min(1).optional(),
+  fixtureVariant: z.enum(['complete', 'text_only', 'partial_optional_failure']).default('complete'),
 });
 
 export function createApp(store: FileFoundryStore, options: { staticDir?: string } = {}) {
@@ -39,7 +40,8 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
   app.get('/api/health', (_request, response) => response.json({ ok: true, service: 'pi-content-foundry', mode: 'fixture-only' }));
   app.get('/api/capabilities', (_request, response) => response.json({
     sourceTypes: ['frozen_fixture'],
-    artifactTypes: ['quick_note'],
+    recipes: ['quick_note_v1', 'url_article_v1'],
+    artifactTypes: ['quick_note', 'article_draft', 'article_metadata', 'ask_answer', 'internal_link_plan', 'seo_metadata_proposal'],
     publicationAdapters: ['downloadable_patch'],
     externalCalls: false,
     productionMutation: false,
@@ -56,7 +58,14 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
       if (!idempotencyKey) return response.status(400).json({ error: 'Idempotency-Key is required' });
       const existing = await store.getByIdempotencyKey(idempotencyKey);
       if (existing) return response.status(200).json(existing);
-      const created = await store.create(runFixture(input.actor, idempotencyKey));
+      const run = input.fixtureId === FIXTURE_ID
+        ? runFixture(input.actor, idempotencyKey)
+        : runUrlArticleFixture(input.actor, idempotencyKey, {
+          includeClearedHero: input.fixtureVariant === 'complete',
+          failOptionalDerivative: input.fixtureVariant === 'partial_optional_failure' ? 'seo_metadata_proposal' : undefined,
+          omitPlans: input.fixtureVariant === 'text_only',
+        });
+      const created = await store.create(run);
       return response.status(201).json(created);
     } catch (error) { return next(error); }
   });
@@ -83,6 +92,16 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
     try {
       const edit = ArtifactEditSchema.parse(request.body);
       return response.json(await store.updateArtifact(request.params.id, edit));
+    } catch (error) {
+      if (error instanceof VersionConflictError) return response.status(409).json({ error: error.message });
+      return next(error);
+    }
+  });
+
+  app.put('/api/foundry/runs/:id/artifacts/:artifactId', async (request, response, next) => {
+    try {
+      const update = ArtifactUpdateSchema.parse(request.body);
+      return response.json(await store.updatePackArtifact(request.params.id, request.params.artifactId, update));
     } catch (error) {
       if (error instanceof VersionConflictError) return response.status(409).json({ error: error.message });
       return next(error);

--- a/studio-peninsula-insider/server/app.ts
+++ b/studio-peninsula-insider/server/app.ts
@@ -2,14 +2,23 @@ import express from 'express';
 import helmet from 'helmet';
 import { z } from 'zod';
 import { ArtifactEditSchema, ArtifactUpdateSchema, ReviewDecisionSchema } from '../shared/contracts.js';
-import { buildPatch, FIXTURE_ID, runFixture, runUrlArticleFixture, URL_ARTICLE_FIXTURE_ID } from './fixture-runner.js';
+import {
+  buildArtifactHandoff,
+  buildPatch,
+  FIXTURE_ID,
+  NEWSLETTER_SOCIAL_FIXTURE_ID,
+  runFixture,
+  runNewsletterSocialFixture,
+  runUrlArticleFixture,
+  URL_ARTICLE_FIXTURE_ID,
+} from './fixture-runner.js';
 import { FileFoundryStore, VersionConflictError } from './store.js';
 
 const CreateRunSchema = z.object({
-  fixtureId: z.enum([FIXTURE_ID, URL_ARTICLE_FIXTURE_ID]),
+  fixtureId: z.enum([FIXTURE_ID, URL_ARTICLE_FIXTURE_ID, NEWSLETTER_SOCIAL_FIXTURE_ID]),
   actor: z.string().min(1).default('local-editor'),
   idempotencyKey: z.string().min(1).optional(),
-  fixtureVariant: z.enum(['complete', 'text_only', 'partial_optional_failure']).default('complete'),
+  fixtureVariant: z.enum(['complete', 'text_only', 'partial_optional_failure', 'missing_authoritative_inputs', 'rights_not_cleared']).default('complete'),
 });
 
 export function createApp(store: FileFoundryStore, options: { staticDir?: string } = {}) {
@@ -40,9 +49,13 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
   app.get('/api/health', (_request, response) => response.json({ ok: true, service: 'pi-content-foundry', mode: 'fixture-only' }));
   app.get('/api/capabilities', (_request, response) => response.json({
     sourceTypes: ['frozen_fixture'],
-    recipes: ['quick_note_v1', 'url_article_v1'],
-    artifactTypes: ['quick_note', 'article_draft', 'article_metadata', 'ask_answer', 'internal_link_plan', 'seo_metadata_proposal'],
-    publicationAdapters: ['downloadable_patch'],
+    recipes: ['quick_note_v1', 'url_article_v1', 'newsletter_social_v1'],
+    artifactTypes: [
+      'quick_note', 'article_draft', 'article_metadata', 'ask_answer', 'internal_link_plan', 'seo_metadata_proposal',
+      'insider_note_issue', 'insider_note_subject_set', 'linkedin_post', 'instagram_caption',
+      'instagram_first_comment', 'instagram_carousel_script', 'social_media_brief',
+    ],
+    publicationAdapters: ['downloadable_patch', 'reviewed_draft_handoff'],
     externalCalls: false,
     productionMutation: false,
   }));
@@ -60,10 +73,13 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
       if (existing) return response.status(200).json(existing);
       const run = input.fixtureId === FIXTURE_ID
         ? runFixture(input.actor, idempotencyKey)
-        : runUrlArticleFixture(input.actor, idempotencyKey, {
+        : input.fixtureId === URL_ARTICLE_FIXTURE_ID ? runUrlArticleFixture(input.actor, idempotencyKey, {
           includeClearedHero: input.fixtureVariant === 'complete',
           failOptionalDerivative: input.fixtureVariant === 'partial_optional_failure' ? 'seo_metadata_proposal' : undefined,
           omitPlans: input.fixtureVariant === 'text_only',
+        }) : runNewsletterSocialFixture(input.actor, idempotencyKey, {
+          omitAuthoritativeInputs: input.fixtureVariant === 'missing_authoritative_inputs',
+          clearInstagramRights: input.fixtureVariant !== 'rights_not_cleared',
         });
       const created = await store.create(run);
       return response.status(201).json(created);
@@ -116,6 +132,17 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
       response.type('text/x-diff');
       response.setHeader('Content-Disposition', `attachment; filename="${run.id}.patch"`);
       return response.send(patch);
+    } catch (error) { return next(error); }
+  });
+
+  app.get('/api/foundry/runs/:id/artifacts/:artifactId/handoff', async (request, response, next) => {
+    try {
+      const run = await store.get(request.params.id);
+      if (!run) return response.status(404).json({ error: 'Run not found' });
+      const handoff = buildArtifactHandoff(run, request.params.artifactId);
+      response.type('application/json');
+      response.setHeader('Content-Disposition', `attachment; filename="${handoff.filename}"`);
+      return response.send(handoff.body);
     } catch (error) { return next(error); }
   });
 

--- a/studio-peninsula-insider/server/fixture-runner.ts
+++ b/studio-peninsula-insider/server/fixture-runner.ts
@@ -1,44 +1,189 @@
 import { createHash } from 'node:crypto';
-import type { FoundryRun } from '../shared/contracts.js';
-import { ClaimSchema, FoundryRunSchema, QuickNoteSchema, type Claim } from '../shared/contracts.js';
+import type { z } from 'zod';
+import {
+  ArticleDraftPayloadSchema,
+  ArticleMetadataPayloadSchema,
+  ArtifactVersionSchema,
+  AskAnswerPayloadSchema,
+  ClaimSchema,
+  FoundryRunSchema,
+  InternalLinkPlanPayloadSchema,
+  LegacyFoundryRunSchema,
+  QuickNoteSchema,
+  RecipeDefinitionSchema,
+  SeoMetadataProposalPayloadSchema,
+  type ArtifactVersion,
+  type ArtifactDependency,
+  type Claim,
+  type ClaimSetVersion,
+  type FoundryRun,
+  type GateResult,
+  type LegacyFoundryRun,
+  type RecipeDefinition,
+} from '../shared/contracts.js';
 
-const hash = (value: string) => createHash('sha256').update(value).digest('hex');
+export const hash = (value: string) => createHash('sha256').update(value).digest('hex');
+export const hashValue = (value: unknown) => hash(JSON.stringify(value));
+
+export function resolveArtifactPath(payload: unknown, path: string): unknown {
+  if (path === '$') return payload;
+  const paragraph = path.match(/^\$\.body::paragraph\[(\d+)\]$/);
+  if (paragraph) {
+    if (!payload || typeof payload !== 'object' || typeof (payload as { body?: unknown }).body !== 'string') return undefined;
+    return (payload as { body: string }).body.split(/\n\s*\n/)[Number(paragraph[1])];
+  }
+  if (!path.startsWith('$.')) return undefined;
+  const tokens = path.slice(2).match(/[^.\[\]]+|\[(\d+)\]/g);
+  if (!tokens) return undefined;
+  let current: unknown = payload;
+  for (const token of tokens) {
+    const index = token.match(/^\[(\d+)\]$/);
+    if (index) {
+      if (!Array.isArray(current)) return undefined;
+      current = current[Number(index[1])];
+    } else {
+      if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+      current = (current as Record<string, unknown>)[token];
+    }
+  }
+  return current;
+}
+
+function bindClaimUsage<T extends Array<{ segmentId: string; path: string; claimIds: string[] }>>(payload: unknown, usage: T) {
+  return usage.map((item) => ({ ...item, contentHash: hashValue(resolveArtifactPath(payload, item.path)) }));
+}
 
 export const FIXTURE_ID = 'red-hill-winter-lunch';
+export const URL_ARTICLE_FIXTURE_ID = 'red-hill-url-article';
+
+const PRICE_PATTERN = /(?:\$\s?\d|\bAUD\b|\bprice(?:d|s|band)?\b)/i;
+
+export const QUICK_NOTE_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse({
+  schemaVersion: 'pi.recipe-definition.v1',
+  id: 'quick_note_v1',
+  version: 1,
+  label: 'Quick note',
+  sourceKinds: ['url'],
+  artifacts: [{
+    key: 'quick-note',
+    type: 'quick_note',
+    required: true,
+    dependsOnKeys: [],
+    targetContract: 'astro.quick-notes.v1',
+  }],
+  textOnlyAllowed: true,
+  externalCalls: false,
+});
+
+export const URL_ARTICLE_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse({
+  schemaVersion: 'pi.recipe-definition.v1',
+  id: 'url_article_v1',
+  version: 1,
+  label: 'URL article and Ask pack',
+  sourceKinds: ['url'],
+  artifacts: [
+    { key: 'article-draft', type: 'article_draft', required: true, dependsOnKeys: [], targetContract: 'astro.articles.body.v1' },
+    { key: 'article-metadata', type: 'article_metadata', required: true, dependsOnKeys: ['article-draft'], targetContract: 'astro.articles.frontmatter.v2026-08-21' },
+    { key: 'ask-answer', type: 'ask_answer', required: true, dependsOnKeys: [], targetContract: 'concierge.ask.response.v1' },
+    { key: 'internal-link-plan', type: 'internal_link_plan', required: false, dependsOnKeys: ['article-draft'], targetContract: 'internal.link-plan.v1' },
+    { key: 'seo-metadata', type: 'seo_metadata_proposal', required: false, dependsOnKeys: ['article-draft'], targetContract: 'astro.base-layout.meta.v1' },
+  ],
+  textOnlyAllowed: true,
+  externalCalls: false,
+});
+
+function gate(
+  gateName: GateResult['gate'],
+  passed: boolean,
+  detail: string,
+  claimIds: string[] = [],
+  blocking = true,
+): GateResult {
+  return passed
+    ? { gate: gateName, scope: 'artifact', passed: true, blocking: false, detail, claimIds }
+    : { gate: gateName, scope: 'artifact', passed: false, blocking, detail, claimIds };
+}
+
+function claimIsUsable(claim: Claim | undefined, asOf: string): boolean {
+  return Boolean(
+    claim
+    && !claim.restrictedFromArtifacts
+    && ['supported', 'approved'].includes(claim.verification)
+    && claim.evidence.length > 0
+    && (!claim.expiresAt || claim.expiresAt > asOf),
+  );
+}
+
+export function evaluateArtifactGates(
+  payload: unknown,
+  claims: Claim[],
+  factualSegmentIds: string[],
+  claimUsage: ArtifactVersion['claimUsage'],
+  asOf: string,
+  contract?: { gate: 'astro_article_contract' | 'ask_answer_contract'; schema: z.ZodType },
+): GateResult[] {
+  const publicCopy = JSON.stringify(payload);
+  const claimsById = new Map(claims.map((claim) => [claim.id, claim]));
+  const usageBySegment = new Map(claimUsage.map((usage) => [usage.segmentId, usage]));
+  const usedClaimIds = [...new Set(claimUsage.flatMap((usage) => usage.claimIds))];
+  const uniqueSegments = new Set(factualSegmentIds);
+  const completeUsage = uniqueSegments.size === factualSegmentIds.length
+    && claimUsage.length === factualSegmentIds.length
+    && claimUsage.every((usage) => uniqueSegments.has(usage.segmentId))
+    && factualSegmentIds.every((segmentId) => {
+    const usage = usageBySegment.get(segmentId);
+    if (!usage || usage.claimIds.length === 0) return false;
+    const value = resolveArtifactPath(payload, usage.path);
+    return value !== undefined && value !== null && value !== '' && usage.contentHash === hashValue(value);
+  });
+  const paragraphUsages = claimUsage.filter((usage) => /^\$\.body::paragraph\[\d+\]$/.test(usage.path));
+  const paragraphCoverage = paragraphUsages.length === 0 || (
+    payload !== null
+    && typeof payload === 'object'
+    && typeof (payload as { body?: unknown }).body === 'string'
+    && (payload as { body: string }).body.split(/\n\s*\n/).length === paragraphUsages.length
+    && paragraphUsages.every((usage, index) => usage.path === `$.body::paragraph[${index}]`)
+  );
+  const lineageComplete = completeUsage && paragraphCoverage;
+  const supportedClaims = usedClaimIds.length > 0 && usedClaimIds.every((claimId) => claimIsUsable(claimsById.get(claimId), asOf));
+  const results: GateResult[] = [
+    gate('no_price', !PRICE_PATTERN.test(publicCopy), 'Public artifact content must not contain pricing.'),
+    gate('no_em_dash', !/—/.test(publicCopy), 'Public artifact content must not contain em dashes; en dashes remain valid for ranges.'),
+    gate('claim_usage_complete', lineageComplete, lineageComplete ? 'Every factual segment resolves to current content and maps to at least one claim.' : 'A factual segment is missing, changed, unresolved or lacks a claim mapping.', usedClaimIds),
+    gate('supported_claims_only', supportedClaims, supportedClaims ? 'Every used claim is current, supported, evidenced and unrestricted.' : 'A used claim is missing, expired, unsupported, unevidenced or restricted.', usedClaimIds),
+    gate('dependency_current', true, 'Every dependency points to the current locked version.'),
+  ];
+  if (contract) {
+    const parsed = contract.schema.safeParse(payload);
+    results.push(gate(contract.gate, parsed.success, parsed.success ? 'Payload matches the target contract.' : 'Payload does not match the target contract.'));
+  }
+  return results;
+}
 
 export function evaluateQuickNoteGates(
   payload: { headline: string; dek?: string; body: string },
   claims: Claim[],
   claimIds: string[],
-) {
-  const publicCopy = `${payload.headline} ${payload.dek ?? ''} ${payload.body}`;
-  const claimsById = new Map(claims.map((claim) => [claim.id, claim]));
-  const supportedClaimsPassed = claimIds.length > 0 && claimIds.every((claimId) => {
-    const claim = claimsById.get(claimId);
-    return Boolean(
-      claim
-      && !claim.restrictedFromArtifacts
-      && ['supported', 'approved'].includes(claim.verification)
-      && claim.evidence.length > 0,
-    );
-  });
-  return [
-    { gate: 'no_price', passed: !/(?:\$\s?\d|\bAUD\b|\bprice(?:d|s)?\b)/i.test(publicCopy), detail: 'Public copy must not contain pricing.' },
-    { gate: 'no_em_dash', passed: !/—/.test(publicCopy), detail: 'Public copy must not contain em dashes; en dashes remain valid for ranges.' },
-    { gate: 'supported_claims_only', passed: supportedClaimsPassed, detail: supportedClaimsPassed ? 'Every selected claim is supported, evidenced and unrestricted.' : 'A selected claim is missing, unsupported, unevidenced or restricted.' },
-  ];
+): GateResult[] {
+  return evaluateArtifactGates(
+    payload,
+    claims,
+    ['quick-note-copy'],
+    bindClaimUsage(payload, [{ segmentId: 'quick-note-copy', path: '$', claimIds }]),
+    '2026-08-21T05:00:00.000Z',
+  );
 }
 
-export function runFixture(actor: string, idempotencyKey: string): FoundryRun {
+function fixtureSource(actor: string) {
   const capturedAt = '2026-08-21T05:00:00.000Z';
   const sourceUrl = 'https://example.test/red-hill-winter-lunch';
   const sourceId = 'source-url-red-hill';
-  const locationClaim = 'The venue is in Red Hill.';
-  const dateClaim = 'The winter lunch is available on Saturday 29 August.';
-  const observation = 'The covered dining room suits a wet-weather lunch.';
-  const unsupported = 'This is the Peninsula\'s best lunch.';
-  const restrictedPrice = 'The set menu is $95.';
-
+  const rawClaims = [
+    { id: 'claim-location', text: 'The venue is in Red Hill.', origin: 'external_fact', verification: 'supported', locator: 'p:1' },
+    { id: 'claim-date', text: 'The winter lunch is available on Saturday 29 August.', origin: 'external_fact', verification: 'supported', locator: 'p:2' },
+    { id: 'claim-booking', text: 'Booking is required for the winter lunch.', origin: 'external_fact', verification: 'supported', locator: 'p:3' },
+    { id: 'claim-observation', text: 'The covered dining room suits a wet-weather lunch.', origin: 'first_party_observation', verification: 'approved', locator: 'note:1' },
+  ] as const;
   const evidence = (excerpt: string, locator: string) => [{
     sourceItemId: sourceId,
     locatorType: 'paragraph' as const,
@@ -47,105 +192,559 @@ export function runFixture(actor: string, idempotencyKey: string): FoundryRun {
     excerptHash: hash(excerpt),
     capturedAt,
   }];
-
-  const body = 'A covered dining room makes this Red Hill lunch a useful wet-weather option. The winter lunch is listed for Saturday 29 August, with booking required.';
   const claims = ClaimSchema.array().parse([
-    { id: 'claim-location', text: locationClaim, origin: 'external_fact', verification: 'supported', evidence: evidence(locationClaim, 'p:1'), restrictedFromArtifacts: false },
-    { id: 'claim-date', text: dateClaim, origin: 'external_fact', verification: 'supported', evidence: evidence(dateClaim, 'p:2'), restrictedFromArtifacts: false },
-    { id: 'claim-observation', text: observation, origin: 'first_party_observation', verification: 'approved', evidence: evidence(observation, 'note:1'), restrictedFromArtifacts: false },
-    { id: 'claim-unsupported', text: unsupported, origin: 'inference', verification: 'unsupported', evidence: [], restrictedFromArtifacts: true, restrictionReason: 'No independent evidence supports the superlative.' },
-    { id: 'claim-price', text: restrictedPrice, origin: 'external_fact', verification: 'supported', evidence: evidence(restrictedPrice, 'p:3'), restrictedFromArtifacts: true, restrictionReason: 'PI outputs do not publish prices.' },
+    ...rawClaims.map((claim) => ({ ...claim, evidence: evidence(claim.text, claim.locator), restrictedFromArtifacts: false })),
+    { id: 'claim-expired', text: 'A preview service ran on Friday 14 August.', origin: 'external_fact', verification: 'supported', evidence: evidence('A preview service ran on Friday 14 August.', 'p:4'), expiresAt: '2026-08-15T00:00:00.000Z', restrictedFromArtifacts: false },
+    { id: 'claim-unsupported', text: 'This is the Peninsula\'s best lunch.', origin: 'inference', verification: 'unsupported', evidence: [], restrictedFromArtifacts: true, restrictionReason: 'No independent evidence supports the superlative.' },
+    { id: 'claim-price', text: 'The set menu is $95.', origin: 'external_fact', verification: 'supported', evidence: evidence('The set menu is $95.', 'p:5'), restrictedFromArtifacts: true, restrictionReason: 'PI outputs do not publish prices.' },
   ]);
-  const artifactClaimIds = ['claim-location', 'claim-date', 'claim-observation'];
+  const claimSet: ClaimSetVersion = {
+    schemaVersion: 'pi.claim-set.v1',
+    id: 'claim-set-red-hill-winter-lunch',
+    version: 1,
+    contentHash: hashValue(claims),
+    createdAt: capturedAt,
+    lockedAt: capturedAt,
+    lockedBy: actor,
+    claims,
+  };
+  const bundle = {
+    schemaVersion: 'pi.intake-bundle.v1' as const,
+    id: `bundle-${FIXTURE_ID}`,
+    title: 'Red Hill winter lunch fixture',
+    submittedBy: actor,
+    capturedAt,
+    sourceItems: [{ id: sourceId, kind: 'url' as const, uri: sourceUrl, contentHash: hash(claims.map((claim) => claim.text).join('\n')), capturedAt }],
+  };
+  const angle = {
+    id: 'angle-rainy-lunch',
+    version: 1,
+    label: 'Rainy-day lunch',
+    framing: 'A practical, locally grounded wet-weather lunch option.',
+    evidenceClaimIds: ['claim-location', 'claim-date', 'claim-observation'],
+    selectedBy: 'fixture-policy',
+  };
+  return { capturedAt, sourceUrl, claims, claimSet, bundle, angle };
+}
+
+function claimSetDependency(claimSet: ClaimSetVersion) {
+  return { kind: 'claim_set' as const, id: claimSet.id, version: claimSet.version, contentHash: claimSet.contentHash };
+}
+
+function angleDependency(angle: { id: string; version: number; label: string; framing: string; evidenceClaimIds: string[] }) {
+  return { kind: 'angle' as const, id: angle.id, version: angle.version, contentHash: hashValue(angle) };
+}
+
+function withArtifactHash<T extends Omit<ArtifactVersion, 'contentHash'>>(artifact: T): ArtifactVersion {
+  return ArtifactVersionSchema.parse({ ...artifact, contentHash: hashValue(artifact.payload) });
+}
+
+export function artifactDependenciesCurrent(
+  run: FoundryRun,
+  artifact: ArtifactVersion,
+  visiting: Set<string> = new Set([artifact.id]),
+): boolean {
+  if (artifact.contentHash !== hashValue(artifact.payload)
+    || artifact.angleId !== run.angle.id
+    || artifact.angleVersion !== run.angle.version) return false;
+  const claimSetDependencies = artifact.dependencies.filter((dependency) => dependency.kind === 'claim_set');
+  const angleDependencies = artifact.dependencies.filter((dependency) => dependency.kind === 'angle');
+  if (claimSetDependencies.length !== 1 || angleDependencies.length !== 1) return false;
+  const mediaDependencies = artifact.dependencies.filter((dependency) => dependency.kind === 'media_rights');
+  if (artifact.type === 'article_metadata') {
+    if (artifact.payload.astroPatchReady !== Boolean(artifact.payload.heroImage && mediaDependencies.length === 1)) return false;
+  } else if (mediaDependencies.length > 0) return false;
+
+  const completedById = new Map(run.artifactPack.completed.map((candidate) => [candidate.id, candidate]));
+  const dependencyCurrent = (dependency: ArtifactDependency): boolean => {
+    switch (dependency.kind) {
+      case 'claim_set':
+        return dependency.id === run.claimSet.id
+          && dependency.version === run.claimSet.version
+          && dependency.contentHash === run.claimSet.contentHash
+          && run.claimSet.contentHash === hashValue(run.claimSet.claims);
+      case 'angle':
+        return dependency.id === run.angle.id
+          && dependency.version === run.angle.version
+          && dependency.contentHash === hashValue(run.angle);
+      case 'media_rights':
+        return artifact.type === 'article_metadata'
+          && Boolean(artifact.payload.heroImage)
+          && dependency.status === 'cleared'
+          && dependency.contentHash === hashValue(artifact.payload.heroImage);
+      case 'artifact': {
+        const target = completedById.get(dependency.id);
+        if (!target || visiting.has(target.id)) return false;
+        if (dependency.version !== target.version || dependency.contentHash !== target.contentHash) return false;
+        return artifactDependenciesCurrent(run, target, new Set(visiting).add(target.id));
+      }
+    }
+  };
+  return artifact.dependencies.every(dependencyCurrent);
+}
+
+export function runFixture(actor: string, idempotencyKey: string): FoundryRun {
+  const { capturedAt, sourceUrl, claims, claimSet, bundle, angle } = fixtureSource(actor);
   const payload = QuickNoteSchema.parse({
     headline: 'A wet-weather lunch option in Red Hill',
     dek: 'A covered dining room and a confirmed Saturday service make this one to keep for a rainy Peninsula day.',
     section: 'eat',
     tag: 'event',
-    publishedAt: '2026-08-21T05:00:00.000Z',
+    publishedAt: capturedAt,
     expiresAt: '2026-08-30T00:00:00.000Z',
     verifiedAt: capturedAt,
     verifiedBy: actor,
     sources: [{ kind: 'venue-site', url: sourceUrl, checkedAt: capturedAt }],
     status: 'draft',
-    body,
+    body: 'A covered dining room makes this Red Hill lunch a useful wet-weather option. The winter lunch is listed for Saturday 29 August, with booking required.',
   });
-
-  const gateResults = evaluateQuickNoteGates(payload, claims, artifactClaimIds);
-
+  const claimIds = ['claim-location', 'claim-date', 'claim-booking', 'claim-observation'];
+  const artifact = withArtifactHash({
+    id: 'artifact-quick-note-red-hill',
+    key: 'quick-note',
+    version: 1,
+    type: 'quick_note' as const,
+    angleId: angle.id,
+    angleVersion: angle.version,
+    factualSegmentIds: ['quick-note-copy'],
+    claimUsage: bindClaimUsage(payload, [{ segmentId: 'quick-note-copy', path: '$', claimIds }]),
+    claimIds,
+    dependencies: [claimSetDependency(claimSet), angleDependency(angle)],
+    payload,
+    gateResults: evaluateQuickNoteGates(payload, claims, claimIds),
+  });
   return FoundryRunSchema.parse({
+    schemaVersion: 'pi.foundry-run.v2',
     id: `run-${hash(idempotencyKey).slice(0, 12)}`,
     idempotencyKey,
     version: 1,
     status: 'ready_for_review',
     createdAt: capturedAt,
     updatedAt: capturedAt,
-    bundle: {
-      schemaVersion: 'pi.intake-bundle.v1',
-      id: `bundle-${FIXTURE_ID}`,
-      title: 'Red Hill winter lunch fixture',
-      submittedBy: actor,
-      capturedAt,
-      sourceItems: [{ id: sourceId, kind: 'url', uri: sourceUrl, contentHash: hash([locationClaim, dateClaim, observation, unsupported, restrictedPrice].join('\n')), capturedAt }],
-    },
+    bundle,
+    recipe: QUICK_NOTE_RECIPE,
+    claimSet,
     claims,
-    angle: {
-      id: 'angle-rainy-lunch',
-      label: 'Rainy-day lunch',
-      framing: 'A practical, locally grounded wet-weather lunch option.',
-      evidenceClaimIds: ['claim-location', 'claim-date', 'claim-observation'],
-      selectedBy: 'fixture-policy',
-    },
-    artifact: {
-      id: 'artifact-quick-note-red-hill',
+    angle,
+    artifact,
+    artifactPack: {
+      schemaVersion: 'pi.artifact-pack.v1',
+      id: `pack-${hash(idempotencyKey).slice(0, 12)}`,
       version: 1,
-      type: 'quick_note',
-      claimIds: artifactClaimIds,
-      angleId: 'angle-rainy-lunch',
-      payload,
-      gateResults,
+      recipeId: QUICK_NOTE_RECIPE.id,
+      recipeVersion: QUICK_NOTE_RECIPE.version,
+      claimSetRef: claimSetDependency(claimSet),
+      angleRef: { id: angle.id, version: angle.version },
+      status: 'complete',
+      completed: [artifact],
+      failed: [],
+      omitted: [],
+      reviews: [],
     },
     blockers: [],
-    audit: [{ at: capturedAt, actor, type: 'fixture_run_created', detail: 'Deterministic fixture reached review without external calls.' }],
+    audit: [{ at: capturedAt, actor, type: 'fixture_run_created', detail: 'Deterministic quick-note fixture reached review without external calls.' }],
   });
 }
 
-export function buildPatch(run: FoundryRun): string {
-  if (run.status !== 'accepted') throw new Error('Artifact must be accepted before patch export');
-  const note = run.artifact.payload;
-  const publicCopy = `${note.headline} ${note.dek ?? ''} ${note.body}`;
-  if (run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed)) throw new Error('Artifact has unresolved gates');
-  if (note.tag === 'pricing' || /(?:\$\s?\d|\bAUD\b|\bprice(?:d|s)?\b)/i.test(publicCopy)) throw new Error('PI outputs cannot contain pricing');
-  if (/—/.test(publicCopy)) throw new Error('PI outputs cannot contain em dashes');
-  const slug = '2026-08-21-red-hill-wet-weather-lunch.md';
-  const content = [
-    '---',
-    `headline: ${JSON.stringify(note.headline)}`,
-    `dek: ${JSON.stringify(note.dek ?? '')}`,
-    `section: ${note.section}`,
-    `tag: ${note.tag}`,
-    `publishedAt: ${note.publishedAt}`,
-    `expiresAt: ${note.expiresAt}`,
-    ...(note.verifiedAt ? [`verifiedAt: ${note.verifiedAt}`] : []),
-    ...(note.verifiedBy ? [`verifiedBy: ${JSON.stringify(note.verifiedBy)}`] : []),
-    'sources:',
-    ...note.sources.flatMap((source) => [
-      `  - kind: ${source.kind}`,
-      ...(source.url ? [`    url: ${source.url}`] : []),
-      ...(source.checkedAt ? [`    checkedAt: ${source.checkedAt}`] : []),
-    ]),
-    'status: draft',
-    '---',
-    '',
-    ...note.body.split(/\r?\n/),
-  ];
-  return [
-    `diff --git a/next/src/content/quick-notes/${slug} b/next/src/content/quick-notes/${slug}`,
+export function migrateLegacyRun(input: unknown): FoundryRun {
+  const legacy: LegacyFoundryRun = LegacyFoundryRunSchema.parse(input);
+  const claimSet: ClaimSetVersion = {
+    schemaVersion: 'pi.claim-set.v1',
+    id: `claim-set-${legacy.id}`,
+    version: 1,
+    contentHash: hashValue(legacy.claims),
+    createdAt: legacy.createdAt,
+    lockedAt: legacy.createdAt,
+    lockedBy: legacy.bundle.submittedBy,
+    claims: legacy.claims,
+  };
+  const dependency = claimSetDependency(claimSet);
+  const selectedAngleDependency = angleDependency({ ...legacy.angle, version: 1 });
+  const knownGates = new Set<GateResult['gate']>(['no_price', 'no_em_dash', 'supported_claims_only']);
+  const gateResults = legacy.artifact.gateResults.map((result) => {
+    if (!knownGates.has(result.gate as GateResult['gate'])) throw new Error(`Unsupported legacy gate ${result.gate}`);
+    return gate(result.gate as GateResult['gate'], result.passed, result.detail, legacy.artifact.claimIds);
+  });
+  const artifact = withArtifactHash({
+    id: legacy.artifact.id,
+    key: 'quick-note',
+    version: legacy.artifact.version,
+    type: 'quick_note' as const,
+    angleId: legacy.artifact.angleId,
+    angleVersion: 1,
+    factualSegmentIds: ['quick-note-copy'],
+    claimUsage: bindClaimUsage(legacy.artifact.payload, [{ segmentId: 'quick-note-copy', path: '$', claimIds: legacy.artifact.claimIds }]),
+    claimIds: legacy.artifact.claimIds,
+    dependencies: [dependency, selectedAngleDependency],
+    payload: legacy.artifact.payload,
+    gateResults,
+  });
+  const reviews = legacy.review ? [{
+    id: `review-${hashValue([legacy.id, legacy.review]).slice(0, 16)}`,
+    artifactId: artifact.id,
+    artifactVersion: artifact.version,
+    decision: legacy.review.decision,
+    reviewer: legacy.review.reviewer,
+    note: legacy.review.note,
+    decidedAt: legacy.review.decidedAt,
+    status: 'current' as const,
+    dependencySnapshot: artifact.dependencies,
+    authority: 'draft_handoff_only' as const,
+  }] : [];
+  return FoundryRunSchema.parse({
+    schemaVersion: 'pi.foundry-run.v2',
+    id: legacy.id,
+    idempotencyKey: legacy.idempotencyKey,
+    version: legacy.version,
+    status: legacy.status,
+    createdAt: legacy.createdAt,
+    updatedAt: legacy.updatedAt,
+    bundle: legacy.bundle,
+    recipe: QUICK_NOTE_RECIPE,
+    claimSet,
+    claims: legacy.claims,
+    angle: { ...legacy.angle, version: 1 },
+    artifact,
+    artifactPack: {
+      schemaVersion: 'pi.artifact-pack.v1',
+      id: `pack-${legacy.id}`,
+      version: Math.max(1, legacy.artifact.version),
+      recipeId: QUICK_NOTE_RECIPE.id,
+      recipeVersion: QUICK_NOTE_RECIPE.version,
+      claimSetRef: dependency,
+      angleRef: { id: legacy.angle.id, version: 1 },
+      status: 'complete',
+      completed: [artifact],
+      failed: [],
+      omitted: [],
+      reviews,
+    },
+    blockers: legacy.blockers,
+    review: legacy.review,
+    audit: [...legacy.audit, {
+      at: legacy.updatedAt,
+      actor: 'store-migration',
+      type: 'legacy_run_migrated',
+      detail: 'Loaded the v0.1 quick-note snapshot into the v2 artifact-pack contract.',
+    }],
+  });
+}
+
+export function runUrlArticleFixture(
+  actor: string,
+  idempotencyKey: string,
+  options: { failOptionalDerivative?: 'seo_metadata_proposal'; omitPlans?: boolean; includeClearedHero?: boolean } = {},
+): FoundryRun {
+  const { capturedAt, claims, claimSet, bundle, angle } = fixtureSource(actor);
+  const dependency = claimSetDependency(claimSet);
+  const selectedAngleDependency = angleDependency(angle);
+  const articlePayload = ArticleDraftPayloadSchema.parse({
+    slug: 'red-hill-wet-weather-lunch',
+    body: [
+      'A covered dining room gives this Red Hill lunch genuine wet-weather utility.',
+      '',
+      'The winter lunch is listed for Saturday 29 August, with booking required.',
+      '',
+      'That combination makes it a practical option when a Peninsula day needs an indoor anchor.',
+    ].join('\n'),
+  });
+  const articleUsage = bindClaimUsage(articlePayload, [
+    { segmentId: 'article-location', path: '$.body::paragraph[0]', claimIds: ['claim-location', 'claim-observation'] },
+    { segmentId: 'article-date', path: '$.body::paragraph[1]', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'article-utility', path: '$.body::paragraph[2]', claimIds: ['claim-observation'] },
+  ]);
+  const article = withArtifactHash({
+    id: 'artifact-article-red-hill', key: 'article-draft', version: 1, type: 'article_draft' as const,
+    angleId: angle.id, angleVersion: angle.version,
+    factualSegmentIds: articleUsage.map((usage) => usage.segmentId), claimUsage: articleUsage,
+    dependencies: [dependency, selectedAngleDependency], payload: articlePayload,
+    gateResults: evaluateArtifactGates(articlePayload, claims, articleUsage.map((usage) => usage.segmentId), articleUsage, capturedAt),
+  });
+  const articleDependency = { kind: 'artifact' as const, id: article.id, version: article.version, contentHash: article.contentHash };
+  const clearedHero = options.includeClearedHero ? {
+    src: '/images/sourced/place-red-hill-01.webp',
+    alt: 'Red Hill hinterland in late autumn',
+    credit: 'Peninsula Insider',
+    license: 'other-licensed' as const,
+  } : undefined;
+  const metadataPayload = ArticleMetadataPayloadSchema.parse({
+    title: 'A wet-weather lunch option in Red Hill',
+    dek: 'A covered dining room and a confirmed Saturday service make this a practical rainy-day anchor.',
+    author: 'editorial',
+    houseByline: true,
+    publishedAt: '2026-08-21',
+    heroImage: clearedHero,
+    astroPatchReady: Boolean(clearedHero),
+    format: 'service',
+    tags: ['red-hill', 'eat', 'rainy-day'],
+    relatedVenues: [], relatedExperiences: [], relatedPlaces: [], relatedArticles: [], relatedItineraries: [],
+    readingTimeMinutes: 2, featured: false, status: 'draft', lastVerified: '2026-08-21',
+    aiSummary: ['Covered dining makes this a useful wet-weather lunch.', 'The listed service is Saturday 29 August.'],
+    faq: [{ question: 'When is the Red Hill winter lunch available?', answer: 'The fixture source lists Saturday 29 August, with booking required.' }],
+    sitemapExclude: true,
+    section: 'journal',
+    clusterLinks: [{ label: 'Explore Red Hill', href: '/explore/places/red-hill/' }],
+  });
+  const metadataUsage = bindClaimUsage(metadataPayload, [
+    { segmentId: 'metadata-dek', path: '$.dek', claimIds: ['claim-location', 'claim-date', 'claim-observation'] },
+    { segmentId: 'metadata-summary-1', path: '$.aiSummary[0]', claimIds: ['claim-observation'] },
+    { segmentId: 'metadata-summary-2', path: '$.aiSummary[1]', claimIds: ['claim-date'] },
+    { segmentId: 'metadata-faq-answer', path: '$.faq[0].answer', claimIds: ['claim-date', 'claim-booking'] },
+  ]);
+  const metadataGates = evaluateArtifactGates(
+    metadataPayload,
+    claims,
+    metadataUsage.map((usage) => usage.segmentId),
+    metadataUsage,
+    capturedAt,
+    clearedHero ? { gate: 'astro_article_contract', schema: ArticleMetadataPayloadSchema } : undefined,
+  );
+  metadataGates.push(gate(
+    'astro_patch_ready',
+    Boolean(clearedHero),
+    clearedHero ? 'A separately rights-cleared hero placement makes the Astro patch adapter available.' : 'Text artifacts remain reviewable, but Astro patch export waits for a rights-cleared hero placement.',
+    [],
+    false,
+  ));
+  const metadataDependencies: ArtifactVersion['dependencies'] = [dependency, selectedAngleDependency, articleDependency];
+  if (clearedHero) {
+    metadataDependencies.push({
+      kind: 'media_rights' as const,
+      id: 'rights-place-red-hill-01',
+      version: 1,
+      contentHash: hashValue(clearedHero),
+      status: 'cleared' as const,
+    });
+  }
+  const metadata = withArtifactHash({
+    id: 'artifact-article-metadata-red-hill', key: 'article-metadata', version: 1, type: 'article_metadata' as const,
+    angleId: angle.id, angleVersion: angle.version,
+    factualSegmentIds: metadataUsage.map((usage) => usage.segmentId), claimUsage: metadataUsage,
+    dependencies: metadataDependencies, payload: metadataPayload,
+    gateResults: metadataGates,
+  });
+  const askPayload = AskAnswerPayloadSchema.parse({
+    answer: 'For a rainy Red Hill lunch, this covered dining room is a practical option. The fixture source lists the winter lunch for Saturday 29 August, with booking required.',
+    recommendations: [{
+      title: 'Red Hill wet-weather lunch',
+      href: '/journal/red-hill-wet-weather-lunch/',
+      why: 'Covered dining and a confirmed Saturday service make it useful in wet weather.',
+      venue_type: 'restaurant',
+      region: 'red-hill',
+    }],
+    follow_on: ['What else works in Red Hill when it rains?'],
+    provenance_footer: 'Drafted from a locked Peninsula Insider fixture claim set. Verify live details before visiting.',
+  });
+  const askUsage = bindClaimUsage(askPayload, [
+    { segmentId: 'ask-answer', path: '$.answer', claimIds: ['claim-location', 'claim-date', 'claim-booking', 'claim-observation'] },
+    { segmentId: 'ask-recommendation', path: '$.recommendations[0].why', claimIds: ['claim-date', 'claim-booking', 'claim-observation'] },
+  ]);
+  const ask = withArtifactHash({
+    id: 'artifact-ask-red-hill', key: 'ask-answer', version: 1, type: 'ask_answer' as const,
+    angleId: angle.id, angleVersion: angle.version,
+    factualSegmentIds: askUsage.map((usage) => usage.segmentId), claimUsage: askUsage,
+    dependencies: [dependency, selectedAngleDependency], payload: askPayload,
+    gateResults: evaluateArtifactGates(askPayload, claims, askUsage.map((usage) => usage.segmentId), askUsage, capturedAt, { gate: 'ask_answer_contract', schema: AskAnswerPayloadSchema }),
+  });
+  const completed: ArtifactVersion[] = [article, metadata, ask];
+  const failed = [];
+  const omitted = [];
+  if (options.omitPlans) {
+    omitted.push(
+      { key: 'internal-link-plan', type: 'internal_link_plan' as const, reason: 'not_requested' as const, detail: 'Optional plan was not requested.' },
+      { key: 'seo-metadata', type: 'seo_metadata_proposal' as const, reason: 'not_requested' as const, detail: 'Optional proposal was not requested.' },
+    );
+  } else {
+    const linkPayload = InternalLinkPlanPayloadSchema.parse({ links: [{ label: 'Explore Red Hill', href: '/explore/places/red-hill/', placement: 'After the second paragraph' }] });
+    const linkUsage = bindClaimUsage(linkPayload, [{ segmentId: 'link-label', path: '$.links[0].label', claimIds: ['claim-location'] }]);
+    completed.push(withArtifactHash({
+      id: 'artifact-links-red-hill', key: 'internal-link-plan', version: 1, type: 'internal_link_plan' as const,
+      angleId: angle.id, angleVersion: angle.version, factualSegmentIds: ['link-label'], claimUsage: linkUsage,
+      dependencies: [dependency, selectedAngleDependency, articleDependency], payload: linkPayload,
+      gateResults: evaluateArtifactGates(linkPayload, claims, ['link-label'], linkUsage, capturedAt),
+    }));
+    if (options.failOptionalDerivative === 'seo_metadata_proposal') {
+      failed.push({
+        key: 'seo-metadata', type: 'seo_metadata_proposal' as const, required: false,
+        code: 'fixture_derivative_failure' as const,
+        detail: 'Synthetic fixture failure proves independent derivative handling.', attemptedAt: capturedAt,
+      });
+    } else {
+      const seoPayload = SeoMetadataProposalPayloadSchema.parse({
+        title: 'Red Hill wet-weather lunch option',
+        description: 'A covered Red Hill dining room with a winter lunch listed for Saturday 29 August.',
+        canonicalPath: '/journal/red-hill-wet-weather-lunch/',
+      });
+      const seoUsage = bindClaimUsage(seoPayload, [{ segmentId: 'seo-description', path: '$.description', claimIds: ['claim-location', 'claim-date', 'claim-observation'] }]);
+      completed.push(withArtifactHash({
+        id: 'artifact-seo-red-hill', key: 'seo-metadata', version: 1, type: 'seo_metadata_proposal' as const,
+        angleId: angle.id, angleVersion: angle.version, factualSegmentIds: ['seo-description'], claimUsage: seoUsage,
+        dependencies: [dependency, selectedAngleDependency, articleDependency], payload: seoPayload,
+        gateResults: evaluateArtifactGates(seoPayload, claims, ['seo-description'], seoUsage, capturedAt),
+      }));
+    }
+  }
+  return FoundryRunSchema.parse({
+    schemaVersion: 'pi.foundry-run.v2',
+    id: `run-${hash(idempotencyKey).slice(0, 12)}`,
+    idempotencyKey,
+    version: 1,
+    status: 'ready_for_review',
+    createdAt: capturedAt,
+    updatedAt: capturedAt,
+    bundle: { ...bundle, id: `bundle-${URL_ARTICLE_FIXTURE_ID}`, title: 'Red Hill URL article fixture' },
+    recipe: URL_ARTICLE_RECIPE,
+    claimSet,
+    angle,
+    artifactPack: {
+      schemaVersion: 'pi.artifact-pack.v1', id: `pack-${hash(idempotencyKey).slice(0, 12)}`, version: 1,
+      recipeId: URL_ARTICLE_RECIPE.id, recipeVersion: URL_ARTICLE_RECIPE.version,
+      claimSetRef: dependency, angleRef: { id: angle.id, version: angle.version },
+      status: failed.length > 0 || omitted.length > 0 ? 'partial' : 'complete',
+      completed, failed, omitted, reviews: [],
+    },
+    blockers: [],
+    audit: [{ at: capturedAt, actor, type: 'fixture_run_created', detail: 'Deterministic URL article pack reached review without external calls.' }],
+  });
+}
+
+function acceptedCurrentReview(run: FoundryRun, artifact: ArtifactVersion): boolean {
+  return run.artifactPack.reviews.some((review) => (
+    review.artifactId === artifact.id
+    && review.artifactVersion === artifact.version
+    && review.decision === 'accepted'
+    && review.status === 'current'
+    && JSON.stringify(review.dependencySnapshot) === JSON.stringify(artifact.dependencies)
+    && artifactDependenciesCurrent(run, artifact)
+  ));
+}
+
+function diffForNewFile(path: string, content: string[]): string {
+  const patch = [
+    `diff --git a/${path} b/${path}`,
     'new file mode 100644',
     '--- /dev/null',
-    `+++ b/next/src/content/quick-notes/${slug}`,
+    `+++ b/${path}`,
     `@@ -0,0 +1,${content.length} @@`,
     ...content.map((line) => `+${line}`),
     '',
   ].join('\n');
+  if (!validateNewFilePatch(patch)) throw new Error('Generated patch failed structural validation');
+  return patch;
+}
+
+export function validateNewFilePatch(patch: string): boolean {
+  const lines = patch.split('\n');
+  if (!lines[0]?.startsWith('diff --git a/') || lines[1] !== 'new file mode 100644' || lines[2] !== '--- /dev/null') return false;
+  if (!lines[3]?.startsWith('+++ b/')) return false;
+  const hunkIndex = lines.findIndex((line) => /^@@ -0,0 \+1,\d+ @@$/.test(line));
+  if (hunkIndex !== 4) return false;
+  const expected = Number(lines[hunkIndex].match(/\+1,(\d+)/)?.[1]);
+  const additions = lines.slice(hunkIndex + 1).filter((line) => line.startsWith('+'));
+  return Number.isInteger(expected) && expected > 0 && additions.length === expected;
+}
+
+function assertArtifactReady(run: FoundryRun, artifact: ArtifactVersion): void {
+  if (artifact.gateResults.some((result) => !result.passed && result.blocking)) throw new Error(`Artifact ${artifact.id} has unresolved gates`);
+  const freshGates = artifact.type === 'quick_note'
+    ? evaluateQuickNoteGates(artifact.payload, run.claimSet.claims, artifact.claimIds)
+    : evaluateArtifactGates(
+      artifact.payload,
+      run.claimSet.claims,
+      artifact.factualSegmentIds,
+      artifact.claimUsage,
+      new Date().toISOString(),
+      artifact.type === 'ask_answer'
+        ? { gate: 'ask_answer_contract', schema: AskAnswerPayloadSchema }
+        : artifact.type === 'article_metadata' && artifact.payload.astroPatchReady
+          ? { gate: 'astro_article_contract', schema: ArticleMetadataPayloadSchema }
+          : undefined,
+    );
+  if (freshGates.some((result) => !result.passed && result.blocking)) throw new Error(`Artifact ${artifact.id} failed fresh export gates`);
+  if (!artifactDependenciesCurrent(run, artifact)) throw new Error(`Artifact ${artifact.id} has stale dependencies`);
+  if (!acceptedCurrentReview(run, artifact)) throw new Error(`Artifact ${artifact.id} requires a current accepted draft-handoff review`);
+  const publicCopy = JSON.stringify(artifact.payload);
+  if (PRICE_PATTERN.test(publicCopy)) throw new Error('PI outputs cannot contain pricing');
+  if (/—/.test(publicCopy)) throw new Error('PI outputs cannot contain em dashes');
+}
+
+export function buildPatch(run: FoundryRun): string {
+  if (run.blockers.length > 0) throw new Error('Run has unresolved blockers');
+  if (run.recipe.id === QUICK_NOTE_RECIPE.id) {
+    if (!run.artifact) throw new Error('Quick-note compatibility artifact is missing');
+    assertArtifactReady(run, run.artifact);
+    const note = run.artifact.payload;
+    const path = 'next/src/content/quick-notes/2026-08-21-red-hill-wet-weather-lunch.md';
+    const content = [
+      '---',
+      `headline: ${JSON.stringify(note.headline)}`,
+      `dek: ${JSON.stringify(note.dek ?? '')}`,
+      `section: ${note.section}`,
+      `tag: ${note.tag}`,
+      `publishedAt: ${note.publishedAt}`,
+      `expiresAt: ${note.expiresAt}`,
+      ...(note.verifiedAt ? [`verifiedAt: ${note.verifiedAt}`] : []),
+      ...(note.verifiedBy ? [`verifiedBy: ${JSON.stringify(note.verifiedBy)}`] : []),
+      'sources:',
+      ...note.sources.flatMap((source) => [
+        `  - kind: ${source.kind}`,
+        ...(source.url ? [`    url: ${source.url}`] : []),
+        ...(source.checkedAt ? [`    checkedAt: ${source.checkedAt}`] : []),
+      ]),
+      'status: draft',
+      '---',
+      '',
+      ...note.body.split(/\r?\n/),
+    ];
+    return diffForNewFile(path, content);
+  }
+
+  const article = run.artifactPack.completed.find((item) => item.type === 'article_draft');
+  const metadata = run.artifactPack.completed.find((item) => item.type === 'article_metadata');
+  if (!article || article.type !== 'article_draft' || !metadata || metadata.type !== 'article_metadata') {
+    throw new Error('Article draft and metadata are required for patch export');
+  }
+  assertArtifactReady(run, article);
+  assertArtifactReady(run, metadata);
+  const meta = metadata.payload;
+  if (!meta.astroPatchReady || !meta.heroImage) {
+    throw new Error('Article patch export requires a separately rights-cleared hero placement');
+  }
+  const content = [
+    '---',
+    `title: ${JSON.stringify(meta.title)}`,
+    `dek: ${JSON.stringify(meta.dek)}`,
+    `author: ${JSON.stringify(meta.author)}`,
+    `houseByline: ${meta.houseByline}`,
+    `publishedAt: ${meta.publishedAt}`,
+    'heroImage:',
+    `  src: ${JSON.stringify(meta.heroImage.src)}`,
+    `  alt: ${JSON.stringify(meta.heroImage.alt)}`,
+    `  credit: ${JSON.stringify(meta.heroImage.credit)}`,
+    `  license: ${JSON.stringify(meta.heroImage.license)}`,
+    `format: ${JSON.stringify(meta.format)}`,
+    `tags: ${JSON.stringify(meta.tags)}`,
+    `relatedVenues: ${JSON.stringify(meta.relatedVenues)}`,
+    `relatedExperiences: ${JSON.stringify(meta.relatedExperiences)}`,
+    `relatedPlaces: ${JSON.stringify(meta.relatedPlaces)}`,
+    `relatedArticles: ${JSON.stringify(meta.relatedArticles)}`,
+    `relatedItineraries: ${JSON.stringify(meta.relatedItineraries)}`,
+    ...(meta.readingTimeMinutes ? [`readingTimeMinutes: ${meta.readingTimeMinutes}`] : []),
+    `featured: ${meta.featured}`,
+    'status: draft',
+    ...(meta.lastVerified ? [`lastVerified: ${meta.lastVerified}`] : []),
+    ...(meta.clusterLinks ? [`clusterLinks: ${JSON.stringify(meta.clusterLinks)}`] : []),
+    ...(meta.aiSummary ? [`aiSummary: ${JSON.stringify(meta.aiSummary)}`] : []),
+    ...(meta.faq ? [
+      'faq:',
+      ...meta.faq.flatMap((item) => [`  - question: ${JSON.stringify(item.question)}`, `    answer: ${JSON.stringify(item.answer)}`]),
+    ] : []),
+    `sitemapExclude: ${meta.sitemapExclude}`,
+    `section: ${meta.section}`,
+    ...(meta.planShape ? [`planShape: ${meta.planShape}`] : []),
+    '---',
+    '',
+    ...article.payload.body.split(/\r?\n/),
+  ];
+  return diffForNewFile(`next/src/content/articles/${article.payload.slug}.md`, content);
 }

--- a/studio-peninsula-insider/server/fixture-runner.ts
+++ b/studio-peninsula-insider/server/fixture-runner.ts
@@ -7,11 +7,18 @@ import {
   AskAnswerPayloadSchema,
   ClaimSchema,
   FoundryRunSchema,
+  InstagramCaptionPayloadSchema,
+  InstagramCarouselScriptPayloadSchema,
+  InstagramFirstCommentPayloadSchema,
+  InsiderNoteIssuePayloadSchema,
+  InsiderNoteSubjectSetPayloadSchema,
   InternalLinkPlanPayloadSchema,
   LegacyFoundryRunSchema,
+  LinkedInPostPayloadSchema,
   QuickNoteSchema,
   RecipeDefinitionSchema,
   SeoMetadataProposalPayloadSchema,
+  SocialMediaBriefPayloadSchema,
   type ArtifactVersion,
   type ArtifactDependency,
   type Claim,
@@ -55,6 +62,7 @@ function bindClaimUsage<T extends Array<{ segmentId: string; path: string; claim
 
 export const FIXTURE_ID = 'red-hill-winter-lunch';
 export const URL_ARTICLE_FIXTURE_ID = 'red-hill-url-article';
+export const NEWSLETTER_SOCIAL_FIXTURE_ID = 'red-hill-newsletter-social';
 
 const PRICE_PATTERN = /(?:\$\s?\d|\bAUD\b|\bprice(?:d|s|band)?\b)/i;
 
@@ -87,6 +95,26 @@ export const URL_ARTICLE_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse
     { key: 'ask-answer', type: 'ask_answer', required: true, dependsOnKeys: [], targetContract: 'concierge.ask.response.v1' },
     { key: 'internal-link-plan', type: 'internal_link_plan', required: false, dependsOnKeys: ['article-draft'], targetContract: 'internal.link-plan.v1' },
     { key: 'seo-metadata', type: 'seo_metadata_proposal', required: false, dependsOnKeys: ['article-draft'], targetContract: 'astro.base-layout.meta.v1' },
+  ],
+  textOnlyAllowed: true,
+  externalCalls: false,
+});
+
+export const NEWSLETTER_SOCIAL_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse({
+  schemaVersion: 'pi.recipe-definition.v1',
+  id: 'newsletter_social_v1',
+  version: 1,
+  label: 'Insider Note and social draft pack',
+  sourceKinds: ['url', 'text_note', 'image'],
+  artifacts: [
+    { key: 'article-draft', type: 'article_draft', required: true, dependsOnKeys: [], targetContract: 'astro.articles.body.v1' },
+    { key: 'insider-note-issue', type: 'insider_note_issue', required: true, dependsOnKeys: ['article-draft'], targetContract: 'email.insider-note.positions.v1' },
+    { key: 'insider-note-subjects', type: 'insider_note_subject_set', required: true, dependsOnKeys: ['insider-note-issue'], targetContract: 'email.insider-note.subject-set.v1' },
+    { key: 'linkedin-post', type: 'linkedin_post', required: true, dependsOnKeys: ['article-draft'], targetContract: 'social.linkedin.draft.v1' },
+    { key: 'instagram-caption', type: 'instagram_caption', required: true, dependsOnKeys: ['article-draft'], targetContract: 'social.instagram.caption-draft.v1' },
+    { key: 'instagram-first-comment', type: 'instagram_first_comment', required: true, dependsOnKeys: ['instagram-caption'], targetContract: 'social.instagram.first-comment-draft.v1' },
+    { key: 'instagram-carousel', type: 'instagram_carousel_script', required: false, dependsOnKeys: ['article-draft'], targetContract: 'social.instagram.carousel-script.v1' },
+    { key: 'social-media-brief', type: 'social_media_brief', required: true, dependsOnKeys: ['instagram-carousel'], targetContract: 'social.media-placement-brief.v1' },
   ],
   textOnlyAllowed: true,
   externalCalls: false,
@@ -160,6 +188,178 @@ export function evaluateArtifactGates(
   return results;
 }
 
+const CURRENT_FIXTURE_VENUES = new Map([
+  ['/stay/cassis/', 'Cassis Red Hill'],
+  ['/stay/hotel-sorrento/', 'Hotel Sorrento'],
+]);
+
+function hasRequiredEmailUtm(href: string, campaignCode: string): boolean {
+  try {
+    const url = new URL(href);
+    return url.searchParams.get('utm_source') === 'email'
+      && url.searchParams.get('utm_medium') === 'newsletter'
+      && url.searchParams.get('utm_campaign') === campaignCode;
+  } catch {
+    return false;
+  }
+}
+
+function collectPropertyValues(input: unknown, property: string): unknown[] {
+  if (Array.isArray(input)) return input.flatMap((item) => collectPropertyValues(item, property));
+  if (!input || typeof input !== 'object') return [];
+  return Object.entries(input as Record<string, unknown>).flatMap(([key, value]) => [
+    ...(key === property ? [value] : []),
+    ...collectPropertyValues(value, property),
+  ]);
+}
+
+export function evaluateArtifactFormatGates(
+  type: ArtifactVersion['type'],
+  payload: unknown,
+  claims: Claim[],
+  asOf: string,
+): GateResult[] {
+  if (type === 'insider_note_issue') {
+    const parsed = InsiderNoteIssuePayloadSchema.safeParse(payload);
+    const issue = parsed.success ? parsed.data : undefined;
+    const locked = Boolean(issue
+      && issue.positions[0].name === 'The Insider Note'
+      && issue.positions[0].tagline === 'Written from inside the region'
+      && issue.positions[9].replyPrompt === 'Been somewhere brilliant this week that we should know about? Just hit reply. We read everything.'
+      && issue.positions[9].signoff === 'The Insider.'
+      && issue.positions[10].includeUnsubscribe
+      && issue.positions[10].includeStreetAddress);
+    const leadVerb = Boolean(issue && /^(?:Book|Go|Visit|Plan|Check|Reserve|Explore)\b/i.test(issue.positions[2].cta.label)
+      && !/^Read more\b/i.test(issue.positions[2].cta.label));
+    const ctaCounts = issue ? [
+      1,
+      issue.positions[4].status === 'included' ? issue.positions[4].picks.filter((pick) => pick.cta).length : 0,
+      issue.positions[6].status === 'included' ? issue.positions[6].rows.filter((row) => row.link).length : 0,
+      issue.positions[7].status === 'included' ? 1 : 0,
+    ] : [2];
+    const ctasValid = leadVerb && ctaCounts.every((count) => count <= 1);
+    const hrefs = issue ? collectPropertyValues(issue.positions, 'href').filter((value): value is string => typeof value === 'string') : [];
+    const utmsValid = Boolean(issue && hrefs.length > 0 && hrefs.every((href) => hasRequiredEmailUtm(href, issue.campaignCode)));
+    const weather = issue?.positions[3];
+    const reply = issue?.positions[5];
+    const replyLineage = !reply || reply.status === 'omitted' || reply.claimIds.some((claimId) => (
+      claims.find((claim) => claim.id === claimId)?.evidence.some((evidence) => (
+        evidence.sourceItemId === reply.sourceLocator.sourceItemId
+        && evidence.locator === reply.sourceLocator.locator
+        && evidence.excerptHash === reply.sourceLocator.excerptHash
+        && hash(reply.quote) === reply.sourceLocator.excerptHash
+      ))
+    ));
+    const authoritativeInputs = Boolean(issue
+      && (!weather || weather.status === 'omitted' || weather.claimIds.length > 0)
+      && (!reply || reply.status === 'omitted' || (reply.claimIds.length > 0 && reply.privacy === 'first_name_only' && replyLineage)));
+    const venueRefs = issue ? collectPropertyValues(issue.positions, 'venue').filter((value): value is { name: string; path: string } => (
+      Boolean(value && typeof value === 'object' && 'name' in value && 'path' in value)
+    )) : [];
+    const venueNamesCurrent = Boolean(issue && venueRefs.every((venue) => CURRENT_FIXTURE_VENUES.get(venue.path) === venue.name));
+    const introValid = Boolean(issue && issue.positions[1].tense === 'past' && issue.positions[1].lines.length > 0 && issue.positions[1].lines.length <= 2);
+    const secondaryValid = Boolean(issue && (issue.positions[4].status === 'omitted' || issue.positions[4].picks.length === 2));
+    const also = issue?.positions[6];
+    const chronological = !also ? false : also.status === 'omitted' || (
+      also.rows.length <= 3 && also.rows.every((row, index) => index === 0 || row.date >= also.rows[index - 1].date)
+    );
+    const booking = issue?.positions[7];
+    const bookingValid = !booking ? false : booking.status === 'omitted' || (
+      (booking.line.text.match(/[.!?](?:\s|$)/g) ?? []).length === 1
+      && booking.timeSensitiveClaimIds.length > 0
+      && booking.timeSensitiveClaimIds.every((claimId) => booking.line.claimIds.includes(claimId))
+      && booking.timeSensitiveClaimIds.every((claimId) => claimIsUsable(claims.find((claim) => claim.id === claimId), asOf))
+    );
+    const poll = issue?.positions[8];
+    const pollManual = Boolean(issue && poll && (
+      (poll.status === 'editorial_decision' && poll.suppliedQuestion === null && poll.suppliedBy === null)
+      || (poll.status === 'editorial_supplied' && Boolean(poll.suppliedQuestion && poll.suppliedBy))
+    ));
+    return [
+      gate('insider_note_contract', parsed.success, parsed.success ? 'Payload preserves the stable 11-position Insider Note union.' : 'Payload does not match the stable 11-position Insider Note contract.'),
+      gate('locked_copy_unchanged', locked, locked ? 'Masthead, reply prompt, sign-off and footer obligations are unchanged.' : 'Locked Insider Note copy or footer obligations changed.'),
+      gate('cta_limit', ctasValid, ctasValid ? 'The lead CTA is a verb and every variable position has at most one CTA.' : 'A position has too many CTAs or the lead CTA is not an allowed verb.'),
+      gate('email_utm_complete', utmsValid, utmsValid ? 'Every issue link carries the required email newsletter campaign parameters.' : 'One or more issue links is missing the required Insider Note campaign parameters.'),
+      gate('authoritative_input_present', authoritativeInputs, authoritativeInputs ? 'Weather and reader reply are either sourced or honestly omitted.' : 'Weather or reader reply lacks authoritative claim lineage.'),
+      gate('venue_name_current', venueNamesCurrent, venueNamesCurrent ? 'Every referenced venue name matches its current site record.' : 'A referenced venue name does not match the current site record.'),
+      gate('intro_shape', introValid, introValid ? 'The intro is explicitly past tense and contains no more than two lines.' : 'The intro must be past tense and contain one or two lines.'),
+      gate('secondary_picks_shape', secondaryValid, secondaryValid ? 'Secondary picks are honestly omitted or contain exactly two picks.' : 'A present secondary-picks position must contain exactly two picks.'),
+      gate('chronological_rows', chronological, chronological ? 'Also This Week contains at most three chronological rows.' : 'Also This Week rows must be chronological and limited to three.'),
+      gate('booking_note_contract', bookingValid, bookingValid ? 'The booking note is one time-sensitive sentence with current evidence and one link.' : 'The booking note must be one time-sensitive sourced sentence with one link.'),
+      gate('poll_manual_only', pollManual, pollManual ? 'The poll remains unset or contains a separately supplied editorial question.' : 'The recipe cannot generate a poll question.'),
+      gate('no_external_action', Boolean(issue && issue.scheduleAt === null && issue.operationalState === 'draft_only' && issue.sendAuthority === 'james_only'), 'This artifact cannot schedule or send and preserves James-only send authority.'),
+    ];
+  }
+
+  if (type === 'insider_note_subject_set') {
+    const parsed = InsiderNoteSubjectSetPayloadSchema.safeParse(payload);
+    const subjectSet = parsed.success ? parsed.data : undefined;
+    const normalizeCandidate = (value: string) => value.toLocaleLowerCase().replace(/\s+/g, ' ').replace(/[.!?,;:]+$/g, '').trim();
+    const candidates = subjectSet?.pairs.flatMap((pair) => [normalizeCandidate(pair.subject), normalizeCandidate(pair.previewText)]) ?? [];
+    const distinct = candidates.length === 6 && new Set(candidates).size === 6;
+    return [
+      gate('subject_set_contract', parsed.success, parsed.success ? 'The subject artifact contains exactly three subject and preview pairs.' : 'The subject artifact does not match its contract.'),
+      gate('subject_pairs_distinct', distinct, distinct ? 'All three subjects and all three previews are genuinely distinct.' : 'Subjects and previews must be genuinely distinct.'),
+      gate('james_selection_required', Boolean(subjectSet && subjectSet.selectedPairId === null && subjectSet.selectionAuthority === 'james_only'), 'No subject is selected in the draft artifact; only James can choose one.'),
+      gate('no_external_action', Boolean(subjectSet && subjectSet.scheduleAt === null && subjectSet.sendAuthority === 'james_only'), 'This artifact cannot schedule or send and preserves James-only send authority.'),
+    ];
+  }
+
+  const socialSchemas = {
+    linkedin_post: LinkedInPostPayloadSchema,
+    instagram_caption: InstagramCaptionPayloadSchema,
+    instagram_first_comment: InstagramFirstCommentPayloadSchema,
+    instagram_carousel_script: InstagramCarouselScriptPayloadSchema,
+    social_media_brief: SocialMediaBriefPayloadSchema,
+  } as const;
+  if (type in socialSchemas) {
+    const schema = socialSchemas[type as keyof typeof socialSchemas];
+    const parsed = schema.safeParse(payload);
+    const draft = parsed.success ? parsed.data as { scheduleAt: null; publicationAuthority: 'james_only'; operationalState: 'draft_only' } : undefined;
+    const results = [
+      gate('social_contract', parsed.success, parsed.success ? 'Payload matches its channel-specific draft contract.' : 'Payload does not match its channel-specific draft contract.'),
+      gate('no_external_action', Boolean(draft && draft.scheduleAt === null && draft.publicationAuthority === 'james_only' && draft.operationalState === 'draft_only'), 'This artifact cannot schedule or publish and preserves James-only publication authority.'),
+    ];
+    if (type === 'linkedin_post') {
+      const post = LinkedInPostPayloadSchema.safeParse(payload);
+      results.push(gate('linkedin_post_contract', post.success, post.success ? 'LinkedIn copy has a specific opening, 50 to 300 words, one separate link, at most three hashtags and no engagement bait.' : 'LinkedIn copy violates its specific-opening, length, link, hashtag or engagement-bait rules.'));
+    }
+    if (type === 'instagram_caption') {
+      const caption = InstagramCaptionPayloadSchema.safeParse(payload);
+      results.push(gate('instagram_caption_contract', caption.success, caption.success ? 'Instagram caption is observation-first, 2 to 4 lines and keeps hashtags outside caption copy.' : 'Instagram caption violates its line, voice or hashtag rules.'));
+    }
+    if (type === 'instagram_first_comment') {
+      const comment = InstagramFirstCommentPayloadSchema.safeParse(payload);
+      results.push(gate('instagram_first_comment_contract', comment.success, comment.success ? 'First-comment draft has 3 to 5 unique hashtag candidates with placement unresolved.' : 'First-comment hashtag candidates must be 3 to 5 unique values and placement must remain unresolved.'));
+    }
+    if (type === 'instagram_carousel_script') {
+      const carousel = InstagramCarouselScriptPayloadSchema.safeParse(payload);
+      results.push(gate('carousel_script_contract', carousel.success, carousel.success ? 'Carousel contains 3 to 5 ordered, claim-linked slides.' : 'Carousel must contain 3 to 5 ordered, claim-linked slides.'));
+    }
+    if (type === 'social_media_brief') {
+      const brief = SocialMediaBriefPayloadSchema.safeParse(payload);
+      const rights = brief.success
+        && brief.data.placementRights.status === 'cleared'
+        && brief.data.placementRights.allowedSurfaces.includes(brief.data.targetSurface)
+        && ['none', 'released'].includes(brief.data.placementRights.recognisablePeople);
+      results.push(gate('media_placement_rights', rights, rights ? 'Placement rights explicitly allow this Instagram surface.' : 'Instagram handoff is blocked until rights allow the exact target surface and people are released.'));
+    }
+    return results;
+  }
+
+  return [];
+}
+
+export function socialMediaRightsSnapshot(payload: z.infer<typeof SocialMediaBriefPayloadSchema>) {
+  return {
+    assetId: payload.assetId,
+    targetSurface: payload.targetSurface,
+    placement: payload.placement,
+    mediaType: payload.mediaType,
+    placementRights: payload.placementRights,
+  };
+}
+
 export function evaluateQuickNoteGates(
   payload: { headline: string; dek?: string; body: string },
   claims: Claim[],
@@ -183,9 +383,14 @@ function fixtureSource(actor: string) {
     { id: 'claim-date', text: 'The winter lunch is available on Saturday 29 August.', origin: 'external_fact', verification: 'supported', locator: 'p:2' },
     { id: 'claim-booking', text: 'Booking is required for the winter lunch.', origin: 'external_fact', verification: 'supported', locator: 'p:3' },
     { id: 'claim-observation', text: 'The covered dining room suits a wet-weather lunch.', origin: 'first_party_observation', verification: 'approved', locator: 'note:1' },
+    { id: 'claim-weather', text: 'Saturday is forecast to reach 16 degrees with showers and a 5:48 pm sunset.', origin: 'external_fact', verification: 'supported', locator: 'weather:1' },
+    { id: 'claim-reply', text: 'A supplied reader reply says the covered room saved a rainy lunch.', evidenceExcerpt: 'The covered room saved our rainy lunch.', origin: 'first_party_observation', verification: 'approved', locator: 'reply:1' },
+    { id: 'claim-venue-name', text: 'The site venue record spells the name Cassis Red Hill.', origin: 'external_fact', verification: 'supported', locator: 'venue:cassis' },
+    { id: 'claim-venue-name-2', text: 'The site venue record spells the name Hotel Sorrento.', origin: 'external_fact', verification: 'supported', locator: 'venue:hotel-sorrento' },
+    { id: 'claim-image', text: 'The fixture image depicts the Red Hill hinterland in late autumn.', origin: 'first_party_observation', verification: 'approved', locator: 'image:1' },
   ] as const;
-  const evidence = (excerpt: string, locator: string) => [{
-    sourceItemId: sourceId,
+  const evidence = (excerpt: string, locator: string, sourceItemId = sourceId) => [{
+    sourceItemId,
     locatorType: 'paragraph' as const,
     locator,
     excerpt,
@@ -193,7 +398,15 @@ function fixtureSource(actor: string) {
     capturedAt,
   }];
   const claims = ClaimSchema.array().parse([
-    ...rawClaims.map((claim) => ({ ...claim, evidence: evidence(claim.text, claim.locator), restrictedFromArtifacts: false })),
+    ...rawClaims.map((claim) => ({
+      ...claim,
+      evidence: evidence(
+        'evidenceExcerpt' in claim ? claim.evidenceExcerpt : claim.text,
+        claim.locator,
+        claim.id === 'claim-reply' ? 'source-reader-reply' : claim.id === 'claim-image' ? 'source-image-red-hill' : sourceId,
+      ),
+      restrictedFromArtifacts: false,
+    })),
     { id: 'claim-expired', text: 'A preview service ran on Friday 14 August.', origin: 'external_fact', verification: 'supported', evidence: evidence('A preview service ran on Friday 14 August.', 'p:4'), expiresAt: '2026-08-15T00:00:00.000Z', restrictedFromArtifacts: false },
     { id: 'claim-unsupported', text: 'This is the Peninsula\'s best lunch.', origin: 'inference', verification: 'unsupported', evidence: [], restrictedFromArtifacts: true, restrictionReason: 'No independent evidence supports the superlative.' },
     { id: 'claim-price', text: 'The set menu is $95.', origin: 'external_fact', verification: 'supported', evidence: evidence('The set menu is $95.', 'p:5'), restrictedFromArtifacts: true, restrictionReason: 'PI outputs do not publish prices.' },
@@ -214,7 +427,11 @@ function fixtureSource(actor: string) {
     title: 'Red Hill winter lunch fixture',
     submittedBy: actor,
     capturedAt,
-    sourceItems: [{ id: sourceId, kind: 'url' as const, uri: sourceUrl, contentHash: hash(claims.map((claim) => claim.text).join('\n')), capturedAt }],
+    sourceItems: [
+      { id: sourceId, kind: 'url' as const, uri: sourceUrl, contentHash: hash(claims.map((claim) => claim.text).join('\n')), capturedAt },
+      { id: 'source-reader-reply', kind: 'text_note' as const, contentHash: hash('The covered room saved our rainy lunch.'), capturedAt },
+      { id: 'source-image-red-hill', kind: 'image' as const, contentHash: hash('fixture-red-hill-hinterland-late-autumn'), capturedAt },
+    ],
   };
   const angle = {
     id: 'angle-rainy-lunch',
@@ -253,6 +470,9 @@ export function artifactDependenciesCurrent(
   const mediaDependencies = artifact.dependencies.filter((dependency) => dependency.kind === 'media_rights');
   if (artifact.type === 'article_metadata') {
     if (artifact.payload.astroPatchReady !== Boolean(artifact.payload.heroImage && mediaDependencies.length === 1)) return false;
+  } else if (artifact.type === 'social_media_brief') {
+    const cleared = artifact.payload.placementRights.status === 'cleared';
+    if (cleared !== (mediaDependencies.length === 1)) return false;
   } else if (mediaDependencies.length > 0) return false;
 
   const completedById = new Map(run.artifactPack.completed.map((candidate) => [candidate.id, candidate]));
@@ -268,10 +488,17 @@ export function artifactDependenciesCurrent(
           && dependency.version === run.angle.version
           && dependency.contentHash === hashValue(run.angle);
       case 'media_rights':
-        return artifact.type === 'article_metadata'
-          && Boolean(artifact.payload.heroImage)
+        if (artifact.type === 'article_metadata') {
+          return Boolean(artifact.payload.heroImage)
+            && dependency.status === 'cleared'
+            && dependency.contentHash === hashValue(artifact.payload.heroImage);
+        }
+        return artifact.type === 'social_media_brief'
+          && artifact.payload.placementRights.status === 'cleared'
+          && artifact.payload.placementRights.allowedSurfaces.includes(artifact.payload.targetSurface)
+          && artifact.payload.placementRights.rightsId === dependency.id
           && dependency.status === 'cleared'
-          && dependency.contentHash === hashValue(artifact.payload.heroImage);
+          && dependency.contentHash === hashValue(socialMediaRightsSnapshot(artifact.payload));
       case 'artifact': {
         const target = completedById.get(dependency.id);
         if (!target || visiting.has(target.id)) return false;
@@ -608,6 +835,267 @@ export function runUrlArticleFixture(
   });
 }
 
+export function runNewsletterSocialFixture(
+  actor: string,
+  idempotencyKey: string,
+  options: { omitAuthoritativeInputs?: boolean; clearInstagramRights?: boolean } = {},
+): FoundryRun {
+  const base = runUrlArticleFixture(actor, idempotencyKey, { omitPlans: true });
+  const article = base.artifactPack.completed.find((artifact) => artifact.type === 'article_draft');
+  if (!article || article.type !== 'article_draft') throw new Error('Newsletter and social fixture requires its current article draft');
+  const capturedAt = base.updatedAt;
+  const claims = base.claimSet.claims;
+  const commonDependencies = [claimSetDependency(base.claimSet), angleDependency(base.angle)];
+  const articleDependency = { kind: 'artifact' as const, id: article.id, version: article.version, contentHash: article.contentHash };
+  const campaignCode = 'insider-note-07';
+  const emailUrl = (path: string) => `https://peninsulainsider.com.au${path}?utm_source=email&utm_medium=newsletter&utm_campaign=${campaignCode}`;
+
+  const issuePayload = InsiderNoteIssuePayloadSchema.parse({
+    schemaVersion: 'pi.insider-note-issue.v1',
+    issueNumber: 7,
+    campaignCode,
+    targetReleaseDate: '2026-08-26',
+    scheduleAt: null,
+    sendAuthority: 'james_only',
+    operationalState: 'draft_only',
+    positions: [
+      { id: 'insider_note.position.01.masthead', position: 1, key: 'masthead', status: 'locked', name: 'The Insider Note', tagline: 'Written from inside the region', issueNumberRoman: 'VII', dateRange: '24–30 August 2026' },
+      { id: 'insider_note.position.02.intro', position: 2, key: 'intro', status: 'included', tense: 'past', lines: [{ id: 'intro-1', text: 'Rain settled over Red Hill, and the covered room proved its worth.', claimIds: ['claim-location', 'claim-observation'] }] },
+      {
+        id: 'insider_note.position.03.lead_today_move', position: 3, key: 'lead_today_move', status: 'included',
+        headline: { id: 'lead-headline', text: 'Make Saturday lunch the indoor anchor', claimIds: ['claim-date', 'claim-observation'] },
+        body: { id: 'lead-body', text: 'The winter lunch is listed for Saturday 29 August, with booking required.', claimIds: ['claim-date', 'claim-booking'] },
+        cta: { id: 'lead-cta', label: 'Book the Saturday lunch', href: emailUrl('/journal/red-hill-wet-weather-lunch/'), claimIds: ['claim-date', 'claim-booking'] },
+      },
+      options.omitAuthoritativeInputs
+        ? { id: 'insider_note.position.04.weather_strip', position: 4, key: 'weather_strip', status: 'omitted', reason: 'missing_authoritative_input' }
+        : { id: 'insider_note.position.04.weather_strip', position: 4, key: 'weather_strip', status: 'included', day: 'Saturday', temperatureC: 16, sky: 'Showers', sunsetTime: '5:48 pm', claimIds: ['claim-weather'] },
+      {
+        id: 'insider_note.position.05.secondary_picks', position: 5, key: 'secondary_picks', status: 'included',
+        picks: [
+          {
+            id: 'secondary-cassis', dayStamp: 'SAT', category: 'STAY',
+            venue: { name: 'Cassis Red Hill', path: '/stay/cassis/', claimIds: ['claim-venue-name', 'claim-location'] },
+            line: { id: 'secondary-cassis-line', text: 'Cassis Red Hill sits in the Red Hill corridor.', claimIds: ['claim-venue-name', 'claim-location'] },
+          },
+          {
+            id: 'secondary-hotel-sorrento', dayStamp: 'SUN', category: 'STAY',
+            venue: { name: 'Hotel Sorrento', path: '/stay/hotel-sorrento/', claimIds: ['claim-venue-name-2'] },
+            line: { id: 'secondary-hotel-sorrento-line', text: 'The site record names this stay Hotel Sorrento.', claimIds: ['claim-venue-name-2'] },
+          },
+        ],
+      },
+      options.omitAuthoritativeInputs
+        ? { id: 'insider_note.position.06.reader_reply', position: 6, key: 'reader_reply', status: 'omitted', reason: 'no_usable_reply' }
+        : {
+          id: 'insider_note.position.06.reader_reply', position: 6, key: 'reader_reply', status: 'included', firstName: 'Mia',
+          quote: 'The covered room saved our rainy lunch.', claimIds: ['claim-reply'], privacy: 'first_name_only',
+          sourceLocator: { sourceItemId: 'source-reader-reply', locator: 'reply:1', excerptHash: hash('The covered room saved our rainy lunch.') },
+        },
+      {
+        id: 'insider_note.position.07.also_this_week', position: 7, key: 'also_this_week', status: 'included',
+        rows: [{ id: 'also-1', date: '2026-08-29', dayStamp: 'SAT', line: { id: 'also-line-1', text: 'The listed winter lunch falls on Saturday 29 August.', claimIds: ['claim-date'] } }],
+      },
+      {
+        id: 'insider_note.position.08.booking_note', position: 8, key: 'booking_note', status: 'included',
+        line: { id: 'booking-line', text: 'Booking is required for the Saturday winter lunch.', claimIds: ['claim-date', 'claim-booking'] },
+        link: { id: 'booking-link', label: 'Book the winter lunch', href: emailUrl('/journal/red-hill-wet-weather-lunch/'), claimIds: ['claim-date', 'claim-booking'] },
+        timeSensitiveClaimIds: ['claim-date', 'claim-booking'],
+      },
+      { id: 'insider_note.position.09.poll', position: 9, key: 'poll', status: 'editorial_decision', delivery: 'beehiiv_native', suppliedQuestion: null, suppliedBy: null },
+      { id: 'insider_note.position.10.reply_prompt_signoff', position: 10, key: 'reply_prompt_signoff', status: 'locked', replyPrompt: 'Been somewhere brilliant this week that we should know about? Just hit reply. We read everything.', signoff: 'The Insider.' },
+      {
+        id: 'insider_note.position.11.footer', position: 11, key: 'footer', status: 'locked', issueNumberRoman: 'VII', dateRange: '24–30 August 2026',
+        navigation: [
+          { key: 'this_weekend', id: 'footer-weekend', label: 'this weekend', href: emailUrl('/this-weekend/'), claimIds: ['claim-date'] },
+          { key: 'whats_on', id: 'footer-whats-on', label: "what's on", href: emailUrl('/whats-on/'), claimIds: ['claim-date'] },
+          { key: 'journal', id: 'footer-journal', label: 'journal', href: emailUrl('/journal/'), claimIds: ['claim-date'] },
+        ],
+        includeUnsubscribe: true,
+        includeStreetAddress: true,
+      },
+    ],
+  });
+  const issueUsageSeed = [
+    { segmentId: 'issue-date-range', path: '$.positions[0].dateRange', claimIds: ['claim-date'] },
+    { segmentId: 'issue-intro', path: '$.positions[1].lines[0].text', claimIds: ['claim-location', 'claim-observation'] },
+    { segmentId: 'issue-lead-headline', path: '$.positions[2].headline.text', claimIds: ['claim-date', 'claim-observation'] },
+    { segmentId: 'issue-lead-body', path: '$.positions[2].body.text', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'issue-lead-cta', path: '$.positions[2].cta.label', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'issue-secondary-venue', path: '$.positions[4].picks[0].venue.name', claimIds: ['claim-venue-name'] },
+    { segmentId: 'issue-secondary-line', path: '$.positions[4].picks[0].line.text', claimIds: ['claim-venue-name', 'claim-location'] },
+    { segmentId: 'issue-secondary-venue-2', path: '$.positions[4].picks[1].venue.name', claimIds: ['claim-venue-name-2'] },
+    { segmentId: 'issue-secondary-line-2', path: '$.positions[4].picks[1].line.text', claimIds: ['claim-venue-name-2'] },
+    { segmentId: 'issue-also-line', path: '$.positions[6].rows[0].line.text', claimIds: ['claim-date'] },
+    { segmentId: 'issue-booking-line', path: '$.positions[7].line.text', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'issue-booking-link', path: '$.positions[7].link.label', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'issue-footer-range', path: '$.positions[10].dateRange', claimIds: ['claim-date'] },
+    ...(options.omitAuthoritativeInputs ? [] : [
+      { segmentId: 'issue-weather', path: '$.positions[3]', claimIds: ['claim-weather'] },
+      { segmentId: 'issue-reader-reply', path: '$.positions[5].quote', claimIds: ['claim-reply'] },
+    ]),
+  ];
+  const issueUsage = bindClaimUsage(issuePayload, issueUsageSeed);
+  const issue = withArtifactHash({
+    id: 'artifact-insider-note-07', key: 'insider-note-issue', version: 1, type: 'insider_note_issue' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: issueUsage.map((usage) => usage.segmentId), claimUsage: issueUsage,
+    dependencies: [...commonDependencies, articleDependency], payload: issuePayload,
+    gateResults: [
+      ...evaluateArtifactGates(issuePayload, claims, issueUsage.map((usage) => usage.segmentId), issueUsage, capturedAt),
+      ...evaluateArtifactFormatGates('insider_note_issue', issuePayload, claims, capturedAt),
+    ],
+  });
+  const issueDependency = { kind: 'artifact' as const, id: issue.id, version: issue.version, contentHash: issue.contentHash };
+
+  const subjectPayload = InsiderNoteSubjectSetPayloadSchema.parse({
+    schemaVersion: 'pi.insider-note-subject-set.v1',
+    pairs: [
+      { id: 'subject-a', subject: 'A rainy-day lunch move for Red Hill', previewText: 'Covered dining and a Saturday service worth planning around.' },
+      { id: 'subject-b', subject: 'What to do with a wet Saturday', previewText: 'One practical Red Hill anchor, plus the week in brief.' },
+      { id: 'subject-c', subject: 'Red Hill, under cover', previewText: 'The winter lunch listed for Saturday 29 August needs a booking.' },
+    ],
+    selectedPairId: null,
+    selectionAuthority: 'james_only',
+    scheduleAt: null,
+    sendAuthority: 'james_only',
+  });
+  const subjectUsage = bindClaimUsage(subjectPayload, subjectPayload.pairs.flatMap((pair, index) => [
+    { segmentId: `subject-${index + 1}`, path: `$.pairs[${index}].subject`, claimIds: ['claim-location', 'claim-date', 'claim-observation'] },
+    { segmentId: `preview-${index + 1}`, path: `$.pairs[${index}].previewText`, claimIds: ['claim-location', 'claim-date', 'claim-booking', 'claim-observation'] },
+  ]));
+  const subjectSet = withArtifactHash({
+    id: 'artifact-insider-note-subjects-07', key: 'insider-note-subjects', version: 1, type: 'insider_note_subject_set' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: subjectUsage.map((usage) => usage.segmentId), claimUsage: subjectUsage,
+    dependencies: [...commonDependencies, issueDependency], payload: subjectPayload,
+    gateResults: [
+      ...evaluateArtifactGates(subjectPayload, claims, subjectUsage.map((usage) => usage.segmentId), subjectUsage, capturedAt),
+      ...evaluateArtifactFormatGates('insider_note_subject_set', subjectPayload, claims, capturedAt),
+    ],
+  });
+
+  const linkedInPayload = LinkedInPostPayloadSchema.parse({
+    schemaVersion: 'pi.linkedin-post.v1',
+    openingMode: 'specific_observation',
+    text: 'A covered dining room changes the shape of a wet Peninsula day. In Red Hill, the winter lunch is listed for Saturday 29 August, with booking required. The useful part is not novelty for its own sake. It is having one dependable indoor anchor before the rest of the day takes shape. That is the kind of practical local detail Peninsula Insider is built to surface.',
+    destinationUrl: 'https://peninsulainsider.com.au/journal/red-hill-wet-weather-lunch/?utm_source=linkedin&utm_medium=social&utm_campaign=red-hill-wet-weather-lunch',
+    hashtags: ['#RedHill', '#MorningtonPeninsula'],
+    scheduleAt: null, publicationAuthority: 'james_only', operationalState: 'draft_only',
+  });
+  const linkedInUsage = bindClaimUsage(linkedInPayload, [{ segmentId: 'linkedin-copy', path: '$.text', claimIds: ['claim-location', 'claim-date', 'claim-booking', 'claim-observation'] }]);
+  const linkedIn = withArtifactHash({
+    id: 'artifact-linkedin-red-hill', key: 'linkedin-post', version: 1, type: 'linkedin_post' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: ['linkedin-copy'], claimUsage: linkedInUsage,
+    dependencies: [...commonDependencies, articleDependency], payload: linkedInPayload,
+    gateResults: [...evaluateArtifactGates(linkedInPayload, claims, ['linkedin-copy'], linkedInUsage, capturedAt), ...evaluateArtifactFormatGates('linkedin_post', linkedInPayload, claims, capturedAt)],
+  });
+
+  const captionPayload = InstagramCaptionPayloadSchema.parse({
+    schemaVersion: 'pi.instagram-caption.v1',
+    openingMode: 'observation',
+    captionDraft: 'A covered room changes the shape of a wet Peninsula day.\nThe Red Hill winter lunch is listed for 29 August, with booking required.',
+    destinationPath: '/journal/red-hill-wet-weather-lunch/',
+    cadenceDecision: 'unresolved', hashtagPlacementDecision: 'unresolved',
+    scheduleAt: null, publicationAuthority: 'james_only', operationalState: 'draft_only',
+  });
+  const captionUsage = bindClaimUsage(captionPayload, [{ segmentId: 'instagram-caption', path: '$.captionDraft', claimIds: ['claim-location', 'claim-date', 'claim-booking', 'claim-observation'] }]);
+  const caption = withArtifactHash({
+    id: 'artifact-instagram-caption-red-hill', key: 'instagram-caption', version: 1, type: 'instagram_caption' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: ['instagram-caption'], claimUsage: captionUsage,
+    dependencies: [...commonDependencies, articleDependency], payload: captionPayload,
+    gateResults: [...evaluateArtifactGates(captionPayload, claims, ['instagram-caption'], captionUsage, capturedAt), ...evaluateArtifactFormatGates('instagram_caption', captionPayload, claims, capturedAt)],
+  });
+  const captionDependency = { kind: 'artifact' as const, id: caption.id, version: caption.version, contentHash: caption.contentHash };
+
+  const firstCommentPayload = InstagramFirstCommentPayloadSchema.parse({
+    schemaVersion: 'pi.instagram-first-comment.v1',
+    commentDraft: 'Save this for the next wet-weather Peninsula plan.',
+    hashtagCandidates: ['#RedHill', '#MorningtonPeninsula', '#PeninsulaInsider'],
+    placementDecision: 'unresolved', cadenceDecision: 'unresolved',
+    scheduleAt: null, publicationAuthority: 'james_only', operationalState: 'draft_only',
+  });
+  const firstCommentUsage = bindClaimUsage(firstCommentPayload, [
+    { segmentId: 'instagram-first-comment', path: '$.commentDraft', claimIds: ['claim-observation'] },
+    { segmentId: 'instagram-hashtag-candidates', path: '$.hashtagCandidates', claimIds: ['claim-location'] },
+  ]);
+  const firstComment = withArtifactHash({
+    id: 'artifact-instagram-first-comment-red-hill', key: 'instagram-first-comment', version: 1, type: 'instagram_first_comment' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: firstCommentUsage.map((usage) => usage.segmentId), claimUsage: firstCommentUsage,
+    dependencies: [...commonDependencies, captionDependency], payload: firstCommentPayload,
+    gateResults: [...evaluateArtifactGates(firstCommentPayload, claims, firstCommentUsage.map((usage) => usage.segmentId), firstCommentUsage, capturedAt), ...evaluateArtifactFormatGates('instagram_first_comment', firstCommentPayload, claims, capturedAt)],
+  });
+
+  const carouselPayload = InstagramCarouselScriptPayloadSchema.parse({
+    schemaVersion: 'pi.instagram-carousel-script.v1',
+    slides: [
+      { number: 1, heading: 'Wet Saturday?', body: 'Start with one indoor anchor in Red Hill.', claimIds: ['claim-location', 'claim-observation'] },
+      { number: 2, heading: 'The move', body: 'The winter lunch is listed for Saturday 29 August.', claimIds: ['claim-date'] },
+      { number: 3, heading: 'Before you go', body: 'Booking is required.', claimIds: ['claim-booking'] },
+    ],
+    scheduleAt: null, publicationAuthority: 'james_only', operationalState: 'draft_only',
+  });
+  const carouselUsage = bindClaimUsage(carouselPayload, carouselPayload.slides.map((slide, index) => ({
+    segmentId: `carousel-slide-${slide.number}`, path: `$.slides[${index}]`, claimIds: slide.claimIds,
+  })));
+  const carousel = withArtifactHash({
+    id: 'artifact-instagram-carousel-red-hill', key: 'instagram-carousel', version: 1, type: 'instagram_carousel_script' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: carouselUsage.map((usage) => usage.segmentId), claimUsage: carouselUsage,
+    dependencies: [...commonDependencies, articleDependency], payload: carouselPayload,
+    gateResults: [...evaluateArtifactGates(carouselPayload, claims, carouselUsage.map((usage) => usage.segmentId), carouselUsage, capturedAt), ...evaluateArtifactFormatGates('instagram_carousel_script', carouselPayload, claims, capturedAt)],
+  });
+  const carouselDependency = { kind: 'artifact' as const, id: carousel.id, version: carousel.version, contentHash: carousel.contentHash };
+
+  const placementRights = options.clearInstagramRights === false
+    ? { status: 'not_cleared' as const, allowedSurfaces: ['website'] as const, recognisablePeople: 'unknown' as const }
+    : { status: 'cleared' as const, allowedSurfaces: ['instagram'] as const, recognisablePeople: 'none' as const, rightsId: 'rights-red-hill-instagram-01' };
+  const mediaBriefPayload = SocialMediaBriefPayloadSchema.parse({
+    schemaVersion: 'pi.social-media-brief.v1', assetId: 'asset-red-hill-hinterland-01',
+    targetSurface: 'instagram', placement: 'carousel', mediaType: 'carousel',
+    description: 'A three-frame Red Hill wet-weather carousel using the cleared hinterland image.',
+    altText: 'Red Hill hinterland in late autumn beneath a grey sky.',
+    placementRights,
+    scheduleAt: null, publicationAuthority: 'james_only', operationalState: 'draft_only',
+  });
+  const mediaUsage = bindClaimUsage(mediaBriefPayload, [
+    { segmentId: 'media-description', path: '$.description', claimIds: ['claim-image', 'claim-location'] },
+    { segmentId: 'media-alt', path: '$.altText', claimIds: ['claim-image'] },
+  ]);
+  const mediaDependencies: ArtifactVersion['dependencies'] = [...commonDependencies, carouselDependency];
+  if (placementRights.status === 'cleared') {
+    mediaDependencies.push({
+      kind: 'media_rights', id: placementRights.rightsId, version: 1,
+      contentHash: hashValue(socialMediaRightsSnapshot(mediaBriefPayload)), status: 'cleared',
+    });
+  }
+  const mediaBrief = withArtifactHash({
+    id: 'artifact-social-media-brief-red-hill', key: 'social-media-brief', version: 1, type: 'social_media_brief' as const,
+    angleId: base.angle.id, angleVersion: base.angle.version,
+    factualSegmentIds: mediaUsage.map((usage) => usage.segmentId), claimUsage: mediaUsage,
+    dependencies: mediaDependencies, payload: mediaBriefPayload,
+    gateResults: [...evaluateArtifactGates(mediaBriefPayload, claims, mediaUsage.map((usage) => usage.segmentId), mediaUsage, capturedAt), ...evaluateArtifactFormatGates('social_media_brief', mediaBriefPayload, claims, capturedAt)],
+  });
+
+  const completed: ArtifactVersion[] = [article, issue, subjectSet, linkedIn, caption, firstComment, carousel, mediaBrief];
+  return FoundryRunSchema.parse({
+    ...base,
+    bundle: { ...base.bundle, id: `bundle-${NEWSLETTER_SOCIAL_FIXTURE_ID}`, title: 'Red Hill newsletter and social fixture' },
+    recipe: NEWSLETTER_SOCIAL_RECIPE,
+    artifactPack: {
+      ...base.artifactPack,
+      recipeId: NEWSLETTER_SOCIAL_RECIPE.id,
+      recipeVersion: NEWSLETTER_SOCIAL_RECIPE.version,
+      status: 'complete', completed, failed: [], omitted: [], reviews: [],
+    },
+    blockers: [],
+    audit: [{ at: capturedAt, actor, type: 'fixture_run_created', detail: 'Deterministic Insider Note and social draft pack reached review without external calls.' }],
+  });
+}
+
 function acceptedCurrentReview(run: FoundryRun, artifact: ArtifactVersion): boolean {
   return run.artifactPack.reviews.some((review) => (
     review.artifactId === artifact.id
@@ -645,6 +1133,7 @@ export function validateNewFilePatch(patch: string): boolean {
 }
 
 function assertArtifactReady(run: FoundryRun, artifact: ArtifactVersion): void {
+  if (!run.evaluationAsOf) throw new Error('Run must be reconciled against an explicit evaluation time before export');
   if (artifact.gateResults.some((result) => !result.passed && result.blocking)) throw new Error(`Artifact ${artifact.id} has unresolved gates`);
   const freshGates = artifact.type === 'quick_note'
     ? evaluateQuickNoteGates(artifact.payload, run.claimSet.claims, artifact.claimIds)
@@ -653,19 +1142,52 @@ function assertArtifactReady(run: FoundryRun, artifact: ArtifactVersion): void {
       run.claimSet.claims,
       artifact.factualSegmentIds,
       artifact.claimUsage,
-      new Date().toISOString(),
+      run.evaluationAsOf,
       artifact.type === 'ask_answer'
         ? { gate: 'ask_answer_contract', schema: AskAnswerPayloadSchema }
         : artifact.type === 'article_metadata' && artifact.payload.astroPatchReady
           ? { gate: 'astro_article_contract', schema: ArticleMetadataPayloadSchema }
           : undefined,
     );
+  freshGates.push(...evaluateArtifactFormatGates(artifact.type, artifact.payload, run.claimSet.claims, run.evaluationAsOf));
   if (freshGates.some((result) => !result.passed && result.blocking)) throw new Error(`Artifact ${artifact.id} failed fresh export gates`);
   if (!artifactDependenciesCurrent(run, artifact)) throw new Error(`Artifact ${artifact.id} has stale dependencies`);
   if (!acceptedCurrentReview(run, artifact)) throw new Error(`Artifact ${artifact.id} requires a current accepted draft-handoff review`);
   const publicCopy = JSON.stringify(artifact.payload);
   if (PRICE_PATTERN.test(publicCopy)) throw new Error('PI outputs cannot contain pricing');
   if (/—/.test(publicCopy)) throw new Error('PI outputs cannot contain em dashes');
+}
+
+export function buildArtifactHandoff(run: FoundryRun, artifactId: string): { filename: string; body: string } {
+  if (run.blockers.length > 0) throw new Error('Run has unresolved blockers');
+  const artifact = run.artifactPack.completed.find((candidate) => candidate.id === artifactId);
+  if (!artifact) throw new Error('Artifact not found');
+  assertArtifactReady(run, artifact);
+  const requirement = run.recipe.artifacts.find((candidate) => candidate.key === artifact.key);
+  if (!requirement) throw new Error('Artifact is not declared by the active recipe');
+  const body = `${JSON.stringify({
+    schemaVersion: 'pi.draft-handoff.v1',
+    authority: 'draft_handoff_only',
+    publication: false,
+    scheduling: false,
+    evaluationAsOf: run.evaluationAsOf,
+    runRef: { id: run.id, version: run.version },
+    claimSetRef: run.artifactPack.claimSetRef,
+    angleRef: run.artifactPack.angleRef,
+    artifact: {
+      id: artifact.id,
+      key: artifact.key,
+      type: artifact.type,
+      version: artifact.version,
+      contentHash: artifact.contentHash,
+      targetContract: requirement.targetContract,
+      claimUsage: artifact.claimUsage,
+      payload: artifact.payload,
+    },
+  }, null, 2)}\n`;
+  if (PRICE_PATTERN.test(body)) throw new Error('PI handoffs cannot contain pricing');
+  if (/—/.test(body)) throw new Error('PI handoffs cannot contain em dashes');
+  return { filename: `${run.id}-${artifact.key}.json`, body };
 }
 
 export function buildPatch(run: FoundryRun): string {

--- a/studio-peninsula-insider/server/store.ts
+++ b/studio-peninsula-insider/server/store.ts
@@ -1,18 +1,156 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
-import { FoundryRunSchema, QuickNoteSchema, type ArtifactEdit, type FoundryRun, type ReviewDecision } from '../shared/contracts.js';
-import { evaluateQuickNoteGates } from './fixture-runner.js';
+import {
+  ArticleDraftPayloadSchema,
+  ArticleMetadataPayloadSchema,
+  ArtifactUpdateSchema,
+  ArtifactVersionSchema,
+  AskAnswerPayloadSchema,
+  FoundryRunSchema,
+  InternalLinkPlanPayloadSchema,
+  QuickNoteSchema,
+  SeoMetadataProposalPayloadSchema,
+  type ArtifactEdit,
+  type ArtifactUpdate,
+  type ArtifactVersion,
+  type FoundryRun,
+  type GateResult,
+  type ReviewDecision,
+} from '../shared/contracts.js';
+import { artifactDependenciesCurrent, evaluateArtifactGates, evaluateQuickNoteGates, hashValue, migrateLegacyRun } from './fixture-runner.js';
 
 interface StoreFile {
   schemaVersion: 'pi.foundry-file-store.v1';
   runs: FoundryRun[];
 }
 
+function blockingGateFailed(artifact: ArtifactVersion): boolean {
+  return artifact.gateResults.some((result) => !result.passed && result.blocking);
+}
+
+function requiredArtifactIds(run: FoundryRun): Set<string> {
+  const requiredKeys = new Set(run.recipe.artifacts.filter((requirement) => requirement.required).map((requirement) => requirement.key));
+  return new Set(run.artifactPack.completed.filter((artifact) => requiredKeys.has(artifact.key)).map((artifact) => artifact.id));
+}
+
+function deriveRunStatus(run: FoundryRun): FoundryRun['status'] {
+  const requiredKeys = new Set(run.recipe.artifacts.filter((requirement) => requirement.required).map((requirement) => requirement.key));
+  const requiredFailure = run.artifactPack.failed.some((failure) => failure.required)
+    || run.artifactPack.completed.some((artifact) => requiredKeys.has(artifact.key) && blockingGateFailed(artifact));
+  if (run.blockers.length > 0 || requiredFailure) return 'needs_revision';
+
+  const requiredIds = requiredArtifactIds(run);
+  const requiredRejected = run.artifactPack.reviews.some((review) => (
+    review.status === 'current' && review.decision === 'rejected' && requiredIds.has(review.artifactId)
+  ));
+  if (requiredRejected) return 'needs_revision';
+
+  // Run-level accepted is retained only for the single-artifact v0.1 contract.
+  if (run.recipe.id === 'quick_note_v1' && run.artifact) {
+    const current = run.artifactPack.reviews.find((review) => review.artifactId === run.artifact?.id && review.status === 'current');
+    if (current?.decision === 'accepted') return 'accepted';
+    if (current?.decision === 'rejected') return 'rejected';
+  }
+  return 'ready_for_review';
+}
+
 function normalizeDerivedStatus(run: FoundryRun): FoundryRun {
-  const hasFailedGate = run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed);
-  if (!hasFailedGate || !['ready_for_review', 'accepted'].includes(run.status)) return run;
-  return FoundryRunSchema.parse({ ...run, status: 'needs_revision', review: undefined });
+  const asOf = new Date().toISOString();
+  const completed = run.artifactPack.completed.map((artifact) => {
+    const current = artifactDependenciesCurrent(run, artifact);
+    const evaluatedGates = gatesForUpdatedArtifact(
+      run, artifact, artifact.payload, artifact.factualSegmentIds, artifact.claimUsage, asOf,
+    );
+    const gateResults = evaluatedGates.map((evaluated) => {
+      if (artifact.type !== 'quick_note') return evaluated;
+      const storedFailure = artifact.gateResults.find((stored) => stored.gate === evaluated.gate && !stored.passed);
+      return storedFailure ?? evaluated;
+    }).filter((result) => result.gate !== 'dependency_current');
+    gateResults.push(current
+      ? {
+        gate: 'dependency_current', scope: 'artifact', passed: true, blocking: false,
+        detail: 'Claim-set, angle, artifact and media-rights dependencies match their current snapshots.', claimIds: [],
+      }
+      : {
+        gate: 'dependency_current', scope: 'artifact', passed: false, blocking: true,
+        detail: 'One or more claim-set, angle, artifact or media-rights dependencies are stale; regenerate this artifact.', claimIds: [],
+      });
+    return ArtifactVersionSchema.parse({ ...artifact, gateResults });
+  });
+  const currentById = new Map(completed.map((artifact) => [artifact.id, artifact]));
+  const reviews = run.artifactPack.reviews.map((review) => {
+    if (review.status === 'stale') return review;
+    const artifact = currentById.get(review.artifactId);
+    const snapshotMatches = artifact
+      && review.artifactVersion === artifact.version
+      && JSON.stringify(review.dependencySnapshot) === JSON.stringify(artifact.dependencies)
+      && !blockingGateFailed(artifact);
+    return snapshotMatches ? review : { ...review, status: 'stale' as const };
+  });
+  const compatibilityArtifact = run.artifact
+    ? completed.find((artifact) => artifact.id === run.artifact?.id && artifact.type === 'quick_note')
+    : undefined;
+  const compatibilityReviewCurrent = compatibilityArtifact && reviews.some((review) => (
+    review.artifactId === compatibilityArtifact.id && review.status === 'current'
+  ));
+  const normalized = FoundryRunSchema.parse({
+    ...run,
+    artifact: compatibilityArtifact,
+    review: compatibilityReviewCurrent ? run.review : undefined,
+    artifactPack: { ...run.artifactPack, completed, reviews },
+  });
+  return FoundryRunSchema.parse({ ...normalized, status: deriveRunStatus(normalized) });
+}
+
+function parseStoredRun(input: unknown): FoundryRun {
+  const current = FoundryRunSchema.safeParse(input);
+  return normalizeDerivedStatus(current.success ? current.data : migrateLegacyRun(input));
+}
+
+function parsePayloadForArtifact(artifact: ArtifactVersion, payload: unknown): ArtifactVersion['payload'] {
+  switch (artifact.type) {
+    case 'quick_note': return QuickNoteSchema.parse(payload);
+    case 'article_draft': return ArticleDraftPayloadSchema.parse(payload);
+    case 'article_metadata': return ArticleMetadataPayloadSchema.parse(payload);
+    case 'ask_answer': return AskAnswerPayloadSchema.parse(payload);
+    case 'internal_link_plan': return InternalLinkPlanPayloadSchema.parse(payload);
+    case 'seo_metadata_proposal': return SeoMetadataProposalPayloadSchema.parse(payload);
+  }
+}
+
+function gatesForUpdatedArtifact(
+  run: FoundryRun,
+  artifact: ArtifactVersion,
+  payload: unknown,
+  factualSegmentIds: string[],
+  claimUsage: ArtifactVersion['claimUsage'],
+  asOf = run.updatedAt,
+): GateResult[] {
+  if (artifact.type === 'quick_note') {
+    const note = QuickNoteSchema.parse(payload);
+    return evaluateQuickNoteGates(note, run.claimSet.claims, claimUsage.flatMap((usage) => usage.claimIds));
+  }
+  const contract = artifact.type === 'ask_answer'
+    ? { gate: 'ask_answer_contract' as const, schema: AskAnswerPayloadSchema }
+    : artifact.type === 'article_metadata' && ArticleMetadataPayloadSchema.parse(payload).astroPatchReady
+      ? { gate: 'astro_article_contract' as const, schema: ArticleMetadataPayloadSchema }
+      : undefined;
+  const results = evaluateArtifactGates(
+    payload,
+    run.claimSet.claims,
+    factualSegmentIds,
+    claimUsage,
+    asOf,
+    contract,
+  );
+  if (artifact.type === 'article_metadata') {
+    const metadata = ArticleMetadataPayloadSchema.parse(payload);
+    results.push(metadata.astroPatchReady
+      ? { gate: 'astro_patch_ready', scope: 'artifact', passed: true, blocking: false, detail: 'A separately rights-cleared hero placement makes the Astro patch adapter available.', claimIds: [] }
+      : { gate: 'astro_patch_ready', scope: 'artifact', passed: false, blocking: false, detail: 'Text artifacts remain reviewable, but Astro patch export waits for a rights-cleared hero placement.', claimIds: [] });
+  }
+  return results;
 }
 
 export class VersionConflictError extends Error {}
@@ -45,9 +183,9 @@ export class FileFoundryStore {
   private async read(): Promise<StoreFile> {
     try {
       const raw = await readFile(this.filePath, 'utf8');
-      const parsed = JSON.parse(raw) as StoreFile;
-      if (parsed.schemaVersion !== 'pi.foundry-file-store.v1') throw new Error('Unsupported Foundry store schema');
-      return { schemaVersion: parsed.schemaVersion, runs: parsed.runs.map((run) => normalizeDerivedStatus(FoundryRunSchema.parse(run))) };
+      const parsed = JSON.parse(raw) as { schemaVersion?: string; runs?: unknown[] };
+      if (parsed.schemaVersion !== 'pi.foundry-file-store.v1' || !Array.isArray(parsed.runs)) throw new Error('Unsupported Foundry store schema');
+      return { schemaVersion: parsed.schemaVersion, runs: parsed.runs.map(parseStoredRun) };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { schemaVersion: 'pi.foundry-file-store.v1', runs: [] };
       throw error;
@@ -87,9 +225,10 @@ export class FileFoundryStore {
       const data = await this.read();
       const existing = data.runs.find((item) => item.idempotencyKey === run.idempotencyKey);
       if (existing) return existing;
-      data.runs.unshift(FoundryRunSchema.parse(run));
+      const parsed = normalizeDerivedStatus(FoundryRunSchema.parse(run));
+      data.runs.unshift(parsed);
       await this.write(data);
-      return run;
+      return parsed;
     });
   }
 
@@ -102,28 +241,50 @@ export class FileFoundryStore {
       if (run.version !== decision.expectedVersion) {
         throw new VersionConflictError(`Expected version ${decision.expectedVersion}; current version is ${run.version}`);
       }
-      if (decision.decision === 'accepted' && (run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed))) {
-        throw new Error('Artifact has unresolved blockers or failed gates');
+      const artifactId = decision.artifactId ?? run.artifact?.id;
+      if (!artifactId) throw new Error('artifactId is required for an artifact pack review');
+      const artifact = run.artifactPack.completed.find((candidate) => candidate.id === artifactId);
+      if (!artifact) throw new Error('Artifact not found in completed pack items');
+      if (decision.expectedArtifactVersion && decision.expectedArtifactVersion !== artifact.version) {
+        throw new VersionConflictError(`Expected artifact version ${decision.expectedArtifactVersion}; current version is ${artifact.version}`);
+      }
+      if (decision.decision === 'accepted' && blockingGateFailed(artifact)) {
+        throw new Error('Artifact has unresolved blocking gates');
       }
       const now = new Date().toISOString();
-      const updated = FoundryRunSchema.parse({
+      const reviews = run.artifactPack.reviews
+        .map((review) => review.artifactId === artifact.id && review.status === 'current' ? { ...review, status: 'stale' as const } : review);
+      reviews.push({
+        id: `review-${randomUUID()}`,
+        artifactId: artifact.id,
+        artifactVersion: artifact.version,
+        decision: decision.decision,
+        reviewer: decision.reviewer,
+        note: decision.note,
+        decidedAt: now,
+        status: 'current',
+        dependencySnapshot: artifact.dependencies,
+        authority: 'draft_handoff_only',
+      });
+      const candidate = FoundryRunSchema.parse({
         ...run,
         version: run.version + 1,
-        status: decision.decision,
         updatedAt: now,
-        review: {
+        artifactPack: { ...run.artifactPack, version: run.artifactPack.version + 1, reviews },
+        review: run.artifact?.id === artifact.id ? {
           decision: decision.decision,
           reviewer: decision.reviewer,
           note: decision.note,
           decidedAt: now,
-        },
+        } : run.review,
         audit: [...run.audit, {
           at: now,
           actor: decision.reviewer,
-          type: 'review_decision',
-          detail: `${decision.decision} artifact ${run.artifact.id}`,
+          type: 'artifact_review_decision',
+          detail: `${decision.decision} draft handoff for artifact ${artifact.id}; publication authority was not granted.`,
         }],
       });
+      const updated = normalizeDerivedStatus(candidate);
       data.runs[index] = updated;
       await this.write(data);
       return updated;
@@ -131,45 +292,110 @@ export class FileFoundryStore {
   }
 
   async updateArtifact(id: string, edit: ArtifactEdit): Promise<FoundryRun> {
+    const input = ArtifactUpdateSchema.parse({
+      editor: edit.editor,
+      expectedVersion: edit.expectedVersion,
+      expectedArtifactVersion: 1,
+      payload: undefined,
+    });
     return this.mutate(async () => {
       const data = await this.read();
       const index = data.runs.findIndex((run) => run.id === id);
       if (index < 0) throw new Error('Run not found');
       const run = data.runs[index];
-      if (run.version !== edit.expectedVersion) {
-        throw new VersionConflictError(`Expected version ${edit.expectedVersion}; current version is ${run.version}`);
-      }
-
-      const payload = QuickNoteSchema.parse({
-        ...run.artifact.payload,
-        headline: edit.headline,
-        dek: edit.dek,
-        body: edit.body,
-      });
-      const now = new Date().toISOString();
-      const gateResults = evaluateQuickNoteGates(payload, run.claims, run.artifact.claimIds);
-      const updated = FoundryRunSchema.parse({
-        ...run,
-        version: run.version + 1,
-        status: gateResults.some((gate) => !gate.passed) ? 'needs_revision' : 'ready_for_review',
-        updatedAt: now,
-        review: undefined,
-        artifact: {
-          ...run.artifact,
-          version: run.artifact.version + 1,
-          payload,
-          gateResults,
-        },
-        audit: [...run.audit, {
-          at: now,
-          actor: edit.editor,
-          type: 'artifact_edited',
-          detail: `Edited artifact ${run.artifact.id}; any prior decision was invalidated.`,
-        }],
-      });
+      if (!run.artifact) throw new Error('Compatibility edit endpoint supports quick-note runs only');
+      input.expectedArtifactVersion = run.artifact.version;
+      input.payload = QuickNoteSchema.parse({ ...run.artifact.payload, headline: edit.headline, dek: edit.dek, body: edit.body });
+      const updated = this.applyArtifactUpdate(run, run.artifact.id, input);
       data.runs[index] = updated;
       await this.write(data);
       return updated;
     });
+  }
+
+  async updatePackArtifact(id: string, artifactId: string, rawUpdate: ArtifactUpdate): Promise<FoundryRun> {
+    const update = ArtifactUpdateSchema.parse(rawUpdate);
+    return this.mutate(async () => {
+      const data = await this.read();
+      const index = data.runs.findIndex((run) => run.id === id);
+      if (index < 0) throw new Error('Run not found');
+      const updated = this.applyArtifactUpdate(data.runs[index], artifactId, update);
+      data.runs[index] = updated;
+      await this.write(data);
+      return updated;
+    });
+  }
+
+  private applyArtifactUpdate(run: FoundryRun, artifactId: string, update: ArtifactUpdate): FoundryRun {
+    if (run.version !== update.expectedVersion) {
+      throw new VersionConflictError(`Expected version ${update.expectedVersion}; current version is ${run.version}`);
+    }
+    const artifactIndex = run.artifactPack.completed.findIndex((candidate) => candidate.id === artifactId);
+    if (artifactIndex < 0) throw new Error('Artifact not found');
+    const current = run.artifactPack.completed[artifactIndex];
+    if (current.version !== update.expectedArtifactVersion) {
+      throw new VersionConflictError(`Expected artifact version ${update.expectedArtifactVersion}; current version is ${current.version}`);
+    }
+    let payload = parsePayloadForArtifact(current, update.payload);
+    let dependencies = current.dependencies;
+    let factualSegmentIds = update.factualSegmentIds;
+    let claimUsage = update.claimUsage;
+    if (current.type === 'quick_note') {
+      factualSegmentIds = ['quick-note-copy'];
+      claimUsage = [{
+        segmentId: 'quick-note-copy', path: '$',
+        claimIds: current.claimUsage.flatMap((usage) => usage.claimIds), contentHash: hashValue(payload),
+      }];
+    } else if (!factualSegmentIds || !claimUsage) {
+      throw new Error('Non-quick artifact edits require factualSegmentIds and claimUsage to be replaced atomically with the payload');
+    }
+    if (current.type === 'article_metadata') {
+      const metadata = ArticleMetadataPayloadSchema.parse(payload);
+      const retainedMedia = current.dependencies.filter((dependency) => (
+        dependency.kind === 'media_rights'
+        && metadata.heroImage
+        && dependency.contentHash === hashValue(metadata.heroImage)
+      ));
+      dependencies = [
+        ...current.dependencies.filter((dependency) => dependency.kind !== 'media_rights'),
+        ...retainedMedia,
+      ];
+      payload = ArticleMetadataPayloadSchema.parse({
+        ...metadata,
+        astroPatchReady: Boolean(metadata.heroImage && retainedMedia.length === 1),
+      });
+    }
+    const changed = ArtifactVersionSchema.parse({
+      ...current,
+      version: current.version + 1,
+      contentHash: hashValue(payload),
+      payload,
+      factualSegmentIds,
+      claimUsage,
+      dependencies,
+      gateResults: gatesForUpdatedArtifact(run, current, payload, factualSegmentIds, claimUsage),
+    });
+    const completed = run.artifactPack.completed.map((artifact, index) => index === artifactIndex ? changed : artifact);
+    const now = new Date().toISOString();
+    const candidate = FoundryRunSchema.parse({
+      ...run,
+      version: run.version + 1,
+      updatedAt: now,
+      artifact: run.artifact?.id === changed.id && changed.type === 'quick_note' ? changed : run.artifact,
+      review: run.artifact?.id === changed.id ? undefined : run.review,
+      artifactPack: {
+        ...run.artifactPack,
+        version: run.artifactPack.version + 1,
+        completed,
+        reviews: run.artifactPack.reviews,
+      },
+      audit: [...run.audit, {
+        at: now,
+        actor: update.editor,
+        type: 'artifact_edited',
+        detail: `Edited artifact ${changed.id}; read-time dependency reconciliation invalidated its review and all transitive dependent reviews.`,
+      }],
+    });
+    return normalizeDerivedStatus(candidate);
   }
 }

--- a/studio-peninsula-insider/server/store.ts
+++ b/studio-peninsula-insider/server/store.ts
@@ -8,9 +8,16 @@ import {
   ArtifactVersionSchema,
   AskAnswerPayloadSchema,
   FoundryRunSchema,
+  InstagramCaptionPayloadSchema,
+  InstagramCarouselScriptPayloadSchema,
+  InstagramFirstCommentPayloadSchema,
+  InsiderNoteIssuePayloadSchema,
+  InsiderNoteSubjectSetPayloadSchema,
   InternalLinkPlanPayloadSchema,
+  LinkedInPostPayloadSchema,
   QuickNoteSchema,
   SeoMetadataProposalPayloadSchema,
+  SocialMediaBriefPayloadSchema,
   type ArtifactEdit,
   type ArtifactUpdate,
   type ArtifactVersion,
@@ -18,7 +25,7 @@ import {
   type GateResult,
   type ReviewDecision,
 } from '../shared/contracts.js';
-import { artifactDependenciesCurrent, evaluateArtifactGates, evaluateQuickNoteGates, hashValue, migrateLegacyRun } from './fixture-runner.js';
+import { artifactDependenciesCurrent, evaluateArtifactFormatGates, evaluateArtifactGates, evaluateQuickNoteGates, hashValue, migrateLegacyRun, socialMediaRightsSnapshot } from './fixture-runner.js';
 
 interface StoreFile {
   schemaVersion: 'pi.foundry-file-store.v1';
@@ -55,8 +62,7 @@ function deriveRunStatus(run: FoundryRun): FoundryRun['status'] {
   return 'ready_for_review';
 }
 
-function normalizeDerivedStatus(run: FoundryRun): FoundryRun {
-  const asOf = new Date().toISOString();
+function normalizeDerivedStatus(run: FoundryRun, asOf: string): FoundryRun {
   const completed = run.artifactPack.completed.map((artifact) => {
     const current = artifactDependenciesCurrent(run, artifact);
     const evaluatedGates = gatesForUpdatedArtifact(
@@ -96,6 +102,7 @@ function normalizeDerivedStatus(run: FoundryRun): FoundryRun {
   ));
   const normalized = FoundryRunSchema.parse({
     ...run,
+    evaluationAsOf: asOf,
     artifact: compatibilityArtifact,
     review: compatibilityReviewCurrent ? run.review : undefined,
     artifactPack: { ...run.artifactPack, completed, reviews },
@@ -103,9 +110,9 @@ function normalizeDerivedStatus(run: FoundryRun): FoundryRun {
   return FoundryRunSchema.parse({ ...normalized, status: deriveRunStatus(normalized) });
 }
 
-function parseStoredRun(input: unknown): FoundryRun {
+function parseStoredRun(input: unknown, asOf: string): FoundryRun {
   const current = FoundryRunSchema.safeParse(input);
-  return normalizeDerivedStatus(current.success ? current.data : migrateLegacyRun(input));
+  return normalizeDerivedStatus(current.success ? current.data : migrateLegacyRun(input), asOf);
 }
 
 function parsePayloadForArtifact(artifact: ArtifactVersion, payload: unknown): ArtifactVersion['payload'] {
@@ -116,6 +123,13 @@ function parsePayloadForArtifact(artifact: ArtifactVersion, payload: unknown): A
     case 'ask_answer': return AskAnswerPayloadSchema.parse(payload);
     case 'internal_link_plan': return InternalLinkPlanPayloadSchema.parse(payload);
     case 'seo_metadata_proposal': return SeoMetadataProposalPayloadSchema.parse(payload);
+    case 'insider_note_issue': return InsiderNoteIssuePayloadSchema.parse(payload);
+    case 'insider_note_subject_set': return InsiderNoteSubjectSetPayloadSchema.parse(payload);
+    case 'linkedin_post': return LinkedInPostPayloadSchema.parse(payload);
+    case 'instagram_caption': return InstagramCaptionPayloadSchema.parse(payload);
+    case 'instagram_first_comment': return InstagramFirstCommentPayloadSchema.parse(payload);
+    case 'instagram_carousel_script': return InstagramCarouselScriptPayloadSchema.parse(payload);
+    case 'social_media_brief': return SocialMediaBriefPayloadSchema.parse(payload);
   }
 }
 
@@ -125,7 +139,7 @@ function gatesForUpdatedArtifact(
   payload: unknown,
   factualSegmentIds: string[],
   claimUsage: ArtifactVersion['claimUsage'],
-  asOf = run.updatedAt,
+  asOf: string,
 ): GateResult[] {
   if (artifact.type === 'quick_note') {
     const note = QuickNoteSchema.parse(payload);
@@ -144,6 +158,7 @@ function gatesForUpdatedArtifact(
     asOf,
     contract,
   );
+  results.push(...evaluateArtifactFormatGates(artifact.type, payload, run.claimSet.claims, asOf));
   if (artifact.type === 'article_metadata') {
     const metadata = ArticleMetadataPayloadSchema.parse(payload);
     results.push(metadata.astroPatchReady
@@ -159,13 +174,23 @@ export class FileFoundryStore {
   private mutationQueue: Promise<void> = Promise.resolve();
   private readonly filePath: string;
 
-  constructor(filePath: string, allowedRoot = dirname(filePath)) {
+  constructor(
+    filePath: string,
+    allowedRoot = dirname(filePath),
+    private readonly evaluationClock: () => string = () => new Date().toISOString(),
+  ) {
     const root = resolve(allowedRoot);
     this.filePath = resolve(filePath);
     const candidate = relative(root, this.filePath);
     if (candidate.startsWith('..') || isAbsolute(candidate)) {
       throw new Error('Foundry store path must remain inside its configured data root');
     }
+  }
+
+  private evaluationAsOf(): string {
+    const asOf = this.evaluationClock();
+    if (!Number.isFinite(Date.parse(asOf))) throw new Error('Foundry evaluation clock must return an ISO timestamp');
+    return asOf;
   }
 
   private async mutate<T>(operation: () => Promise<T>): Promise<T> {
@@ -180,12 +205,12 @@ export class FileFoundryStore {
     }
   }
 
-  private async read(): Promise<StoreFile> {
+  private async read(asOf = this.evaluationAsOf()): Promise<StoreFile> {
     try {
       const raw = await readFile(this.filePath, 'utf8');
       const parsed = JSON.parse(raw) as { schemaVersion?: string; runs?: unknown[] };
       if (parsed.schemaVersion !== 'pi.foundry-file-store.v1' || !Array.isArray(parsed.runs)) throw new Error('Unsupported Foundry store schema');
-      return { schemaVersion: parsed.schemaVersion, runs: parsed.runs.map(parseStoredRun) };
+      return { schemaVersion: parsed.schemaVersion, runs: parsed.runs.map((run) => parseStoredRun(run, asOf)) };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { schemaVersion: 'pi.foundry-file-store.v1', runs: [] };
       throw error;
@@ -222,10 +247,11 @@ export class FileFoundryStore {
 
   async create(run: FoundryRun): Promise<FoundryRun> {
     return this.mutate(async () => {
-      const data = await this.read();
+      const asOf = this.evaluationAsOf();
+      const data = await this.read(asOf);
       const existing = data.runs.find((item) => item.idempotencyKey === run.idempotencyKey);
       if (existing) return existing;
-      const parsed = normalizeDerivedStatus(FoundryRunSchema.parse(run));
+      const parsed = normalizeDerivedStatus(FoundryRunSchema.parse(run), asOf);
       data.runs.unshift(parsed);
       await this.write(data);
       return parsed;
@@ -234,7 +260,8 @@ export class FileFoundryStore {
 
   async review(id: string, decision: ReviewDecision): Promise<FoundryRun> {
     return this.mutate(async () => {
-      const data = await this.read();
+      const asOf = this.evaluationAsOf();
+      const data = await this.read(asOf);
       const index = data.runs.findIndex((run) => run.id === id);
       if (index < 0) throw new Error('Run not found');
       const run = data.runs[index];
@@ -251,7 +278,7 @@ export class FileFoundryStore {
       if (decision.decision === 'accepted' && blockingGateFailed(artifact)) {
         throw new Error('Artifact has unresolved blocking gates');
       }
-      const now = new Date().toISOString();
+      const now = asOf;
       const reviews = run.artifactPack.reviews
         .map((review) => review.artifactId === artifact.id && review.status === 'current' ? { ...review, status: 'stale' as const } : review);
       reviews.push({
@@ -284,7 +311,7 @@ export class FileFoundryStore {
           detail: `${decision.decision} draft handoff for artifact ${artifact.id}; publication authority was not granted.`,
         }],
       });
-      const updated = normalizeDerivedStatus(candidate);
+      const updated = normalizeDerivedStatus(candidate, asOf);
       data.runs[index] = updated;
       await this.write(data);
       return updated;
@@ -299,14 +326,15 @@ export class FileFoundryStore {
       payload: undefined,
     });
     return this.mutate(async () => {
-      const data = await this.read();
+      const asOf = this.evaluationAsOf();
+      const data = await this.read(asOf);
       const index = data.runs.findIndex((run) => run.id === id);
       if (index < 0) throw new Error('Run not found');
       const run = data.runs[index];
       if (!run.artifact) throw new Error('Compatibility edit endpoint supports quick-note runs only');
       input.expectedArtifactVersion = run.artifact.version;
       input.payload = QuickNoteSchema.parse({ ...run.artifact.payload, headline: edit.headline, dek: edit.dek, body: edit.body });
-      const updated = this.applyArtifactUpdate(run, run.artifact.id, input);
+      const updated = this.applyArtifactUpdate(run, run.artifact.id, input, asOf);
       data.runs[index] = updated;
       await this.write(data);
       return updated;
@@ -316,17 +344,18 @@ export class FileFoundryStore {
   async updatePackArtifact(id: string, artifactId: string, rawUpdate: ArtifactUpdate): Promise<FoundryRun> {
     const update = ArtifactUpdateSchema.parse(rawUpdate);
     return this.mutate(async () => {
-      const data = await this.read();
+      const asOf = this.evaluationAsOf();
+      const data = await this.read(asOf);
       const index = data.runs.findIndex((run) => run.id === id);
       if (index < 0) throw new Error('Run not found');
-      const updated = this.applyArtifactUpdate(data.runs[index], artifactId, update);
+      const updated = this.applyArtifactUpdate(data.runs[index], artifactId, update, asOf);
       data.runs[index] = updated;
       await this.write(data);
       return updated;
     });
   }
 
-  private applyArtifactUpdate(run: FoundryRun, artifactId: string, update: ArtifactUpdate): FoundryRun {
+  private applyArtifactUpdate(run: FoundryRun, artifactId: string, update: ArtifactUpdate, asOf: string): FoundryRun {
     if (run.version !== update.expectedVersion) {
       throw new VersionConflictError(`Expected version ${update.expectedVersion}; current version is ${run.version}`);
     }
@@ -365,6 +394,19 @@ export class FileFoundryStore {
         astroPatchReady: Boolean(metadata.heroImage && retainedMedia.length === 1),
       });
     }
+    if (current.type === 'social_media_brief') {
+      const brief = SocialMediaBriefPayloadSchema.parse(payload);
+      const retainedMedia = current.dependencies.filter((dependency) => (
+        dependency.kind === 'media_rights'
+        && brief.placementRights.status === 'cleared'
+        && brief.placementRights.rightsId === dependency.id
+        && dependency.contentHash === hashValue(socialMediaRightsSnapshot(brief))
+      ));
+      dependencies = [
+        ...current.dependencies.filter((dependency) => dependency.kind !== 'media_rights'),
+        ...retainedMedia,
+      ];
+    }
     const changed = ArtifactVersionSchema.parse({
       ...current,
       version: current.version + 1,
@@ -373,10 +415,10 @@ export class FileFoundryStore {
       factualSegmentIds,
       claimUsage,
       dependencies,
-      gateResults: gatesForUpdatedArtifact(run, current, payload, factualSegmentIds, claimUsage),
+      gateResults: gatesForUpdatedArtifact(run, current, payload, factualSegmentIds, claimUsage, asOf),
     });
     const completed = run.artifactPack.completed.map((artifact, index) => index === artifactIndex ? changed : artifact);
-    const now = new Date().toISOString();
+    const now = asOf;
     const candidate = FoundryRunSchema.parse({
       ...run,
       version: run.version + 1,
@@ -396,6 +438,6 @@ export class FileFoundryStore {
         detail: `Edited artifact ${changed.id}; read-time dependency reconciliation invalidated its review and all transitive dependent reviews.`,
       }],
     });
-    return normalizeDerivedStatus(candidate);
+    return normalizeDerivedStatus(candidate, asOf);
   }
 }

--- a/studio-peninsula-insider/shared/contracts.ts
+++ b/studio-peninsula-insider/shared/contracts.ts
@@ -67,6 +67,13 @@ export const ArtifactTypeSchema = z.enum([
   'ask_answer',
   'internal_link_plan',
   'seo_metadata_proposal',
+  'insider_note_issue',
+  'insider_note_subject_set',
+  'linkedin_post',
+  'instagram_caption',
+  'instagram_first_comment',
+  'instagram_carousel_script',
+  'social_media_brief',
 ]);
 
 export const RecipeArtifactRequirementSchema = z.object({
@@ -97,6 +104,27 @@ export const GateCodeSchema = z.enum([
   'astro_article_contract',
   'ask_answer_contract',
   'astro_patch_ready',
+  'insider_note_contract',
+  'subject_set_contract',
+  'locked_copy_unchanged',
+  'cta_limit',
+  'email_utm_complete',
+  'authoritative_input_present',
+  'venue_name_current',
+  'intro_shape',
+  'secondary_picks_shape',
+  'chronological_rows',
+  'booking_note_contract',
+  'poll_manual_only',
+  'subject_pairs_distinct',
+  'james_selection_required',
+  'social_contract',
+  'linkedin_post_contract',
+  'instagram_caption_contract',
+  'instagram_first_comment_contract',
+  'carousel_script_contract',
+  'media_placement_rights',
+  'no_external_action',
 ]);
 
 const GateResultBaseSchema = z.object({
@@ -230,6 +258,294 @@ export const SeoMetadataProposalPayloadSchema = z.object({
   canonicalPath: z.string().regex(/^\//),
 });
 
+const ClaimIdsSchema = z.array(z.string().min(1)).min(1);
+const DraftLineSchema = z.object({
+  id: z.string().min(1),
+  text: z.string().min(1),
+  claimIds: ClaimIdsSchema,
+});
+const DraftLinkSchema = z.object({
+  label: z.string().min(1),
+  href: z.string().url(),
+  claimIds: ClaimIdsSchema,
+});
+const OmittedPositionSchema = z.object({
+  status: z.literal('omitted'),
+  reason: z.enum(['no_applicable_content', 'missing_authoritative_input', 'no_usable_reply', 'rights_not_cleared']),
+});
+
+export const InsiderNoteMastheadPositionSchema = z.object({
+  id: z.literal('insider_note.position.01.masthead'),
+  position: z.literal(1),
+  key: z.literal('masthead'),
+  status: z.literal('locked'),
+  name: z.literal('The Insider Note'),
+  tagline: z.literal('Written from inside the region'),
+  issueNumberRoman: z.string().regex(/^[IVXLCDM]+$/),
+  dateRange: z.string().min(1),
+});
+
+export const InsiderNoteIntroPositionSchema = z.object({
+  id: z.literal('insider_note.position.02.intro'),
+  position: z.literal(2),
+  key: z.literal('intro'),
+  status: z.literal('included'),
+  tense: z.literal('past'),
+  lines: z.array(DraftLineSchema).min(1).max(2),
+});
+
+export const InsiderNoteLeadPositionSchema = z.object({
+  id: z.literal('insider_note.position.03.lead_today_move'),
+  position: z.literal(3),
+  key: z.literal('lead_today_move'),
+  status: z.literal('included'),
+  headline: DraftLineSchema,
+  body: DraftLineSchema,
+  cta: DraftLinkSchema,
+});
+
+export const InsiderNoteWeatherPositionSchema = z.union([
+  z.object({
+    id: z.literal('insider_note.position.04.weather_strip'),
+    position: z.literal(4),
+    key: z.literal('weather_strip'),
+    status: z.literal('included'),
+    day: z.string().min(1),
+    temperatureC: z.number().int(),
+    sky: z.string().min(1),
+    sunsetTime: z.string().regex(/^\d{1,2}:\d{2}\s?(?:am|pm)$/i),
+    claimIds: ClaimIdsSchema,
+  }),
+  OmittedPositionSchema.extend({ id: z.literal('insider_note.position.04.weather_strip'), position: z.literal(4), key: z.literal('weather_strip') }),
+]);
+
+const InsiderNotePickSchema = z.object({
+  id: z.string().min(1),
+  dayStamp: z.string().min(1),
+  category: z.enum(['EAT', 'WINE', 'STAY', 'EXPLORE', 'CULTURE']),
+  venue: z.object({
+    name: z.string().min(1),
+    path: z.string().regex(/^\/[a-z-]+\/[a-z0-9-]+\/$/),
+    claimIds: ClaimIdsSchema,
+  }).optional(),
+  line: DraftLineSchema,
+  cta: DraftLinkSchema.optional(),
+  image: z.object({
+    src: z.string().min(1),
+    alt: z.string().min(1),
+    rightsId: z.string().min(1),
+    clearedFor: z.literal('email'),
+  }).optional(),
+});
+
+export const InsiderNoteSecondaryPicksPositionSchema = z.union([
+  z.object({
+    id: z.literal('insider_note.position.05.secondary_picks'),
+    position: z.literal(5),
+    key: z.literal('secondary_picks'),
+    status: z.literal('included'),
+    picks: z.tuple([InsiderNotePickSchema, InsiderNotePickSchema]),
+  }),
+  OmittedPositionSchema.extend({ id: z.literal('insider_note.position.05.secondary_picks'), position: z.literal(5), key: z.literal('secondary_picks') }),
+]);
+
+export const InsiderNoteReaderReplyPositionSchema = z.union([
+  z.object({
+    id: z.literal('insider_note.position.06.reader_reply'),
+    position: z.literal(6),
+    key: z.literal('reader_reply'),
+    status: z.literal('included'),
+    firstName: z.string().min(1).regex(/^[^\s]+$/),
+    quote: z.string().min(1),
+    claimIds: ClaimIdsSchema,
+    privacy: z.literal('first_name_only'),
+    sourceLocator: z.object({
+      sourceItemId: z.string().min(1),
+      locator: z.string().min(1),
+      excerptHash: Sha256Schema,
+    }),
+  }),
+  OmittedPositionSchema.extend({ id: z.literal('insider_note.position.06.reader_reply'), position: z.literal(6), key: z.literal('reader_reply') }),
+]);
+
+export const InsiderNoteAlsoThisWeekPositionSchema = z.union([
+  z.object({
+    id: z.literal('insider_note.position.07.also_this_week'),
+    position: z.literal(7),
+    key: z.literal('also_this_week'),
+    status: z.literal('included'),
+    rows: z.array(z.object({
+      id: z.string().min(1),
+      date: z.string().date(),
+      dayStamp: z.string().min(1),
+      line: DraftLineSchema,
+      link: DraftLinkSchema.optional(),
+    })).min(1).max(3).refine((rows) => rows.every((row, index) => index === 0 || row.date >= rows[index - 1].date), 'Rows must be chronological.'),
+  }),
+  OmittedPositionSchema.extend({ id: z.literal('insider_note.position.07.also_this_week'), position: z.literal(7), key: z.literal('also_this_week') }),
+]);
+
+export const InsiderNoteBookingPositionSchema = z.union([
+  z.object({
+    id: z.literal('insider_note.position.08.booking_note'),
+    position: z.literal(8),
+    key: z.literal('booking_note'),
+    status: z.literal('included'),
+    line: DraftLineSchema.extend({
+      text: z.string().min(1).refine((text) => (text.match(/[.!?](?:\s|$)/g) ?? []).length === 1, 'Booking note must be exactly one sentence.'),
+    }),
+    link: DraftLinkSchema,
+    timeSensitiveClaimIds: ClaimIdsSchema,
+  }),
+  OmittedPositionSchema.extend({ id: z.literal('insider_note.position.08.booking_note'), position: z.literal(8), key: z.literal('booking_note') }),
+]);
+
+export const InsiderNotePollPositionSchema = z.object({
+  id: z.literal('insider_note.position.09.poll'),
+  position: z.literal(9),
+  key: z.literal('poll'),
+  status: z.enum(['editorial_decision', 'editorial_supplied']),
+  delivery: z.literal('beehiiv_native'),
+  suppliedQuestion: z.string().min(1).nullable(),
+  suppliedBy: z.string().min(1).nullable(),
+}).superRefine((value, context) => {
+  const supplied = value.status === 'editorial_supplied';
+  if (supplied !== Boolean(value.suppliedQuestion && value.suppliedBy)) {
+    context.addIssue({ code: 'custom', message: 'A poll question must be supplied manually with its editor, or remain unset.' });
+  }
+});
+
+export const InsiderNoteReplySignoffPositionSchema = z.object({
+  id: z.literal('insider_note.position.10.reply_prompt_signoff'),
+  position: z.literal(10),
+  key: z.literal('reply_prompt_signoff'),
+  status: z.literal('locked'),
+  replyPrompt: z.literal('Been somewhere brilliant this week that we should know about? Just hit reply. We read everything.'),
+  signoff: z.literal('The Insider.'),
+});
+
+export const InsiderNoteFooterPositionSchema = z.object({
+  id: z.literal('insider_note.position.11.footer'),
+  position: z.literal(11),
+  key: z.literal('footer'),
+  status: z.literal('locked'),
+  issueNumberRoman: z.string().regex(/^[IVXLCDM]+$/),
+  dateRange: z.string().min(1),
+  navigation: z.tuple([
+    z.object({ id: z.literal('footer-weekend'), key: z.literal('this_weekend'), label: z.literal('this weekend'), href: z.string().url().refine((href) => new URL(href).pathname === '/this-weekend/'), claimIds: ClaimIdsSchema }),
+    z.object({ id: z.literal('footer-whats-on'), key: z.literal('whats_on'), label: z.literal("what's on"), href: z.string().url().refine((href) => new URL(href).pathname === '/whats-on/'), claimIds: ClaimIdsSchema }),
+    z.object({ id: z.literal('footer-journal'), key: z.literal('journal'), label: z.literal('journal'), href: z.string().url().refine((href) => new URL(href).pathname === '/journal/'), claimIds: ClaimIdsSchema }),
+  ]),
+  includeUnsubscribe: z.literal(true),
+  includeStreetAddress: z.literal(true),
+});
+
+export const InsiderNoteIssuePayloadSchema = z.object({
+  schemaVersion: z.literal('pi.insider-note-issue.v1'),
+  issueNumber: z.number().int().positive(),
+  campaignCode: z.string().regex(/^insider-note-\d{2,}$/),
+  positions: z.tuple([
+    InsiderNoteMastheadPositionSchema,
+    InsiderNoteIntroPositionSchema,
+    InsiderNoteLeadPositionSchema,
+    InsiderNoteWeatherPositionSchema,
+    InsiderNoteSecondaryPicksPositionSchema,
+    InsiderNoteReaderReplyPositionSchema,
+    InsiderNoteAlsoThisWeekPositionSchema,
+    InsiderNoteBookingPositionSchema,
+    InsiderNotePollPositionSchema,
+    InsiderNoteReplySignoffPositionSchema,
+    InsiderNoteFooterPositionSchema,
+  ]),
+  targetReleaseDate: z.string().date(),
+  scheduleAt: z.null(),
+  sendAuthority: z.literal('james_only'),
+  operationalState: z.literal('draft_only'),
+});
+
+export const InsiderNoteSubjectSetPayloadSchema = z.object({
+  schemaVersion: z.literal('pi.insider-note-subject-set.v1'),
+  pairs: z.tuple([
+    z.object({ id: z.literal('subject-a'), subject: z.string().min(1).max(120), previewText: z.string().min(1).max(180) }),
+    z.object({ id: z.literal('subject-b'), subject: z.string().min(1).max(120), previewText: z.string().min(1).max(180) }),
+    z.object({ id: z.literal('subject-c'), subject: z.string().min(1).max(120), previewText: z.string().min(1).max(180) }),
+  ]),
+  selectedPairId: z.null(),
+  selectionAuthority: z.literal('james_only'),
+  scheduleAt: z.null(),
+  sendAuthority: z.literal('james_only'),
+});
+
+const DraftOnlySocialSchema = z.object({
+  schemaVersion: z.string().min(1),
+  scheduleAt: z.null(),
+  publicationAuthority: z.literal('james_only'),
+  operationalState: z.literal('draft_only'),
+});
+
+export const LinkedInPostPayloadSchema = DraftOnlySocialSchema.extend({
+  schemaVersion: z.literal('pi.linkedin-post.v1'),
+  openingMode: z.literal('specific_observation'),
+  text: z.string().min(1)
+    .refine((text) => !/https?:\/\//i.test(text), 'The body must not contain an embedded link.')
+    .refine((text) => {
+      const words = text.trim().split(/\s+/).filter(Boolean).length;
+      return words >= 50 && words <= 300;
+    }, 'LinkedIn body must contain 50 to 300 words.')
+    .refine((text) => !/(?:like if|comment below|tag someone|agree\?|thoughts\?)/i.test(text), 'Engagement bait is not allowed.'),
+  destinationUrl: z.string().url(),
+  hashtags: z.array(z.string().regex(/^#[A-Za-z0-9_]+$/)).max(3),
+});
+
+export const InstagramCaptionPayloadSchema = DraftOnlySocialSchema.extend({
+  schemaVersion: z.literal('pi.instagram-caption.v1'),
+  openingMode: z.literal('observation'),
+  captionDraft: z.string().min(1).superRefine((text, context) => {
+    const lines = text.split(/\r?\n/).filter((line) => line.trim());
+    if (lines.length < 2 || lines.length > 4) context.addIssue({ code: 'custom', message: 'Instagram caption must contain 2 to 4 non-empty lines.' });
+    if (/#\w+/.test(text)) context.addIssue({ code: 'custom', message: 'Caption hashtags remain outside the caption draft.' });
+    if (/\bwe recommend\b/i.test(text)) context.addIssue({ code: 'custom', message: 'Caption must not use generic recommendation language.' });
+  }),
+  destinationPath: z.string().regex(/^\//),
+  cadenceDecision: z.literal('unresolved'),
+  hashtagPlacementDecision: z.literal('unresolved'),
+});
+
+export const InstagramFirstCommentPayloadSchema = DraftOnlySocialSchema.extend({
+  schemaVersion: z.literal('pi.instagram-first-comment.v1'),
+  commentDraft: z.string().min(1),
+  hashtagCandidates: z.array(z.string().regex(/^#[A-Za-z0-9_]+$/)).min(3).max(5)
+    .refine((values) => new Set(values.map((value) => value.toLocaleLowerCase())).size === values.length, 'Hashtag candidates must be unique.'),
+  placementDecision: z.literal('unresolved'),
+  cadenceDecision: z.literal('unresolved'),
+});
+
+export const InstagramCarouselScriptPayloadSchema = DraftOnlySocialSchema.extend({
+  schemaVersion: z.literal('pi.instagram-carousel-script.v1'),
+  slides: z.array(z.object({
+    number: z.number().int().positive(),
+    heading: z.string().min(1),
+    body: z.string().min(1),
+    claimIds: ClaimIdsSchema,
+  })).min(3).max(5).refine((slides) => slides.every((slide, index) => slide.number === index + 1), 'Slides must be ordered from 1 without gaps.'),
+});
+
+export const SocialMediaBriefPayloadSchema = DraftOnlySocialSchema.extend({
+  schemaVersion: z.literal('pi.social-media-brief.v1'),
+  assetId: z.string().min(1),
+  targetSurface: z.literal('instagram'),
+  placement: z.enum(['feed', 'carousel']),
+  mediaType: z.enum(['image', 'carousel']),
+  description: z.string().min(1),
+  altText: z.string().min(1),
+  placementRights: z.object({
+    status: z.enum(['cleared', 'not_cleared', 'expired', 'revoked']),
+    allowedSurfaces: z.array(z.enum(['website', 'email', 'instagram', 'linkedin'])),
+    recognisablePeople: z.enum(['none', 'released', 'unreleased', 'unknown']),
+    rightsId: z.string().min(1).optional(),
+  }),
+});
+
 export const ClaimUsageSchema = z.object({
   segmentId: z.string().min(1),
   path: z.string().min(1),
@@ -309,6 +625,41 @@ export const SeoMetadataProposalArtifactSchema = ArtifactVersionBaseSchema.exten
   payload: SeoMetadataProposalPayloadSchema,
 });
 
+export const InsiderNoteIssueArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('insider_note_issue'),
+  payload: InsiderNoteIssuePayloadSchema,
+});
+
+export const InsiderNoteSubjectSetArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('insider_note_subject_set'),
+  payload: InsiderNoteSubjectSetPayloadSchema,
+});
+
+export const LinkedInPostArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('linkedin_post'),
+  payload: LinkedInPostPayloadSchema,
+});
+
+export const InstagramCaptionArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('instagram_caption'),
+  payload: InstagramCaptionPayloadSchema,
+});
+
+export const InstagramFirstCommentArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('instagram_first_comment'),
+  payload: InstagramFirstCommentPayloadSchema,
+});
+
+export const InstagramCarouselScriptArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('instagram_carousel_script'),
+  payload: InstagramCarouselScriptPayloadSchema,
+});
+
+export const SocialMediaBriefArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('social_media_brief'),
+  payload: SocialMediaBriefPayloadSchema,
+});
+
 export const ArtifactVersionSchema = z.discriminatedUnion('type', [
   QuickNoteArtifactSchema,
   ArticleDraftArtifactSchema,
@@ -316,6 +667,13 @@ export const ArtifactVersionSchema = z.discriminatedUnion('type', [
   AskAnswerArtifactSchema,
   InternalLinkPlanArtifactSchema,
   SeoMetadataProposalArtifactSchema,
+  InsiderNoteIssueArtifactSchema,
+  InsiderNoteSubjectSetArtifactSchema,
+  LinkedInPostArtifactSchema,
+  InstagramCaptionArtifactSchema,
+  InstagramFirstCommentArtifactSchema,
+  InstagramCarouselScriptArtifactSchema,
+  SocialMediaBriefArtifactSchema,
 ]);
 
 export const ArtifactFailureSchema = z.object({
@@ -407,6 +765,7 @@ export const FoundryRunSchema = z.object({
   status: z.enum(['ready_for_review', 'needs_revision', 'accepted', 'rejected', 'failed']),
   createdAt: IsoDateTimeSchema,
   updatedAt: IsoDateTimeSchema,
+  evaluationAsOf: IsoDateTimeSchema.optional(),
   bundle: IntakeBundleSchema,
   recipe: RecipeDefinitionSchema,
   claimSet: ClaimSetVersionSchema,

--- a/studio-peninsula-insider/shared/contracts.ts
+++ b/studio-peninsula-insider/shared/contracts.ts
@@ -1,20 +1,23 @@
 import { z } from 'zod';
 
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const IsoDateTimeSchema = z.string().datetime();
+
 export const EvidenceLocatorSchema = z.object({
   sourceItemId: z.string().min(1),
   locatorType: z.enum(['selector', 'paragraph', 'timecode', 'manual']),
   locator: z.string().min(1),
   excerpt: z.string().min(1),
-  excerptHash: z.string().regex(/^[a-f0-9]{64}$/),
-  capturedAt: z.string().datetime(),
+  excerptHash: Sha256Schema,
+  capturedAt: IsoDateTimeSchema,
 });
 
 export const SourceItemSchema = z.object({
   id: z.string().min(1),
   kind: z.enum(['url', 'text_note', 'audio_note', 'image', 'document']),
   uri: z.string().url().optional(),
-  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
-  capturedAt: z.string().datetime(),
+  contentHash: Sha256Schema,
+  capturedAt: IsoDateTimeSchema,
 });
 
 export const IntakeBundleSchema = z.object({
@@ -22,7 +25,7 @@ export const IntakeBundleSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
   submittedBy: z.string().min(1),
-  capturedAt: z.string().datetime(),
+  capturedAt: IsoDateTimeSchema,
   sourceItems: z.array(SourceItemSchema).min(1),
 });
 
@@ -32,55 +35,343 @@ export const ClaimSchema = z.object({
   origin: z.enum(['external_fact', 'first_party_observation', 'opinion', 'inference']),
   verification: z.enum(['supported', 'conflicted', 'stale', 'unsupported', 'approved']),
   evidence: z.array(EvidenceLocatorSchema),
+  expiresAt: IsoDateTimeSchema.optional(),
   restrictedFromArtifacts: z.boolean().default(false),
   restrictionReason: z.string().optional(),
 });
 
+export const ClaimSetVersionSchema = z.object({
+  schemaVersion: z.literal('pi.claim-set.v1'),
+  id: z.string().min(1),
+  version: z.number().int().positive(),
+  contentHash: Sha256Schema,
+  createdAt: IsoDateTimeSchema,
+  lockedAt: IsoDateTimeSchema,
+  lockedBy: z.string().min(1),
+  claims: z.array(ClaimSchema).min(1),
+});
+
 export const StoryAngleSchema = z.object({
   id: z.string().min(1),
+  version: z.number().int().positive().default(1),
   label: z.string().min(1),
   framing: z.string().min(1),
   evidenceClaimIds: z.array(z.string()).min(1),
   selectedBy: z.string().min(1),
 });
 
+export const ArtifactTypeSchema = z.enum([
+  'quick_note',
+  'article_draft',
+  'article_metadata',
+  'ask_answer',
+  'internal_link_plan',
+  'seo_metadata_proposal',
+]);
+
+export const RecipeArtifactRequirementSchema = z.object({
+  key: z.string().min(1),
+  type: ArtifactTypeSchema,
+  required: z.boolean(),
+  dependsOnKeys: z.array(z.string()).default([]),
+  targetContract: z.string().min(1),
+});
+
+export const RecipeDefinitionSchema = z.object({
+  schemaVersion: z.literal('pi.recipe-definition.v1'),
+  id: z.string().min(1),
+  version: z.number().int().positive(),
+  label: z.string().min(1),
+  sourceKinds: z.array(SourceItemSchema.shape.kind).min(1),
+  artifacts: z.array(RecipeArtifactRequirementSchema).min(1),
+  textOnlyAllowed: z.literal(true),
+  externalCalls: z.literal(false),
+});
+
+export const GateCodeSchema = z.enum([
+  'no_price',
+  'no_em_dash',
+  'supported_claims_only',
+  'claim_usage_complete',
+  'dependency_current',
+  'astro_article_contract',
+  'ask_answer_contract',
+  'astro_patch_ready',
+]);
+
+const GateResultBaseSchema = z.object({
+  gate: GateCodeSchema,
+  scope: z.enum(['artifact', 'pack']),
+  detail: z.string().min(1),
+  claimIds: z.array(z.string()).default([]),
+});
+
+export const GateResultSchema = z.discriminatedUnion('passed', [
+  GateResultBaseSchema.extend({ passed: z.literal(true), blocking: z.literal(false) }),
+  GateResultBaseSchema.extend({ passed: z.literal(false), blocking: z.boolean().default(true) }),
+]);
+
 export const QuickNoteSchema = z.object({
   headline: z.string().max(140),
   dek: z.string().max(320).optional(),
   section: z.enum(['eat', 'stay', 'wine', 'explore', 'spa', 'golf', 'whats-on', 'weather', 'note']),
   tag: z.enum(['opening-window', 'menu-change', 'closure', 'event', 'weather', 'editor-note', 'pricing', 'safety']),
-  publishedAt: z.string().datetime(),
-  expiresAt: z.string().datetime(),
-  verifiedAt: z.string().datetime().optional(),
+  publishedAt: IsoDateTimeSchema,
+  expiresAt: IsoDateTimeSchema,
+  verifiedAt: IsoDateTimeSchema.optional(),
   verifiedBy: z.string().optional(),
   sources: z.array(z.object({
     kind: z.enum(['venue-site', 'phone', 'email', 'visit', 'press', 'social', 'gov', 'partner']),
     url: z.string().url().optional(),
     note: z.string().optional(),
-    checkedAt: z.string().datetime().optional(),
+    checkedAt: IsoDateTimeSchema.optional(),
   })),
   status: z.literal('draft'),
   body: z.string().min(1),
 });
 
-export const ArtifactSchema = z.object({
-  id: z.string().min(1),
-  version: z.number().int().positive(),
-  type: z.literal('quick_note'),
-  claimIds: z.array(z.string()),
-  angleId: z.string().min(1),
-  payload: QuickNoteSchema,
-  gateResults: z.array(z.object({
-    gate: z.string(),
-    passed: z.boolean(),
-    detail: z.string(),
+export const ArticleDraftPayloadSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  body: z.string().min(1),
+});
+
+export const ArticleMetadataPayloadSchema = z.object({
+  title: z.string().min(1),
+  dek: z.string().min(1),
+  author: z.string().min(1),
+  houseByline: z.boolean(),
+  publishedAt: z.string().date(),
+  heroImage: z.object({
+    src: z.string().min(1),
+    alt: z.string().min(1),
+    credit: z.string().min(1),
+    license: z.enum([
+      'original-commissioned',
+      'venue-media-kit',
+      'visit-victoria',
+      'wikimedia-cc0',
+      'wikimedia-cc-by',
+      'wikimedia-cc-by-sa',
+      'tmp-unsplash',
+      'tmp-wikimedia',
+      'tmp-pexels',
+      'other-licensed',
+    ]),
+  }).optional(),
+  astroPatchReady: z.boolean(),
+  format: z.enum([
+    'editors-letter',
+    'long-lunch-list',
+    'cellar-door-dispatch',
+    'stay-notes',
+    'slow-peninsula',
+    'insider-edit',
+    'interview',
+    'investigation',
+    'service',
+    'weekend-picker',
+    'hub-guide',
+    'trail-guide',
+    'venue-guide',
+    'peninsula-notes',
+  ]),
+  tags: z.array(z.string()).default([]),
+  relatedVenues: z.array(z.string()).default([]),
+  relatedExperiences: z.array(z.string()).default([]),
+  relatedPlaces: z.array(z.string()).default([]),
+  relatedArticles: z.array(z.string()).default([]),
+  relatedItineraries: z.array(z.string()).default([]),
+  readingTimeMinutes: z.number().positive().optional(),
+  featured: z.boolean().default(false),
+  status: z.literal('draft'),
+  lastVerified: z.string().date().optional(),
+  clusterLinks: z.array(z.object({ label: z.string(), href: z.string() })).optional(),
+  aiSummary: z.array(z.string()).optional(),
+  faq: z.array(z.object({ question: z.string(), answer: z.string() })).optional(),
+  sitemapExclude: z.boolean().default(false),
+  section: z.enum(['journal', 'plans']).default('journal'),
+  planShape: z.enum(['one-night', 'two-night', 'day-trip', 'seasonal']).optional(),
+}).refine((payload) => !payload.astroPatchReady || Boolean(payload.heroImage), {
+  message: 'A rights-cleared hero image is required when astroPatchReady is true.',
+  path: ['heroImage'],
+});
+
+export const AskRecommendationSchema = z.object({
+  title: z.string().min(1),
+  slug: z.string().optional(),
+  href: z.string().optional(),
+  why: z.string().optional(),
+  signature: z.string().optional(),
+  hero_image: z.string().optional(),
+  venue_type: z.string().optional(),
+  category: z.string().optional(),
+  region: z.string().optional(),
+  price_band: z.never().optional(),
+});
+
+export const AskAnswerPayloadSchema = z.object({
+  answer: z.string().min(1),
+  recommendations: z.array(AskRecommendationSchema).default([]),
+  follow_on: z.array(z.string()).default([]),
+  provenance_footer: z.string().default(''),
+});
+
+export const InternalLinkPlanPayloadSchema = z.object({
+  links: z.array(z.object({
+    label: z.string().min(1),
+    href: z.string().regex(/^\//),
+    placement: z.string().min(1),
   })),
 });
 
+export const SeoMetadataProposalPayloadSchema = z.object({
+  title: z.string().min(1).max(70),
+  description: z.string().min(1).max(170),
+  canonicalPath: z.string().regex(/^\//),
+});
+
+export const ClaimUsageSchema = z.object({
+  segmentId: z.string().min(1),
+  path: z.string().min(1),
+  claimIds: z.array(z.string()).min(1),
+  contentHash: Sha256Schema,
+});
+
+export const ArtifactDependencySchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('claim_set'),
+    id: z.string().min(1),
+    version: z.number().int().positive(),
+    contentHash: Sha256Schema,
+  }),
+  z.object({
+    kind: z.literal('artifact'),
+    id: z.string().min(1),
+    version: z.number().int().positive(),
+    contentHash: Sha256Schema,
+  }),
+  z.object({
+    kind: z.literal('angle'),
+    id: z.string().min(1),
+    version: z.number().int().positive(),
+    contentHash: Sha256Schema,
+  }),
+  z.object({
+    kind: z.literal('media_rights'),
+    id: z.string().min(1),
+    version: z.number().int().positive(),
+    contentHash: Sha256Schema,
+    status: z.literal('cleared'),
+  }),
+]);
+
+const ArtifactVersionBaseSchema = z.object({
+  id: z.string().min(1),
+  key: z.string().min(1),
+  version: z.number().int().positive(),
+  contentHash: Sha256Schema,
+  angleId: z.string().min(1),
+  angleVersion: z.number().int().positive(),
+  factualSegmentIds: z.array(z.string()),
+  claimUsage: z.array(ClaimUsageSchema),
+  dependencies: z.array(ArtifactDependencySchema).min(1),
+  gateResults: z.array(GateResultSchema),
+});
+
+export const QuickNoteArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('quick_note'),
+  claimIds: z.array(z.string()),
+  payload: QuickNoteSchema,
+});
+
+export const ArticleDraftArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('article_draft'),
+  payload: ArticleDraftPayloadSchema,
+});
+
+export const ArticleMetadataArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('article_metadata'),
+  payload: ArticleMetadataPayloadSchema,
+});
+
+export const AskAnswerArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('ask_answer'),
+  payload: AskAnswerPayloadSchema,
+});
+
+export const InternalLinkPlanArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('internal_link_plan'),
+  payload: InternalLinkPlanPayloadSchema,
+});
+
+export const SeoMetadataProposalArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: z.literal('seo_metadata_proposal'),
+  payload: SeoMetadataProposalPayloadSchema,
+});
+
+export const ArtifactVersionSchema = z.discriminatedUnion('type', [
+  QuickNoteArtifactSchema,
+  ArticleDraftArtifactSchema,
+  ArticleMetadataArtifactSchema,
+  AskAnswerArtifactSchema,
+  InternalLinkPlanArtifactSchema,
+  SeoMetadataProposalArtifactSchema,
+]);
+
+export const ArtifactFailureSchema = z.object({
+  key: z.string().min(1),
+  type: ArtifactTypeSchema,
+  required: z.boolean(),
+  code: z.enum(['fixture_derivative_failure', 'contract_invalid', 'blocked_claim', 'dependency_failed']),
+  detail: z.string().min(1),
+  attemptedAt: IsoDateTimeSchema,
+});
+
+export const ArtifactOmissionSchema = z.object({
+  key: z.string().min(1),
+  type: ArtifactTypeSchema,
+  reason: z.enum(['not_requested', 'no_applicable_content', 'rights_not_cleared']),
+  detail: z.string().min(1),
+});
+
+export const StoredArtifactReviewDecisionSchema = z.object({
+  id: z.string().min(1),
+  artifactId: z.string().min(1),
+  artifactVersion: z.number().int().positive(),
+  decision: z.enum(['accepted', 'rejected']),
+  reviewer: z.string().min(1),
+  note: z.string().max(500).optional(),
+  decidedAt: IsoDateTimeSchema,
+  status: z.enum(['current', 'stale']),
+  dependencySnapshot: z.array(ArtifactDependencySchema),
+  authority: z.literal('draft_handoff_only'),
+});
+
+export const ArtifactPackSchema = z.object({
+  schemaVersion: z.literal('pi.artifact-pack.v1'),
+  id: z.string().min(1),
+  version: z.number().int().positive(),
+  recipeId: z.string().min(1),
+  recipeVersion: z.number().int().positive(),
+  claimSetRef: z.object({
+    id: z.string().min(1),
+    version: z.number().int().positive(),
+    contentHash: Sha256Schema,
+  }),
+  angleRef: z.object({ id: z.string().min(1), version: z.number().int().positive() }),
+  status: z.enum(['complete', 'partial', 'failed']),
+  completed: z.array(ArtifactVersionSchema),
+  failed: z.array(ArtifactFailureSchema),
+  omitted: z.array(ArtifactOmissionSchema),
+  reviews: z.array(StoredArtifactReviewDecisionSchema),
+});
+
 export const ReviewDecisionSchema = z.object({
+  artifactId: z.string().min(1).optional(),
   decision: z.enum(['accepted', 'rejected']),
   reviewer: z.string().min(1),
   expectedVersion: z.number().int().positive(),
+  expectedArtifactVersion: z.number().int().positive().optional(),
   note: z.string().max(500).optional(),
 });
 
@@ -92,30 +383,81 @@ export const ArtifactEditSchema = z.object({
   body: z.string().min(1),
 });
 
+export const ArtifactUpdateSchema = z.object({
+  editor: z.string().min(1),
+  expectedVersion: z.number().int().positive(),
+  expectedArtifactVersion: z.number().int().positive(),
+  payload: z.unknown(),
+  factualSegmentIds: z.array(z.string().min(1)).optional(),
+  claimUsage: z.array(ClaimUsageSchema).optional(),
+});
+
 export const AuditEventSchema = z.object({
-  at: z.string().datetime(),
+  at: IsoDateTimeSchema,
   actor: z.string().min(1),
   type: z.string().min(1),
   detail: z.string().min(1),
 });
 
 export const FoundryRunSchema = z.object({
+  schemaVersion: z.literal('pi.foundry-run.v2'),
   id: z.string().min(1),
   idempotencyKey: z.string().min(1),
   version: z.number().int().positive(),
   status: z.enum(['ready_for_review', 'needs_revision', 'accepted', 'rejected', 'failed']),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
+  bundle: IntakeBundleSchema,
+  recipe: RecipeDefinitionSchema,
+  claimSet: ClaimSetVersionSchema,
+  angle: StoryAngleSchema,
+  artifactPack: ArtifactPackSchema,
+  blockers: z.array(z.string()),
+  audit: z.array(AuditEventSchema),
+  // v0.1 compatibility projections. New recipes do not populate these fields.
+  claims: z.array(ClaimSchema).optional(),
+  artifact: QuickNoteArtifactSchema.optional(),
+  review: z.object({
+    decision: z.enum(['accepted', 'rejected']),
+    reviewer: z.string(),
+    note: z.string().optional(),
+    decidedAt: IsoDateTimeSchema,
+  }).optional(),
+});
+
+const LegacyGateResultSchema = z.object({
+  gate: z.string().min(1),
+  passed: z.boolean(),
+  detail: z.string().min(1),
+});
+
+export const LegacyQuickNoteArtifactSchema = z.object({
+  id: z.string().min(1),
+  version: z.number().int().positive(),
+  type: z.literal('quick_note'),
+  claimIds: z.array(z.string()),
+  angleId: z.string().min(1),
+  payload: QuickNoteSchema,
+  gateResults: z.array(LegacyGateResultSchema),
+});
+
+export const LegacyFoundryRunSchema = z.object({
+  id: z.string().min(1),
+  idempotencyKey: z.string().min(1),
+  version: z.number().int().positive(),
+  status: z.enum(['ready_for_review', 'needs_revision', 'accepted', 'rejected', 'failed']),
+  createdAt: IsoDateTimeSchema,
+  updatedAt: IsoDateTimeSchema,
   bundle: IntakeBundleSchema,
   claims: z.array(ClaimSchema),
-  angle: StoryAngleSchema,
-  artifact: ArtifactSchema,
+  angle: StoryAngleSchema.omit({ version: true }),
+  artifact: LegacyQuickNoteArtifactSchema,
   blockers: z.array(z.string()),
   review: z.object({
     decision: z.enum(['accepted', 'rejected']),
     reviewer: z.string(),
     note: z.string().optional(),
-    decidedAt: z.string().datetime(),
+    decidedAt: IsoDateTimeSchema,
   }).optional(),
   audit: z.array(AuditEventSchema),
 });
@@ -123,4 +465,12 @@ export const FoundryRunSchema = z.object({
 export type FoundryRun = z.infer<typeof FoundryRunSchema>;
 export type ReviewDecision = z.infer<typeof ReviewDecisionSchema>;
 export type ArtifactEdit = z.infer<typeof ArtifactEditSchema>;
+export type ArtifactUpdate = z.infer<typeof ArtifactUpdateSchema>;
 export type Claim = z.infer<typeof ClaimSchema>;
+export type ClaimSetVersion = z.infer<typeof ClaimSetVersionSchema>;
+export type ArtifactVersion = z.infer<typeof ArtifactVersionSchema>;
+export type ArtifactDependency = z.infer<typeof ArtifactDependencySchema>;
+export type ArtifactPack = z.infer<typeof ArtifactPackSchema>;
+export type GateResult = z.infer<typeof GateResultSchema>;
+export type RecipeDefinition = z.infer<typeof RecipeDefinitionSchema>;
+export type LegacyFoundryRun = z.infer<typeof LegacyFoundryRunSchema>;

--- a/studio-peninsula-insider/src/App.tsx
+++ b/studio-peninsula-insider/src/App.tsx
@@ -2,9 +2,15 @@ import { useEffect, useState } from 'react';
 import type { FoundryRun } from '../shared/contracts';
 
 const FIXTURE_ID = 'red-hill-winter-lunch';
+type QuickNoteRun = FoundryRun & { artifact: NonNullable<FoundryRun['artifact']>; claims: NonNullable<FoundryRun['claims']> };
+
+function asQuickNoteRun(run: FoundryRun): QuickNoteRun | null {
+  if (!run.artifact || run.artifact.type !== 'quick_note') return null;
+  return { ...run, claims: run.claims ?? run.claimSet.claims, artifact: run.artifact };
+}
 
 export function App() {
-  const [run, setRun] = useState<FoundryRun | null>(null);
+  const [run, setRun] = useState<QuickNoteRun | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [draft, setDraft] = useState({ headline: '', dek: '', body: '' });
@@ -12,7 +18,10 @@ export function App() {
   useEffect(() => {
     fetch('/api/foundry/runs')
       .then((response) => response.json())
-      .then((data) => setRun(data.runs?.[0] ?? null))
+      .then((data: { runs?: FoundryRun[] }) => {
+        const quickNote = data.runs?.map(asQuickNoteRun).find((item): item is QuickNoteRun => Boolean(item));
+        setRun(quickNote ?? null);
+      })
       .catch(() => setError('The local API is not available yet.'));
   }, []);
 
@@ -35,7 +44,9 @@ export function App() {
         body: JSON.stringify({ fixtureId: FIXTURE_ID, actor: 'local-editor', idempotencyKey: 'fixture-red-hill-v1' }),
       });
       if (!response.ok) throw new Error('The fixture run could not start.');
-      setRun(await response.json());
+      const created = asQuickNoteRun(await response.json());
+      if (!created) throw new Error('The quick-note fixture returned an incompatible artifact pack.');
+      setRun(created);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'The fixture run failed.');
     } finally { setBusy(false); }
@@ -53,7 +64,9 @@ export function App() {
       });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error ?? 'Review decision failed.');
-      setRun(body);
+      const reviewed = asQuickNoteRun(body);
+      if (!reviewed) throw new Error('The reviewed run is not quick-note compatible.');
+      setRun(reviewed);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'Review decision failed.');
     } finally { setBusy(false); }
@@ -71,7 +84,9 @@ export function App() {
       });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error ?? 'The draft could not be saved.');
-      setRun(body);
+      const saved = asQuickNoteRun(body);
+      if (!saved) throw new Error('The saved run is not quick-note compatible.');
+      setRun(saved);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'The draft could not be saved.');
     } finally { setBusy(false); }

--- a/studio-peninsula-insider/src/App.tsx
+++ b/studio-peninsula-insider/src/App.tsx
@@ -1,187 +1,183 @@
-import { useEffect, useState } from 'react';
-import type { FoundryRun } from '../shared/contracts';
+import { useEffect, useMemo, useState } from 'react';
+import type { ArtifactVersion, FoundryRun } from '../shared/contracts';
 
-const FIXTURE_ID = 'red-hill-winter-lunch';
-type QuickNoteRun = FoundryRun & { artifact: NonNullable<FoundryRun['artifact']>; claims: NonNullable<FoundryRun['claims']> };
+const FIXTURES = [
+  { id: 'red-hill-winter-lunch', label: 'Quick note' },
+  { id: 'red-hill-url-article', label: 'Article + Ask' },
+  { id: 'red-hill-newsletter-social', label: 'Insider Note + social' },
+] as const;
 
-function asQuickNoteRun(run: FoundryRun): QuickNoteRun | null {
-  if (!run.artifact || run.artifact.type !== 'quick_note') return null;
-  return { ...run, claims: run.claims ?? run.claimSet.claims, artifact: run.artifact };
+function titleFor(type: ArtifactVersion['type']) {
+  return type.replaceAll('_', ' ');
+}
+
+function currentReview(run: FoundryRun, artifact: ArtifactVersion) {
+  return run.artifactPack.reviews.find((review) => (
+    review.artifactId === artifact.id && review.artifactVersion === artifact.version && review.status === 'current'
+  ));
+}
+
+function ArtifactPreview({ artifact }: { artifact: ArtifactVersion }) {
+  if (artifact.type === 'insider_note_issue') {
+    return <div className="position-list">
+      {artifact.payload.positions.map((position) => <article className="position" key={position.id}>
+        <div><span>{String(position.position).padStart(2, '0')}</span><strong>{position.key.replaceAll('_', ' ')}</strong></div>
+        <small>{position.id}</small>
+        <pre>{JSON.stringify(position, null, 2)}</pre>
+      </article>)}
+    </div>;
+  }
+  if (artifact.type === 'insider_note_subject_set') {
+    return <div>
+      <div className="authority-note">No pair is selected. Selection authority: James only.</div>
+      <div className="subject-grid">{artifact.payload.pairs.map((pair) => <article key={pair.id}>
+        <small>{pair.id}</small><strong>{pair.subject}</strong><p>{pair.previewText}</p>
+      </article>)}</div>
+    </div>;
+  }
+  return <pre className="payload-preview">{JSON.stringify(artifact.payload, null, 2)}</pre>;
 }
 
 export function App() {
-  const [run, setRun] = useState<QuickNoteRun | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [run, setRun] = useState<FoundryRun | null>(null);
+  const [busyArtifactId, setBusyArtifactId] = useState('');
   const [error, setError] = useState('');
   const [draft, setDraft] = useState({ headline: '', dek: '', body: '' });
 
   useEffect(() => {
     fetch('/api/foundry/runs')
       .then((response) => response.json())
-      .then((data: { runs?: FoundryRun[] }) => {
-        const quickNote = data.runs?.map(asQuickNoteRun).find((item): item is QuickNoteRun => Boolean(item));
-        setRun(quickNote ?? null);
-      })
+      .then((data: { runs?: FoundryRun[] }) => setRun(data.runs?.[0] ?? null))
       .catch(() => setError('The local API is not available yet.'));
   }, []);
 
+  const quickArtifact = run?.artifact?.type === 'quick_note' ? run.artifact : null;
   useEffect(() => {
-    if (!run) return;
-    setDraft({
-      headline: run.artifact.payload.headline,
-      dek: run.artifact.payload.dek ?? '',
-      body: run.artifact.payload.body,
-    });
-  }, [run?.id, run?.artifact.version]);
+    if (!quickArtifact) return;
+    setDraft({ headline: quickArtifact.payload.headline, dek: quickArtifact.payload.dek ?? '', body: quickArtifact.payload.body });
+  }, [run?.id, quickArtifact?.version]);
 
-  async function startRun() {
-    setBusy(true);
-    setError('');
+  const sourceById = useMemo(() => new Map(run?.bundle.sourceItems.map((source) => [source.id, source]) ?? []), [run]);
+  const draftDirty = Boolean(quickArtifact && (
+    draft.headline !== quickArtifact.payload.headline
+    || draft.dek !== (quickArtifact.payload.dek ?? '')
+    || draft.body !== quickArtifact.payload.body
+  ));
+
+  async function startRun(fixtureId: typeof FIXTURES[number]['id'], fixtureVariant = 'complete') {
+    setBusyArtifactId('run'); setError('');
     try {
       const response = await fetch('/api/foundry/runs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fixtureId: FIXTURE_ID, actor: 'local-editor', idempotencyKey: 'fixture-red-hill-v1' }),
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fixtureId, fixtureVariant, actor: 'local-editor', idempotencyKey: `${fixtureId}-${fixtureVariant}-${crypto.randomUUID()}` }),
       });
-      if (!response.ok) throw new Error('The fixture run could not start.');
-      const created = asQuickNoteRun(await response.json());
-      if (!created) throw new Error('The quick-note fixture returned an incompatible artifact pack.');
-      setRun(created);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'The fixture run failed.');
-    } finally { setBusy(false); }
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'The fixture run could not start.');
+      setRun(body);
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'The fixture run failed.'); }
+    finally { setBusyArtifactId(''); }
   }
 
-  async function decide(decision: 'accepted' | 'rejected') {
+  async function decide(artifact: ArtifactVersion, decision: 'accepted' | 'rejected') {
     if (!run) return;
-    setBusy(true);
-    setError('');
+    setBusyArtifactId(artifact.id); setError('');
     try {
       const response = await fetch(`/api/foundry/runs/${run.id}/review`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ decision, reviewer: 'local-editor', expectedVersion: run.version }),
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ artifactId: artifact.id, decision, reviewer: 'local-editor', expectedVersion: run.version, expectedArtifactVersion: artifact.version }),
       });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error ?? 'Review decision failed.');
-      const reviewed = asQuickNoteRun(body);
-      if (!reviewed) throw new Error('The reviewed run is not quick-note compatible.');
-      setRun(reviewed);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'Review decision failed.');
-    } finally { setBusy(false); }
+      setRun(body);
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Review decision failed.'); }
+    finally { setBusyArtifactId(''); }
   }
 
-  async function saveDraft() {
-    if (!run) return;
-    setBusy(true);
-    setError('');
+  async function saveQuickDraft() {
+    if (!run || !quickArtifact) return;
+    setBusyArtifactId(quickArtifact.id); setError('');
     try {
       const response = await fetch(`/api/foundry/runs/${run.id}/artifact`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...draft, editor: 'local-editor', expectedVersion: run.version }),
       });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error ?? 'The draft could not be saved.');
-      const saved = asQuickNoteRun(body);
-      if (!saved) throw new Error('The saved run is not quick-note compatible.');
-      setRun(saved);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'The draft could not be saved.');
-    } finally { setBusy(false); }
+      setRun(body);
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'The draft could not be saved.'); }
+    finally { setBusyArtifactId(''); }
   }
 
-  const sourceById = new Map(run?.bundle.sourceItems.map((source) => [source.id, source]) ?? []);
-  const draftDirty = Boolean(run && (
-    draft.headline !== run.artifact.payload.headline
-    || draft.dek !== (run.artifact.payload.dek ?? '')
-    || draft.body !== run.artifact.payload.body
-  ));
-  const reviewBlocked = Boolean(run && (
-    run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed)
-  ));
+  return <main>
+    <header className="masthead">
+      <div className="wordmark"><span>Peninsula</span> <strong>Insider</strong></div>
+      <div className="environment">PRIVATE WORKBENCH · FIXTURE MODE</div>
+    </header>
 
-  return (
-    <main>
-      <header className="masthead">
-        <div className="wordmark"><span>Peninsula</span> <strong>Insider</strong></div>
-        <div className="environment">PRIVATE WORKBENCH · FIXTURE MODE</div>
-      </header>
+    <section className="hero">
+      <p className="eyebrow">Content Foundry v0.3</p>
+      <h1>One evidence spine. Every draft reviewed on its own.</h1>
+      <p>Build a governed fixture pack, inspect its lineage, and approve only safe draft handoffs. Nothing schedules, sends or publishes from this screen.</p>
+      <div className="fixture-actions">{FIXTURES.map((fixture) => <button key={fixture.id} onClick={() => startRun(fixture.id)} disabled={Boolean(busyArtifactId)}>{fixture.label}</button>)}</div>
+    </section>
 
-      <section className="hero">
-        <p className="eyebrow">Content Foundry v0.1</p>
-        <h1>Evidence first. One source, many useful outputs.</h1>
-        <p>Start with a frozen local fixture, inspect every claim, then make a human review decision. Nothing publishes from this screen.</p>
-        <button onClick={startRun} disabled={busy}>{run ? 'Replay fixture safely' : 'Run the first fixture'}</button>
+    {error && <div className="notice error" role="alert">{error}</div>}
+    {!run && <section className="empty"><h2>No run yet</h2><p>Choose a deterministic package to prove its review spine.</p></section>}
+
+    {run && <>
+      <section className="runbar" aria-live="polite">
+        <div><span>RUN</span><strong>{run.id}</strong></div>
+        <div><span>RECIPE</span><strong>{run.recipe.label}</strong></div>
+        <div><span>STATUS</span><strong className={`status ${run.status}`}>{run.status.replaceAll('_', ' ')}</strong></div>
+        <div><span>EXTERNAL CALLS</span><strong>None</strong></div>
       </section>
 
-      {error && <div className="notice error" role="alert">{error}</div>}
-      {!run && <section className="empty"><h2>No run yet</h2><p>The first deterministic package is ready to prove the full review spine.</p></section>}
-
-      {run && <>
-        <section className="runbar" aria-live="polite">
-          <div><span>RUN</span><strong>{run.id}</strong></div>
-          <div><span>STATUS</span><strong className={`status ${run.status}`}>{run.status.replaceAll('_', ' ')}</strong></div>
-          <div><span>VERSION</span><strong>{run.version}</strong></div>
-          <div><span>EXTERNAL CALLS</span><strong>None</strong></div>
+      <div className="workspace-grid">
+        <section className="panel claims-panel">
+          <div className="panel-heading"><h2 className="eyebrow">Claim ledger</h2><span>{run.claimSet.claims.length} claims</span></div>
+          {run.claimSet.claims.map((claim) => <article className="claim" key={claim.id}>
+            <div className="claim-top"><span className={`pill ${claim.verification}`}>{claim.verification}</span>{claim.restrictedFromArtifacts && <span className="pill restricted">held</span>}</div>
+            <p>{claim.text}</p>
+            <small>{claim.origin.replaceAll('_', ' ')} · {claim.evidence.length} evidence locator{claim.evidence.length === 1 ? '' : 's'}</small>
+            {claim.evidence.length > 0 && <details className="evidence-detail"><summary>Inspect evidence</summary>
+              {claim.evidence.map((item) => {
+                const source = sourceById.get(item.sourceItemId);
+                return <div className="evidence-item" key={`${item.sourceItemId}-${item.locator}`}>
+                  <blockquote>{item.excerpt}</blockquote>
+                  <dl><div><dt>Locator</dt><dd>{item.locatorType}: {item.locator}</dd></div><div><dt>Captured</dt><dd>{new Date(item.capturedAt).toLocaleString('en-AU')}</dd></div><div><dt>Source</dt><dd>{source?.uri ? <a href={source.uri} target="_blank" rel="noreferrer">{source.uri}</a> : item.sourceItemId}</dd></div></dl>
+                </div>;
+              })}
+            </details>}
+            {claim.restrictionReason && <div className="restriction">{claim.restrictionReason}</div>}
+          </article>)}
         </section>
 
-        <div className="workspace-grid">
-          <section className="panel">
-            <div className="panel-heading"><h2 className="eyebrow">Claim ledger</h2><span>{run.claims.length} claims</span></div>
-            {run.claims.map((claim) => <article className="claim" key={claim.id}>
-              <div className="claim-top"><span className={`pill ${claim.verification}`}>{claim.verification}</span>{claim.restrictedFromArtifacts && <span className="pill restricted">held</span>}</div>
-              <p>{claim.text}</p>
-              <small>{claim.origin.replaceAll('_', ' ')} · {claim.evidence.length} evidence locator{claim.evidence.length === 1 ? '' : 's'}</small>
-              {claim.evidence.length > 0 && <details className="evidence-detail">
-                <summary>Inspect evidence</summary>
-                {claim.evidence.map((item) => {
-                  const source = sourceById.get(item.sourceItemId);
-                  return <div className="evidence-item" key={`${item.sourceItemId}-${item.locator}`}>
-                    <blockquote>{item.excerpt}</blockquote>
-                    <dl>
-                      <div><dt>Locator</dt><dd>{item.locatorType}: {item.locator}</dd></div>
-                      <div><dt>Captured</dt><dd>{new Date(item.capturedAt).toLocaleString('en-AU')}</dd></div>
-                      <div><dt>Source</dt><dd>{source?.uri ? <a href={source.uri} target="_blank" rel="noreferrer">{source.uri}</a> : item.sourceItemId}</dd></div>
-                    </dl>
-                  </div>;
-                })}
-              </details>}
-              {claim.restrictionReason && <div className="restriction">{claim.restrictionReason}</div>}
-            </article>)}
-          </section>
-
-          <section className="panel artifact-panel">
-            <div className="panel-heading"><h2 className="eyebrow">Quick-note draft</h2><span>Draft only</span></div>
-            <p className="section-label">{run.artifact.payload.section} · {run.artifact.payload.tag}</p>
-            <label className="editor-field">
-              <span>Headline</span>
-              <textarea rows={2} value={draft.headline} onChange={(event) => setDraft({ ...draft, headline: event.target.value })} />
-            </label>
-            <label className="editor-field">
-              <span>Dek</span>
-              <textarea rows={3} value={draft.dek} onChange={(event) => setDraft({ ...draft, dek: event.target.value })} />
-            </label>
-            <label className="editor-field body-field">
-              <span>Body</span>
-              <textarea rows={7} value={draft.body} onChange={(event) => setDraft({ ...draft, body: event.target.value })} />
-            </label>
-            <div className="gates">
-              {run.artifact.gateResults.map((gate) => <div key={gate.gate} className={gate.passed ? 'gate pass' : 'gate fail'}>
-                <strong>{gate.passed ? 'PASS' : 'BLOCK'}</strong><span>{gate.gate.replaceAll('_', ' ')}</span>
-              </div>)}
-            </div>
-            {draftDirty && <div className="notice unsaved" role="status">Unsaved changes are not reviewed. Save them before approving a draft handoff.</div>}
-            <div className="actions">
-              <button className="secondary" onClick={saveDraft} disabled={busy || !draftDirty}>Save changes</button>
-              <button className="secondary" onClick={() => decide('rejected')} disabled={busy}>Reject</button>
-              <button onClick={() => decide('accepted')} disabled={busy || draftDirty || reviewBlocked}>Approve draft handoff</button>
-            </div>
-            {run.status === 'accepted' && !draftDirty && <a className="download" href={`/api/foundry/runs/${run.id}/patch`}>Download reviewed patch</a>}
-          </section>
-        </div>
-      </>}
-    </main>
-  );
+        <section className="artifact-stack" aria-label="Artifact review panels">
+          {run.artifactPack.completed.map((artifact) => {
+            const review = currentReview(run, artifact);
+            const blocked = artifact.gateResults.some((gate) => !gate.passed && gate.blocking);
+            const isQuick = artifact.type === 'quick_note' && quickArtifact?.id === artifact.id;
+            return <article className="panel artifact-panel" key={artifact.id}>
+              <div className="panel-heading"><h2>{titleFor(artifact.type)}</h2><span>v{artifact.version} · {review ? review.decision : 'unreviewed'}</span></div>
+              <div className="artifact-meta"><span>{artifact.key}</span><span>{artifact.claimUsage.length} lineage bindings</span><span>Draft only</span></div>
+              {isQuick ? <>
+                <label className="editor-field"><span>Headline</span><textarea rows={2} value={draft.headline} onChange={(event) => setDraft({ ...draft, headline: event.target.value })} /></label>
+                <label className="editor-field"><span>Dek</span><textarea rows={3} value={draft.dek} onChange={(event) => setDraft({ ...draft, dek: event.target.value })} /></label>
+                <label className="editor-field body-field"><span>Body</span><textarea rows={7} value={draft.body} onChange={(event) => setDraft({ ...draft, body: event.target.value })} /></label>
+              </> : <ArtifactPreview artifact={artifact} />}
+              <div className="gates">{artifact.gateResults.map((gate) => <div key={gate.gate} className={gate.passed ? 'gate pass' : gate.blocking ? 'gate fail' : 'gate warn'}><strong>{gate.passed ? 'PASS' : gate.blocking ? 'BLOCK' : 'WAIT'}</strong><span>{gate.gate.replaceAll('_', ' ')}</span></div>)}</div>
+              {isQuick && draftDirty && <div className="notice unsaved" role="status">Unsaved changes are not reviewed. Save them before approving a draft handoff.</div>}
+              <div className="actions">
+                {isQuick && <button className="secondary" onClick={saveQuickDraft} disabled={Boolean(busyArtifactId) || !draftDirty}>Save changes</button>}
+                <button className="secondary" onClick={() => decide(artifact, 'rejected')} disabled={Boolean(busyArtifactId)}>Reject</button>
+                <button onClick={() => decide(artifact, 'accepted')} disabled={Boolean(busyArtifactId) || blocked || (isQuick && draftDirty)}>Approve draft handoff</button>
+              </div>
+              {review?.decision === 'accepted' && <a className="download" href={`/api/foundry/runs/${run.id}/artifacts/${artifact.id}/handoff`}>Download reviewed draft handoff</a>}
+              {isQuick && run.status === 'accepted' && !draftDirty && <a className="download secondary-download" href={`/api/foundry/runs/${run.id}/patch`}>Download reviewed patch</a>}
+            </article>;
+          })}
+        </section>
+      </div>
+    </>}
+  </main>;
 }

--- a/studio-peninsula-insider/src/styles.css
+++ b/studio-peninsula-insider/src/styles.css
@@ -14,12 +14,13 @@
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; min-width: 320px; min-height: 100vh; }
+body { margin: 0; min-width: 0; min-height: 100vh; overflow-x: hidden; }
 button, a { font: inherit; }
 button { border: 0; border-radius: 999px; background: #0b2e4a; color: white; padding: 0.8rem 1.25rem; font-weight: 700; cursor: pointer; }
 button:disabled { opacity: 0.55; cursor: wait; }
 button.secondary { background: transparent; color: #0b2e4a; border: 1px solid #9ca7ae; }
 button:focus-visible, a:focus-visible { outline: 3px solid #10527e; outline-offset: 3px; }
+.fixture-actions { display: flex; flex-wrap: wrap; gap: 10px; }
 
 main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding-bottom: 64px; }
 .masthead { min-height: 78px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #cfcac2; }
@@ -43,8 +44,14 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .status { text-transform: capitalize; color: #10527e; }
 .status.accepted { color: #1d6d54; }
 .status.needs_revision, .status.rejected, .status.failed { color: #a33c32; }
-.workspace-grid { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.3fr); gap: 18px; align-items: start; }
+.workspace-grid { display: grid; grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.6fr); gap: 18px; align-items: start; }
 .panel { background: #fbfaf8; border: 1px solid #d7d1c8; border-radius: 18px; padding: 24px; }
+.claims-panel { max-height: calc(100vh - 32px); overflow: auto; position: sticky; top: 16px; }
+.artifact-stack { display: grid; gap: 18px; min-width: 0; }
+.artifact-panel { min-width: 0; }
+.artifact-panel .panel-heading h2 { font-size: clamp(1.35rem, 2.4vw, 2rem); text-transform: capitalize; }
+.artifact-meta { display: flex; flex-wrap: wrap; gap: 7px; margin: -4px 0 18px; }
+.artifact-meta span { border-radius: 999px; padding: 5px 9px; background: #e8e3dc; color: #53636e; font-size: 0.72rem; font-weight: 700; }
 .panel-heading { display: flex; align-items: baseline; justify-content: space-between; border-bottom: 1px solid #ded9d1; padding-bottom: 14px; margin-bottom: 16px; }
 .panel-heading .eyebrow { margin: 0; color: #10527e; }
 .panel-heading > span { color: #53636e; font-size: 0.82rem; }
@@ -76,14 +83,31 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .gate { padding: 12px; border-radius: 10px; display: grid; gap: 4px; font-size: 0.75rem; text-transform: capitalize; }
 .gate.pass { background: #e4ede8; color: #225d49; }
 .gate.fail { background: #f3dfda; color: #8f2f28; }
+.gate.warn { background: #fff1cf; color: #6d4c12; }
 .gate strong { font-size: 0.67rem; letter-spacing: 0.1em; }
 .actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 10px; margin-top: 24px; }
 .download { display: block; margin-top: 16px; text-align: center; color: #0b2e4a; font-weight: 800; }
+.secondary-download { font-weight: 600; }
+.payload-preview, .position pre { max-height: 360px; margin: 16px 0; overflow: auto; border-radius: 12px; padding: 16px; background: #14202a; color: #f2efea; font: 0.76rem/1.55 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+.position-list { display: grid; gap: 9px; max-height: 560px; overflow: auto; padding-right: 4px; }
+.position { border: 1px solid #ded9d1; border-radius: 12px; padding: 12px; background: white; }
+.position > div:first-child { display: flex; gap: 10px; align-items: baseline; text-transform: capitalize; }
+.position > div:first-child span { color: #10527e; font: 800 0.72rem Sora, sans-serif; }
+.position > small { color: #53636e; }
+.position pre { max-height: 180px; margin-bottom: 0; }
+.authority-note { border-left: 4px solid #f5c177; padding: 12px 14px; background: #fff7e5; color: #61440f; font-weight: 700; }
+.subject-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 9px; margin: 14px 0; }
+.subject-grid article { border: 1px solid #ded9d1; border-radius: 12px; padding: 14px; background: white; }
+.subject-grid small, .subject-grid strong { display: block; }
+.subject-grid small { color: #53636e; margin-bottom: 8px; }
+.subject-grid p { color: #53636e; line-height: 1.45; }
 
 @media (max-width: 820px) {
   .environment { display: none; }
   .hero { padding-top: 48px; }
   .runbar { grid-template-columns: 1fr 1fr; }
   .workspace-grid { grid-template-columns: 1fr; }
+  .claims-panel { max-height: none; position: static; }
+  .subject-grid { grid-template-columns: 1fr; }
   .gates { grid-template-columns: 1fr; }
 }

--- a/studio-peninsula-insider/tests/foundry.test.ts
+++ b/studio-peninsula-insider/tests/foundry.test.ts
@@ -427,7 +427,7 @@ describe('generic Content Foundry contracts', () => {
     const page = await request(app).get('/').expect(200).expect('Content-Type', /html/).expect('Content-Security-Policy', /default-src 'self'/);
     expect(page.text).toContain('Foundry container marker');
     const capabilities = await request(app).get('/api/capabilities').expect(200).expect('Cache-Control', 'no-store');
-    expect(capabilities.body.recipes).toEqual(['quick_note_v1', 'url_article_v1']);
+    expect(capabilities.body.recipes).toEqual(['quick_note_v1', 'url_article_v1', 'newsletter_social_v1']);
     expect(capabilities.body.externalCalls).toBe(false);
   });
 });

--- a/studio-peninsula-insider/tests/foundry.test.ts
+++ b/studio-peninsula-insider/tests/foundry.test.ts
@@ -5,8 +5,9 @@ import request from 'supertest';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createApp } from '../server/app.js';
 import { loadRuntimeConfig } from '../server/config.js';
-import { evaluateQuickNoteGates, runFixture } from '../server/fixture-runner.js';
+import { artifactDependenciesCurrent, buildPatch, evaluateArtifactGates, evaluateQuickNoteGates, hashValue, runFixture, runUrlArticleFixture, validateNewFilePatch } from '../server/fixture-runner.js';
 import { FileFoundryStore } from '../server/store.js';
+import type { ArtifactVersion, FoundryRun } from '../shared/contracts.js';
 
 const temporaryDirectories: string[] = [];
 
@@ -18,154 +19,415 @@ async function harness() {
   return { directory, file, store, app: createApp(store) };
 }
 
+function completed(run: FoundryRun, type: ArtifactVersion['type']): ArtifactVersion {
+  const artifact = run.artifactPack.completed.find((candidate) => candidate.type === type);
+  if (!artifact) throw new Error(`Missing ${type}`);
+  return artifact;
+}
+
+async function reviewArtifact(app: ReturnType<typeof createApp>, run: FoundryRun, artifact: ArtifactVersion, decision: 'accepted' | 'rejected' = 'accepted') {
+  const response = await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+    artifactId: artifact.id,
+    decision,
+    reviewer: 'test-editor',
+    expectedVersion: run.version,
+    expectedArtifactVersion: artifact.version,
+  }).expect(200);
+  return response.body as FoundryRun;
+}
+
+function legacySnapshot(run: FoundryRun) {
+  if (!run.artifact || !run.claims) throw new Error('Quick-note compatibility projection missing');
+  return {
+    id: run.id,
+    idempotencyKey: run.idempotencyKey,
+    version: run.version,
+    status: run.status,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    bundle: run.bundle,
+    claims: run.claims,
+    angle: {
+      id: run.angle.id,
+      label: run.angle.label,
+      framing: run.angle.framing,
+      evidenceClaimIds: run.angle.evidenceClaimIds,
+      selectedBy: run.angle.selectedBy,
+    },
+    artifact: {
+      id: run.artifact.id,
+      version: run.artifact.version,
+      type: 'quick_note',
+      claimIds: run.artifact.claimIds,
+      angleId: run.artifact.angleId,
+      payload: run.artifact.payload,
+      gateResults: run.artifact.gateResults
+        .filter((gate) => ['no_price', 'no_em_dash', 'supported_claims_only'].includes(gate.gate))
+        .map(({ gate, passed, detail }) => ({ gate, passed, detail })),
+    },
+    blockers: run.blockers,
+    review: run.review,
+    audit: run.audit,
+  };
+}
+
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
 });
 
-describe('deterministic Foundry fixture', () => {
-  it('creates one evidence-backed run and reuses its idempotency key', async () => {
+describe('generic Content Foundry contracts', () => {
+  it('preserves the v0.1 quick-note API projection and idempotency', async () => {
     const { app } = await harness();
-    const payload = { fixtureId: 'red-hill-winter-lunch', actor: 'test-editor', idempotencyKey: 'same-source-v1' };
+    const payload = { fixtureId: 'red-hill-winter-lunch', actor: 'test-editor', idempotencyKey: 'same-source-v2' };
     const first = await request(app).post('/api/foundry/runs').send(payload).expect(201);
     const replay = await request(app).post('/api/foundry/runs').send(payload).expect(200);
 
     expect(replay.body.id).toBe(first.body.id);
-    expect(first.body.claims).toHaveLength(5);
+    expect(first.body.schemaVersion).toBe('pi.foundry-run.v2');
+    expect(first.body.recipe.id).toBe('quick_note_v1');
+    expect(first.body.claims).toEqual(first.body.claimSet.claims);
+    expect(first.body.artifact.type).toBe('quick_note');
     expect(first.body.artifact.claimIds).not.toContain('claim-unsupported');
+    expect(first.body.artifact.claimIds).not.toContain('claim-expired');
     expect(first.body.artifact.claimIds).not.toContain('claim-price');
-    expect(first.body.artifact.payload.body).not.toMatch(/\$\s?\d|—/);
-    expect(first.body.artifact.gateResults.every((gate: { passed: boolean }) => gate.passed)).toBe(true);
+    expect(first.body.artifactPack.completed).toHaveLength(1);
   });
 
-  it('derives the claim gate and permits en dashes while blocking em dashes', () => {
-    const run = runFixture('test-editor', 'style-law-v1');
-    const enDash = evaluateQuickNoteGates({ headline: 'Open 9–11am', body: 'A supported range.' }, run.claims, run.artifact.claimIds);
-    const emDash = evaluateQuickNoteGates({ headline: 'Open today — bookings required', body: 'A supported note.' }, run.claims, run.artifact.claimIds);
-    const restricted = evaluateQuickNoteGates(run.artifact.payload, run.claims, [...run.artifact.claimIds, 'claim-price']);
+  it('derives price, style, claim-support and expiry gates', () => {
+    const run = runFixture('test-editor', 'style-law-v2');
+    if (!run.artifact) throw new Error('Quick-note artifact missing');
+    const claims = run.claimSet.claims;
+    const enDash = evaluateQuickNoteGates({ headline: 'Open 9–11am', body: 'A supported range.' }, claims, run.artifact.claimIds);
+    const emDash = evaluateQuickNoteGates({ headline: 'Open today — bookings required', body: 'A supported note.' }, claims, run.artifact.claimIds);
+    const restricted = evaluateQuickNoteGates(run.artifact.payload, claims, [...run.artifact.claimIds, 'claim-price']);
+    const expired = evaluateArtifactGates(
+      { answer: 'The preview ran on Friday 14 August.' },
+      claims,
+      ['expired-answer'],
+      [{ segmentId: 'expired-answer', path: '$.answer', claimIds: ['claim-expired'], contentHash: hashValue('The preview ran on Friday 14 August.') }],
+      '2026-08-21T05:00:00.000Z',
+    );
 
     expect(enDash.find((gate) => gate.gate === 'no_em_dash')?.passed).toBe(true);
     expect(emDash.find((gate) => gate.gate === 'no_em_dash')?.passed).toBe(false);
+    expect(restricted.find((gate) => gate.gate === 'no_price')?.passed).toBe(true);
     expect(restricted.find((gate) => gate.gate === 'supported_claims_only')?.passed).toBe(false);
+    expect(expired.find((gate) => gate.gate === 'supported_claims_only')?.passed).toBe(false);
   });
 
-  it('requires idempotency and serializes concurrent mutations', async () => {
-    const { app, store } = await harness();
-    await request(app).post('/api/foundry/runs').send({ fixtureId: 'red-hill-winter-lunch', actor: 'test-editor' }).expect(400);
+  it('loads legacy v0.1 persisted snapshots into deterministic artifact packs across restart', async () => {
+    const { directory, file } = await harness();
+    const legacy = legacySnapshot(runFixture('legacy-editor', 'legacy-store-v1'));
+    const legacyPriceGate = legacy.artifact.gateResults.find((gate) => gate.gate === 'no_price');
+    if (!legacyPriceGate) throw new Error('Legacy price gate missing');
+    legacyPriceGate.passed = false;
+    legacy.status = 'ready_for_review';
+    await writeFile(file, `${JSON.stringify({ schemaVersion: 'pi.foundry-file-store.v1', runs: [legacy] })}\n`, 'utf8');
 
-    const runs = Array.from({ length: 8 }, (_, index) => runFixture('test-editor', `concurrent-${index}`));
-    await Promise.all(runs.map((run) => store.create(run)));
-    expect(await store.list()).toHaveLength(8);
+    const firstRestart = new FileFoundryStore(file, directory);
+    const migrated = await firstRestart.get(legacy.id);
+    const secondRestart = new FileFoundryStore(file, directory);
+    const migratedAgain = await secondRestart.get(legacy.id);
+
+    expect(migrated?.schemaVersion).toBe('pi.foundry-run.v2');
+    expect(migrated?.status).toBe('needs_revision');
+    expect(migrated?.artifactPack.completed[0].id).toBe(legacy.artifact.id);
+    expect(migrated?.claimSet.contentHash).toBe(migratedAgain?.claimSet.contentHash);
+    expect(migrated?.artifactPack.completed[0].contentHash).toBe(migratedAgain?.artifactPack.completed[0].contentHash);
+    expect(migrated?.audit.at(-1)?.type).toBe('legacy_run_migrated');
   });
 
-  it('persists review decisions and rejects stale versions', async () => {
-    const { app, file } = await harness();
+  it('keeps a text-only Article and Ask pack valid without inventing media', async () => {
+    const { app } = await harness();
     const created = await request(app).post('/api/foundry/runs').send({
-      fixtureId: 'red-hill-winter-lunch', actor: 'test-editor', idempotencyKey: 'review-v1',
+      fixtureId: 'red-hill-url-article', fixtureVariant: 'text_only', actor: 'test-editor', idempotencyKey: 'article-text-only-v1',
     }).expect(201);
+    const run = created.body as FoundryRun;
+    const metadata = completed(run, 'article_metadata');
+    if (metadata.type !== 'article_metadata') throw new Error('Metadata narrowing failed');
 
-    const accepted = await request(app).put(`/api/foundry/runs/${created.body.id}/review`).send({
-      decision: 'accepted', reviewer: 'test-editor', expectedVersion: 1,
-    }).expect(200);
-    expect(accepted.body.version).toBe(2);
+    expect(run.status).toBe('ready_for_review');
+    expect(run.artifactPack.status).toBe('partial');
+    expect(metadata.payload.heroImage).toBeUndefined();
+    expect(metadata.payload.astroPatchReady).toBe(false);
+    expect(metadata.gateResults.find((gate) => gate.gate === 'astro_patch_ready')).toMatchObject({ passed: false, blocking: false });
+    expect(JSON.stringify(run.artifactPack.completed)).not.toContain('placeholder');
+    await reviewArtifact(app, run, completed(run, 'article_draft'));
+  });
 
-    await request(app).put(`/api/foundry/runs/${created.body.id}/review`).send({
-      decision: 'rejected', reviewer: 'other-editor', expectedVersion: 1,
+  it('keeps required artifacts reviewable when one optional derivative fails', async () => {
+    const { app } = await harness();
+    const created = await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', fixtureVariant: 'partial_optional_failure', actor: 'test-editor', idempotencyKey: 'article-partial-v1',
+    }).expect(201);
+    let run = created.body as FoundryRun;
+    expect(run.artifactPack.status).toBe('partial');
+    expect(run.artifactPack.failed).toEqual([expect.objectContaining({ type: 'seo_metadata_proposal', required: false })]);
+    expect(run.status).toBe('ready_for_review');
+    expect(JSON.stringify(run.artifactPack.completed)).not.toMatch(/\$\s?\d|—|price_band/);
+    expect(run.artifactPack.completed.every((artifact) => artifact.factualSegmentIds.every((segmentId) => (
+      artifact.claimUsage.some((usage) => usage.segmentId === segmentId && usage.claimIds.length > 0)
+    )))).toBe(true);
+
+    run = await reviewArtifact(app, run, completed(run, 'article_draft'));
+    expect(run.artifactPack.reviews.at(-1)).toMatchObject({ artifactId: 'artifact-article-red-hill', decision: 'accepted', authority: 'draft_handoff_only' });
+    expect(run.status).toBe('ready_for_review');
+  });
+
+  it('fails closed when non-quick payload edits omit or reuse stale factual lineage', async () => {
+    const { app } = await harness();
+    const run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', actor: 'test-editor', idempotencyKey: 'article-lineage-v1',
+    }).expect(201)).body as FoundryRun;
+    const article = completed(run, 'article_draft');
+    if (article.type !== 'article_draft') throw new Error('Article narrowing failed');
+    const appended = { ...article.payload, body: `${article.payload.body}\n\nThe venue seats 500 guests and opens seven days a week.` };
+
+    await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${article.id}`).send({
+      editor: 'test-editor', expectedVersion: run.version, expectedArtifactVersion: article.version, payload: appended,
+    }).expect(400);
+    const staleLineage = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${article.id}`).send({
+      editor: 'test-editor', expectedVersion: run.version, expectedArtifactVersion: article.version, payload: appended,
+      factualSegmentIds: article.factualSegmentIds, claimUsage: article.claimUsage,
+    }).expect(200)).body as FoundryRun;
+    expect(completed(staleLineage, 'article_draft').gateResults.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+
+    const second = runUrlArticleFixture('test-editor', 'article-invalid-locator-v1');
+    const secondArticle = completed(second, 'article_draft');
+    if (secondArticle.type !== 'article_draft') throw new Error('Article narrowing failed');
+    secondArticle.claimUsage[0] = { ...secondArticle.claimUsage[0], path: '$.body[0]' };
+    const invalidLocator = evaluateArtifactGates(
+      secondArticle.payload, second.claimSet.claims, secondArticle.factualSegmentIds, secondArticle.claimUsage, second.updatedAt,
+    );
+    expect(invalidLocator.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+    const changedSegment = { ...article.payload, body: article.payload.body.replace('covered dining room', 'large dining room') };
+    const removedSegment = { ...article.payload, body: article.payload.body.split(/\n\s*\n/).slice(0, 2).join('\n\n') };
+    for (const payload of [changedSegment, removedSegment]) {
+      const gates = evaluateArtifactGates(payload, run.claimSet.claims, article.factualSegmentIds, article.claimUsage, run.updatedAt);
+      expect(gates.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+    }
+  });
+
+  it('derives claim-set, angle and media-rights freshness instead of trusting stored flags', async () => {
+    const base = runUrlArticleFixture('test-editor', 'freshness-unit-v1', { includeClearedHero: true });
+    const article = completed(base, 'article_draft');
+    const metadata = completed(base, 'article_metadata');
+
+    const claimDrift = structuredClone(base);
+    claimDrift.claimSet.version += 1;
+    claimDrift.claimSet.claims[0].text += ' Updated.';
+    claimDrift.claimSet.contentHash = hashValue(claimDrift.claimSet.claims);
+    expect(artifactDependenciesCurrent(claimDrift, completed(claimDrift, 'article_draft'))).toBe(false);
+
+    const angleDrift = structuredClone(base);
+    angleDrift.angle.version += 1;
+    expect(artifactDependenciesCurrent(angleDrift, completed(angleDrift, 'article_draft'))).toBe(false);
+
+    const mediaDrift = structuredClone(base);
+    const driftedMetadata = completed(mediaDrift, 'article_metadata');
+    if (driftedMetadata.type !== 'article_metadata' || !driftedMetadata.payload.heroImage) throw new Error('Cleared metadata missing');
+    driftedMetadata.payload.heroImage.src = '/images/sourced/never-cleared.webp';
+    driftedMetadata.contentHash = hashValue(driftedMetadata.payload);
+    expect(artifactDependenciesCurrent(mediaDrift, driftedMetadata)).toBe(false);
+    expect(artifactDependenciesCurrent(base, article)).toBe(true);
+    expect(artifactDependenciesCurrent(base, metadata)).toBe(true);
+  });
+
+  it('reconciles stored review snapshots on restart and blocks stale export', async () => {
+    const { app, file, directory } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', fixtureVariant: 'complete', actor: 'test-editor', idempotencyKey: 'freshness-restart-v1',
+    }).expect(201)).body as FoundryRun;
+    run = await reviewArtifact(app, run, completed(run, 'article_draft'));
+    run = await reviewArtifact(app, run, completed(run, 'article_metadata'));
+    const stored = JSON.parse(await readFile(file, 'utf8')) as { runs: FoundryRun[] };
+    stored.runs[0].claimSet.version += 1;
+    stored.runs[0].claimSet.claims[0].text += ' Updated.';
+    stored.runs[0].claimSet.contentHash = hashValue(stored.runs[0].claimSet.claims);
+    stored.runs[0].angle.version += 1;
+    const storedMetadata = completed(stored.runs[0], 'article_metadata');
+    if (storedMetadata.type !== 'article_metadata' || !storedMetadata.payload.heroImage) throw new Error('Cleared metadata missing');
+    storedMetadata.payload.heroImage.src = '/images/sourced/never-cleared.webp';
+    storedMetadata.contentHash = hashValue(storedMetadata.payload);
+    await writeFile(file, `${JSON.stringify(stored)}\n`, 'utf8');
+
+    const restarted = new FileFoundryStore(file, directory);
+    const reconciled = await restarted.get(run.id);
+    if (!reconciled) throw new Error('Restarted run missing');
+    expect(reconciled.artifactPack.reviews.every((review) => review.status === 'stale')).toBe(true);
+    expect(reconciled.artifactPack.completed.every((artifact) => artifact.gateResults.some((gate) => gate.gate === 'dependency_current' && !gate.passed))).toBe(true);
+    expect(() => buildPatch(reconciled)).toThrow(/unresolved gates|current accepted/);
+  });
+
+  it('cascades A to B to C review invalidation while preserving an unrelated sibling', async () => {
+    const { app, store } = await harness();
+    let run = runUrlArticleFixture('test-editor', 'transitive-stale-v1', { includeClearedHero: true });
+    const initialMetadata = completed(run, 'article_metadata');
+    const initialSeo = completed(run, 'seo_metadata_proposal');
+    initialSeo.dependencies = initialSeo.dependencies.map((dependency) => dependency.kind === 'artifact'
+      ? { ...dependency, id: initialMetadata.id, version: initialMetadata.version, contentHash: initialMetadata.contentHash }
+      : dependency);
+    run = await store.create(run);
+    run = await reviewArtifact(app, run, completed(run, 'article_draft'));
+    run = await reviewArtifact(app, run, completed(run, 'article_metadata'));
+    run = await reviewArtifact(app, run, completed(run, 'seo_metadata_proposal'));
+    run = await reviewArtifact(app, run, completed(run, 'ask_answer'));
+    const article = completed(run, 'article_draft');
+    if (article.type !== 'article_draft') throw new Error('Article narrowing failed');
+    const editedPayload = { ...article.payload, body: article.payload.body.replace('genuine wet-weather utility', 'real wet-weather utility') };
+    const editedUsage = article.claimUsage.map((usage) => usage.segmentId === 'article-location'
+      ? { ...usage, contentHash: hashValue(editedPayload.body.split(/\n\s*\n/)[0]) }
+      : usage);
+    const edited = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${article.id}`).send({
+      editor: 'test-editor', expectedVersion: run.version, expectedArtifactVersion: article.version,
+      payload: editedPayload, factualSegmentIds: article.factualSegmentIds, claimUsage: editedUsage,
+    }).expect(200)).body as FoundryRun;
+    const reviewStatus = (type: ArtifactVersion['type']) => edited.artifactPack.reviews.find((review) => review.artifactId === completed(edited, type).id)?.status;
+    expect(reviewStatus('article_draft')).toBe('stale');
+    expect(reviewStatus('article_metadata')).toBe('stale');
+    expect(reviewStatus('seo_metadata_proposal')).toBe('stale');
+    expect(reviewStatus('ask_answer')).toBe('current');
+  });
+
+  it('cannot assert media clearance by replacing the hero payload', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', fixtureVariant: 'complete', actor: 'test-editor', idempotencyKey: 'media-bypass-v1',
+    }).expect(201)).body as FoundryRun;
+    run = await reviewArtifact(app, run, completed(run, 'article_draft'));
+    run = await reviewArtifact(app, run, completed(run, 'article_metadata'));
+    const metadata = completed(run, 'article_metadata');
+    if (metadata.type !== 'article_metadata' || !metadata.payload.heroImage) throw new Error('Cleared metadata missing');
+    const replaced = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${metadata.id}`).send({
+      editor: 'test-editor', expectedVersion: run.version, expectedArtifactVersion: metadata.version,
+      payload: { ...metadata.payload, heroImage: { ...metadata.payload.heroImage, src: '/images/sourced/never-cleared.webp' }, astroPatchReady: true },
+      factualSegmentIds: metadata.factualSegmentIds, claimUsage: metadata.claimUsage,
+    }).expect(200)).body as FoundryRun;
+    const replacedMetadata = completed(replaced, 'article_metadata');
+    if (replacedMetadata.type !== 'article_metadata') throw new Error('Metadata narrowing failed');
+    expect(replacedMetadata.payload.astroPatchReady).toBe(false);
+    expect(replacedMetadata.dependencies.some((dependency) => dependency.kind === 'media_rights')).toBe(false);
+    run = await reviewArtifact(app, replaced, replacedMetadata);
+    await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(400);
+  });
+
+  it('stales only an edited artifact and its direct dependents', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', actor: 'test-editor', idempotencyKey: 'article-stale-v1',
+    }).expect(201)).body as FoundryRun;
+    const originalArticle = completed(run, 'article_draft');
+    const originalMetadata = completed(run, 'article_metadata');
+    const originalAsk = completed(run, 'ask_answer');
+    run = await reviewArtifact(app, run, originalArticle);
+    run = await reviewArtifact(app, run, originalMetadata);
+    run = await reviewArtifact(app, run, originalAsk);
+
+    const article = completed(run, 'article_draft');
+    if (article.type !== 'article_draft') throw new Error('Article narrowing failed');
+    const editedPayload = { ...article.payload, body: article.payload.body.replace('genuine wet-weather utility', 'real wet-weather utility') };
+    const editedUsage = article.claimUsage.map((usage) => usage.segmentId === 'article-location'
+      ? { ...usage, contentHash: hashValue(editedPayload.body.split(/\n\s*\n/)[0]) }
+      : usage);
+    const edited = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${article.id}`).send({
+      editor: 'test-editor',
+      expectedVersion: run.version,
+      expectedArtifactVersion: article.version,
+      payload: editedPayload,
+      factualSegmentIds: article.factualSegmentIds,
+      claimUsage: editedUsage,
+    }).expect(200)).body as FoundryRun;
+
+    expect(edited.artifactPack.reviews.find((review) => review.artifactId === article.id)?.status).toBe('stale');
+    expect(edited.artifactPack.reviews.find((review) => review.artifactId === originalMetadata.id)?.status).toBe('stale');
+    expect(edited.artifactPack.reviews.find((review) => review.artifactId === originalAsk.id)?.status).toBe('current');
+    expect(completed(edited, 'article_metadata').gateResults.find((gate) => gate.gate === 'dependency_current')).toMatchObject({ passed: false, blocking: true });
+    expect(completed(edited, 'ask_answer').gateResults.find((gate) => gate.gate === 'dependency_current')).toMatchObject({ passed: true });
+    expect(edited.status).toBe('needs_revision');
+  });
+
+  it('persists independent artifact reviews across restart and rejects stale run versions', async () => {
+    const { app, file, directory } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', actor: 'test-editor', idempotencyKey: 'article-restart-v1',
+    }).expect(201)).body as FoundryRun;
+    const ask = completed(run, 'ask_answer');
+    run = await reviewArtifact(app, run, ask);
+    await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+      artifactId: ask.id, decision: 'rejected', reviewer: 'stale-editor', expectedVersion: 1, expectedArtifactVersion: 1,
     }).expect(409);
 
-    const restartedStore = new FileFoundryStore(file, file.replace(/[\\/]runs\.json$/, ''));
-    const persisted = await restartedStore.get(created.body.id);
-    expect(persisted?.status).toBe('accepted');
+    const restarted = new FileFoundryStore(file, directory);
+    const persisted = await restarted.get(run.id);
+    expect(persisted?.artifactPack.reviews).toHaveLength(1);
+    expect(persisted?.artifactPack.reviews[0]).toMatchObject({ artifactId: ask.id, decision: 'accepted', status: 'current' });
     expect(JSON.parse(await readFile(file, 'utf8')).runs).toHaveLength(1);
   });
 
-  it('normalizes legacy ready state to needs revision when a persisted gate failed', async () => {
-    const { directory, file } = await harness();
-    const legacy = runFixture('legacy-editor', 'legacy-gate-v1');
-    legacy.artifact.gateResults[0] = { gate: 'no_price', passed: false, detail: 'Legacy failed gate.' };
-    await writeFile(file, `${JSON.stringify({ schemaVersion: 'pi.foundry-file-store.v1', runs: [legacy] })}\n`, 'utf8');
+  it('exports a rights-cleared Astro article patch only after the two patch artifacts are accepted', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-url-article', fixtureVariant: 'complete', actor: 'test-editor', idempotencyKey: 'article-patch-v1',
+    }).expect(201)).body as FoundryRun;
+    await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(400);
+    run = await reviewArtifact(app, run, completed(run, 'article_draft'));
+    run = await reviewArtifact(app, run, completed(run, 'article_metadata'));
+    const patch = await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(200);
 
-    const restarted = new FileFoundryStore(file, directory);
-    expect((await restarted.get(legacy.id))?.status).toBe('needs_revision');
+    expect(patch.text).toContain('next/src/content/articles/red-hill-wet-weather-lunch.md');
+    expect(patch.text).toContain('+status: draft');
+    expect(patch.text).toContain('+clusterLinks: [{"label":"Explore Red Hill","href":"/explore/places/red-hill/"}]');
+    expect(patch.text).not.toMatch(/\$\s?\d|—|price_band/);
+    expect(validateNewFilePatch(patch.text)).toBe(true);
   });
 
-  it('versions edits, invalidates approval and blocks restricted copy', async () => {
+  it('preserves quick-note review, edit and multiline patch compatibility', async () => {
     const { app } = await harness();
-    const created = await request(app).post('/api/foundry/runs').set('Idempotency-Key', 'edit-v1').send({
+    let run = (await request(app).post('/api/foundry/runs').set('Idempotency-Key', 'quick-edit-v2').send({
       fixtureId: 'red-hill-winter-lunch', actor: 'test-editor',
-    }).expect(201);
+    }).expect(201)).body as FoundryRun;
+    if (!run.artifact) throw new Error('Quick-note artifact missing');
+    run = await reviewArtifact(app, run, run.artifact);
+    const acceptedVersion = run.version;
+    const edited = (await request(app).put(`/api/foundry/runs/${run.id}/artifact`).send({
+      editor: 'test-editor', expectedVersion: run.version,
+      headline: run.artifact?.payload.headline,
+      dek: run.artifact?.payload.dek,
+      body: 'First paragraph.\n\nSecond paragraph.',
+    }).expect(200)).body as FoundryRun;
+    expect(edited.status).toBe('ready_for_review');
+    expect(edited.review).toBeUndefined();
+    expect(edited.artifactPack.reviews[0].status).toBe('stale');
 
-    const accepted = await request(app).put(`/api/foundry/runs/${created.body.id}/review`).send({
-      decision: 'accepted', reviewer: 'test-editor', expectedVersion: 1,
-    }).expect(200);
-    const edited = await request(app).put(`/api/foundry/runs/${created.body.id}/artifact`).send({
-      editor: 'test-editor', expectedVersion: accepted.body.version,
-      headline: accepted.body.artifact.payload.headline,
-      dek: accepted.body.artifact.payload.dek,
-      body: `${accepted.body.artifact.payload.body} Tickets are priced at $20.`,
-    }).expect(200);
-
-    expect(edited.body.version).toBe(3);
-    expect(edited.body.artifact.version).toBe(2);
-    expect(edited.body.status).toBe('needs_revision');
-    expect(edited.body.review).toBeUndefined();
-    expect(edited.body.artifact.gateResults.find((gate: { gate: string }) => gate.gate === 'no_price').passed).toBe(false);
-
-    await request(app).put(`/api/foundry/runs/${created.body.id}/review`).send({
-      decision: 'accepted', reviewer: 'test-editor', expectedVersion: edited.body.version,
-    }).expect(400);
-    await request(app).put(`/api/foundry/runs/${created.body.id}/artifact`).send({
-      editor: 'stale-editor', expectedVersion: accepted.body.version,
+    await request(app).put(`/api/foundry/runs/${run.id}/artifact`).send({
+      editor: 'stale-editor', expectedVersion: acceptedVersion,
       headline: 'Stale overwrite', dek: '', body: 'This must not win.',
     }).expect(409);
+    if (!edited.artifact) throw new Error('Edited quick-note artifact missing');
+    const reaccepted = await reviewArtifact(app, edited, edited.artifact);
+    const patch = await request(app).get(`/api/foundry/runs/${reaccepted.id}/patch`).expect(200);
+    expect(patch.text).toContain('+First paragraph.\n+\n+Second paragraph.');
   });
 
-  it('fails closed for production fixture mode and path escape', () => {
+  it('requires idempotency, serializes mutations and fails closed outside local fixture mode', async () => {
+    const { app, store } = await harness();
+    await request(app).post('/api/foundry/runs').send({ fixtureId: 'red-hill-winter-lunch', actor: 'test-editor' }).expect(400);
+    const runs = Array.from({ length: 8 }, (_, index) => runFixture('test-editor', `concurrent-v2-${index}`));
+    await Promise.all(runs.map((run) => store.create(run)));
+    expect(await store.list()).toHaveLength(8);
     expect(() => loadRuntimeConfig({ NODE_ENV: 'production' })).toThrow(/disabled in production/);
     expect(() => loadRuntimeConfig({ NODE_ENV: 'test', FOUNDRY_HOST: 'public.example' })).toThrow(/FOUNDRY_HOST/);
     expect(() => new FileFoundryStore('C:\\outside\\runs.json', 'C:\\allowed')).toThrow(/inside its configured data root/);
   });
 
-  it('serves the built Workbench from the same loopback service', async () => {
+  it('serves capabilities and the built Workbench from the same loopback service', async () => {
     const { directory, store } = await harness();
     await writeFile(join(directory, 'index.html'), '<!doctype html><title>Foundry container marker</title>', 'utf8');
     const app = createApp(store, { staticDir: directory });
-
     const page = await request(app).get('/').expect(200).expect('Content-Type', /html/).expect('Content-Security-Policy', /default-src 'self'/);
     expect(page.text).toContain('Foundry container marker');
-    await request(app).get('/api/health').expect(200).expect('Content-Type', /json/).expect('Cache-Control', 'no-store');
-  });
-
-  it('exports a patch only after acceptance', async () => {
-    const { app } = await harness();
-    const created = await request(app).post('/api/foundry/runs').send({
-      fixtureId: 'red-hill-winter-lunch', actor: 'test-editor', idempotencyKey: 'patch-v1',
-    }).expect(201);
-
-    await request(app).get(`/api/foundry/runs/${created.body.id}/patch`).expect(400);
-    await request(app).put(`/api/foundry/runs/${created.body.id}/review`).send({
-      decision: 'accepted', reviewer: 'test-editor', expectedVersion: 1,
-    }).expect(200);
-    const patch = await request(app).get(`/api/foundry/runs/${created.body.id}/patch`).expect(200);
-    expect(patch.text).toContain('next/src/content/quick-notes/2026-08-21-red-hill-wet-weather-lunch.md');
-    expect(patch.text).toContain('status: draft');
-  });
-
-  it('preserves every physical line in multiline Markdown patches', async () => {
-    const { app } = await harness();
-    const created = await request(app).post('/api/foundry/runs').set('Idempotency-Key', 'multiline-v1').send({
-      fixtureId: 'red-hill-winter-lunch', actor: 'test-editor',
-    }).expect(201);
-    const edited = await request(app).put(`/api/foundry/runs/${created.body.id}/artifact`).send({
-      editor: 'test-editor', expectedVersion: 1,
-      headline: created.body.artifact.payload.headline,
-      dek: created.body.artifact.payload.dek,
-      body: 'First paragraph.\n\nSecond paragraph.',
-    }).expect(200);
-    await request(app).put(`/api/foundry/runs/${created.body.id}/review`).send({
-      decision: 'accepted', reviewer: 'test-editor', expectedVersion: edited.body.version,
-    }).expect(200);
-
-    const patch = await request(app).get(`/api/foundry/runs/${created.body.id}/patch`).expect(200);
-    expect(patch.text).toContain('+First paragraph.\n+\n+Second paragraph.');
+    const capabilities = await request(app).get('/api/capabilities').expect(200).expect('Cache-Control', 'no-store');
+    expect(capabilities.body.recipes).toEqual(['quick_note_v1', 'url_article_v1']);
+    expect(capabilities.body.externalCalls).toBe(false);
   });
 });

--- a/studio-peninsula-insider/tests/newsletter-social.test.ts
+++ b/studio-peninsula-insider/tests/newsletter-social.test.ts
@@ -1,0 +1,238 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { ClaimSchema, type ArtifactVersion, type FoundryRun } from '../shared/contracts.js';
+import { createApp } from '../server/app.js';
+import {
+  buildArtifactHandoff,
+  evaluateArtifactFormatGates,
+  evaluateArtifactGates,
+  hashValue,
+  runNewsletterSocialFixture,
+} from '../server/fixture-runner.js';
+import { FileFoundryStore } from '../server/store.js';
+
+function artifact<T extends ArtifactVersion['type']>(run: FoundryRun, type: T): Extract<ArtifactVersion, { type: T }> {
+  const found = run.artifactPack.completed.find((candidate) => candidate.type === type);
+  if (!found || found.type !== type) throw new Error(`Missing ${type}`);
+  return found as Extract<ArtifactVersion, { type: T }>;
+}
+
+async function harness(evaluationClock?: () => string) {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-newsletter-social-'));
+  const store = new FileFoundryStore(join(directory, 'runs.json'), directory, evaluationClock);
+  return { app: createApp(store), store };
+}
+
+async function review(app: ReturnType<typeof createApp>, run: FoundryRun, item: ArtifactVersion) {
+  return (await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+    artifactId: item.id,
+    decision: 'accepted',
+    reviewer: 'fixture-reviewer',
+    expectedVersion: run.version,
+    expectedArtifactVersion: item.version,
+  }).expect(200)).body as FoundryRun;
+}
+
+describe('Insider Note and social recipes', () => {
+  it('builds the stable 11-position issue and channel-specific artifact union', () => {
+    const run = runNewsletterSocialFixture('fixture-editor', 'newsletter-contract-v1');
+    const issue = artifact(run, 'insider_note_issue');
+    const expectedIds = Array.from({ length: 11 }, (_, index) => {
+      const suffixes = ['masthead', 'intro', 'lead_today_move', 'weather_strip', 'secondary_picks', 'reader_reply', 'also_this_week', 'booking_note', 'poll', 'reply_prompt_signoff', 'footer'];
+      return `insider_note.position.${String(index + 1).padStart(2, '0')}.${suffixes[index]}`;
+    });
+    expect(issue.payload.positions.map((position) => position.id)).toEqual(expectedIds);
+    expect(issue.payload.positions[4]).toMatchObject({ status: 'included' });
+    if (issue.payload.positions[4].status !== 'included') throw new Error('Secondary picks omitted');
+    expect(issue.payload.positions[4].picks).toHaveLength(2);
+    expect(issue.payload.positions[8]).toMatchObject({ status: 'editorial_decision', suppliedQuestion: null, suppliedBy: null });
+    expect(issue.gateResults.every((gate) => gate.passed)).toBe(true);
+
+    const subjectSet = artifact(run, 'insider_note_subject_set');
+    expect(subjectSet.payload.pairs).toHaveLength(3);
+    expect(subjectSet.payload).toMatchObject({ selectedPairId: null, selectionAuthority: 'james_only', sendAuthority: 'james_only' });
+    expect(subjectSet.gateResults.every((gate) => gate.passed)).toBe(true);
+    expect(artifact(run, 'instagram_carousel_script').payload.slides).toHaveLength(3);
+    expect(artifact(run, 'instagram_caption').payload.captionDraft.split('\n')).toHaveLength(2);
+    expect(artifact(run, 'instagram_first_comment').payload.hashtagCandidates).toHaveLength(3);
+    expect(artifact(run, 'linkedin_post').payload.hashtags.length).toBeLessThanOrEqual(3);
+    expect(run.artifactPack.completed).toHaveLength(8);
+  });
+
+  it('honestly omits weather and reader reply when authoritative inputs are absent', () => {
+    const run = runNewsletterSocialFixture('fixture-editor', 'newsletter-honest-omission-v1', { omitAuthoritativeInputs: true });
+    const issue = artifact(run, 'insider_note_issue');
+    expect(issue.payload.positions[3]).toMatchObject({ status: 'omitted', reason: 'missing_authoritative_input' });
+    expect(issue.payload.positions[5]).toMatchObject({ status: 'omitted', reason: 'no_usable_reply' });
+    expect(issue.gateResults.find((gate) => gate.gate === 'authoritative_input_present')).toMatchObject({ passed: true });
+    expect(issue.claimUsage.some((usage) => usage.segmentId === 'issue-weather')).toBe(false);
+    expect(issue.claimUsage.some((usage) => usage.segmentId === 'issue-reader-reply')).toBe(false);
+  });
+
+  it('normalizes all six subject candidates for distinctness', () => {
+    const run = runNewsletterSocialFixture('fixture-editor', 'subject-normalization-v1');
+    const subjectSet = artifact(run, 'insider_note_subject_set');
+    const payload = structuredClone(subjectSet.payload);
+    payload.pairs[0].previewText = `${payload.pairs[0].subject.toLocaleUpperCase()}!!!`;
+    const gates = evaluateArtifactFormatGates('insider_note_subject_set', payload, run.claimSet.claims, run.claimSet.lockedAt);
+    expect(gates.find((gate) => gate.gate === 'subject_pairs_distinct')).toMatchObject({ passed: false, blocking: true });
+  });
+
+  it('requires exact first-name-only reader-reply locator lineage', () => {
+    const run = runNewsletterSocialFixture('fixture-editor', 'reply-lineage-v1');
+    const issue = artifact(run, 'insider_note_issue');
+    const payload = structuredClone(issue.payload);
+    if (payload.positions[5].status !== 'included') throw new Error('Reader reply omitted');
+    payload.positions[5].sourceLocator.locator = 'reply:wrong';
+    const gates = evaluateArtifactFormatGates('insider_note_issue', payload, run.claimSet.claims, run.claimSet.lockedAt);
+    expect(gates.find((gate) => gate.gate === 'authoritative_input_present')).toMatchObject({ passed: false, blocking: true });
+    const alteredQuote = structuredClone(issue.payload);
+    if (alteredQuote.positions[5].status !== 'included') throw new Error('Reader reply omitted');
+    alteredQuote.positions[5].quote = 'A different reply.';
+    expect(evaluateArtifactFormatGates('insider_note_issue', alteredQuote, run.claimSet.claims, run.claimSet.lockedAt).find((gate) => gate.gate === 'authoritative_input_present')).toMatchObject({ passed: false, blocking: true });
+  });
+
+  it('blocks nested pricing, broken email UTMs and social format violations', () => {
+    const run = runNewsletterSocialFixture('fixture-editor', 'nested-guardrails-v1');
+    const issue = artifact(run, 'insider_note_issue');
+    const badIssue = structuredClone(issue.payload);
+    if (badIssue.positions[7].status !== 'included') throw new Error('Booking note omitted');
+    badIssue.positions[7].link.href = 'https://peninsulainsider.com.au/journal/red-hill-wet-weather-lunch/';
+    const formatGates = evaluateArtifactFormatGates('insider_note_issue', badIssue, run.claimSet.claims, run.claimSet.lockedAt);
+    expect(formatGates.find((gate) => gate.gate === 'email_utm_complete')).toMatchObject({ passed: false, blocking: true });
+
+    const subjectSet = artifact(run, 'insider_note_subject_set');
+    const priced = structuredClone(subjectSet.payload);
+    priced.pairs[0].subject = 'A $95 lunch in Red Hill';
+    const commonGates = evaluateArtifactGates(priced, run.claimSet.claims, subjectSet.factualSegmentIds, subjectSet.claimUsage, run.updatedAt);
+    expect(commonGates.find((gate) => gate.gate === 'no_price')).toMatchObject({ passed: false, blocking: true });
+
+    const badCaption = { ...artifact(run, 'instagram_caption').payload, captionDraft: '#RedHill one line', openingMode: 'observation' as const };
+    expect(evaluateArtifactFormatGates('instagram_caption', badCaption, run.claimSet.claims, run.claimSet.lockedAt).find((gate) => gate.gate === 'instagram_caption_contract')).toMatchObject({ passed: false });
+    const badLinkedIn = { ...artifact(run, 'linkedin_post').payload, text: 'Thoughts? Like if you agree.' };
+    expect(evaluateArtifactFormatGates('linkedin_post', badLinkedIn, run.claimSet.claims, run.claimSet.lockedAt).find((gate) => gate.gate === 'linkedin_post_contract')).toMatchObject({ passed: false });
+  });
+
+  it('blocks Instagram media review and handoff without exact placement rights', async () => {
+    const { app } = await harness();
+    const run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-newsletter-social', fixtureVariant: 'rights_not_cleared', actor: 'fixture-editor', idempotencyKey: 'rights-block-v1',
+    }).expect(201)).body as FoundryRun;
+    const media = artifact(run, 'social_media_brief');
+    expect(media.gateResults.find((gate) => gate.gate === 'media_placement_rights')).toMatchObject({ passed: false, blocking: true });
+    expect(run.status).toBe('needs_revision');
+    await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+      artifactId: media.id, decision: 'accepted', reviewer: 'fixture-reviewer', expectedVersion: run.version, expectedArtifactVersion: media.version,
+    }).expect(400);
+    await request(app).get(`/api/foundry/runs/${run.id}/artifacts/${media.id}/handoff`).expect(400);
+  });
+
+  it('invalidates placement rights when the bound media asset changes', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-newsletter-social', actor: 'fixture-editor', idempotencyKey: 'rights-asset-swap-v1',
+    }).expect(201)).body as FoundryRun;
+    const media = artifact(run, 'social_media_brief');
+    const payload = { ...media.payload, assetId: 'asset-never-cleared-999' };
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${media.id}`).send({
+      editor: 'fixture-editor', expectedVersion: run.version, expectedArtifactVersion: media.version,
+      payload, factualSegmentIds: media.factualSegmentIds, claimUsage: media.claimUsage,
+    }).expect(200)).body as FoundryRun;
+    const swapped = artifact(run, 'social_media_brief');
+    expect(swapped.dependencies.some((dependency) => dependency.kind === 'media_rights')).toBe(false);
+    expect(swapped.gateResults.find((gate) => gate.gate === 'dependency_current')).toMatchObject({ passed: false, blocking: true });
+    await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+      artifactId: swapped.id, decision: 'accepted', reviewer: 'fixture-reviewer', expectedVersion: run.version, expectedArtifactVersion: swapped.version,
+    }).expect(400);
+    await request(app).get(`/api/foundry/runs/${run.id}/artifacts/${swapped.id}/handoff`).expect(400);
+  });
+
+  it('reconciles expiring booking evidence when the injected evaluation clock advances', async () => {
+    const addBookingExpiry = (source: FoundryRun) => {
+      const run = structuredClone(source);
+      const booking = run.claimSet.claims.find((claim) => claim.id === 'claim-booking');
+      if (!booking) throw new Error('Booking claim missing');
+      booking.expiresAt = '2026-08-25T00:00:00.000Z';
+      run.claimSet.claims = ClaimSchema.array().parse(run.claimSet.claims);
+      run.claimSet.contentHash = hashValue(run.claimSet.claims);
+      run.artifactPack.claimSetRef.contentHash = run.claimSet.contentHash;
+      run.artifactPack.completed = run.artifactPack.completed.map((item) => ({
+        ...item,
+        dependencies: item.dependencies.map((dependency) => dependency.kind === 'claim_set'
+          ? { ...dependency, contentHash: run.claimSet.contentHash }
+          : dependency),
+      })) as ArtifactVersion[];
+      return run;
+    };
+    let evaluationAsOf = '2026-08-22T00:00:00.000Z';
+    const { app, store } = await harness(() => evaluationAsOf);
+    const base = addBookingExpiry(runNewsletterSocialFixture('fixture-editor', 'expiry-clock-advance-v1'));
+    const early = await store.create(base);
+    const earlyIssue = artifact(early, 'insider_note_issue');
+    expect(early.evaluationAsOf).toBe(evaluationAsOf);
+    expect(earlyIssue.gateResults.find((gate) => gate.gate === 'booking_note_contract')).toMatchObject({ passed: true });
+    const reviewedEarly = await store.review(early.id, {
+      artifactId: earlyIssue.id, decision: 'accepted', reviewer: 'fixture-reviewer',
+      expectedVersion: early.version, expectedArtifactVersion: earlyIssue.version,
+    });
+    expect(JSON.parse(buildArtifactHandoff(reviewedEarly, earlyIssue.id).body)).toMatchObject({
+      authority: 'draft_handoff_only', evaluationAsOf,
+    });
+
+    evaluationAsOf = '2026-08-26T00:00:00.000Z';
+    const late = await store.get(early.id) as FoundryRun;
+    const lateIssue = artifact(late, 'insider_note_issue');
+    expect(late.evaluationAsOf).toBe(evaluationAsOf);
+    expect(lateIssue.gateResults.find((gate) => gate.gate === 'booking_note_contract')).toMatchObject({ passed: false, blocking: true });
+    expect(late.artifactPack.reviews.find((item) => item.artifactId === lateIssue.id)?.status).toBe('stale');
+    await expect(store.review(late.id, {
+      artifactId: lateIssue.id, decision: 'accepted', reviewer: 'fixture-reviewer',
+      expectedVersion: late.version, expectedArtifactVersion: lateIssue.version,
+    })).rejects.toThrow('unresolved blocking gates');
+    await request(app).get(`/api/foundry/runs/${late.id}/artifacts/${lateIssue.id}/handoff`).expect(400);
+  });
+
+  it('persists independent reviews and exports only the accepted artifact handoff', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-newsletter-social', actor: 'fixture-editor', idempotencyKey: 'independent-handoff-v1',
+    }).expect(201)).body as FoundryRun;
+    const issue = artifact(run, 'insider_note_issue');
+    const subjects = artifact(run, 'insider_note_subject_set');
+    await request(app).get(`/api/foundry/runs/${run.id}/artifacts/${issue.id}/handoff`).expect(400);
+    run = await review(app, run, issue);
+    const handoff = await request(app).get(`/api/foundry/runs/${run.id}/artifacts/${issue.id}/handoff`).expect(200).expect('Content-Type', /json/);
+    expect(handoff.body).toMatchObject({ authority: 'draft_handoff_only', publication: false, scheduling: false });
+    expect(handoff.body.artifact.payload).toMatchObject({ sendAuthority: 'james_only', scheduleAt: null });
+    expect(JSON.stringify(handoff.body)).not.toMatch(/\$\s?\d|—/);
+    await request(app).get(`/api/foundry/runs/${run.id}/artifacts/${subjects.id}/handoff`).expect(400);
+    run = await review(app, run, artifact(run, 'insider_note_subject_set'));
+    expect(run.artifactPack.reviews.filter((item) => item.status === 'current')).toHaveLength(2);
+    expect(buildArtifactHandoff(run, artifact(run, 'insider_note_subject_set').id).body).toContain('"selectedPairId": null');
+  });
+
+  it('stales issue and dependent subject reviews after an atomic issue edit', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: 'red-hill-newsletter-social', actor: 'fixture-editor', idempotencyKey: 'newsletter-stale-v1',
+    }).expect(201)).body as FoundryRun;
+    run = await review(app, run, artifact(run, 'insider_note_issue'));
+    run = await review(app, run, artifact(run, 'insider_note_subject_set'));
+    const issue = artifact(run, 'insider_note_issue');
+    const payload = structuredClone(issue.payload);
+    payload.positions[1].lines[0].text = 'Rain settled over Red Hill, and the covered room showed its value.';
+    const claimUsage = issue.claimUsage.map((usage) => usage.segmentId === 'issue-intro'
+      ? { ...usage, contentHash: hashValue(payload.positions[1].lines[0].text) }
+      : usage);
+    const edited = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${issue.id}`).send({
+      editor: 'fixture-editor', expectedVersion: run.version, expectedArtifactVersion: issue.version,
+      payload, factualSegmentIds: issue.factualSegmentIds, claimUsage,
+    }).expect(200)).body as FoundryRun;
+    expect(edited.artifactPack.reviews.filter((item) => item.status === 'current')).toHaveLength(0);
+    expect(edited.artifactPack.reviews.filter((item) => item.status === 'stale')).toHaveLength(2);
+    await request(app).get(`/api/foundry/runs/${edited.id}/artifacts/${issue.id}/handoff`).expect(400);
+  });
+});


### PR DESCRIPTION
## Summary

- introduce versioned generic recipe, claim-set, artifact-pack, discriminated artifact, typed gate and per-artifact review contracts
- add the deterministic `url_article_v1` fixture for Article, metadata, Ask and optional plan derivatives while preserving the v0.1 quick-note API and restart migration
- enforce atomic claim lineage, current claim/angle/artifact/media dependencies, server-derived hero readiness and independent draft-handoff authority
- map current Astro article fields including `clusterLinks`, preserve Ask provenance, and reject all public price and em-dash surfaces

## Verification

- independent frozen-tree adversarial review: PASS
- `npm run typecheck`: PASS
- `npm test`: 16/16 PASS
- `npm run build`: PASS
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- exact Node 22.23.2 container build and test: PASS
- hardened loopback runtime smoke: PASS as non-root with read-only rootfs, dropped capabilities and no external calls
- generated article patch: real `git apply --check -` PASS

## Boundaries

Fixture-only and local-only. No URL egress, provider or model calls, production database, Git apply, CMS mutation, publication or distribution authority is introduced. Every review grants `draft_handoff_only` authority.

This is a stacked draft PR targeting `feature/content-foundry-workbench`.

Closes #326