### PR TITLE
feat(foundry): add governed pre-production recipes

### DIFF
--- a/docs/architecture-decisions/content-foundry-preproduction-contract.md
+++ b/docs/architecture-decisions/content-foundry-preproduction-contract.md
@@ -1,0 +1,35 @@
+# Content Foundry pre-production contract
+
+Date: 2026-08-21
+
+Status: implemented locally for review
+
+Issue: #328
+
+## Decision
+
+Add three deterministic, fixture-only recipe families on the existing `pi.foundry-run.v2` and `pi.artifact-pack.v1` contracts:
+
+- `explainer_preproduction_v1` for the explainer core, FAQ, carousel, voiceover and visualisation brief;
+- `podcast_preproduction_v1` for the evidence dossier, angle, run sheet, interview guide, host script, provisional show notes and provisional chapters;
+- `short_video_preproduction_v1` for hooks, separate 30-second and 60-second scripts, shot list, scene manifest, overlays, subtitles, thumbnail copy and platform captions.
+
+Each pre-production artifact has a discriminated payload kind, immutable payload hash, exact claim-set and angle dependencies, and exact upstream artifact versions. Every user-visible factual or fact-implying question, label, title, prompt, section, scene, overlay, caption and spoken segment has a locator, content hash and one or more claim IDs. Derivatives cannot become independent truth sources.
+
+## Production boundary
+
+All fixture payloads remain at `text_preproduction`. Unassigned media is a valid nonblocking state for reviewing text. It never implies readiness to record or render.
+
+Media readiness passes only when every required placement has a unique assignment binding the exact asset version and hash, placement path, surface, rights record and releases to a matching server-held cleared-rights dependency. Unassigned shots, missing placements, unrelated rights records and changed assets fail closed. Recognisable people also require assignment-bound release identifiers. Human voice clearance requires an assignment-bound release identifier. Illustrative generation requires a separately recorded approval identifier and persistent disclosure.
+
+Simulated contributor dialogue, cloned voice, synthetic voice and generated documentary treatment are blocking policy failures. This V1 exposes no provider, model, recording, rendering, scheduling, sending or publishing endpoint.
+
+## Timing and review
+
+Voiceover, podcast and video durations use integer milliseconds. Run sheets and scenes are ordered and contiguous. Overlays, subtitles and chapters are ordered, non-overlapping and bounded by the declared duration. A timing mismatch is a blocking gate.
+
+Reviews remain independent per artifact and grant `draft_handoff_only` authority. Read and export paths reconcile claim-set, angle, rights and transitive artifact dependencies. Editing an upstream artifact stales every dependent review while leaving unrelated branches current.
+
+## Compatibility
+
+The quick-note and Article plus Ask recipes, legacy restart migration, local file adapter and reviewed Astro patch flow remain unchanged. Pre-production packs cannot produce a patch because they have no publication adapter.

--- a/studio-peninsula-insider/README.md
+++ b/studio-peninsula-insider/README.md
@@ -16,6 +16,8 @@ The shell performs no model calls, Git writes, CMS writes, publication or extern
 
 `url_article_v1` can produce article body, article metadata, Ask answer, internal-link plan and SEO metadata proposal artifacts. Text-only packs remain valid and reviewable. Astro patch export stays unavailable until a separately rights-cleared hero placement exists. Reviews approve draft handoff only and never grant publication authority.
 
+V1 pre-production fixture recipes add governed explainer, podcast and short-video planning packs. Every factual or spoken segment retains claim lineage and exact upstream artifact versions. Text plans are reviewable with media unassigned. Recording and render readiness remain unavailable until exact rights, releases, approvals and disclosures exist, and the application exposes no record, render, schedule, send or publish endpoint.
+
 ## Run locally
 
 ```powershell

--- a/studio-peninsula-insider/server/app.ts
+++ b/studio-peninsula-insider/server/app.ts
@@ -3,10 +3,16 @@ import helmet from 'helmet';
 import { z } from 'zod';
 import { ArtifactEditSchema, ArtifactUpdateSchema, ReviewDecisionSchema } from '../shared/contracts.js';
 import { buildPatch, FIXTURE_ID, runFixture, runUrlArticleFixture, URL_ARTICLE_FIXTURE_ID } from './fixture-runner.js';
+import {
+  EXPLAINER_FIXTURE_ID,
+  PODCAST_FIXTURE_ID,
+  runPreproductionFixture,
+  SHORT_VIDEO_FIXTURE_ID,
+} from './preproduction-fixtures.js';
 import { FileFoundryStore, VersionConflictError } from './store.js';
 
 const CreateRunSchema = z.object({
-  fixtureId: z.enum([FIXTURE_ID, URL_ARTICLE_FIXTURE_ID]),
+  fixtureId: z.enum([FIXTURE_ID, URL_ARTICLE_FIXTURE_ID, EXPLAINER_FIXTURE_ID, PODCAST_FIXTURE_ID, SHORT_VIDEO_FIXTURE_ID]),
   actor: z.string().min(1).default('local-editor'),
   idempotencyKey: z.string().min(1).optional(),
   fixtureVariant: z.enum(['complete', 'text_only', 'partial_optional_failure']).default('complete'),
@@ -40,11 +46,22 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
   app.get('/api/health', (_request, response) => response.json({ ok: true, service: 'pi-content-foundry', mode: 'fixture-only' }));
   app.get('/api/capabilities', (_request, response) => response.json({
     sourceTypes: ['frozen_fixture'],
-    recipes: ['quick_note_v1', 'url_article_v1'],
-    artifactTypes: ['quick_note', 'article_draft', 'article_metadata', 'ask_answer', 'internal_link_plan', 'seo_metadata_proposal'],
+    recipes: ['quick_note_v1', 'url_article_v1', 'explainer_preproduction_v1', 'podcast_preproduction_v1', 'short_video_preproduction_v1'],
+    artifactTypes: [
+      'quick_note', 'article_draft', 'article_metadata', 'ask_answer', 'internal_link_plan', 'seo_metadata_proposal',
+      'explainer_core', 'explainer_faq', 'explainer_carousel', 'explainer_voiceover', 'explainer_visualisation',
+      'podcast_evidence_dossier', 'podcast_angle', 'podcast_run_sheet', 'podcast_interview_guide', 'podcast_script', 'podcast_show_notes', 'podcast_chapters',
+      'video_hooks', 'video_script', 'video_shot_list', 'video_scenes', 'video_overlays', 'video_subtitles', 'video_thumbnail', 'video_platform_captions',
+    ],
     publicationAdapters: ['downloadable_patch'],
     externalCalls: false,
     productionMutation: false,
+    recording: false,
+    rendering: false,
+    scheduling: false,
+    sending: false,
+    publishing: false,
+    syntheticVoice: false,
   }));
 
   app.get('/api/foundry/runs', async (_request, response, next) => {
@@ -60,11 +77,18 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
       if (existing) return response.status(200).json(existing);
       const run = input.fixtureId === FIXTURE_ID
         ? runFixture(input.actor, idempotencyKey)
-        : runUrlArticleFixture(input.actor, idempotencyKey, {
+        : input.fixtureId === URL_ARTICLE_FIXTURE_ID
+          ? runUrlArticleFixture(input.actor, idempotencyKey, {
           includeClearedHero: input.fixtureVariant === 'complete',
           failOptionalDerivative: input.fixtureVariant === 'partial_optional_failure' ? 'seo_metadata_proposal' : undefined,
           omitPlans: input.fixtureVariant === 'text_only',
-        });
+          })
+          : runPreproductionFixture(
+            input.fixtureId === EXPLAINER_FIXTURE_ID ? 'explainer' : input.fixtureId === PODCAST_FIXTURE_ID ? 'podcast' : 'short_video',
+            input.actor,
+            idempotencyKey,
+            { failOptionalDerivative: input.fixtureVariant === 'partial_optional_failure' },
+          );
       const created = await store.create(run);
       return response.status(201).json(created);
     } catch (error) { return next(error); }

--- a/studio-peninsula-insider/server/fixture-runner.ts
+++ b/studio-peninsula-insider/server/fixture-runner.ts
@@ -21,6 +21,13 @@ import {
   type LegacyFoundryRun,
   type RecipeDefinition,
 } from '../shared/contracts.js';
+import {
+  isPreproductionArtifactType,
+  parsePreproductionPayload,
+  PreproductionPayloadSchema,
+  requiredPreproductionLineagePaths,
+} from '../shared/preproduction-contracts.js';
+import { mediaReadinessCurrent } from './preproduction-policy.js';
 
 export const hash = (value: string) => createHash('sha256').update(value).digest('hex');
 export const hashValue = (value: unknown) => hash(JSON.stringify(value));
@@ -49,7 +56,7 @@ export function resolveArtifactPath(payload: unknown, path: string): unknown {
   return current;
 }
 
-function bindClaimUsage<T extends Array<{ segmentId: string; path: string; claimIds: string[] }>>(payload: unknown, usage: T) {
+export function bindClaimUsage<T extends Array<{ segmentId: string; path: string; claimIds: string[] }>>(payload: unknown, usage: T) {
   return usage.map((item) => ({ ...item, contentHash: hashValue(resolveArtifactPath(payload, item.path)) }));
 }
 
@@ -144,7 +151,15 @@ export function evaluateArtifactGates(
     && (payload as { body: string }).body.split(/\n\s*\n/).length === paragraphUsages.length
     && paragraphUsages.every((usage, index) => usage.path === `$.body::paragraph[${index}]`)
   );
-  const lineageComplete = completeUsage && paragraphCoverage;
+  const preproductionPayload = PreproductionPayloadSchema.safeParse(payload);
+  const preproductionCoverage = !preproductionPayload.success || (() => {
+    const requiredPaths = requiredPreproductionLineagePaths(preproductionPayload.data);
+    const mappedPaths = claimUsage.map((usage) => usage.path);
+    return requiredPaths.length === mappedPaths.length
+      && new Set(mappedPaths).size === mappedPaths.length
+      && requiredPaths.every((path) => mappedPaths.includes(path));
+  })();
+  const lineageComplete = completeUsage && paragraphCoverage && preproductionCoverage;
   const supportedClaims = usedClaimIds.length > 0 && usedClaimIds.every((claimId) => claimIsUsable(claimsById.get(claimId), asOf));
   const results: GateResult[] = [
     gate('no_price', !PRICE_PATTERN.test(publicCopy), 'Public artifact content must not contain pricing.'),
@@ -174,7 +189,7 @@ export function evaluateQuickNoteGates(
   );
 }
 
-function fixtureSource(actor: string) {
+export function fixtureSource(actor: string) {
   const capturedAt = '2026-08-21T05:00:00.000Z';
   const sourceUrl = 'https://example.test/red-hill-winter-lunch';
   const sourceId = 'source-url-red-hill';
@@ -227,15 +242,15 @@ function fixtureSource(actor: string) {
   return { capturedAt, sourceUrl, claims, claimSet, bundle, angle };
 }
 
-function claimSetDependency(claimSet: ClaimSetVersion) {
+export function claimSetDependency(claimSet: ClaimSetVersion) {
   return { kind: 'claim_set' as const, id: claimSet.id, version: claimSet.version, contentHash: claimSet.contentHash };
 }
 
-function angleDependency(angle: { id: string; version: number; label: string; framing: string; evidenceClaimIds: string[] }) {
+export function angleDependency(angle: { id: string; version: number; label: string; framing: string; evidenceClaimIds: string[] }) {
   return { kind: 'angle' as const, id: angle.id, version: angle.version, contentHash: hashValue(angle) };
 }
 
-function withArtifactHash<T extends Omit<ArtifactVersion, 'contentHash'>>(artifact: T): ArtifactVersion {
+export function withArtifactHash<T extends Omit<ArtifactVersion, 'contentHash'>>(artifact: T): ArtifactVersion {
   return ArtifactVersionSchema.parse({ ...artifact, contentHash: hashValue(artifact.payload) });
 }
 
@@ -253,6 +268,9 @@ export function artifactDependenciesCurrent(
   const mediaDependencies = artifact.dependencies.filter((dependency) => dependency.kind === 'media_rights');
   if (artifact.type === 'article_metadata') {
     if (artifact.payload.astroPatchReady !== Boolean(artifact.payload.heroImage && mediaDependencies.length === 1)) return false;
+  } else if (isPreproductionArtifactType(artifact.type)) {
+    const payload = parsePreproductionPayload(artifact.type, artifact.payload);
+    if (!mediaReadinessCurrent(payload, artifact.dependencies)) return false;
   } else if (mediaDependencies.length > 0) return false;
 
   const completedById = new Map(run.artifactPack.completed.map((candidate) => [candidate.id, candidate]));
@@ -268,10 +286,20 @@ export function artifactDependenciesCurrent(
           && dependency.version === run.angle.version
           && dependency.contentHash === hashValue(run.angle);
       case 'media_rights':
-        return artifact.type === 'article_metadata'
-          && Boolean(artifact.payload.heroImage)
-          && dependency.status === 'cleared'
-          && dependency.contentHash === hashValue(artifact.payload.heroImage);
+        if (artifact.type === 'article_metadata') {
+          return Boolean(artifact.payload.heroImage)
+            && dependency.status === 'cleared'
+            && dependency.contentHash === hashValue(artifact.payload.heroImage);
+        }
+        if (isPreproductionArtifactType(artifact.type)) {
+          const payload = parsePreproductionPayload(artifact.type, artifact.payload);
+          return payload.boundary.rightsSnapshots.some((snapshot) => (
+            snapshot.id === dependency.id
+            && snapshot.version === dependency.version
+            && snapshot.contentHash === dependency.contentHash
+          ));
+        }
+        return false;
       case 'artifact': {
         const target = completedById.get(dependency.id);
         if (!target || visiting.has(target.id)) return false;

--- a/studio-peninsula-insider/server/preproduction-fixtures.ts
+++ b/studio-peninsula-insider/server/preproduction-fixtures.ts
@@ -1,0 +1,402 @@
+import {
+  ArtifactVersionSchema,
+  FoundryRunSchema,
+  RecipeDefinitionSchema,
+  type ArtifactDependency,
+  type ArtifactVersion,
+  type Claim,
+  type FoundryRun,
+  type RecipeDefinition,
+} from '../shared/contracts.js';
+import {
+  PreproductionPayloadSchema,
+  requiredPreproductionLineagePaths,
+  type PreproductionArtifactType,
+  type PreproductionPayload,
+  type ProductionBoundary,
+} from '../shared/preproduction-contracts.js';
+import {
+  angleDependency,
+  bindClaimUsage,
+  claimSetDependency,
+  evaluateArtifactGates,
+  fixtureSource,
+  hash,
+  hashValue,
+} from './fixture-runner.js';
+import { evaluatePreproductionGates } from './preproduction-policy.js';
+
+export const EXPLAINER_FIXTURE_ID = 'red-hill-explainer-preproduction';
+export const PODCAST_FIXTURE_ID = 'red-hill-podcast-preproduction';
+export const SHORT_VIDEO_FIXTURE_ID = 'red-hill-short-video-preproduction';
+
+export const EXPLAINER_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse({
+  schemaVersion: 'pi.recipe-definition.v1', id: 'explainer_preproduction_v1', version: 1,
+  label: 'Explainer pre-production', sourceKinds: ['url'], textOnlyAllowed: true, externalCalls: false,
+  artifacts: [
+    { key: 'explainer-core', type: 'explainer_core', required: true, dependsOnKeys: [], targetContract: 'foundry.explainer-core.v1' },
+    { key: 'explainer-faq', type: 'explainer_faq', required: true, dependsOnKeys: ['explainer-core'], targetContract: 'foundry.explainer-faq.v1' },
+    { key: 'explainer-carousel', type: 'explainer_carousel', required: false, dependsOnKeys: ['explainer-core'], targetContract: 'foundry.explainer-carousel.v1' },
+    { key: 'explainer-voiceover', type: 'explainer_voiceover', required: true, dependsOnKeys: ['explainer-core'], targetContract: 'foundry.explainer-voiceover.v1' },
+    { key: 'explainer-visualisation', type: 'explainer_visualisation', required: false, dependsOnKeys: ['explainer-core'], targetContract: 'foundry.explainer-visualisation.v1' },
+  ],
+});
+
+export const PODCAST_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse({
+  schemaVersion: 'pi.recipe-definition.v1', id: 'podcast_preproduction_v1', version: 1,
+  label: 'Podcast pre-production', sourceKinds: ['url'], textOnlyAllowed: true, externalCalls: false,
+  artifacts: [
+    { key: 'podcast-evidence', type: 'podcast_evidence_dossier', required: true, dependsOnKeys: [], targetContract: 'foundry.podcast-evidence.v1' },
+    { key: 'podcast-angle', type: 'podcast_angle', required: true, dependsOnKeys: ['podcast-evidence'], targetContract: 'foundry.podcast-angle.v1' },
+    { key: 'podcast-run-sheet', type: 'podcast_run_sheet', required: true, dependsOnKeys: ['podcast-angle'], targetContract: 'foundry.podcast-run-sheet.v1' },
+    { key: 'podcast-interview-guide', type: 'podcast_interview_guide', required: true, dependsOnKeys: ['podcast-angle'], targetContract: 'foundry.podcast-interview-guide.v1' },
+    { key: 'podcast-script', type: 'podcast_script', required: true, dependsOnKeys: ['podcast-run-sheet'], targetContract: 'foundry.podcast-script.v1' },
+    { key: 'podcast-show-notes', type: 'podcast_show_notes', required: false, dependsOnKeys: ['podcast-script'], targetContract: 'foundry.podcast-show-notes.v1' },
+    { key: 'podcast-chapters', type: 'podcast_chapters', required: false, dependsOnKeys: ['podcast-script'], targetContract: 'foundry.podcast-chapters.v1' },
+  ],
+});
+
+export const SHORT_VIDEO_RECIPE: RecipeDefinition = RecipeDefinitionSchema.parse({
+  schemaVersion: 'pi.recipe-definition.v1', id: 'short_video_preproduction_v1', version: 1,
+  label: 'Short-video pre-production', sourceKinds: ['url'], textOnlyAllowed: true, externalCalls: false,
+  artifacts: [
+    { key: 'video-hooks', type: 'video_hooks', required: true, dependsOnKeys: [], targetContract: 'foundry.video-hooks.v1' },
+    { key: 'video-script-30', type: 'video_script', required: true, dependsOnKeys: ['video-hooks'], targetContract: 'foundry.video-script-30.v1' },
+    { key: 'video-script-60', type: 'video_script', required: true, dependsOnKeys: ['video-hooks'], targetContract: 'foundry.video-script-60.v1' },
+    { key: 'video-shot-list', type: 'video_shot_list', required: true, dependsOnKeys: ['video-script-60'], targetContract: 'foundry.video-shot-list.v1' },
+    { key: 'video-scenes', type: 'video_scenes', required: true, dependsOnKeys: ['video-script-60'], targetContract: 'foundry.video-scenes.v1' },
+    { key: 'video-overlays', type: 'video_overlays', required: true, dependsOnKeys: ['video-script-60'], targetContract: 'foundry.video-overlays.v1' },
+    { key: 'video-subtitles', type: 'video_subtitles', required: true, dependsOnKeys: ['video-script-30'], targetContract: 'foundry.video-subtitles.v1' },
+    { key: 'video-thumbnail', type: 'video_thumbnail', required: false, dependsOnKeys: ['video-scenes'], targetContract: 'foundry.video-thumbnail.v1' },
+    { key: 'video-platform-captions', type: 'video_platform_captions', required: false, dependsOnKeys: ['video-script-30'], targetContract: 'foundry.video-platform-captions.v1' },
+  ],
+});
+
+const boundary = (): ProductionBoundary => ({
+  stage: 'text_preproduction', mediaStatus: 'unassigned', rightsSnapshots: [], mediaAssignments: [], recognisablePeople: false,
+  releaseIds: [], voiceMode: 'human_unassigned', generationMode: 'none',
+});
+
+type UsageSeed = { segmentId: string; path: string; claimIds: string[] };
+
+function makeArtifact(
+  type: PreproductionArtifactType,
+  key: string,
+  payloadInput: unknown,
+  usageSeeds: UsageSeed[],
+  dependencies: ArtifactDependency[],
+  claims: Claim[],
+  asOf: string,
+): ArtifactVersion {
+  const payload = PreproductionPayloadSchema.parse(payloadInput);
+  if (payload.kind !== type) throw new Error(`Fixture payload ${payload.kind} does not match ${type}`);
+  const titleClaimIds = [...new Set(usageSeeds.flatMap((usage) => usage.claimIds))];
+  const titleBoundSeeds = usageSeeds.some((usage) => usage.path === '$.title')
+    ? usageSeeds
+    : [{ segmentId: `${key}-title`, path: '$.title', claimIds: titleClaimIds }, ...usageSeeds];
+  const allUsageSeeds = requiredPreproductionLineagePaths(payload).reduce<UsageSeed[]>((seeds, path) => {
+    if (seeds.some((usage) => usage.path === path)) return seeds;
+    const container = path.replace(/\.[A-Za-z][A-Za-z0-9]*$/, '');
+    const related = seeds.filter((usage) => usage.path.startsWith(`${container}.`));
+    const claimIds = [...new Set((related.length > 0 ? related : seeds).flatMap((usage) => usage.claimIds))];
+    return [...seeds, {
+      segmentId: `${key}-lineage-${path.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-|-$/g, '')}`,
+      path,
+      claimIds,
+    }];
+  }, titleBoundSeeds);
+  const claimUsage = bindClaimUsage(payload, allUsageSeeds);
+  return ArtifactVersionSchema.parse({
+    id: `artifact-${key}-red-hill`, key, version: 1, type,
+    contentHash: hashValue(payload), angleId: 'angle-rainy-lunch', angleVersion: 1,
+    factualSegmentIds: allUsageSeeds.map((usage) => usage.segmentId), claimUsage, dependencies, payload,
+    gateResults: [
+      ...evaluateArtifactGates(payload, claims, allUsageSeeds.map((usage) => usage.segmentId), claimUsage, asOf),
+      ...evaluatePreproductionGates(payload, dependencies),
+    ],
+  });
+}
+
+const artifactDependency = (artifact: ArtifactVersion): ArtifactDependency => ({
+  kind: 'artifact', id: artifact.id, version: artifact.version, contentHash: artifact.contentHash,
+});
+
+function buildExplainer(claims: Claim[], dependencies: ArtifactDependency[], capturedAt: string): ArtifactVersion[] {
+  const core = makeArtifact('explainer_core', 'explainer-core', {
+    kind: 'explainer_core', title: 'Why covered dining matters on a wet Peninsula day',
+    thesis: 'A covered Red Hill lunch can anchor a rainy-day plan.',
+    sections: [
+      { id: 'core-location', text: 'The venue is in Red Hill.' },
+      { id: 'core-service', text: 'The winter lunch is listed for Saturday 29 August, with booking required.' },
+      { id: 'core-weather', text: 'The covered dining room suits a wet-weather lunch.' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'core-thesis', path: '$.thesis', claimIds: ['claim-location', 'claim-observation'] },
+    { segmentId: 'core-location', path: '$.sections[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'core-service', path: '$.sections[1].text', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'core-weather', path: '$.sections[2].text', claimIds: ['claim-observation'] },
+  ], dependencies, claims, capturedAt);
+  const upstream = [...dependencies, artifactDependency(core)];
+  const faq = makeArtifact('explainer_faq', 'explainer-faq', {
+    kind: 'explainer_faq', title: 'Wet-weather lunch questions', items: [
+      { id: 'faq-when', question: 'When is the winter lunch listed?', answer: 'Saturday 29 August, with booking required.' },
+      { id: 'faq-why', question: 'Why does it work in wet weather?', answer: 'The dining room is covered.' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'faq-when', path: '$.items[0].answer', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'faq-why', path: '$.items[1].answer', claimIds: ['claim-observation'] },
+  ], upstream, claims, capturedAt);
+  const carousel = makeArtifact('explainer_carousel', 'explainer-carousel', {
+    kind: 'explainer_carousel', title: 'A rainy-day Red Hill anchor', slides: [
+      { id: 'slide-1', headline: 'Start in Red Hill', body: 'The venue is in Red Hill.' },
+      { id: 'slide-2', headline: 'Stay under cover', body: 'The dining room is covered.' },
+      { id: 'slide-3', headline: 'Book the listed lunch', body: 'The winter lunch is listed for Saturday 29 August, with booking required.' },
+    ], boundary: boundary(),
+  }, [0, 1, 2].map((index) => ({
+    segmentId: `slide-${index + 1}`, path: `$.slides[${index}].body`,
+    claimIds: index === 0 ? ['claim-location'] : index === 1 ? ['claim-observation'] : ['claim-date', 'claim-booking'],
+  })).flatMap((bodyUsage, index) => [
+    { segmentId: `slide-${index + 1}-headline`, path: `$.slides[${index}].headline`, claimIds: bodyUsage.claimIds },
+    bodyUsage,
+  ]), upstream, claims, capturedAt);
+  const voiceover = makeArtifact('explainer_voiceover', 'explainer-voiceover', {
+    kind: 'explainer_voiceover', title: 'Wet-weather explainer voiceover', targetDurationMs: 60_000,
+    segments: [
+      { id: 'voice-1', text: 'A rainy Peninsula day does not have to stop in Red Hill.', durationMs: 20_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'voice-2', text: 'This covered dining room gives lunch a practical indoor anchor.', durationMs: 20_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'voice-3', text: 'The winter lunch is listed for Saturday 29 August, with booking required.', durationMs: 20_000, contentMode: 'editorial_narration', speaker: 'host' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'voice-1', path: '$.segments[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'voice-2', path: '$.segments[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'voice-3', path: '$.segments[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], upstream, claims, capturedAt);
+  const visualisation = makeArtifact('explainer_visualisation', 'explainer-visualisation', {
+    kind: 'explainer_visualisation', title: 'Red Hill rainy-day sequence', chartType: 'timeline',
+    points: [
+      { id: 'point-place', label: 'Place', valueText: 'Red Hill' },
+      { id: 'point-date', label: 'Listed service', valueText: 'Saturday 29 August' },
+      { id: 'point-booking', label: 'Planning note', valueText: 'Booking required' },
+    ], sourceNote: 'Fixture claim set only.', boundary: boundary(),
+  }, [
+    { segmentId: 'point-place', path: '$.points[0].valueText', claimIds: ['claim-location'] },
+    { segmentId: 'point-date', path: '$.points[1].valueText', claimIds: ['claim-date'] },
+    { segmentId: 'point-booking', path: '$.points[2].valueText', claimIds: ['claim-booking'] },
+  ], upstream, claims, capturedAt);
+  return [core, faq, carousel, voiceover, visualisation];
+}
+
+function buildPodcast(claims: Claim[], dependencies: ArtifactDependency[], capturedAt: string): ArtifactVersion[] {
+  const evidence = makeArtifact('podcast_evidence_dossier', 'podcast-evidence', {
+    kind: 'podcast_evidence_dossier', title: 'Red Hill wet-weather evidence', evidenceItems: [
+      { id: 'evidence-place', text: 'The venue is in Red Hill.' },
+      { id: 'evidence-service', text: 'The winter lunch is listed for Saturday 29 August, with booking required.' },
+      { id: 'evidence-observation', text: 'The covered dining room suits a wet-weather lunch.' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'evidence-place', path: '$.evidenceItems[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'evidence-service', path: '$.evidenceItems[1].text', claimIds: ['claim-date', 'claim-booking'] },
+    { segmentId: 'evidence-observation', path: '$.evidenceItems[2].text', claimIds: ['claim-observation'] },
+  ], dependencies, claims, capturedAt);
+  const angle = makeArtifact('podcast_angle', 'podcast-angle', {
+    kind: 'podcast_angle', title: 'A practical rainy-day lunch', promise: 'Explain how covered dining can anchor a wet Red Hill day.',
+    audience: 'Peninsula visitors and locals planning around rain.', avoidClaims: ['Do not claim this is the best lunch.'], boundary: boundary(),
+  }, [{ segmentId: 'angle-promise', path: '$.promise', claimIds: ['claim-location', 'claim-observation'] }],
+  [...dependencies, artifactDependency(evidence)], claims, capturedAt);
+  const angleUpstream = [...dependencies, artifactDependency(angle)];
+  const runSheet = makeArtifact('podcast_run_sheet', 'podcast-run-sheet', {
+    kind: 'podcast_run_sheet', title: 'Three-minute fixture run sheet', targetDurationMs: 180_000, segments: [
+      { id: 'run-1', title: 'Set-up', text: 'Locate the lunch in Red Hill.', startMs: 0, endMs: 60_000 },
+      { id: 'run-2', title: 'Evidence', text: 'Explain the covered dining observation.', startMs: 60_000, endMs: 120_000 },
+      { id: 'run-3', title: 'Service note', text: 'State the listed date and booking requirement.', startMs: 120_000, endMs: 180_000 },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'run-1', path: '$.segments[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'run-2', path: '$.segments[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'run-3', path: '$.segments[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], angleUpstream, claims, capturedAt);
+  const guide = makeArtifact('podcast_interview_guide', 'podcast-interview-guide', {
+    kind: 'podcast_interview_guide', title: 'Interview guide', questions: [
+      { id: 'question-cover', prompt: 'How does the covered dining room change a rainy-day visit?', rationale: 'The source observation identifies covered dining.' },
+      { id: 'question-booking', prompt: 'What should a guest confirm before visiting?', rationale: 'The listed winter lunch requires booking.' },
+    ], prohibitedPrompts: ['Do not ask a contributor to repeat unverified superlatives.'], boundary: boundary(),
+  }, [
+    { segmentId: 'question-cover', path: '$.questions[0].rationale', claimIds: ['claim-observation'] },
+    { segmentId: 'question-booking', path: '$.questions[1].rationale', claimIds: ['claim-booking'] },
+  ], angleUpstream, claims, capturedAt);
+  const script = makeArtifact('podcast_script', 'podcast-script', {
+    kind: 'podcast_script', title: 'Three-minute host script', targetDurationMs: 180_000, segments: [
+      { id: 'podcast-1', text: 'Today we are in Red Hill, planning lunch around a wet Peninsula day.', durationMs: 60_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'podcast-2', text: 'The covered dining room gives the visit a practical indoor anchor.', durationMs: 60_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'podcast-3', text: 'The winter lunch is listed for Saturday 29 August, with booking required.', durationMs: 60_000, contentMode: 'editorial_narration', speaker: 'host' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'podcast-1', path: '$.segments[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'podcast-2', path: '$.segments[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'podcast-3', path: '$.segments[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], [...dependencies, artifactDependency(evidence), artifactDependency(runSheet)], claims, capturedAt);
+  const scriptUpstream = [...dependencies, artifactDependency(script)];
+  const showNotes = makeArtifact('podcast_show_notes', 'podcast-show-notes', {
+    kind: 'podcast_show_notes', title: 'Provisional show notes', summary: 'A Red Hill wet-weather lunch plan based on a covered dining room and a listed Saturday service.',
+    bullets: [{ id: 'note-date', text: 'Listed for Saturday 29 August.' }, { id: 'note-booking', text: 'Booking is required.' }], provisional: true, boundary: boundary(),
+  }, [
+    { segmentId: 'notes-summary', path: '$.summary', claimIds: ['claim-location', 'claim-date', 'claim-observation'] },
+    { segmentId: 'note-date', path: '$.bullets[0].text', claimIds: ['claim-date'] },
+    { segmentId: 'note-booking', path: '$.bullets[1].text', claimIds: ['claim-booking'] },
+  ], scriptUpstream, claims, capturedAt);
+  const chapters = makeArtifact('podcast_chapters', 'podcast-chapters', {
+    kind: 'podcast_chapters', title: 'Provisional chapters', targetDurationMs: 180_000, provisional: true, items: [
+      { id: 'chapter-1', title: 'Red Hill', text: 'Place and rainy-day framing.', startMs: 0, endMs: 60_000 },
+      { id: 'chapter-2', title: 'Covered dining', text: 'The covered-room observation.', startMs: 60_000, endMs: 120_000 },
+      { id: 'chapter-3', title: 'Service details', text: 'The listed date and booking requirement.', startMs: 120_000, endMs: 180_000 },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'chapter-1', path: '$.items[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'chapter-2', path: '$.items[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'chapter-3', path: '$.items[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], scriptUpstream, claims, capturedAt);
+  return [evidence, angle, runSheet, guide, script, showNotes, chapters];
+}
+
+function buildVideo(claims: Claim[], dependencies: ArtifactDependency[], capturedAt: string): ArtifactVersion[] {
+  const hooks = makeArtifact('video_hooks', 'video-hooks', {
+    kind: 'video_hooks', title: 'Short-video hooks', variants: [
+      { id: 'hook-1', text: 'Rain in Red Hill? Start with a covered lunch.', durationMs: 3_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'hook-2', text: 'This covered dining room can anchor a wet Peninsula day.', durationMs: 3_000, contentMode: 'editorial_narration', speaker: 'host' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'hook-1', path: '$.variants[0].text', claimIds: ['claim-location', 'claim-observation'] },
+    { segmentId: 'hook-2', path: '$.variants[1].text', claimIds: ['claim-observation'] },
+  ], dependencies, claims, capturedAt);
+  const hooksUpstream = [...dependencies, artifactDependency(hooks)];
+  const script30 = makeArtifact('video_script', 'video-script-30', {
+    kind: 'video_script', title: '30-second script', targetSeconds: 30, segments: [
+      { id: 'script30-1', text: 'Rain in Red Hill? Start with a covered lunch.', durationMs: 10_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'script30-2', text: 'The covered dining room gives the day an indoor anchor.', durationMs: 10_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'script30-3', text: 'The winter lunch is listed for Saturday 29 August, with booking required.', durationMs: 10_000, contentMode: 'editorial_narration', speaker: 'host' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'script30-1', path: '$.segments[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'script30-2', path: '$.segments[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'script30-3', path: '$.segments[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], hooksUpstream, claims, capturedAt);
+  const script60 = makeArtifact('video_script', 'video-script-60', {
+    kind: 'video_script', title: '60-second script', targetSeconds: 60, segments: [
+      { id: 'script60-1', text: 'A wet Peninsula day can still have a useful Red Hill anchor.', durationMs: 20_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'script60-2', text: 'The dining room is covered, which suits a rainy-day lunch.', durationMs: 20_000, contentMode: 'editorial_narration', speaker: 'host' },
+      { id: 'script60-3', text: 'The winter lunch is listed for Saturday 29 August, with booking required.', durationMs: 20_000, contentMode: 'editorial_narration', speaker: 'host' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'script60-1', path: '$.segments[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'script60-2', path: '$.segments[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'script60-3', path: '$.segments[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], hooksUpstream, claims, capturedAt);
+  const script60Upstream = [...dependencies, artifactDependency(script60)];
+  const shots = makeArtifact('video_shot_list', 'video-shot-list', {
+    kind: 'video_shot_list', title: 'Unassigned shot list', targetDurationMs: 60_000, shots: [
+      { id: 'shot-1', description: 'Establish Red Hill without implying current conditions.', durationMs: 20_000, source: 'unassigned' },
+      { id: 'shot-2', description: 'Show the covered dining observation only after rights clearance.', durationMs: 20_000, source: 'unassigned' },
+      { id: 'shot-3', description: 'Use a text card for the listed date and booking requirement.', durationMs: 20_000, source: 'unassigned' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'shot-1', path: '$.shots[0].description', claimIds: ['claim-location'] },
+    { segmentId: 'shot-2', path: '$.shots[1].description', claimIds: ['claim-observation'] },
+    { segmentId: 'shot-3', path: '$.shots[2].description', claimIds: ['claim-date', 'claim-booking'] },
+  ], script60Upstream, claims, capturedAt);
+  const scenes = makeArtifact('video_scenes', 'video-scenes', {
+    kind: 'video_scenes', title: 'Scene manifest', targetDurationMs: 60_000, scenes: [
+      { id: 'scene-1', title: 'Red Hill', text: 'Red Hill location card.', startMs: 0, endMs: 20_000, treatment: 'text_only' },
+      { id: 'scene-2', title: 'Under cover', text: 'Covered dining observation card.', startMs: 20_000, endMs: 40_000, treatment: 'text_only' },
+      { id: 'scene-3', title: 'Plan ahead', text: 'Saturday 29 August and booking-required card.', startMs: 40_000, endMs: 60_000, treatment: 'text_only' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'scene-1', path: '$.scenes[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'scene-2', path: '$.scenes[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'scene-3', path: '$.scenes[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], script60Upstream, claims, capturedAt);
+  const overlays = makeArtifact('video_overlays', 'video-overlays', {
+    kind: 'video_overlays', title: 'Overlay ledger', targetDurationMs: 60_000, items: [
+      { id: 'overlay-1', title: 'Location', text: 'Red Hill', startMs: 0, endMs: 8_000 },
+      { id: 'overlay-2', title: 'Service', text: 'Saturday 29 August', startMs: 24_000, endMs: 34_000 },
+      { id: 'overlay-3', title: 'Planning', text: 'Booking required', startMs: 44_000, endMs: 54_000 },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'overlay-1', path: '$.items[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'overlay-2', path: '$.items[1].text', claimIds: ['claim-date'] },
+    { segmentId: 'overlay-3', path: '$.items[2].text', claimIds: ['claim-booking'] },
+  ], script60Upstream, claims, capturedAt);
+  const script30Upstream = [...dependencies, artifactDependency(script30)];
+  const subtitles = makeArtifact('video_subtitles', 'video-subtitles', {
+    kind: 'video_subtitles', title: '30-second subtitles', language: 'en-AU', targetDurationMs: 30_000, cues: [
+      { id: 'subtitle-1', title: 'Hook', text: 'Rain in Red Hill? Start with a covered lunch.', startMs: 0, endMs: 10_000 },
+      { id: 'subtitle-2', title: 'Reason', text: 'The covered dining room gives the day an indoor anchor.', startMs: 10_000, endMs: 20_000 },
+      { id: 'subtitle-3', title: 'Service', text: 'Saturday 29 August. Booking required.', startMs: 20_000, endMs: 30_000 },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'subtitle-1', path: '$.cues[0].text', claimIds: ['claim-location'] },
+    { segmentId: 'subtitle-2', path: '$.cues[1].text', claimIds: ['claim-observation'] },
+    { segmentId: 'subtitle-3', path: '$.cues[2].text', claimIds: ['claim-date', 'claim-booking'] },
+  ], script30Upstream, claims, capturedAt);
+  const thumbnail = makeArtifact('video_thumbnail', 'video-thumbnail', {
+    kind: 'video_thumbnail', title: 'Thumbnail copy', variants: [
+      { id: 'thumbnail-1', headline: 'A rainy-day Red Hill lunch', visualBrief: 'Use a text-led Red Hill treatment until rights-cleared media is assigned.' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'thumbnail-1-headline', path: '$.variants[0].headline', claimIds: ['claim-location', 'claim-observation'] },
+    { segmentId: 'thumbnail-1-brief', path: '$.variants[0].visualBrief', claimIds: ['claim-location'] },
+  ],
+  [...dependencies, artifactDependency(scenes)], claims, capturedAt);
+  const captions = makeArtifact('video_platform_captions', 'video-platform-captions', {
+    kind: 'video_platform_captions', title: 'Platform caption drafts', items: [
+      { id: 'caption-instagram', platform: 'instagram', caption: 'A covered dining room can anchor a rainy Red Hill lunch. The winter lunch is listed for Saturday 29 August, with booking required.' },
+      { id: 'caption-youtube', platform: 'youtube', caption: 'Plan a wet-weather Red Hill lunch around covered dining and a listed Saturday service.' },
+    ], boundary: boundary(),
+  }, [
+    { segmentId: 'caption-instagram', path: '$.items[0].caption', claimIds: ['claim-location', 'claim-date', 'claim-booking', 'claim-observation'] },
+    { segmentId: 'caption-youtube', path: '$.items[1].caption', claimIds: ['claim-location', 'claim-date', 'claim-observation'] },
+  ], script30Upstream, claims, capturedAt);
+  return [hooks, script30, script60, shots, scenes, overlays, subtitles, thumbnail, captions];
+}
+
+export type PreproductionFamily = 'explainer' | 'podcast' | 'short_video';
+
+export function runPreproductionFixture(
+  family: PreproductionFamily,
+  actor: string,
+  idempotencyKey: string,
+  options: { failOptionalDerivative?: boolean } = {},
+): FoundryRun {
+  const { capturedAt, claims, claimSet, bundle, angle } = fixtureSource(actor);
+  const dependencies: ArtifactDependency[] = [claimSetDependency(claimSet), angleDependency(angle)];
+  const recipe = family === 'explainer' ? EXPLAINER_RECIPE : family === 'podcast' ? PODCAST_RECIPE : SHORT_VIDEO_RECIPE;
+  const fixtureId = family === 'explainer' ? EXPLAINER_FIXTURE_ID : family === 'podcast' ? PODCAST_FIXTURE_ID : SHORT_VIDEO_FIXTURE_ID;
+  let completed = family === 'explainer'
+    ? buildExplainer(claims, dependencies, capturedAt)
+    : family === 'podcast'
+      ? buildPodcast(claims, dependencies, capturedAt)
+      : buildVideo(claims, dependencies, capturedAt);
+  const failed = [];
+  if (options.failOptionalDerivative) {
+    const failedType = family === 'explainer' ? 'explainer_visualisation' : family === 'podcast' ? 'podcast_show_notes' : 'video_platform_captions';
+    const failedArtifact = completed.find((artifact) => artifact.type === failedType);
+    if (!failedArtifact) throw new Error(`Optional fixture derivative ${failedType} missing`);
+    completed = completed.filter((artifact) => artifact.id !== failedArtifact.id);
+    failed.push({
+      key: failedArtifact.key, type: failedArtifact.type, required: false as const, code: 'fixture_derivative_failure' as const,
+      detail: 'The deterministic optional derivative failed without invalidating its completed siblings.', attemptedAt: capturedAt,
+    });
+  }
+  return FoundryRunSchema.parse({
+    schemaVersion: 'pi.foundry-run.v2', id: `run-${hash(idempotencyKey).slice(0, 12)}`, idempotencyKey, version: 1,
+    status: 'ready_for_review', createdAt: capturedAt, updatedAt: capturedAt,
+    bundle: { ...bundle, id: `bundle-${fixtureId}`, title: `${recipe.label} fixture` }, recipe, claimSet, angle,
+    artifactPack: {
+      schemaVersion: 'pi.artifact-pack.v1', id: `pack-${hash(idempotencyKey).slice(0, 12)}`, version: 1,
+      recipeId: recipe.id, recipeVersion: recipe.version, claimSetRef: claimSetDependency(claimSet),
+      angleRef: { id: angle.id, version: angle.version }, status: failed.length ? 'partial' : 'complete',
+      completed, failed, omitted: [], reviews: [],
+    },
+    blockers: [],
+    audit: [{ at: capturedAt, actor, type: 'fixture_run_created', detail: `${recipe.label} reached text review without recording, rendering or external calls.` }],
+  });
+}

--- a/studio-peninsula-insider/server/preproduction-policy.ts
+++ b/studio-peninsula-insider/server/preproduction-policy.ts
@@ -1,0 +1,184 @@
+import { createHash } from 'node:crypto';
+import {
+  PreproductionPayloadSchema,
+  type PreproductionPayload,
+} from '../shared/preproduction-contracts.js';
+import type { ArtifactDependency, GateResult } from '../shared/contracts.js';
+
+function gate(name: 'preproduction_policy' | 'timing_valid' | 'media_render_ready', passed: boolean, detail: string, blocking = true): GateResult {
+  return passed
+    ? { gate: name, scope: 'artifact', passed: true, blocking: false, detail, claimIds: [] }
+    : { gate: name, scope: 'artifact', passed: false, blocking, detail, claimIds: [] };
+}
+
+function orderedAndBounded(items: Array<{ startMs: number; endMs: number }>, targetDurationMs: number, contiguous: boolean): boolean {
+  if (items.length === 0 || items[0].startMs !== 0) return false;
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (item.endMs <= item.startMs || item.endMs > targetDurationMs) return false;
+    if (index > 0) {
+      const previous = items[index - 1];
+      if (item.startMs < previous.endMs || (contiguous && item.startMs !== previous.endMs)) return false;
+    }
+  }
+  return !contiguous || items.at(-1)?.endMs === targetDurationMs;
+}
+
+function timingCurrent(payload: PreproductionPayload): boolean {
+  switch (payload.kind) {
+    case 'explainer_voiceover':
+    case 'podcast_script':
+      return payload.segments.reduce((total, segment) => total + segment.durationMs, 0) === payload.targetDurationMs;
+    case 'podcast_run_sheet':
+      return orderedAndBounded(payload.segments, payload.targetDurationMs, true);
+    case 'podcast_chapters':
+      return orderedAndBounded(payload.items, payload.targetDurationMs, false);
+    case 'video_script':
+      return payload.segments.reduce((total, segment) => total + segment.durationMs, 0) === payload.targetSeconds * 1_000;
+    case 'video_shot_list':
+      return payload.shots.reduce((total, shot) => total + shot.durationMs, 0) === payload.targetDurationMs;
+    case 'video_scenes':
+      return orderedAndBounded(payload.scenes, payload.targetDurationMs, true);
+    case 'video_overlays':
+      return orderedAndBounded(payload.items, payload.targetDurationMs, false);
+    case 'video_subtitles':
+      return orderedAndBounded(payload.cues, payload.targetDurationMs, false);
+    default:
+      return true;
+  }
+}
+
+function includesSimulatedContributor(payload: PreproductionPayload): boolean {
+  return JSON.stringify(payload).includes('"contentMode":"simulated_contributor"');
+}
+
+function policyCurrent(payload: PreproductionPayload): boolean {
+  const boundary = payload.boundary;
+  if (includesSimulatedContributor(payload)) return false;
+  if (boundary.voiceMode === 'synthetic' || boundary.voiceMode === 'cloned') return false;
+  if (boundary.voiceMode === 'human_cleared' && !boundary.voiceReleaseId) return false;
+  if (boundary.generationMode === 'documentary') return false;
+  if (boundary.generationMode === 'illustrative' && payload.kind === 'video_scenes' && payload.scenes.some((scene) => scene.treatment === 'documentary')) return false;
+  if (payload.kind === 'video_shot_list' && payload.shots.some((shot) => shot.source === 'approved_illustrative') && boundary.generationMode !== 'illustrative') return false;
+  if (payload.kind === 'video_scenes' && payload.scenes.some((scene) => scene.treatment === 'illustrative') && boundary.generationMode !== 'illustrative') return false;
+  if (boundary.generationMode === 'illustrative' && (!boundary.generationApprovalId || !boundary.generationDisclosure)) return false;
+  return true;
+}
+
+type MediaAssignment = PreproductionPayload['boundary']['mediaAssignments'][number];
+
+function sameStringSet(left: string[], right: string[]): boolean {
+  return left.length === right.length && [...left].sort().every((value, index) => value === [...right].sort()[index]);
+}
+
+function requiredMediaPlacements(payload: PreproductionPayload): Array<{ path: string; surface: MediaAssignment['surface'] }> {
+  switch (payload.kind) {
+    case 'explainer_carousel':
+      return payload.slides.map((_, index) => ({ path: `$.slides[${index}]`, surface: payload.boundary.generationMode === 'illustrative' ? 'illustration' : 'image' }));
+    case 'explainer_visualisation':
+      return payload.points.map((_, index) => ({ path: `$.points[${index}]`, surface: 'illustration' }));
+    case 'explainer_voiceover':
+    case 'podcast_script':
+    case 'video_script':
+      return payload.segments.map((_, index) => ({ path: `$.segments[${index}]`, surface: 'audio' }));
+    case 'video_hooks':
+      return payload.variants.map((_, index) => ({ path: `$.variants[${index}]`, surface: 'audio' }));
+    case 'video_shot_list':
+      return payload.shots.map((shot, index) => ({
+        path: `$.shots[${index}]`,
+        surface: shot.source === 'approved_illustrative' ? 'illustration' : 'video',
+      }));
+    case 'video_scenes':
+      return payload.scenes.flatMap((scene, index) => scene.treatment === 'text_only' ? [] : [{
+        path: `$.scenes[${index}]`,
+        surface: scene.treatment === 'illustrative' ? 'illustration' as const : 'video' as const,
+      }]);
+    case 'video_thumbnail':
+      return payload.variants.map((_, index) => ({ path: `$.variants[${index}]`, surface: payload.boundary.generationMode === 'illustrative' ? 'illustration' : 'image' }));
+    default:
+      return [];
+  }
+}
+
+export function mediaRightsBindingHash(assignment: MediaAssignment): string {
+  return createHash('sha256').update(JSON.stringify({
+    asset: assignment.asset,
+    placementPath: assignment.placementPath,
+    surface: assignment.surface,
+    rights: assignment.rights,
+    recognisablePeople: assignment.recognisablePeople,
+    releaseIds: [...assignment.releaseIds].sort(),
+  })).digest('hex');
+}
+
+export function mediaReadinessCurrent(payload: PreproductionPayload, dependencies: ArtifactDependency[]): boolean {
+  const boundary = payload.boundary;
+  const mediaDependencies = dependencies.filter((dependency) => dependency.kind === 'media_rights');
+  if (boundary.mediaStatus === 'unassigned') {
+    return boundary.rightsSnapshots.length === 0 && boundary.mediaAssignments.length === 0 && mediaDependencies.length === 0;
+  }
+  const requiredPlacements = requiredMediaPlacements(payload);
+  if (requiredPlacements.length === 0 || boundary.mediaAssignments.length !== requiredPlacements.length) return false;
+  if (boundary.rightsSnapshots.length !== boundary.mediaAssignments.length || mediaDependencies.length !== boundary.mediaAssignments.length) return false;
+  if (new Set(boundary.mediaAssignments.map((assignment) => assignment.placementPath)).size !== boundary.mediaAssignments.length) return false;
+  const assignmentRightsRefs = boundary.mediaAssignments.map((assignment) => `${assignment.rights.id}@${assignment.rights.version}`);
+  const snapshotRightsRefs = boundary.rightsSnapshots.map((snapshot) => `${snapshot.id}@${snapshot.version}`);
+  const dependencyRightsRefs = mediaDependencies.map((dependency) => `${dependency.id}@${dependency.version}`);
+  if (new Set(assignmentRightsRefs).size !== assignmentRightsRefs.length
+    || new Set(snapshotRightsRefs).size !== snapshotRightsRefs.length
+    || new Set(dependencyRightsRefs).size !== dependencyRightsRefs.length) return false;
+  if (!requiredPlacements.every((required) => boundary.mediaAssignments.some((assignment) => (
+    assignment.placementPath === required.path && assignment.surface === required.surface
+  )))) return false;
+  if (payload.kind === 'video_shot_list' && payload.shots.some((shot) => shot.source === 'unassigned')) return false;
+  const assignedReleaseIds = [...new Set(boundary.mediaAssignments.flatMap((assignment) => assignment.releaseIds))];
+  if (!sameStringSet(boundary.releaseIds, assignedReleaseIds)) return false;
+  if (boundary.recognisablePeople !== boundary.mediaAssignments.some((assignment) => assignment.recognisablePeople)) return false;
+  if (boundary.mediaAssignments.some((assignment) => assignment.recognisablePeople && assignment.releaseIds.length === 0)) return false;
+  if (['explainer_voiceover', 'podcast_script', 'video_hooks', 'video_script'].includes(payload.kind)
+    && (boundary.voiceMode !== 'human_cleared' || !boundary.voiceReleaseId)) return false;
+  if (boundary.voiceMode === 'human_cleared' && !boundary.voiceReleaseId) return false;
+  if (boundary.voiceReleaseId && !boundary.mediaAssignments.every((assignment) => assignment.surface !== 'audio' || assignment.releaseIds.includes(boundary.voiceReleaseId!))) return false;
+  if (boundary.generationMode === 'illustrative' && (!boundary.generationApprovalId || !boundary.generationDisclosure)) return false;
+  if (boundary.generationMode === 'documentary' || boundary.voiceMode === 'synthetic' || boundary.voiceMode === 'cloned') return false;
+  return boundary.mediaAssignments.every((assignment) => {
+    const bindingHash = mediaRightsBindingHash(assignment);
+    const snapshot = boundary.rightsSnapshots.find((candidate) => candidate.id === assignment.rights.id && candidate.version === assignment.rights.version);
+    const dependency = mediaDependencies.find((candidate) => candidate.id === assignment.rights.id && candidate.version === assignment.rights.version);
+    return snapshot?.contentHash === bindingHash
+      && dependency?.kind === 'media_rights'
+      && dependency.contentHash === bindingHash
+      && dependency.status === 'cleared';
+  });
+}
+
+export function evaluatePreproductionGates(payloadInput: unknown, dependencies: ArtifactDependency[]): GateResult[] {
+  const payload = PreproductionPayloadSchema.parse(payloadInput);
+  const policyPassed = policyCurrent(payload);
+  const timingPassed = timingCurrent(payload);
+  const mediaPassed = mediaReadinessCurrent(payload, dependencies);
+  return [
+    gate(
+      'preproduction_policy',
+      policyPassed,
+      policyPassed
+        ? 'No simulated contributor, cloned voice, synthetic voice or generated documentary treatment is authorised.'
+        : 'Simulated contributors, cloned or synthetic voice, generated documentary treatment, or undisclosed illustrative generation are blocked.',
+    ),
+    gate(
+      'timing_valid',
+      timingPassed,
+      timingPassed ? 'Timed segments are ordered and match the declared duration.' : 'Timed segments overlap, leave an invalid boundary or do not match the declared duration.',
+    ),
+    gate(
+      'media_render_ready',
+      mediaPassed && payload.boundary.mediaStatus === 'ready',
+      mediaPassed && payload.boundary.mediaStatus === 'ready'
+        ? 'Every assigned medium has matching rights, releases and required disclosure.'
+        : payload.boundary.mediaStatus === 'unassigned' && mediaPassed
+          ? 'Text pre-production is reviewable; media and render readiness remain deliberately unassigned.'
+          : 'Media or render readiness lacks exact rights, releases, approval or disclosure.',
+      payload.boundary.mediaStatus === 'ready',
+    ),
+  ];
+}

--- a/studio-peninsula-insider/server/store.ts
+++ b/studio-peninsula-insider/server/store.ts
@@ -18,7 +18,9 @@ import {
   type GateResult,
   type ReviewDecision,
 } from '../shared/contracts.js';
+import { isPreproductionArtifactType, parsePreproductionPayload } from '../shared/preproduction-contracts.js';
 import { artifactDependenciesCurrent, evaluateArtifactGates, evaluateQuickNoteGates, hashValue, migrateLegacyRun } from './fixture-runner.js';
+import { evaluatePreproductionGates } from './preproduction-policy.js';
 
 interface StoreFile {
   schemaVersion: 'pi.foundry-file-store.v1';
@@ -116,6 +118,9 @@ function parsePayloadForArtifact(artifact: ArtifactVersion, payload: unknown): A
     case 'ask_answer': return AskAnswerPayloadSchema.parse(payload);
     case 'internal_link_plan': return InternalLinkPlanPayloadSchema.parse(payload);
     case 'seo_metadata_proposal': return SeoMetadataProposalPayloadSchema.parse(payload);
+    default:
+      if (isPreproductionArtifactType(artifact.type)) return parsePreproductionPayload(artifact.type, payload);
+      throw new Error(`Unsupported artifact type ${String(artifact.type)}`);
   }
 }
 
@@ -149,6 +154,9 @@ function gatesForUpdatedArtifact(
     results.push(metadata.astroPatchReady
       ? { gate: 'astro_patch_ready', scope: 'artifact', passed: true, blocking: false, detail: 'A separately rights-cleared hero placement makes the Astro patch adapter available.', claimIds: [] }
       : { gate: 'astro_patch_ready', scope: 'artifact', passed: false, blocking: false, detail: 'Text artifacts remain reviewable, but Astro patch export waits for a rights-cleared hero placement.', claimIds: [] });
+  }
+  if (isPreproductionArtifactType(artifact.type)) {
+    results.push(...evaluatePreproductionGates(payload, artifact.dependencies));
   }
   return results;
 }

--- a/studio-peninsula-insider/shared/contracts.ts
+++ b/studio-peninsula-insider/shared/contracts.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PreproductionArtifactTypeSchema, PreproductionPayloadSchema } from './preproduction-contracts.js';
 
 const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 const IsoDateTimeSchema = z.string().datetime();
@@ -67,6 +68,7 @@ export const ArtifactTypeSchema = z.enum([
   'ask_answer',
   'internal_link_plan',
   'seo_metadata_proposal',
+  ...PreproductionArtifactTypeSchema.options,
 ]);
 
 export const RecipeArtifactRequirementSchema = z.object({
@@ -97,6 +99,9 @@ export const GateCodeSchema = z.enum([
   'astro_article_contract',
   'ask_answer_contract',
   'astro_patch_ready',
+  'preproduction_policy',
+  'timing_valid',
+  'media_render_ready',
 ]);
 
 const GateResultBaseSchema = z.object({
@@ -309,13 +314,22 @@ export const SeoMetadataProposalArtifactSchema = ArtifactVersionBaseSchema.exten
   payload: SeoMetadataProposalPayloadSchema,
 });
 
-export const ArtifactVersionSchema = z.discriminatedUnion('type', [
+export const PreproductionArtifactSchema = ArtifactVersionBaseSchema.extend({
+  type: PreproductionArtifactTypeSchema,
+  payload: PreproductionPayloadSchema,
+}).refine((artifact) => artifact.type === artifact.payload.kind, {
+  message: 'Pre-production artifact type must match its discriminated payload kind.',
+  path: ['payload', 'kind'],
+});
+
+export const ArtifactVersionSchema = z.union([
   QuickNoteArtifactSchema,
   ArticleDraftArtifactSchema,
   ArticleMetadataArtifactSchema,
   AskAnswerArtifactSchema,
   InternalLinkPlanArtifactSchema,
   SeoMetadataProposalArtifactSchema,
+  PreproductionArtifactSchema,
 ]);
 
 export const ArtifactFailureSchema = z.object({

--- a/studio-peninsula-insider/shared/preproduction-contracts.ts
+++ b/studio-peninsula-insider/shared/preproduction-contracts.ts
@@ -1,0 +1,230 @@
+import { z } from 'zod';
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+
+export const PreproductionArtifactTypeSchema = z.enum([
+  'explainer_core',
+  'explainer_faq',
+  'explainer_carousel',
+  'explainer_voiceover',
+  'explainer_visualisation',
+  'podcast_evidence_dossier',
+  'podcast_angle',
+  'podcast_run_sheet',
+  'podcast_interview_guide',
+  'podcast_script',
+  'podcast_show_notes',
+  'podcast_chapters',
+  'video_hooks',
+  'video_script',
+  'video_shot_list',
+  'video_scenes',
+  'video_overlays',
+  'video_subtitles',
+  'video_thumbnail',
+  'video_platform_captions',
+]);
+
+export const RightsSnapshotSchema = z.object({
+  id: z.string().min(1),
+  version: z.number().int().positive(),
+  contentHash: Sha256Schema,
+});
+
+export const MediaAssignmentSchema = z.object({
+  id: z.string().min(1),
+  placementPath: z.string().regex(/^\$\.(?:[A-Za-z][A-Za-z0-9]*)(?:\[\d+\])?(?:\.[A-Za-z][A-Za-z0-9]*)?$/),
+  surface: z.enum(['audio', 'image', 'video', 'illustration']),
+  asset: z.object({
+    id: z.string().min(1),
+    version: z.number().int().positive(),
+    contentHash: Sha256Schema,
+  }),
+  rights: z.object({ id: z.string().min(1), version: z.number().int().positive() }),
+  recognisablePeople: z.boolean().default(false),
+  releaseIds: z.array(z.string().min(1)).default([]),
+});
+
+export const ProductionBoundarySchema = z.object({
+  stage: z.literal('text_preproduction'),
+  mediaStatus: z.enum(['unassigned', 'ready']),
+  rightsSnapshots: z.array(RightsSnapshotSchema).default([]),
+  mediaAssignments: z.array(MediaAssignmentSchema).default([]),
+  recognisablePeople: z.boolean().default(false),
+  releaseIds: z.array(z.string().min(1)).default([]),
+  voiceMode: z.enum(['human_unassigned', 'human_cleared', 'synthetic', 'cloned']).default('human_unassigned'),
+  voiceReleaseId: z.string().min(1).optional(),
+  generationMode: z.enum(['none', 'illustrative', 'documentary']).default('none'),
+  generationApprovalId: z.string().min(1).optional(),
+  generationDisclosure: z.string().min(1).optional(),
+});
+
+const TextSegmentSchema = z.object({
+  id: z.string().min(1),
+  text: z.string().min(1),
+});
+
+const SpokenSegmentSchema = TextSegmentSchema.extend({
+  durationMs: z.number().int().positive(),
+  contentMode: z.enum(['editorial_narration', 'source_quote', 'simulated_contributor']).default('editorial_narration'),
+  speaker: z.string().min(1).default('host'),
+});
+
+const TimedSegmentSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  text: z.string().min(1),
+  startMs: z.number().int().nonnegative(),
+  endMs: z.number().int().positive(),
+});
+
+const Boundary = { boundary: ProductionBoundarySchema };
+
+export const ExplainerCorePayloadSchema = z.object({
+  kind: z.literal('explainer_core'), title: z.string().min(1), thesis: z.string().min(1), sections: z.array(TextSegmentSchema).min(1), ...Boundary,
+});
+export const ExplainerFaqPayloadSchema = z.object({
+  kind: z.literal('explainer_faq'), title: z.string().min(1), items: z.array(z.object({ id: z.string().min(1), question: z.string().min(1), answer: z.string().min(1) })).min(1), ...Boundary,
+});
+export const ExplainerCarouselPayloadSchema = z.object({
+  kind: z.literal('explainer_carousel'), title: z.string().min(1), slides: z.array(z.object({ id: z.string().min(1), headline: z.string().min(1), body: z.string().min(1) })).min(2), ...Boundary,
+});
+export const ExplainerVoiceoverPayloadSchema = z.object({
+  kind: z.literal('explainer_voiceover'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), segments: z.array(SpokenSegmentSchema).min(1), ...Boundary,
+});
+export const ExplainerVisualisationPayloadSchema = z.object({
+  kind: z.literal('explainer_visualisation'), title: z.string().min(1), chartType: z.enum(['timeline', 'comparison', 'map', 'stat_card']), points: z.array(z.object({ id: z.string().min(1), label: z.string().min(1), valueText: z.string().min(1) })).min(1), sourceNote: z.string().min(1), ...Boundary,
+});
+
+export const PodcastEvidenceDossierPayloadSchema = z.object({
+  kind: z.literal('podcast_evidence_dossier'), title: z.string().min(1), evidenceItems: z.array(TextSegmentSchema).min(1), ...Boundary,
+});
+export const PodcastAnglePayloadSchema = z.object({
+  kind: z.literal('podcast_angle'), title: z.string().min(1), promise: z.string().min(1), audience: z.string().min(1), avoidClaims: z.array(z.string()).default([]), ...Boundary,
+});
+export const PodcastRunSheetPayloadSchema = z.object({
+  kind: z.literal('podcast_run_sheet'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), segments: z.array(TimedSegmentSchema).min(1), ...Boundary,
+});
+export const PodcastInterviewGuidePayloadSchema = z.object({
+  kind: z.literal('podcast_interview_guide'), title: z.string().min(1), questions: z.array(z.object({ id: z.string().min(1), prompt: z.string().min(1), rationale: z.string().min(1) })).min(1), prohibitedPrompts: z.array(z.string()).default([]), ...Boundary,
+});
+export const PodcastScriptPayloadSchema = z.object({
+  kind: z.literal('podcast_script'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), segments: z.array(SpokenSegmentSchema).min(1), ...Boundary,
+});
+export const PodcastShowNotesPayloadSchema = z.object({
+  kind: z.literal('podcast_show_notes'), title: z.string().min(1), summary: z.string().min(1), bullets: z.array(TextSegmentSchema).min(1), provisional: z.literal(true), ...Boundary,
+});
+export const PodcastChaptersPayloadSchema = z.object({
+  kind: z.literal('podcast_chapters'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), items: z.array(TimedSegmentSchema).min(1), provisional: z.literal(true), ...Boundary,
+});
+
+export const VideoHooksPayloadSchema = z.object({
+  kind: z.literal('video_hooks'), title: z.string().min(1), variants: z.array(SpokenSegmentSchema).min(2), ...Boundary,
+});
+export const VideoScriptPayloadSchema = z.object({
+  kind: z.literal('video_script'), title: z.string().min(1), targetSeconds: z.union([z.literal(30), z.literal(60)]), segments: z.array(SpokenSegmentSchema).min(1), ...Boundary,
+});
+export const VideoShotListPayloadSchema = z.object({
+  kind: z.literal('video_shot_list'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), shots: z.array(z.object({ id: z.string().min(1), description: z.string().min(1), durationMs: z.number().int().positive(), source: z.enum(['unassigned', 'rights_cleared', 'approved_illustrative']) })).min(1), ...Boundary,
+});
+export const VideoScenesPayloadSchema = z.object({
+  kind: z.literal('video_scenes'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), scenes: z.array(TimedSegmentSchema.extend({ treatment: z.enum(['documentary', 'illustrative', 'text_only']) })).min(1), ...Boundary,
+});
+export const VideoOverlaysPayloadSchema = z.object({
+  kind: z.literal('video_overlays'), title: z.string().min(1), targetDurationMs: z.number().int().positive(), items: z.array(TimedSegmentSchema).min(1), ...Boundary,
+});
+export const VideoSubtitlesPayloadSchema = z.object({
+  kind: z.literal('video_subtitles'), title: z.string().min(1), language: z.literal('en-AU'), targetDurationMs: z.number().int().positive(), cues: z.array(TimedSegmentSchema).min(1), ...Boundary,
+});
+export const VideoThumbnailPayloadSchema = z.object({
+  kind: z.literal('video_thumbnail'), title: z.string().min(1), variants: z.array(z.object({ id: z.string().min(1), headline: z.string().min(1), visualBrief: z.string().min(1) })).min(1), ...Boundary,
+});
+export const VideoPlatformCaptionsPayloadSchema = z.object({
+  kind: z.literal('video_platform_captions'), title: z.string().min(1), items: z.array(z.object({ id: z.string().min(1), platform: z.enum(['instagram', 'youtube', 'tiktok', 'linkedin']), caption: z.string().min(1) })).min(1), ...Boundary,
+});
+
+export const PreproductionPayloadSchema = z.discriminatedUnion('kind', [
+  ExplainerCorePayloadSchema,
+  ExplainerFaqPayloadSchema,
+  ExplainerCarouselPayloadSchema,
+  ExplainerVoiceoverPayloadSchema,
+  ExplainerVisualisationPayloadSchema,
+  PodcastEvidenceDossierPayloadSchema,
+  PodcastAnglePayloadSchema,
+  PodcastRunSheetPayloadSchema,
+  PodcastInterviewGuidePayloadSchema,
+  PodcastScriptPayloadSchema,
+  PodcastShowNotesPayloadSchema,
+  PodcastChaptersPayloadSchema,
+  VideoHooksPayloadSchema,
+  VideoScriptPayloadSchema,
+  VideoShotListPayloadSchema,
+  VideoScenesPayloadSchema,
+  VideoOverlaysPayloadSchema,
+  VideoSubtitlesPayloadSchema,
+  VideoThumbnailPayloadSchema,
+  VideoPlatformCaptionsPayloadSchema,
+]);
+
+export type PreproductionArtifactType = z.infer<typeof PreproductionArtifactTypeSchema>;
+export type PreproductionPayload = z.infer<typeof PreproductionPayloadSchema>;
+export type ProductionBoundary = z.infer<typeof ProductionBoundarySchema>;
+
+export function isPreproductionArtifactType(value: string): value is PreproductionArtifactType {
+  return PreproductionArtifactTypeSchema.safeParse(value).success;
+}
+
+export function parsePreproductionPayload(type: PreproductionArtifactType, payload: unknown): PreproductionPayload {
+  const parsed = PreproductionPayloadSchema.parse(payload);
+  if (parsed.kind !== type) throw new Error(`Artifact type ${type} does not match payload kind ${parsed.kind}`);
+  return parsed;
+}
+
+export function requiredPreproductionLineagePaths(payload: PreproductionPayload): string[] {
+  const paths = (() => {
+    switch (payload.kind) {
+    case 'explainer_core':
+      return ['$.thesis', ...payload.sections.map((_, index) => `$.sections[${index}].text`)];
+    case 'explainer_faq':
+      return payload.items.flatMap((_, index) => [`$.items[${index}].question`, `$.items[${index}].answer`]);
+    case 'explainer_carousel':
+      return payload.slides.flatMap((_, index) => [`$.slides[${index}].headline`, `$.slides[${index}].body`]);
+    case 'explainer_voiceover':
+    case 'podcast_script':
+    case 'video_script':
+      return payload.segments.flatMap((_, index) => [`$.segments[${index}].text`, `$.segments[${index}].speaker`]);
+    case 'explainer_visualisation':
+      return [...payload.points.flatMap((_, index) => [`$.points[${index}].label`, `$.points[${index}].valueText`]), '$.sourceNote'];
+    case 'podcast_evidence_dossier':
+      return payload.evidenceItems.map((_, index) => `$.evidenceItems[${index}].text`);
+    case 'podcast_angle':
+      return ['$.promise', '$.audience', ...payload.avoidClaims.map((_, index) => `$.avoidClaims[${index}]`)];
+    case 'podcast_run_sheet':
+      return payload.segments.flatMap((_, index) => [`$.segments[${index}].title`, `$.segments[${index}].text`]);
+    case 'podcast_interview_guide':
+      return [
+        ...payload.questions.flatMap((_, index) => [`$.questions[${index}].prompt`, `$.questions[${index}].rationale`]),
+        ...payload.prohibitedPrompts.map((_, index) => `$.prohibitedPrompts[${index}]`),
+      ];
+    case 'podcast_show_notes':
+      return ['$.summary', ...payload.bullets.map((_, index) => `$.bullets[${index}].text`)];
+    case 'podcast_chapters':
+      return payload.items.flatMap((_, index) => [`$.items[${index}].title`, `$.items[${index}].text`]);
+    case 'video_hooks':
+      return payload.variants.flatMap((_, index) => [`$.variants[${index}].text`, `$.variants[${index}].speaker`]);
+    case 'video_shot_list':
+      return payload.shots.map((_, index) => `$.shots[${index}].description`);
+    case 'video_scenes':
+      return payload.scenes.flatMap((_, index) => [`$.scenes[${index}].title`, `$.scenes[${index}].text`]);
+    case 'video_overlays':
+      return payload.items.flatMap((_, index) => [`$.items[${index}].title`, `$.items[${index}].text`]);
+    case 'video_subtitles':
+      return payload.cues.flatMap((_, index) => [`$.cues[${index}].title`, `$.cues[${index}].text`]);
+    case 'video_thumbnail':
+      return payload.variants.flatMap((_, index) => [`$.variants[${index}].headline`, `$.variants[${index}].visualBrief`]);
+    case 'video_platform_captions':
+      return payload.items.map((_, index) => `$.items[${index}].caption`);
+    }
+  })();
+  return ['$.title', ...paths];
+}

--- a/studio-peninsula-insider/src/App.tsx
+++ b/studio-peninsula-insider/src/App.tsx
@@ -2,6 +2,11 @@ import { useEffect, useState } from 'react';
 import type { FoundryRun } from '../shared/contracts';
 
 const FIXTURE_ID = 'red-hill-winter-lunch';
+const PREPRODUCTION_FIXTURES = [
+  { id: 'red-hill-explainer-preproduction', label: 'Explainer pack' },
+  { id: 'red-hill-podcast-preproduction', label: 'Podcast pack' },
+  { id: 'red-hill-short-video-preproduction', label: 'Short-video pack' },
+] as const;
 type QuickNoteRun = FoundryRun & { artifact: NonNullable<FoundryRun['artifact']>; claims: NonNullable<FoundryRun['claims']> };
 
 function asQuickNoteRun(run: FoundryRun): QuickNoteRun | null {
@@ -11,6 +16,7 @@ function asQuickNoteRun(run: FoundryRun): QuickNoteRun | null {
 
 export function App() {
   const [run, setRun] = useState<QuickNoteRun | null>(null);
+  const [packRun, setPackRun] = useState<FoundryRun | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [draft, setDraft] = useState({ headline: '', dek: '', body: '' });
@@ -21,6 +27,7 @@ export function App() {
       .then((data: { runs?: FoundryRun[] }) => {
         const quickNote = data.runs?.map(asQuickNoteRun).find((item): item is QuickNoteRun => Boolean(item));
         setRun(quickNote ?? null);
+        setPackRun(data.runs?.find((item) => item.recipe.id.endsWith('_preproduction_v1')) ?? null);
       })
       .catch(() => setError('The local API is not available yet.'));
   }, []);
@@ -49,6 +56,45 @@ export function App() {
       setRun(created);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'The fixture run failed.');
+    } finally { setBusy(false); }
+  }
+
+  async function startPack(fixtureId: typeof PREPRODUCTION_FIXTURES[number]['id']) {
+    setBusy(true);
+    setError('');
+    try {
+      const response = await fetch('/api/foundry/runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fixtureId, actor: 'local-editor', idempotencyKey: `ui-${fixtureId}-v1` }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'The pre-production fixture could not start.');
+      setPackRun(body);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'The pre-production fixture failed.');
+    } finally { setBusy(false); }
+  }
+
+  async function decidePackArtifact(artifactId: string, decision: 'accepted' | 'rejected') {
+    if (!packRun) return;
+    const artifact = packRun.artifactPack.completed.find((candidate) => candidate.id === artifactId);
+    if (!artifact) return;
+    setBusy(true);
+    setError('');
+    try {
+      const response = await fetch(`/api/foundry/runs/${packRun.id}/review`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          artifactId, decision, reviewer: 'local-editor', expectedVersion: packRun.version, expectedArtifactVersion: artifact.version,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'Artifact review failed.');
+      setPackRun(body);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Artifact review failed.');
     } finally { setBusy(false); }
   }
 
@@ -114,6 +160,11 @@ export function App() {
         <h1>Evidence first. One source, many useful outputs.</h1>
         <p>Start with a frozen local fixture, inspect every claim, then make a human review decision. Nothing publishes from this screen.</p>
         <button onClick={startRun} disabled={busy}>{run ? 'Replay fixture safely' : 'Run the first fixture'}</button>
+        <div className="recipe-launcher" aria-label="Pre-production fixture recipes">
+          {PREPRODUCTION_FIXTURES.map((fixture) => (
+            <button className="secondary" key={fixture.id} onClick={() => startPack(fixture.id)} disabled={busy}>{fixture.label}</button>
+          ))}
+        </div>
       </section>
 
       {error && <div className="notice error" role="alert">{error}</div>}
@@ -182,6 +233,45 @@ export function App() {
           </section>
         </div>
       </>}
+
+      {packRun && <section className="artifact-pack" aria-labelledby="preproduction-pack-heading">
+        <div className="panel-heading">
+          <div>
+            <p className="eyebrow">Draft handoff only</p>
+            <h2 id="preproduction-pack-heading">{packRun.recipe.label}</h2>
+          </div>
+          <span aria-live="polite">{packRun.artifactPack.completed.length} completed · {packRun.artifactPack.failed.length} failed</span>
+        </div>
+        <p className="pack-boundary">Text pre-production can be reviewed here. Recording, media assignment, rendering, scheduling, sending and publishing remain unavailable.</p>
+        <div className="artifact-card-grid">
+          {packRun.artifactPack.completed.map((artifact) => {
+            const blocking = artifact.gateResults.some((gate) => !gate.passed && gate.blocking);
+            const review = packRun.artifactPack.reviews.find((candidate) => candidate.artifactId === artifact.id && candidate.status === 'current');
+            return <article className="artifact-card" key={artifact.id} aria-labelledby={`${artifact.id}-heading`}>
+              <div className="artifact-card-heading">
+                <div><p className="eyebrow">{artifact.type.replaceAll('_', ' ')}</p><h3 id={`${artifact.id}-heading`}>{artifact.key}</h3></div>
+                <span className={`pill ${blocking ? 'restricted' : ''}`}>{blocking ? 'blocked' : 'reviewable'}</span>
+              </div>
+              <dl className="artifact-meta">
+                <div><dt>Version</dt><dd>{artifact.version}</dd></div>
+                <div><dt>Claim segments</dt><dd>{artifact.claimUsage.length}</dd></div>
+                <div><dt>Dependencies</dt><dd>{artifact.dependencies.length}</dd></div>
+                <div><dt>Review</dt><dd>{review ? `${review.decision} · ${review.authority.replaceAll('_', ' ')}` : 'Awaiting decision'}</dd></div>
+              </dl>
+              <div className="gates">
+                {artifact.gateResults.map((gate) => <div key={gate.gate} className={gate.passed ? 'gate pass' : gate.blocking ? 'gate fail' : 'gate pending'}>
+                  <strong>{gate.passed ? 'PASS' : gate.blocking ? 'BLOCK' : 'PENDING'}</strong><span>{gate.gate.replaceAll('_', ' ')}</span>
+                </div>)}
+              </div>
+              <details className="payload-preview"><summary>Inspect draft payload and lineage</summary><pre>{JSON.stringify({ payload: artifact.payload, claimUsage: artifact.claimUsage, dependencies: artifact.dependencies }, null, 2)}</pre></details>
+              <div className="actions">
+                <button className="secondary" onClick={() => decidePackArtifact(artifact.id, 'rejected')} disabled={busy}>Reject</button>
+                <button onClick={() => decidePackArtifact(artifact.id, 'accepted')} disabled={busy || blocking}>Approve draft handoff</button>
+              </div>
+            </article>;
+          })}
+        </div>
+      </section>}
     </main>
   );
 }

--- a/studio-peninsula-insider/src/styles.css
+++ b/studio-peninsula-insider/src/styles.css
@@ -32,6 +32,7 @@ main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding-bottom: 64
 h1, h2 { font-family: Sora, Figtree, sans-serif; letter-spacing: -0.045em; margin: 0; }
 h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .hero > p:not(.eyebrow) { max-width: 650px; font-size: 1.15rem; line-height: 1.65; color: #53636e; margin: 1.5rem 0; }
+.recipe-launcher { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
 .notice, .empty { padding: 24px; border-radius: 16px; border: 1px solid #cfcac2; background: #fbfaf8; }
 .notice.error { border-color: #b84135; color: #8f2f28; }
 .notice.unsaved { margin-top: 14px; padding: 12px 14px; border-color: #d9a340; background: #fff7e5; color: #6d4c12; font-size: 0.82rem; }
@@ -76,9 +77,27 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .gate { padding: 12px; border-radius: 10px; display: grid; gap: 4px; font-size: 0.75rem; text-transform: capitalize; }
 .gate.pass { background: #e4ede8; color: #225d49; }
 .gate.fail { background: #f3dfda; color: #8f2f28; }
+.gate.pending { background: #fff3d6; color: #6d4c12; }
 .gate strong { font-size: 0.67rem; letter-spacing: 0.1em; }
 .actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 10px; margin-top: 24px; }
 .download { display: block; margin-top: 16px; text-align: center; color: #0b2e4a; font-weight: 800; }
+.artifact-pack { margin-top: 32px; background: #fbfaf8; border: 1px solid #d7d1c8; border-radius: 18px; padding: 24px; }
+.artifact-pack .panel-heading > div { display: grid; gap: 6px; }
+.artifact-pack .panel-heading h2 { font-size: clamp(1.7rem, 3vw, 2.6rem); }
+.pack-boundary { max-width: 760px; color: #53636e; line-height: 1.55; }
+.artifact-card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; margin-top: 20px; }
+.artifact-card { border: 1px solid #ded9d1; border-radius: 14px; padding: 18px; background: white; min-width: 0; }
+.artifact-card-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.artifact-card-heading .eyebrow { margin: 0 0 5px; color: #10527e; }
+.artifact-card-heading h3 { margin: 0; font: 700 1.15rem/1.2 Sora, Figtree, sans-serif; overflow-wrap: anywhere; }
+.artifact-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 16px 0; }
+.artifact-meta div { display: grid; gap: 3px; }
+.artifact-meta dt { color: #53636e; font-size: 0.68rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; }
+.artifact-meta dd { margin: 0; font-size: 0.82rem; overflow-wrap: anywhere; }
+.artifact-card .gates { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.payload-preview { margin-top: 14px; border: 1px solid #ded9d1; border-radius: 10px; }
+.payload-preview summary { cursor: pointer; padding: 11px 12px; color: #10527e; font-weight: 800; }
+.payload-preview pre { max-height: 320px; overflow: auto; margin: 0; padding: 12px; border-top: 1px solid #ded9d1; background: #f2efea; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 0.72rem; line-height: 1.45; }
 
 @media (max-width: 820px) {
   .environment { display: none; }
@@ -86,4 +105,6 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
   .runbar { grid-template-columns: 1fr 1fr; }
   .workspace-grid { grid-template-columns: 1fr; }
   .gates { grid-template-columns: 1fr; }
+  .artifact-card-grid { grid-template-columns: 1fr; }
+  .artifact-card .gates { grid-template-columns: 1fr; }
 }

--- a/studio-peninsula-insider/tests/foundry.test.ts
+++ b/studio-peninsula-insider/tests/foundry.test.ts
@@ -427,7 +427,10 @@ describe('generic Content Foundry contracts', () => {
     const page = await request(app).get('/').expect(200).expect('Content-Type', /html/).expect('Content-Security-Policy', /default-src 'self'/);
     expect(page.text).toContain('Foundry container marker');
     const capabilities = await request(app).get('/api/capabilities').expect(200).expect('Cache-Control', 'no-store');
-    expect(capabilities.body.recipes).toEqual(['quick_note_v1', 'url_article_v1']);
+    expect(capabilities.body.recipes).toEqual([
+      'quick_note_v1', 'url_article_v1', 'explainer_preproduction_v1', 'podcast_preproduction_v1', 'short_video_preproduction_v1',
+    ]);
     expect(capabilities.body.externalCalls).toBe(false);
+    expect(capabilities.body).toMatchObject({ recording: false, rendering: false, scheduling: false, sending: false, publishing: false, syntheticVoice: false });
   });
 });

--- a/studio-peninsula-insider/tests/preproduction.test.ts
+++ b/studio-peninsula-insider/tests/preproduction.test.ts
@@ -1,0 +1,406 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import request from 'supertest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ArtifactVersionSchema, type ArtifactVersion, type FoundryRun } from '../shared/contracts.js';
+import { isPreproductionArtifactType, parsePreproductionPayload } from '../shared/preproduction-contracts.js';
+import { createApp } from '../server/app.js';
+import { artifactDependenciesCurrent, evaluateArtifactGates, hashValue, resolveArtifactPath } from '../server/fixture-runner.js';
+import {
+  EXPLAINER_FIXTURE_ID,
+  PODCAST_FIXTURE_ID,
+  runPreproductionFixture,
+  SHORT_VIDEO_FIXTURE_ID,
+} from '../server/preproduction-fixtures.js';
+import { evaluatePreproductionGates, mediaRightsBindingHash } from '../server/preproduction-policy.js';
+import { FileFoundryStore } from '../server/store.js';
+
+const temporaryDirectories: string[] = [];
+
+async function harness() {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-foundry-preproduction-'));
+  temporaryDirectories.push(directory);
+  const file = join(directory, 'runs.json');
+  const store = new FileFoundryStore(file, directory);
+  return { directory, file, store, app: createApp(store) };
+}
+
+function byKey(run: FoundryRun, key: string): ArtifactVersion {
+  const artifact = run.artifactPack.completed.find((candidate) => candidate.key === key);
+  if (!artifact) throw new Error(`Missing artifact ${key}`);
+  return artifact;
+}
+
+async function reviewArtifact(app: ReturnType<typeof createApp>, run: FoundryRun, artifact: ArtifactVersion) {
+  return (await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+    artifactId: artifact.id, decision: 'accepted', reviewer: 'preproduction-reviewer',
+    expectedVersion: run.version, expectedArtifactVersion: artifact.version,
+  }).expect(200)).body as FoundryRun;
+}
+
+async function assertStaleLineageRejected(
+  app: ReturnType<typeof createApp>,
+  run: FoundryRun,
+  artifact: ArtifactVersion,
+  payload: unknown,
+): Promise<FoundryRun> {
+  const edited = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${artifact.id}`).send({
+    editor: 'lineage-adversary', expectedVersion: run.version, expectedArtifactVersion: artifact.version,
+    payload, factualSegmentIds: artifact.factualSegmentIds, claimUsage: artifact.claimUsage,
+  }).expect(200)).body as FoundryRun;
+  const updatedArtifact = byKey(edited, artifact.key);
+  expect(updatedArtifact.gateResults.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+  await request(app).put(`/api/foundry/runs/${edited.id}/review`).send({
+    artifactId: updatedArtifact.id, decision: 'accepted', reviewer: 'lineage-adversary',
+    expectedVersion: edited.version, expectedArtifactVersion: updatedArtifact.version,
+  }).expect(400);
+  return edited;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe('governed pre-production recipes', () => {
+  it('builds complete explainer, podcast and short-video packs with exact lineage and upstream versions', () => {
+    const fixtures = [
+      runPreproductionFixture('explainer', 'test-editor', 'explainer-complete-v1'),
+      runPreproductionFixture('podcast', 'test-editor', 'podcast-complete-v1'),
+      runPreproductionFixture('short_video', 'test-editor', 'video-complete-v1'),
+    ];
+    expect(fixtures.map((run) => run.artifactPack.completed.length)).toEqual([5, 7, 9]);
+    for (const run of fixtures) {
+      expect(run.artifactPack.status).toBe('complete');
+      expect(run.status).toBe('ready_for_review');
+      expect(JSON.stringify(run.artifactPack.completed)).not.toMatch(/\$\s?\d|—|price_band/);
+      const completedById = new Map(run.artifactPack.completed.map((artifact) => [artifact.id, artifact]));
+      for (const artifact of run.artifactPack.completed) {
+        expect(isPreproductionArtifactType(artifact.type)).toBe(true);
+        expect(artifactDependenciesCurrent(run, artifact)).toBe(true);
+        expect(artifact.gateResults.some((gate) => !gate.passed && gate.blocking)).toBe(false);
+        expect(artifact.gateResults.find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: false });
+        expect(artifact.factualSegmentIds).toHaveLength(artifact.claimUsage.length);
+        for (const usage of artifact.claimUsage) {
+          expect(artifact.factualSegmentIds).toContain(usage.segmentId);
+          expect(usage.contentHash).toBe(hashValue(resolveArtifactPath(artifact.payload, usage.path)));
+          expect(usage.claimIds.length).toBeGreaterThan(0);
+          for (const claimId of usage.claimIds) {
+            expect(run.claimSet.claims.find((claim) => claim.id === claimId)?.evidence.length).toBeGreaterThan(0);
+          }
+        }
+        for (const dependency of artifact.dependencies.filter((candidate) => candidate.kind === 'artifact')) {
+          const upstream = completedById.get(dependency.id);
+          expect(upstream).toBeDefined();
+          expect(dependency).toMatchObject({ version: upstream?.version, contentHash: upstream?.contentHash });
+        }
+      }
+    }
+    expect(fixtures[2].artifactPack.completed.flatMap((artifact) => (
+      'kind' in artifact.payload && artifact.payload.kind === 'video_script' ? [artifact.payload.targetSeconds] : []
+    ))).toEqual([30, 60]);
+  });
+
+  it('detects appended spoken, scene and overlay segments that do not have atomic lineage', () => {
+    const podcast = runPreproductionFixture('podcast', 'test-editor', 'lineage-podcast-v1');
+    const script = structuredClone(byKey(podcast, 'podcast-script'));
+    if (script.type !== 'podcast_script' || script.payload.kind !== 'podcast_script') throw new Error('Podcast script narrowing failed');
+    script.payload.segments.push({
+      id: 'invented-speaker', text: 'A contributor says this is the Peninsula favourite.', durationMs: 1_000,
+      contentMode: 'source_quote', speaker: 'contributor',
+    });
+    const scriptGates = evaluateArtifactGates(script.payload, podcast.claimSet.claims, script.factualSegmentIds, script.claimUsage, podcast.updatedAt);
+    expect(scriptGates.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+
+    const video = runPreproductionFixture('short_video', 'test-editor', 'lineage-video-v1');
+    const scenes = structuredClone(byKey(video, 'video-scenes'));
+    if (scenes.type !== 'video_scenes' || scenes.payload.kind !== 'video_scenes') throw new Error('Video scenes narrowing failed');
+    scenes.payload.scenes.push({ id: 'invented-scene', title: 'Crowd', text: 'A full dining room.', startMs: 60_000, endMs: 61_000, treatment: 'documentary' });
+    const sceneGates = evaluateArtifactGates(scenes.payload, video.claimSet.claims, scenes.factualSegmentIds, scenes.claimUsage, video.updatedAt);
+    expect(sceneGates.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+
+    const overlays = structuredClone(byKey(video, 'video-overlays'));
+    if (overlays.type !== 'video_overlays' || overlays.payload.kind !== 'video_overlays') throw new Error('Video overlay narrowing failed');
+    overlays.payload.items.push({ id: 'invented-overlay', title: 'Claim', text: 'Open every day', startMs: 55_000, endMs: 59_000 });
+    const overlayGates = evaluateArtifactGates(overlays.payload, video.claimSet.claims, overlays.factualSegmentIds, overlays.claimUsage, video.updatedAt);
+    expect(overlayGates.find((gate) => gate.gate === 'claim_usage_complete')).toMatchObject({ passed: false, blocking: true });
+  });
+
+  it('fails closed through the API when a question, label, prompt, title or appended guidance lacks fresh lineage', async () => {
+    const { app } = await harness();
+    let explainer = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: EXPLAINER_FIXTURE_ID, actor: 'test-editor', idempotencyKey: 'lineage-surfaces-explainer-v1',
+    }).expect(201)).body as FoundryRun;
+    let artifact = byKey(explainer, 'explainer-faq');
+    if (artifact.type !== 'explainer_faq' || artifact.payload.kind !== 'explainer_faq') throw new Error('FAQ narrowing failed');
+    const faqPayload = structuredClone(artifact.payload);
+    faqPayload.items[0].question = 'Why is this venue open seven days a week?';
+    explainer = await assertStaleLineageRejected(app, explainer, artifact, faqPayload);
+    artifact = byKey(explainer, 'explainer-visualisation');
+    if (artifact.type !== 'explainer_visualisation' || artifact.payload.kind !== 'explainer_visualisation') throw new Error('Visualisation narrowing failed');
+    const visualisationPayload = structuredClone(artifact.payload);
+    visualisationPayload.points[0].label = 'Open every day';
+    await assertStaleLineageRejected(app, explainer, artifact, visualisationPayload);
+
+    let podcast = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: PODCAST_FIXTURE_ID, actor: 'test-editor', idempotencyKey: 'lineage-surfaces-podcast-v1',
+    }).expect(201)).body as FoundryRun;
+    artifact = byKey(podcast, 'podcast-interview-guide');
+    if (artifact.type !== 'podcast_interview_guide' || artifact.payload.kind !== 'podcast_interview_guide') throw new Error('Interview guide narrowing failed');
+    const guidePayload = structuredClone(artifact.payload);
+    guidePayload.questions[0].prompt = 'Why does every local recommend this venue?';
+    podcast = await assertStaleLineageRejected(app, podcast, artifact, guidePayload);
+    artifact = byKey(podcast, 'podcast-angle');
+    if (artifact.type !== 'podcast_angle' || artifact.payload.kind !== 'podcast_angle') throw new Error('Podcast angle narrowing failed');
+    const anglePayload = structuredClone(artifact.payload);
+    anglePayload.avoidClaims.push('The venue is open seven days a week.');
+    await assertStaleLineageRejected(app, podcast, artifact, anglePayload);
+
+    const video = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: SHORT_VIDEO_FIXTURE_ID, actor: 'test-editor', idempotencyKey: 'lineage-surfaces-video-v1',
+    }).expect(201)).body as FoundryRun;
+    artifact = byKey(video, 'video-overlays');
+    if (artifact.type !== 'video_overlays' || artifact.payload.kind !== 'video_overlays') throw new Error('Overlay narrowing failed');
+    const overlayPayload = structuredClone(artifact.payload);
+    overlayPayload.items[0].title = 'Open every day';
+    await assertStaleLineageRejected(app, video, artifact, overlayPayload);
+  });
+
+  it('applies price and em-dash laws to nested pre-production payloads', () => {
+    const video = runPreproductionFixture('short_video', 'test-editor', 'nested-style-law-v1');
+    const captions = structuredClone(byKey(video, 'video-platform-captions'));
+    if (captions.type !== 'video_platform_captions' || captions.payload.kind !== 'video_platform_captions') throw new Error('Caption narrowing failed');
+    captions.payload.items[0].caption = 'Book the $95 lunch.';
+    captions.payload.items[1].caption = 'Covered dining — useful in rain.';
+    const gates = evaluateArtifactGates(captions.payload, video.claimSet.claims, captions.factualSegmentIds, captions.claimUsage, video.updatedAt);
+    expect(gates.find((gate) => gate.gate === 'no_price')).toMatchObject({ passed: false, blocking: true });
+    expect(gates.find((gate) => gate.gate === 'no_em_dash')).toMatchObject({ passed: false, blocking: true });
+  });
+
+  it('validates deterministic timing for narration, run sheets, scenes, overlays and subtitles', () => {
+    const video = runPreproductionFixture('short_video', 'test-editor', 'timing-video-v1');
+    const script = structuredClone(byKey(video, 'video-script-30'));
+    if (script.type !== 'video_script' || script.payload.kind !== 'video_script') throw new Error('Video script narrowing failed');
+    script.payload.segments[0].durationMs += 1_000;
+    expect(evaluatePreproductionGates(script.payload, script.dependencies).find((gate) => gate.gate === 'timing_valid')).toMatchObject({ passed: false, blocking: true });
+
+    const podcast = runPreproductionFixture('podcast', 'test-editor', 'timing-podcast-v1');
+    const runSheet = structuredClone(byKey(podcast, 'podcast-run-sheet'));
+    if (runSheet.type !== 'podcast_run_sheet' || runSheet.payload.kind !== 'podcast_run_sheet') throw new Error('Run sheet narrowing failed');
+    runSheet.payload.segments[1].startMs = 50_000;
+    expect(evaluatePreproductionGates(runSheet.payload, runSheet.dependencies).find((gate) => gate.gate === 'timing_valid')).toMatchObject({ passed: false, blocking: true });
+
+    const subtitles = structuredClone(byKey(video, 'video-subtitles'));
+    if (subtitles.type !== 'video_subtitles' || subtitles.payload.kind !== 'video_subtitles') throw new Error('Subtitle narrowing failed');
+    subtitles.payload.cues[2].endMs = 31_000;
+    expect(evaluatePreproductionGates(subtitles.payload, subtitles.dependencies).find((gate) => gate.gate === 'timing_valid')).toMatchObject({ passed: false, blocking: true });
+  });
+
+  it('blocks simulated contributors, synthetic or cloned voice and unsafe generated treatments', () => {
+    const podcast = runPreproductionFixture('podcast', 'test-editor', 'policy-podcast-v1');
+    const script = structuredClone(byKey(podcast, 'podcast-script'));
+    if (script.type !== 'podcast_script' || script.payload.kind !== 'podcast_script') throw new Error('Podcast script narrowing failed');
+    script.payload.segments[0].contentMode = 'simulated_contributor';
+    expect(evaluatePreproductionGates(script.payload, script.dependencies).find((gate) => gate.gate === 'preproduction_policy')).toMatchObject({ passed: false, blocking: true });
+
+    for (const voiceMode of ['synthetic', 'cloned'] as const) {
+      const unsafeVoice = structuredClone(script.payload);
+      unsafeVoice.segments[0].contentMode = 'editorial_narration';
+      unsafeVoice.boundary.voiceMode = voiceMode;
+      expect(evaluatePreproductionGates(unsafeVoice, script.dependencies).find((gate) => gate.gate === 'preproduction_policy')).toMatchObject({ passed: false, blocking: true });
+    }
+
+    const video = runPreproductionFixture('short_video', 'test-editor', 'policy-video-v1');
+    const scenes = structuredClone(byKey(video, 'video-scenes'));
+    if (scenes.type !== 'video_scenes' || scenes.payload.kind !== 'video_scenes') throw new Error('Video scenes narrowing failed');
+    scenes.payload.boundary.generationMode = 'documentary';
+    expect(evaluatePreproductionGates(scenes.payload, scenes.dependencies).find((gate) => gate.gate === 'preproduction_policy')).toMatchObject({ passed: false, blocking: true });
+    scenes.payload.boundary.generationMode = 'illustrative';
+    expect(evaluatePreproductionGates(scenes.payload, scenes.dependencies).find((gate) => gate.gate === 'preproduction_policy')).toMatchObject({ passed: false, blocking: true });
+    scenes.payload.boundary.generationApprovalId = 'approval-illustrative-1';
+    scenes.payload.boundary.generationDisclosure = 'Illustrative generated scene, not documentary footage.';
+    expect(evaluatePreproductionGates(scenes.payload, scenes.dependencies).find((gate) => gate.gate === 'preproduction_policy')).toMatchObject({ passed: true });
+  });
+
+  it('requires exact asset, placement, surface, rights and release bindings before media readiness can pass', () => {
+    const run = runPreproductionFixture('short_video', 'test-editor', 'media-ready-v1');
+    const shots = structuredClone(byKey(run, 'video-shot-list'));
+    if (shots.type !== 'video_shot_list' || shots.payload.kind !== 'video_shot_list') throw new Error('Video shot-list narrowing failed');
+    shots.payload.boundary.mediaStatus = 'ready';
+    expect(evaluatePreproductionGates(shots.payload, shots.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+
+    shots.payload.boundary.mediaAssignments = shots.payload.shots.map((_, index) => ({
+      id: `assignment-shot-${index + 1}`,
+      placementPath: `$.shots[${index}]`,
+      surface: 'video' as const,
+      asset: { id: `asset-shot-${index + 1}`, version: 1, contentHash: hashValue({ asset: `shot-${index + 1}` }) },
+      rights: { id: `rights-shot-${index + 1}`, version: 1 },
+      recognisablePeople: index === 0,
+      releaseIds: index === 0 ? ['release-person-fixture'] : [],
+    }));
+    const boundSnapshots = shots.payload.boundary.mediaAssignments.map((assignment) => ({
+      ...assignment.rights, contentHash: mediaRightsBindingHash(assignment),
+    }));
+    shots.payload.boundary.rightsSnapshots = boundSnapshots;
+    shots.payload.boundary.recognisablePeople = true;
+    shots.payload.boundary.releaseIds = ['release-person-fixture'];
+    shots.dependencies.push(...boundSnapshots.map((snapshot) => ({ kind: 'media_rights' as const, ...snapshot, status: 'cleared' as const })));
+    expect(evaluatePreproductionGates(shots.payload, shots.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+    shots.payload.shots.forEach((shot) => { shot.source = 'rights_cleared'; });
+
+    const missingPlacement = structuredClone(shots.payload);
+    missingPlacement.boundary.mediaAssignments.pop();
+    expect(evaluatePreproductionGates(missingPlacement, shots.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+    const swappedAsset = structuredClone(shots.payload);
+    swappedAsset.boundary.mediaAssignments[0].asset.id = 'asset-never-cleared';
+    expect(evaluatePreproductionGates(swappedAsset, shots.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+    const unrelatedRights = structuredClone(shots.payload);
+    const unrelatedDependencies = structuredClone(shots.dependencies);
+    const unrelatedHash = hashValue({ unrelated: 'asset' });
+    unrelatedRights.boundary.rightsSnapshots[0].contentHash = unrelatedHash;
+    const unrelatedDependency = unrelatedDependencies.find((dependency) => dependency.kind === 'media_rights' && dependency.id === unrelatedRights.boundary.rightsSnapshots[0].id);
+    if (!unrelatedDependency) throw new Error('Expected media dependency');
+    unrelatedDependency.contentHash = unrelatedHash;
+    expect(evaluatePreproductionGates(unrelatedRights, unrelatedDependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+    const releaseMismatch = structuredClone(shots.payload);
+    releaseMismatch.boundary.mediaAssignments[0].releaseIds = ['release-different-person'];
+    expect(evaluatePreproductionGates(releaseMismatch, shots.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+
+    shots.contentHash = hashValue(shots.payload);
+    shots.gateResults = shots.gateResults.filter((gate) => !['media_render_ready', 'preproduction_policy', 'timing_valid'].includes(gate.gate));
+    shots.gateResults.push(...evaluatePreproductionGates(shots.payload, shots.dependencies));
+    const parsed = ArtifactVersionSchema.parse(shots);
+    const replaced = structuredClone(run);
+    replaced.artifactPack.completed = replaced.artifactPack.completed.map((artifact) => artifact.id === parsed.id ? parsed : artifact);
+    expect(artifactDependenciesCurrent(replaced, parsed)).toBe(true);
+    expect(parsed.gateResults.find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: true, blocking: false });
+
+    const podcast = runPreproductionFixture('podcast', 'test-editor', 'voice-ready-v1');
+    const podcastScript = structuredClone(byKey(podcast, 'podcast-script'));
+    if (podcastScript.type !== 'podcast_script' || podcastScript.payload.kind !== 'podcast_script') throw new Error('Podcast script narrowing failed');
+    podcastScript.payload.boundary.mediaStatus = 'ready';
+    expect(evaluatePreproductionGates(podcastScript.payload, podcastScript.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+    podcastScript.payload.boundary.voiceMode = 'human_cleared';
+    podcastScript.payload.boundary.voiceReleaseId = 'release-host-fixture';
+    podcastScript.payload.boundary.releaseIds = ['release-host-fixture'];
+    podcastScript.payload.boundary.mediaAssignments = podcastScript.payload.segments.map((_, index) => ({
+      id: `assignment-audio-${index + 1}`,
+      placementPath: `$.segments[${index}]`,
+      surface: 'audio' as const,
+      asset: { id: `asset-audio-${index + 1}`, version: 1, contentHash: hashValue({ asset: `audio-${index + 1}` }) },
+      rights: { id: `rights-audio-${index + 1}`, version: 1 },
+      recognisablePeople: false,
+      releaseIds: ['release-host-fixture'],
+    }));
+    podcastScript.payload.boundary.rightsSnapshots = podcastScript.payload.boundary.mediaAssignments.map((assignment) => ({
+      ...assignment.rights, contentHash: mediaRightsBindingHash(assignment),
+    }));
+    podcastScript.dependencies.push(...podcastScript.payload.boundary.rightsSnapshots.map((snapshot) => ({
+      kind: 'media_rights' as const, ...snapshot, status: 'cleared' as const,
+    })));
+    expect(evaluatePreproductionGates(podcastScript.payload, podcastScript.dependencies).find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: true, blocking: false });
+  });
+
+  it('does not let an artifact update self-assert media readiness without server-held rights dependencies', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: SHORT_VIDEO_FIXTURE_ID, actor: 'test-editor', idempotencyKey: 'media-api-bypass-v1',
+    }).expect(201)).body as FoundryRun;
+    const shots = byKey(run, 'video-shot-list');
+    if (shots.type !== 'video_shot_list' || shots.payload.kind !== 'video_shot_list') throw new Error('Video shot-list narrowing failed');
+    const payload = structuredClone(shots.payload);
+    payload.boundary.mediaStatus = 'ready';
+    payload.shots.forEach((shot) => { shot.source = 'rights_cleared'; });
+    payload.boundary.mediaAssignments = payload.shots.map((_, index) => ({
+      id: `client-assignment-${index + 1}`, placementPath: `$.shots[${index}]`, surface: 'video' as const,
+      asset: { id: `client-asset-${index + 1}`, version: 1, contentHash: hashValue({ client: index }) },
+      rights: { id: `client-rights-${index + 1}`, version: 1 }, recognisablePeople: false, releaseIds: [],
+    }));
+    payload.boundary.rightsSnapshots = payload.boundary.mediaAssignments.map((assignment) => ({
+      ...assignment.rights, contentHash: mediaRightsBindingHash(assignment),
+    }));
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${shots.id}`).send({
+      editor: 'media-adversary', expectedVersion: run.version, expectedArtifactVersion: shots.version,
+      payload, factualSegmentIds: shots.factualSegmentIds, claimUsage: shots.claimUsage,
+    }).expect(200)).body as FoundryRun;
+    const edited = byKey(run, 'video-shot-list');
+    expect(edited.dependencies.some((dependency) => dependency.kind === 'media_rights')).toBe(false);
+    expect(edited.gateResults.find((gate) => gate.gate === 'media_render_ready')).toMatchObject({ passed: false, blocking: true });
+    await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+      artifactId: edited.id, decision: 'accepted', reviewer: 'media-adversary',
+      expectedVersion: run.version, expectedArtifactVersion: edited.version,
+    }).expect(400);
+  });
+
+  it('keeps required siblings reviewable when one optional derivative fails', async () => {
+    const { app } = await harness();
+    for (const fixtureId of [EXPLAINER_FIXTURE_ID, PODCAST_FIXTURE_ID, SHORT_VIDEO_FIXTURE_ID]) {
+      const response = await request(app).post('/api/foundry/runs').send({
+        fixtureId, fixtureVariant: 'partial_optional_failure', actor: 'test-editor', idempotencyKey: `partial-${fixtureId}`,
+      }).expect(201);
+      const run = response.body as FoundryRun;
+      expect(run.artifactPack.status).toBe('partial');
+      expect(run.artifactPack.failed).toEqual([expect.objectContaining({ required: false })]);
+      expect(run.status).toBe('ready_for_review');
+      expect(run.artifactPack.completed.every((artifact) => !artifact.gateResults.some((gate) => !gate.passed && gate.blocking))).toBe(true);
+    }
+  });
+
+  it('cascades exact upstream staleness while preserving an unrelated script branch', async () => {
+    const { app, file, directory } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: SHORT_VIDEO_FIXTURE_ID, actor: 'test-editor', idempotencyKey: 'video-staleness-v1',
+    }).expect(201)).body as FoundryRun;
+    for (const key of ['video-script-30', 'video-subtitles', 'video-platform-captions', 'video-script-60', 'video-scenes']) {
+      run = await reviewArtifact(app, run, byKey(run, key));
+    }
+    const script = byKey(run, 'video-script-30');
+    if (script.type !== 'video_script' || script.payload.kind !== 'video_script') throw new Error('Video script narrowing failed');
+    const payload = structuredClone(script.payload);
+    payload.segments[0].text = 'Wet day in Red Hill? Start with a covered lunch.';
+    const claimUsage = script.claimUsage.map((usage) => usage.segmentId === 'script30-1'
+      ? { ...usage, contentHash: hashValue(payload.segments[0].text) }
+      : usage);
+    const edited = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${script.id}`).send({
+      editor: 'test-editor', expectedVersion: run.version, expectedArtifactVersion: script.version,
+      payload, factualSegmentIds: script.factualSegmentIds, claimUsage,
+    }).expect(200)).body as FoundryRun;
+    const status = (key: string) => edited.artifactPack.reviews.find((review) => review.artifactId === byKey(edited, key).id)?.status;
+    expect(status('video-script-30')).toBe('stale');
+    expect(status('video-subtitles')).toBe('stale');
+    expect(status('video-platform-captions')).toBe('stale');
+    expect(status('video-script-60')).toBe('current');
+    expect(status('video-scenes')).toBe('current');
+    expect(byKey(edited, 'video-subtitles').gateResults.find((gate) => gate.gate === 'dependency_current')).toMatchObject({ passed: false, blocking: true });
+
+    const restarted = new FileFoundryStore(file, directory);
+    const persisted = await restarted.get(run.id);
+    expect(persisted?.artifactPack.reviews.find((review) => review.artifactId === byKey(edited, 'video-scenes').id)?.status).toBe('current');
+    expect(persisted?.artifactPack.reviews.find((review) => review.artifactId === byKey(edited, 'video-subtitles').id)?.status).toBe('stale');
+  });
+
+  it('rejects policy-violating edits and exposes no record, render, schedule, send or publish endpoint', async () => {
+    const { app } = await harness();
+    let run = (await request(app).post('/api/foundry/runs').send({
+      fixtureId: PODCAST_FIXTURE_ID, actor: 'test-editor', idempotencyKey: 'podcast-negative-capability-v1',
+    }).expect(201)).body as FoundryRun;
+    const script = byKey(run, 'podcast-script');
+    if (script.type !== 'podcast_script' || script.payload.kind !== 'podcast_script') throw new Error('Podcast script narrowing failed');
+    const payload = structuredClone(script.payload);
+    payload.segments[0].contentMode = 'simulated_contributor';
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/artifacts/${script.id}`).send({
+      editor: 'test-editor', expectedVersion: run.version, expectedArtifactVersion: script.version,
+      payload, factualSegmentIds: script.factualSegmentIds, claimUsage: script.claimUsage,
+    }).expect(200)).body as FoundryRun;
+    const edited = byKey(run, 'podcast-script');
+    expect(edited.gateResults.find((gate) => gate.gate === 'preproduction_policy')).toMatchObject({ passed: false, blocking: true });
+    await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+      artifactId: edited.id, decision: 'accepted', reviewer: 'unsafe-reviewer',
+      expectedVersion: run.version, expectedArtifactVersion: edited.version,
+    }).expect(400);
+    await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(400);
+    for (const capability of ['record', 'render', 'schedule', 'send', 'publish']) {
+      await request(app).post(`/api/foundry/${capability}`).send({ runId: run.id }).expect(404);
+    }
+  });
+});


### PR DESCRIPTION
Closes #328

## Outcome

Adds governed, deterministic V1 pre-production packs for explainers, podcasts, and short video on top of the artifact-pack branch.

- Explainer: core, FAQ, carousel, voiceover, visualisation
- Podcast: evidence dossier, angle, run sheet, interview guide, script, show notes, chapters
- Short video: hooks, distinct 30 and 60 second scripts, shot list, scenes, overlays, subtitles, thumbnail, platform captions
- Every user-visible factual or fact-implying field carries claim/evidence lineage and exact upstream versions
- Media readiness requires exact assignment-level asset, placement, surface, rights, and release bindings to server-held dependencies
- Per-artifact draft-handoff review UI supports independent accept or reject decisions

## Authority boundary

Text pre-production can be reviewed with media unassigned. Recording, rendering, scheduling, sending, publishing, provider calls, model calls, synthetic voice, cloned voice, generated documentary treatment, production mutation, and external calls remain unavailable. Illustrative generation requires a recorded approval and persistent disclosure. Existing quick-note and Article plus Ask recipes remain supported.

## Verification

- Independent frozen-tree review: PASS after reproducing and closing lineage and unrelated-rights bypasses
- TypeScript: PASS
- Tests: 27/27 PASS
- Production build: PASS
- npm audit: 0 vulnerabilities
- Node 22.23.2 build and container tests: PASS, 27/27
- Hardened runtime: PASS as node with read-only root, no-new-privileges, all capabilities dropped, tmpfs data and tmp
- Live API: health and page 200; complete packs at 5, 7, and 9 artifacts; zero blocking failures; all media readiness gates deliberately pending and nonblocking
- Negative routes: record, render, schedule, send, and publish return 404

## Stack

Base: `feature/content-foundry-artifact-pack`
Head: `feature/content-foundry-preproduction`
Commit: `199ab0a67c`

This PR is intentionally draft and must not be merged until its stacked base is ready and human approval is recorded.