### PR TITLE
feat(foundry): add guarded real URL workflow

### DIFF
--- a/.github/workflows/content-foundry-ci.yml
+++ b/.github/workflows/content-foundry-ci.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'studio-peninsula-insider/**'
+      - 'next/src/content.config.ts'
       - '.github/workflows/content-foundry-ci.yml'
   push:
     branches:
       - 'feature/content-foundry-*'
     paths:
       - 'studio-peninsula-insider/**'
+      - 'next/src/content.config.ts'
       - '.github/workflows/content-foundry-ci.yml'
 
 permissions:

--- a/docs/architecture-decisions/content-foundry-capture-kernel.md
+++ b/docs/architecture-decisions/content-foundry-capture-kernel.md
@@ -1,12 +1,12 @@
 # Content Foundry sealed capture kernel
 
 Date: 2026-08-21
-Status: implemented behind a default-off flag; no caller exposed
+Status: implemented behind a default-off flag; callable only by the loopback orchestration boundary from issue #325
 Tracks: DELI-693, GitHub issue #324, stacked base `ebe0702bd369641f3235dc7c54955c678b54eb8e`
 
 ## Decision
 
-Real URL ingestion must pass through one sealed `CaptureKernel`. The kernel is backend-only, has no Express route, UI action or provider adapter, and remains disabled unless `FOUNDRY_REAL_URLS_ENABLED=1`. The local Compose runtime explicitly sets the flag to `0`.
+Real URL ingestion must pass through one sealed `CaptureKernel`. The kernel remains backend-only and disabled unless `FOUNDRY_REAL_URLS_ENABLED=1`. Issue #325 adds one local orchestration caller and a flag-gated loopback API/UI; no other route, provider adapter or workflow may call the transport. The local Compose runtime explicitly sets the flag to `0`.
 
 The kernel owns URL policy, DNS validation, the pinned HTTPS connection, redirect handling, byte and time bounds, immutable storage and inert extraction. CI rejects direct HTTP clients or socket-opening imports outside the single pinned transport module.
 
@@ -29,7 +29,7 @@ Blobs are addressed by SHA-256 under a root-contained path. Writes use `wx`, fil
 
 ## Extraction and evidence
 
-Only `text/html` and `text/plain` with UTF-8 or US-ASCII enter extraction. Gzip, deflate and Brotli are decoded under separate wire and decoded limits. DNS, headers, body idle time, total capture time and concurrency are independently bounded; the total deadline wraps extraction, blob writes and manifest persistence as well as network work. `parse5` parses HTML without script execution or subresource fetching; script, style, template, SVG and similar non-story nodes are excluded. Prompt-like text in ordinary content remains inert evidence text.
+Only `text/html` and `text/plain` with UTF-8 or US-ASCII enter extraction. Gzip, deflate and Brotli are decoded under separate wire and decoded limits. DNS, headers, body idle time, total capture time and concurrency are independently bounded; the total deadline wraps extraction, blob writes and manifest persistence as well as network work. `parse5` parses HTML without script execution or subresource fetching; script, style, template, SVG and similar non-story nodes are excluded. Extractor v2 retains at most 256 segments and 4,000 characters per segment. Prompt-like text in ordinary content remains inert evidence text and is held from artifacts.
 
 Every extracted block has a stable locator and hash. A capture evidence locator names both the source and extraction revision and resolves only when its excerpt and hash reproduce from that immutable revision.
 

--- a/docs/architecture-decisions/content-foundry-real-url-orchestration.md
+++ b/docs/architecture-decisions/content-foundry-real-url-orchestration.md
@@ -1,0 +1,44 @@
+# Content Foundry local real URL orchestration
+
+Date: 2026-08-21
+Status: implemented behind a default-off local flag
+Tracks: DELI-693, GitHub issue #325, stacked base `9e7e2d197db73bbbc3678103e8f201172ab3fa85`
+
+## Decision
+
+Add one disabled-by-default, native-loopback vertical slice around the immutable `CaptureKernel`:
+
+```text
+human HTTPS URL -> persisted capture projection -> immutable capture -> evidence-linked draft -> human review -> downloadable patch
+```
+
+The terminal capture manifest stays immutable. A separate schema-versioned projection records queued and capturing state before outbound work, then atomically materializes the safe terminal summary and any Foundry run. It stores only redacted URLs, hashes, immutable IDs and controlled codes. Exact query values exist only in the request closure. A persisted request fingerprint binds refreshes to the exact original URL identity without persisting query values. Real-URL reads fail closed unless the immutable capture repository is available: every revision summary, source item, claim, locator, excerpt and excerpt hash is reproduced from its sealed manifest and extraction. The read-only immutable resolver is wired even when capture is disabled, so turning the flag off disables routes and network authority without making previously captured work unreadable.
+
+## Local security boundary
+
+- `FOUNDRY_REAL_URLS_ENABLED` defaults to `0`; malformed values fail startup.
+- Production startup remains rejected. Flag-on startup additionally requires native `127.0.0.1`, never `0.0.0.0`.
+- Every API and SPA response requires the exact loopback Host and configured port. All flag-on API mutations require the custom CSRF header and, when Origin is present, the exact HTTP origin.
+- The API permits one active capture, one submitted page, no crawl, no automatic retry and no batch input.
+- Operator projections omit DNS answers, selected and remote addresses, raw exceptions and raw failure details. Redirect URLs and submitted URLs retain only redacted query values.
+- Source HTML is never returned or rendered. Extracted excerpts are React text, bounded to 4,000 characters per segment, and explicitly labelled source-supported rather than independently verified.
+- Idempotency binds the operation type, exact request fingerprint, refresh target and submitted target version. Only an exact retry replays; changed context conflicts before network work.
+
+## Crash and refresh semantics
+
+The projection is saved as queued and then capturing before the kernel is invoked. The kernel commits its immutable manifest before projection materialization. At startup, every nonterminal projection is reconciled by deterministic attempt ID:
+
+- manifest present: materialize it idempotently without another network request;
+- manifest absent: record terminal `capture_interrupted`, with no automatic refetch.
+
+An extracted refresh appends a new revision, advances both the source head and artifact dependency, and stales every current review decision while retaining the append-only history. While it is queued or capturing, server-side storage locks reject artifact changes, review decisions and patch export for that run with `source_refresh_in_progress`. Terminal immutable provenance is retained even if workflow materialization cannot complete; restart reconciliation never refetches it. A no-story refresh still advances the source head, but retains the prior extracted artifact dependency; this visible mismatch blocks review and patch export. Held and failed refreshes create no source head and do not stale the prior review.
+
+Freshness means only `current` or `superseded` relative to the logical source head plus the immutable capture time. No unsupported time-to-live or independent-verification claim is inferred.
+
+## Human authority and retained gates
+
+A real-source draft starts with source kind `unclassified-web`. Before review, a human must classify it, select immutable evidence-backed claims and explicitly confirm the source-led angle. `web` is the truthful generic classification when a more specific source kind does not apply. Every factual or fact-implying Quick Note field is a read-only, deterministic server reproduction of the selected immutable claims. Per-field content hashes, per-segment claim lineage and a full-export binding cover the complete payload, source classification and target path. They are recomputed at read, edit, review and export after resolving the immutable capture; arbitrary copy or metadata under old claim IDs fails closed.
+
+Each accepted or rejected decision also writes a content-addressed immutable review receipt outside the mutable run store using exclusive create, file sync and directory sync. The receipt binds the exact run and artifact versions, immutable dependencies, selected claim IDs, source classification and confirmation, angle, full payload, lineage, target, gates and blockers. Current reads and export require that sealed snapshot to match; source-kind, claim or status substitution cannot self-certify by recomputing mutable hashes. Editing or refreshing stales the receipt reference without deleting its history. Legacy unsealed approvals migrate to explicit `legacy_unsealed` stale history and `needs_revision` rather than retaining export authority or bricking startup. Patch export independently rechecks current source dependency, classification, claim gates, accepted review, the shared no-price law (including cost, charge, fee, currency and free wording) and the no-em-dash law.
+
+This decision grants no provider/model call, credentials, team-network access, production deployment, CMS/Git mutation, publication, distribution, spend or retention authority. The fixture workflow remains available unchanged.

--- a/next/src/content.config.ts
+++ b/next/src/content.config.ts
@@ -1279,7 +1279,7 @@ const quickNotes = defineCollection({
     verifiedBy: z.string().optional(),
     verdict: z.string().max(140).optional(),  // pull-quote-style verdict
     sources: z.array(z.object({
-      kind: z.enum(['venue-site', 'phone', 'email', 'visit', 'press', 'social', 'gov', 'partner']),
+      kind: z.enum(['web', 'venue-site', 'phone', 'email', 'visit', 'press', 'social', 'gov', 'partner']),
       url: z.string().url().optional(),
       note: z.string().optional(),
       checkedAt: z.coerce.date().optional(),

--- a/studio-peninsula-insider/README.md
+++ b/studio-peninsula-insider/README.md
@@ -1,14 +1,16 @@
 # Peninsula Insider Workbench
 
-Private, fixture-only Content Foundry shell for DELI-693.
+Private, local Content Foundry Workbench for DELI-693.
 
 ## Current vertical slice
 
-`frozen URL fixture -> evidence ledger -> quick-note draft -> human review -> downloadable patch`
+`frozen fixture or one human-submitted HTTPS page -> evidence ledger -> quick-note draft -> human review -> downloadable patch`
 
 The shell performs no model calls, Git writes, CMS writes, publication or external distribution. Its atomic file-backed store is a single-process development/test adapter behind the durable run contract; startup fails closed in production. PostgreSQL, authentication and private storage remain explicit later gates.
 
-The next URL-ingestion foundation is present only as a sealed backend kernel. `FOUNDRY_REAL_URLS_ENABLED` defaults to `0`, Compose pins it to `0`, and no route, UI or provider invokes it. Enabling the flag alone exposes nothing. A later reviewed change must add the private caller after the capture boundary and threat model are accepted.
+Real URL capture remains disabled by default and Compose pins `FOUNDRY_REAL_URLS_ENABLED=0`. When explicitly enabled in the native development runtime, it accepts one human-submitted HTTPS page at a time through the sealed capture kernel. It does not crawl, retry, execute source HTML, fetch subresources or call a model. The API and page reject non-loopback Host headers; every flag-on API mutation also requires the same-origin boundary and `X-Foundry-CSRF: 1`.
+
+Capture attempts are visible while queued or capturing and finish as extracted, held, no-story or failed with safe operator codes. Source bytes, extraction revisions and attempt manifests remain immutable. Refresh creates a new attempt; a changed source head makes every dependent review stale, while an active refresh blocks edits, review and patch export. A real-source draft cannot reach review until a human classifies the source, selects source-supported claims and confirms the angle. Its public fields are read-only, server-generated reproductions of those selected immutable assertions; every read, edit, review and export resolves source summaries, evidence and copy back to the sealed capture manifest. Per-field, per-segment and full-export hashes bind all public metadata and the target path. Accepted and rejected snapshots are sealed in content-addressed review receipts outside the mutable run store; legacy unsealed approvals become stale and require re-review. Price language, including ordinary cost/charge/fee/currency wording, and em dashes remain prohibited. Workbench approval is still not independent verification and not publication.
 
 ## Run locally
 
@@ -19,6 +21,16 @@ npm run dev
 
 - UI: `http://127.0.0.1:4311`
 - API: `http://127.0.0.1:4310/api/health`
+
+To expose the bounded real URL workflow for a local development session only:
+
+```powershell
+$env:FOUNDRY_REAL_URLS_ENABLED = '1'
+$env:FOUNDRY_HOST = '127.0.0.1'
+npm run dev
+```
+
+The browser UI remains on port 4311 and proxies same-origin API requests to the exact loopback API host. Never enable this mode on a team interface or in production; the current file-store runtime has no authentication or retention policy.
 
 ## Run the team-ready local container
 
@@ -42,6 +54,8 @@ npm test
 npm run build
 npm run check:capture-boundary
 ```
+
+All automated tests use injected DNS and transport doubles and make no public network calls. A live canary is a separate, explicit operator action and is never part of CI.
 
 Runtime state is written under `.foundry-data/` and is ignored by the repository-wide `node_modules/` rule plus the Studio-specific ignore entry added with this module.
 

--- a/studio-peninsula-insider/server/app.ts
+++ b/studio-peninsula-insider/server/app.ts
@@ -3,7 +3,16 @@ import helmet from 'helmet';
 import { z } from 'zod';
 import { ArtifactEditSchema, ReviewDecisionSchema } from '../shared/contracts.js';
 import { buildPatch, FIXTURE_ID, runFixture } from './fixture-runner.js';
-import { FileFoundryStore, VersionConflictError } from './store.js';
+import type { RealUrlCoordinator } from './real-url-coordinator.js';
+import { CaptureSourceMismatchError } from './real-url-coordinator.js';
+import {
+  CaptureBusyError,
+  CaptureProjectionConflictError,
+  CaptureRefreshTargetError,
+  FileFoundryStore,
+  RunRefreshInProgressError,
+  VersionConflictError,
+} from './store.js';
 
 const CreateRunSchema = z.object({
   fixtureId: z.literal(FIXTURE_ID),
@@ -11,9 +20,75 @@ const CreateRunSchema = z.object({
   idempotencyKey: z.string().min(1).optional(),
 });
 
-export function createApp(store: FileFoundryStore, options: { staticDir?: string } = {}) {
+const UrlCaptureSchema = z.object({
+  url: z.string().min(1).max(2_048),
+  actor: z.string().min(1).max(120).default('local-editor'),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+const UrlRefreshSchema = UrlCaptureSchema.extend({
+  expectedVersion: z.number().int().positive(),
+});
+
+function parseSafeLocalHost(request: express.Request, expectedHost?: string): URL | undefined {
+  const host = request.get('host') ?? '';
+  let hostUrl: URL;
+  try { hostUrl = new URL(`http://${host}`); } catch { return undefined; }
+  if (!['127.0.0.1', 'localhost'].includes(hostUrl.hostname)) {
+    return undefined;
+  }
+  if (expectedHost && hostUrl.host !== expectedHost) return undefined;
+  return hostUrl;
+}
+
+function requireSafeLocalMutation(expectedHost?: string) {
+  return (request: express.Request, response: express.Response, next: express.NextFunction) => {
+    const hostUrl = parseSafeLocalHost(request, expectedHost);
+    if (!hostUrl) return response.status(403).json({ error: { code: 'local_origin_required' } });
+    const origin = request.get('origin');
+    if (origin) {
+      let originUrl: URL;
+      try { originUrl = new URL(origin); } catch { return response.status(403).json({ error: { code: 'same_origin_required' } }); }
+      if (originUrl.protocol !== 'http:' || originUrl.host !== hostUrl.host) {
+        return response.status(403).json({ error: { code: 'same_origin_required' } });
+      }
+    }
+    if (request.get('x-foundry-csrf') !== '1') {
+      return response.status(403).json({ error: { code: 'csrf_header_required' } });
+    }
+    return next();
+  };
+}
+
+function safeCaptureError(error: unknown): { status: number; code: string } {
+  if (error instanceof CaptureProjectionConflictError) return { status: 409, code: 'idempotency_conflict' };
+  if (error instanceof CaptureBusyError) return { status: 409, code: 'capture_busy' };
+  if (error instanceof VersionConflictError) return { status: 409, code: 'workflow_version_conflict' };
+  if (error instanceof RunRefreshInProgressError) return { status: 409, code: 'source_refresh_in_progress' };
+  if (error instanceof CaptureRefreshTargetError) return { status: 400, code: 'source_mismatch' };
+  if (error instanceof CaptureSourceMismatchError) return { status: 400, code: 'source_mismatch' };
+  const policyCode = (error as { code?: unknown }).code;
+  if (typeof policyCode === 'string' && /^[a-z][a-z0-9_]{1,79}$/.test(policyCode)) return { status: 400, code: policyCode };
+  return { status: 400, code: 'invalid_capture_request' };
+}
+
+export function createApp(store: FileFoundryStore, options: {
+  staticDir?: string;
+  realUrlsEnabled?: boolean;
+  coordinator?: RealUrlCoordinator;
+  expectedHost?: string;
+} = {}) {
+  const realUrlsEnabled = options.realUrlsEnabled ?? false;
+  if (realUrlsEnabled && !options.coordinator) throw new Error('Real URL capture requires the sealed coordinator');
+  if (realUrlsEnabled && !store.hasImmutableCaptureResolver()) throw new Error('Real URL capture requires immutable manifest validation');
   const app = express();
   app.disable('x-powered-by');
+  app.use((request, response, next) => {
+    if (!parseSafeLocalHost(request, options.expectedHost)) {
+      return response.status(403).json({ error: { code: 'local_host_required' } });
+    }
+    return next();
+  });
   app.use(helmet({
     contentSecurityPolicy: {
       directives: {
@@ -35,15 +110,75 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
     response.setHeader('Cache-Control', 'no-store');
     next();
   });
+  if (realUrlsEnabled) {
+    const mutationGuard = requireSafeLocalMutation(options.expectedHost);
+    app.use('/api', (request, response, next) => (
+      ['GET', 'HEAD', 'OPTIONS'].includes(request.method) ? next() : mutationGuard(request, response, next)
+    ));
+  }
 
-  app.get('/api/health', (_request, response) => response.json({ ok: true, service: 'pi-content-foundry', mode: 'fixture-only' }));
+  app.get('/api/health', (_request, response) => response.json({
+    ok: true,
+    service: 'pi-content-foundry',
+    mode: realUrlsEnabled ? 'local-real-url-enabled' : 'fixture-only',
+  }));
   app.get('/api/capabilities', (_request, response) => response.json({
-    sourceTypes: ['frozen_fixture'],
+    sourceTypes: realUrlsEnabled ? ['frozen_fixture', 'https_url'] : ['frozen_fixture'],
     artifactTypes: ['quick_note'],
     publicationAdapters: ['downloadable_patch'],
-    externalCalls: false,
+    externalCalls: realUrlsEnabled,
     productionMutation: false,
+    realUrlCapture: {
+      enabled: realUrlsEnabled,
+      scope: 'one_human_submitted_https_page',
+      crawling: false,
+      automaticRetry: false,
+      persistedUrlQueries: 'values_redacted',
+    },
   }));
+
+  if (realUrlsEnabled && options.coordinator) {
+    app.get('/api/foundry/captures', async (_request, response, next) => {
+      try { return response.json({ captures: await store.listCaptureProjections() }); } catch (error) { return next(error); }
+    });
+    app.get('/api/foundry/captures/:id', async (request, response, next) => {
+      try {
+        const projection = await store.getCaptureProjection(request.params.id);
+        return projection ? response.json(projection) : response.status(404).json({ error: { code: 'capture_not_found' } });
+      } catch (error) { return next(error); }
+    });
+    app.post('/api/foundry/captures', async (request, response) => {
+      try {
+        const input = UrlCaptureSchema.parse(request.body);
+        const idempotencyKey = request.header('Idempotency-Key') ?? input.idempotencyKey;
+        if (!idempotencyKey) return response.status(400).json({ error: { code: 'idempotency_key_required' } });
+        const result = await options.coordinator!.submit({ ...input, idempotencyKey });
+        return response.status(result.created ? 202 : 200).json(result.projection);
+      } catch (error) {
+        if (error instanceof z.ZodError) return response.status(400).json({ error: { code: 'invalid_capture_request' } });
+        const safe = safeCaptureError(error);
+        return response.status(safe.status).json({ error: { code: safe.code } });
+      }
+    });
+    app.post('/api/foundry/runs/:id/refresh', async (request, response) => {
+      try {
+        const input = UrlRefreshSchema.parse(request.body);
+        const idempotencyKey = request.header('Idempotency-Key') ?? input.idempotencyKey;
+        if (!idempotencyKey) return response.status(400).json({ error: { code: 'idempotency_key_required' } });
+        const result = await options.coordinator!.submit({
+          ...input,
+          idempotencyKey,
+          refreshRunId: request.params.id,
+          expectedRunVersion: input.expectedVersion,
+        });
+        return response.status(result.created ? 202 : 200).json(result.projection);
+      } catch (error) {
+        if (error instanceof z.ZodError) return response.status(400).json({ error: { code: 'invalid_capture_request' } });
+        const safe = safeCaptureError(error);
+        return response.status(safe.status).json({ error: { code: safe.code } });
+      }
+    });
+  }
 
   app.get('/api/foundry/runs', async (_request, response, next) => {
     try { response.json({ runs: await store.list() }); } catch (error) { next(error); }
@@ -75,6 +210,7 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
       return response.json(await store.review(request.params.id, decision));
     } catch (error) {
       if (error instanceof VersionConflictError) return response.status(409).json({ error: error.message });
+      if (error instanceof RunRefreshInProgressError) return response.status(409).json({ error: { code: 'source_refresh_in_progress' } });
       return next(error);
     }
   });
@@ -85,19 +221,24 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
       return response.json(await store.updateArtifact(request.params.id, edit));
     } catch (error) {
       if (error instanceof VersionConflictError) return response.status(409).json({ error: error.message });
+      if (error instanceof RunRefreshInProgressError) return response.status(409).json({ error: { code: 'source_refresh_in_progress' } });
       return next(error);
     }
   });
 
   app.get('/api/foundry/runs/:id/patch', async (request, response, next) => {
     try {
-      const run = await store.get(request.params.id);
-      if (!run) return response.status(404).json({ error: 'Run not found' });
-      const patch = buildPatch(run);
+      const { run, immutableRecord } = await store.validateForExport(request.params.id);
+      const patch = buildPatch(run, immutableRecord);
       response.type('text/x-diff');
       response.setHeader('Content-Disposition', `attachment; filename="${run.id}.patch"`);
       return response.send(patch);
-    } catch (error) { return next(error); }
+    } catch (error) {
+      if (error instanceof RunRefreshInProgressError) {
+        return response.status(409).json({ error: { code: 'source_refresh_in_progress' } });
+      }
+      return next(error);
+    }
   });
 
   if (options.staticDir) {
@@ -109,6 +250,9 @@ export function createApp(store: FileFoundryStore, options: { staticDir?: string
   }
 
   app.use((error: unknown, _request: express.Request, response: express.Response, _next: express.NextFunction) => {
+    if (realUrlsEnabled) {
+      return response.status(400).json({ error: { code: error instanceof z.ZodError ? 'invalid_request' : 'request_failed' } });
+    }
     if (error instanceof z.ZodError) return response.status(400).json({ error: 'Invalid request', issues: error.issues });
     const message = error instanceof Error ? error.message : 'Unexpected error';
     return response.status(400).json({ error: message });

--- a/studio-peninsula-insider/server/capture/extractor.ts
+++ b/studio-peninsula-insider/server/capture/extractor.ts
@@ -15,6 +15,9 @@ interface HtmlNode {
 
 const BLOCK_ELEMENTS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'blockquote', 'dt', 'dd', 'pre', 'figcaption', 'td', 'th']);
 const EXCLUDED_ELEMENTS = new Set(['script', 'style', 'noscript', 'template', 'svg', 'canvas']);
+export const MAX_EXTRACTION_BLOCK_CHARS = 4_000;
+export const MAX_EXTRACTION_BLOCKS = 256;
+export const MAX_EXTRACTION_TEXT_CHARS = 512_000;
 
 export class ExtractionError extends Error {}
 
@@ -66,7 +69,28 @@ export function decodeText(content: Uint8Array, charset: 'utf-8' | 'us-ascii'): 
 
 export function extractBlocks(content: string, mediaType: 'text/html' | 'text/plain') {
   const texts = mediaType === 'text/html' ? htmlBlocks(content) : plainTextBlocks(content);
-  return texts.map((text, index) => Object.freeze({
+  const bounded: string[] = [];
+  let retainedChars = 0;
+  for (const text of texts) {
+    let remainder = text;
+    while (remainder && bounded.length < MAX_EXTRACTION_BLOCKS && retainedChars < MAX_EXTRACTION_TEXT_CHARS) {
+      const remainingBudget = MAX_EXTRACTION_TEXT_CHARS - retainedChars;
+      const limit = Math.min(MAX_EXTRACTION_BLOCK_CHARS, remainingBudget);
+      let splitAt = Math.min(remainder.length, limit);
+      if (remainder.length > limit) {
+        const wordBoundary = remainder.slice(0, limit + 1).lastIndexOf(' ');
+        if (wordBoundary >= Math.floor(limit / 2)) splitAt = wordBoundary;
+      }
+      const segment = remainder.slice(0, splitAt).trim();
+      if (segment) {
+        bounded.push(segment);
+        retainedChars += segment.length;
+      }
+      remainder = remainder.slice(splitAt).trim();
+    }
+    if (bounded.length >= MAX_EXTRACTION_BLOCKS || retainedChars >= MAX_EXTRACTION_TEXT_CHARS) break;
+  }
+  return bounded.map((text, index) => Object.freeze({
     locator: `block:${String(index + 1).padStart(6, '0')}`,
     text,
     textHash: sha256(text),
@@ -85,7 +109,7 @@ export function buildExtractionRevision(input: {
   return ExtractionRevisionSchema.parse({
     schemaVersion: 'pi.extraction-revision.v1',
     ...input,
-    extractorVersion: 'pi.parse5-text.v1',
+    extractorVersion: 'pi.parse5-text.v2',
   });
 }
 

--- a/studio-peninsula-insider/server/capture/kernel.ts
+++ b/studio-peninsula-insider/server/capture/kernel.ts
@@ -87,6 +87,26 @@ export interface CaptureInput {
 export class CaptureDisabledError extends Error {}
 export class CaptureIdempotencyConflictError extends Error {}
 
+export function captureRequestIdentity(input: CaptureInput): {
+  readonly canonicalUrl: URL;
+  readonly safeRequestedUrl: string;
+  readonly requestFingerprint: string;
+  readonly idempotencyKeyHash: string;
+  readonly attemptId: string;
+} {
+  if (!input.idempotencyKey.trim() || input.idempotencyKey.length > 256) throw new Error('A bounded idempotency key is required');
+  const canonicalUrl = canonicalizeCaptureUrl(input.url);
+  const requestFingerprint = sha256(canonicalUrl.href);
+  const idempotencyKeyHash = sha256(input.idempotencyKey);
+  return Object.freeze({
+    canonicalUrl,
+    safeRequestedUrl: redactCaptureUrl(canonicalUrl),
+    requestFingerprint,
+    idempotencyKeyHash,
+    attemptId: `capture-${idempotencyKeyHash.slice(0, 24)}`,
+  });
+}
+
 class CaptureStageError extends Error {
   constructor(
     readonly stage: 'policy' | 'dns' | 'transport' | 'body' | 'extraction' | 'storage',
@@ -221,11 +241,8 @@ export class CaptureKernel {
 
   async capture(input: CaptureInput): Promise<CaptureRecord> {
     if (!this.dependencies.enabled) throw new CaptureDisabledError('Real URL capture is disabled');
-    if (!input.idempotencyKey.trim() || input.idempotencyKey.length > 256) throw new Error('A bounded idempotency key is required');
-    const canonicalUrl = canonicalizeCaptureUrl(input.url);
-    const requestFingerprint = sha256(canonicalUrl.href);
-    const safeRequestedUrl = redactCaptureUrl(canonicalUrl);
-    const keyHash = sha256(input.idempotencyKey);
+    const identity = captureRequestIdentity(input);
+    const { canonicalUrl, requestFingerprint, safeRequestedUrl, idempotencyKeyHash: keyHash } = identity;
     const deadlineAt = Date.now() + this.limits.totalTimeoutMs;
     const active = this.inFlight.get(keyHash);
     if (active) {
@@ -302,18 +319,19 @@ export class CaptureKernel {
       assertWithinDeadline('storage');
       return waitFor(this.dependencies.repository.save(record), 'storage');
     };
+    const redirects: Array<{
+      url: string;
+      status: number;
+      location: string;
+      resolvedAddresses: string[];
+      selectedAddress: string;
+      remoteAddress: string;
+    }> = [];
+    const safeRedirects = () => redirects.map(({ url, status, location }) => ({ url, status, location }));
 
     try {
       let currentUrl = initialUrl;
       events.push(event('capturing', this.now().toISOString()));
-      const redirects: Array<{
-        url: string;
-        status: number;
-        location: string;
-        resolvedAddresses: string[];
-        selectedAddress: string;
-        remoteAddress: string;
-      }> = [];
 
       for (let redirectCount = 0; ; redirectCount += 1) {
         assertWithinDeadline('dns');
@@ -475,6 +493,7 @@ export class CaptureKernel {
             completedAt: this.now().toISOString(),
             state: finalState,
             events,
+            redirects: safeRedirects(),
             sourceRevisionId,
             extractionRevisionId,
             outcomeReason: blocks.length === 0 ? { code: 'no_extractable_text', detail: 'No extractable story text was found.' } : undefined,
@@ -496,7 +515,7 @@ export class CaptureKernel {
           attempt: {
             schemaVersion: 'pi.capture-attempt.v1', id: attemptId, idempotencyKeyHash: keyHash,
             requestFingerprint,
-            requestedUrl: safeRequestedUrl, createdAt, completedAt, state: 'held', events,
+            requestedUrl: safeRequestedUrl, createdAt, completedAt, state: 'held', events, redirects: safeRedirects(),
             sourceRevisionId: sourceRevision?.id,
             outcomeReason: { code: error.code, detail: error.message },
           },
@@ -511,7 +530,7 @@ export class CaptureKernel {
         attempt: {
           schemaVersion: 'pi.capture-attempt.v1', id: attemptId, idempotencyKeyHash: keyHash,
           requestFingerprint,
-          requestedUrl: safeRequestedUrl, createdAt, completedAt, state: 'failed', events,
+          requestedUrl: safeRequestedUrl, createdAt, completedAt, state: 'failed', events, redirects: safeRedirects(),
           sourceRevisionId: sourceRevision?.id,
           failure: { stage: failure.stage, code: failure.code, message: failure.message },
         },
@@ -524,11 +543,20 @@ export class CaptureKernel {
 }
 
 export function createCaptureKernel(root: string, environment: NodeJS.ProcessEnv = process.env): CaptureKernel {
-  return new CaptureKernel({
+  return createCaptureRuntime(root, environment).kernel;
+}
+
+export function createCaptureRuntime(root: string, environment: NodeJS.ProcessEnv = process.env): {
+  readonly kernel: CaptureKernel;
+  readonly repository: FileCaptureRepository;
+} {
+  const repository = new FileCaptureRepository(root);
+  const kernel = new CaptureKernel({
     enabled: realUrlCaptureEnabled(environment),
     resolver: new NodeDnsResolver(),
     transport: createPinnedHttpsTransport(),
     blobs: new ContentAddressedBlobStore(root),
-    repository: new FileCaptureRepository(root),
+    repository,
   });
+  return Object.freeze({ kernel, repository });
 }

--- a/studio-peninsula-insider/server/capture/policy.ts
+++ b/studio-peninsula-insider/server/capture/policy.ts
@@ -142,7 +142,7 @@ export async function resolveAndValidate(
   }));
   const blocked = normalized.filter((answer) => !isPublicAddress(answer.address));
   if (blocked.length > 0) {
-    throw new CapturePolicyError('non_public_address', `DNS included blocked address ${blocked[0].address}`);
+    throw new CapturePolicyError('non_public_address', 'DNS included a non-public or special-use address');
   }
 
   const unique = new Map(normalized.map((answer) => [`${answer.family}:${answer.address}`, answer]));

--- a/studio-peninsula-insider/server/capture/transport.ts
+++ b/studio-peninsula-insider/server/capture/transport.ts
@@ -1,4 +1,4 @@
-import { request as httpsRequest } from 'node:https';
+import { request as httpsRequest, type RequestOptions } from 'node:https';
 import type { LookupFunction } from 'node:net';
 import { sameIpAddress } from './policy.js';
 import type { CaptureTransport, TransportRequest, TransportResponse } from './transport-contract.js';
@@ -19,9 +19,10 @@ class PinnedHttpsTransport implements CaptureTransport {
       const lookup: LookupFunction = (_hostname, _options, callback) => {
         callback(null, input.pinnedAddress.address, input.pinnedAddress.family);
       };
-      const request = httpsRequest(input.url, {
+      const options: RequestOptions & { autoSelectFamily: false } = {
         method: 'GET',
         agent: false,
+        autoSelectFamily: false,
         lookup,
         maxHeaderSize: input.maxHeaderBytes,
         signal: input.signal,
@@ -30,7 +31,8 @@ class PinnedHttpsTransport implements CaptureTransport {
           'accept-encoding': 'gzip, deflate, br',
           'user-agent': 'PeninsulaInsider-CaptureKernel/0.1',
         },
-      }, (response) => {
+      };
+      const request = httpsRequest(input.url, options, (response) => {
         const remoteAddress = response.socket.remoteAddress;
         if (!remoteAddress || !sameIpAddress(remoteAddress, input.pinnedAddress.address)) {
           response.destroy();

--- a/studio-peninsula-insider/server/config.ts
+++ b/studio-peninsula-insider/server/config.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative, resolve } from 'node:path';
+import { realUrlCaptureEnabled } from './capture/kernel.js';
 
 export interface RuntimeConfig {
   dataFile: string;
@@ -6,6 +7,7 @@ export interface RuntimeConfig {
   environment: string;
   host: '127.0.0.1' | '0.0.0.0';
   port: number;
+  realUrlsEnabled: boolean;
   staticDir?: string;
 }
 
@@ -19,6 +21,7 @@ export function loadRuntimeConfig(environment = process.env): RuntimeConfig {
   }
 
   const runtime = environment.NODE_ENV ?? 'development';
+  const realUrlsEnabled = realUrlCaptureEnabled(environment);
   if (runtime === 'production') {
     throw new Error('The fixture-auth, file-store Workbench is disabled in production');
   }
@@ -27,13 +30,20 @@ export function loadRuntimeConfig(environment = process.env): RuntimeConfig {
   if (host !== '127.0.0.1' && host !== '0.0.0.0') {
     throw new Error('FOUNDRY_HOST must be 127.0.0.1 or 0.0.0.0');
   }
+  if (realUrlsEnabled && host !== '127.0.0.1') {
+    throw new Error('Real URL capture requires native loopback FOUNDRY_HOST=127.0.0.1');
+  }
+
+  const port = Number(environment.FOUNDRY_PORT ?? 4310);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('FOUNDRY_PORT must be a valid TCP port');
 
   return {
     dataFile,
     dataRoot,
     environment: runtime,
     host,
-    port: Number(environment.FOUNDRY_PORT ?? 4310),
+    port,
+    realUrlsEnabled,
     staticDir: environment.FOUNDRY_STATIC_DIR ? resolve(environment.FOUNDRY_STATIC_DIR) : undefined,
   };
 }

--- a/studio-peninsula-insider/server/fixture-runner.ts
+++ b/studio-peninsula-insider/server/fixture-runner.ts
@@ -1,6 +1,9 @@
 import { createHash } from 'node:crypto';
+import type { CaptureRecord } from '../shared/capture-contracts.js';
 import type { FoundryRun } from '../shared/contracts.js';
 import { ClaimSchema, FoundryRunSchema, QuickNoteSchema, type Claim } from '../shared/contracts.js';
+import { containsEmDash, containsPriceLanguage } from '../shared/editorial-laws.js';
+import { assertRealUrlArtifactAgainstCapture, assertRealUrlContentLineage } from './real-url-lineage.js';
 
 const hash = (value: string) => createHash('sha256').update(value).digest('hex');
 
@@ -10,6 +13,7 @@ export function evaluateQuickNoteGates(
   payload: { headline: string; dek?: string; body: string },
   claims: Claim[],
   claimIds: string[],
+  options: { requireSourceReview?: boolean; sourceReviewComplete?: boolean } = {},
 ) {
   const publicCopy = `${payload.headline} ${payload.dek ?? ''} ${payload.body}`;
   const claimsById = new Map(claims.map((claim) => [claim.id, claim]));
@@ -23,9 +27,16 @@ export function evaluateQuickNoteGates(
     );
   });
   return [
-    { gate: 'no_price', passed: !/(?:\$\s?\d|\bAUD\b|\bprice(?:d|s)?\b)/i.test(publicCopy), detail: 'Public copy must not contain pricing.' },
-    { gate: 'no_em_dash', passed: !/—/.test(publicCopy), detail: 'Public copy must not contain em dashes; en dashes remain valid for ranges.' },
+    { gate: 'no_price', passed: !containsPriceLanguage(publicCopy), detail: 'Public copy must not contain pricing.' },
+    { gate: 'no_em_dash', passed: !containsEmDash(publicCopy), detail: 'Public copy must not contain em dashes; en dashes remain valid for ranges.' },
     { gate: 'supported_claims_only', passed: supportedClaimsPassed, detail: supportedClaimsPassed ? 'Every selected claim is supported, evidenced and unrestricted.' : 'A selected claim is missing, unsupported, unevidenced or restricted.' },
+    ...(options.requireSourceReview ? [{
+      gate: 'human_source_review',
+      passed: Boolean(options.sourceReviewComplete),
+      detail: options.sourceReviewComplete
+        ? 'A human classified the source and confirmed the selected source assertions and angle.'
+        : 'A human must classify the source and confirm the selected source assertions and angle.',
+    }] : []),
   ];
 }
 
@@ -100,6 +111,7 @@ export function runFixture(actor: string, idempotencyKey: string): FoundryRun {
       id: 'artifact-quick-note-red-hill',
       version: 1,
       type: 'quick_note',
+      targetPath: 'next/src/content/quick-notes/2026-08-21-red-hill-wet-weather-lunch.md',
       claimIds: artifactClaimIds,
       angleId: 'angle-rainy-lunch',
       payload,
@@ -110,29 +122,37 @@ export function runFixture(actor: string, idempotencyKey: string): FoundryRun {
   });
 }
 
-export function buildPatch(run: FoundryRun): string {
+export function buildPatch(run: FoundryRun, immutableRecord?: CaptureRecord): string {
+  if (run.capture && !immutableRecord) {
+    throw new Error('Real URL patch export requires immutable capture validation');
+  }
+  if (run.capture) assertRealUrlArtifactAgainstCapture(run, immutableRecord!);
+  assertRealUrlContentLineage(run);
   if (run.status !== 'accepted') throw new Error('Artifact must be accepted before patch export');
+  if (run.capture && run.capture.currentAttemptId !== run.capture.artifactAttemptId) throw new Error('Artifact evidence is stale against the current source head');
+  if (run.capture && !run.artifact.sourceReview) throw new Error('Real URL artifacts require human source and claim confirmation');
   const note = run.artifact.payload;
+  if (note.sources.some((source) => source.kind === 'unclassified-web')) throw new Error('Artifact source classification is incomplete');
   const publicCopy = `${note.headline} ${note.dek ?? ''} ${note.body}`;
   if (run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed)) throw new Error('Artifact has unresolved gates');
-  if (note.tag === 'pricing' || /(?:\$\s?\d|\bAUD\b|\bprice(?:d|s)?\b)/i.test(publicCopy)) throw new Error('PI outputs cannot contain pricing');
-  if (/—/.test(publicCopy)) throw new Error('PI outputs cannot contain em dashes');
-  const slug = '2026-08-21-red-hill-wet-weather-lunch.md';
+  if (note.tag === 'pricing' || containsPriceLanguage(publicCopy)) throw new Error('PI outputs cannot contain pricing');
+  if (containsEmDash(publicCopy)) throw new Error('PI outputs cannot contain em dashes');
+  const targetPath = run.artifact.targetPath ?? 'next/src/content/quick-notes/2026-08-21-red-hill-wet-weather-lunch.md';
   const content = [
     '---',
     `headline: ${JSON.stringify(note.headline)}`,
     `dek: ${JSON.stringify(note.dek ?? '')}`,
     `section: ${note.section}`,
     `tag: ${note.tag}`,
-    `publishedAt: ${note.publishedAt}`,
-    `expiresAt: ${note.expiresAt}`,
-    ...(note.verifiedAt ? [`verifiedAt: ${note.verifiedAt}`] : []),
+    `publishedAt: ${JSON.stringify(note.publishedAt)}`,
+    `expiresAt: ${JSON.stringify(note.expiresAt)}`,
+    ...(note.verifiedAt ? [`verifiedAt: ${JSON.stringify(note.verifiedAt)}`] : []),
     ...(note.verifiedBy ? [`verifiedBy: ${JSON.stringify(note.verifiedBy)}`] : []),
     'sources:',
     ...note.sources.flatMap((source) => [
       `  - kind: ${source.kind}`,
-      ...(source.url ? [`    url: ${source.url}`] : []),
-      ...(source.checkedAt ? [`    checkedAt: ${source.checkedAt}`] : []),
+      ...(source.url ? [`    url: ${JSON.stringify(source.url)}`] : []),
+      ...(source.checkedAt ? [`    checkedAt: ${JSON.stringify(source.checkedAt)}`] : []),
     ]),
     'status: draft',
     '---',
@@ -140,10 +160,10 @@ export function buildPatch(run: FoundryRun): string {
     ...note.body.split(/\r?\n/),
   ];
   return [
-    `diff --git a/next/src/content/quick-notes/${slug} b/next/src/content/quick-notes/${slug}`,
+    `diff --git a/${targetPath} b/${targetPath}`,
     'new file mode 100644',
     '--- /dev/null',
-    `+++ b/next/src/content/quick-notes/${slug}`,
+    `+++ b/${targetPath}`,
     `@@ -0,0 +1,${content.length} @@`,
     ...content.map((line) => `+${line}`),
     '',

--- a/studio-peninsula-insider/server/index.ts
+++ b/studio-peninsula-insider/server/index.ts
@@ -1,11 +1,31 @@
+import { resolve } from 'node:path';
 import { createApp } from './app.js';
+import { createCaptureRuntime } from './capture/kernel.js';
+import { FileCaptureRepository } from './capture/repository.js';
 import { loadRuntimeConfig } from './config.js';
+import { RealUrlCoordinator } from './real-url-coordinator.js';
 import { FileFoundryStore } from './store.js';
 
 const config = loadRuntimeConfig();
-const store = new FileFoundryStore(config.dataFile, config.dataRoot);
+let coordinator: RealUrlCoordinator | undefined;
+let captureRuntime: ReturnType<typeof createCaptureRuntime> | undefined;
+const captureRoot = resolve(config.dataRoot, 'real-url-capture');
+if (config.realUrlsEnabled) {
+  captureRuntime = createCaptureRuntime(captureRoot);
+}
+const immutableCaptureResolver = captureRuntime?.repository ?? new FileCaptureRepository(captureRoot);
+const store = new FileFoundryStore(config.dataFile, config.dataRoot, immutableCaptureResolver);
+if (captureRuntime) {
+  coordinator = new RealUrlCoordinator(store, captureRuntime.kernel, captureRuntime.repository);
+  await coordinator.reconcile();
+}
 
-createApp(store, { staticDir: config.staticDir }).listen(config.port, config.host, () => {
+createApp(store, {
+  staticDir: config.staticDir,
+  realUrlsEnabled: config.realUrlsEnabled,
+  coordinator,
+  expectedHost: `127.0.0.1:${config.port}`,
+}).listen(config.port, config.host, () => {
   const displayHost = config.host === '0.0.0.0' ? '127.0.0.1' : config.host;
   console.log(`Peninsula Insider Workbench listening on http://${displayHost}:${config.port}`);
 });

--- a/studio-peninsula-insider/server/real-url-coordinator.ts
+++ b/studio-peninsula-insider/server/real-url-coordinator.ts
@@ -1,0 +1,144 @@
+import { createHash } from 'node:crypto';
+import type { CaptureProjection } from '../shared/contracts.js';
+import type { CaptureRecord } from '../shared/capture-contracts.js';
+import {
+  CaptureDisabledError,
+  CaptureIdempotencyConflictError,
+  captureRequestIdentity,
+  type CaptureInput,
+} from './capture/kernel.js';
+import type { FileFoundryStore } from './store.js';
+import { CaptureProjectionConflictError, VersionConflictError } from './store.js';
+
+export interface CaptureKernelPort {
+  capture(input: CaptureInput): Promise<CaptureRecord>;
+}
+
+export interface CaptureRepositoryPort {
+  get(attemptId: string): Promise<CaptureRecord | undefined>;
+}
+
+export class CaptureSourceMismatchError extends Error {}
+
+function bindOperationContext(input: {
+  requestFingerprint: string;
+  refreshRunId?: string;
+  expectedRunVersion?: number;
+}): string {
+  return createHash('sha256').update(JSON.stringify({
+    operation: input.refreshRunId ? 'refresh' : 'initial',
+    requestFingerprint: input.requestFingerprint,
+    refreshRunId: input.refreshRunId ?? null,
+    expectedRunVersion: input.expectedRunVersion ?? null,
+  })).digest('hex');
+}
+
+export class RealUrlCoordinator {
+  private readonly inFlight = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly store: FileFoundryStore,
+    private readonly kernel: CaptureKernelPort,
+    private readonly repository: CaptureRepositoryPort,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async submit(input: {
+    url: string;
+    actor: string;
+    idempotencyKey: string;
+    refreshRunId?: string;
+    expectedRunVersion?: number;
+  }): Promise<{ projection: CaptureProjection; created: boolean }> {
+    const identity = captureRequestIdentity({ url: input.url, idempotencyKey: input.idempotencyKey });
+    const operationFingerprint = bindOperationContext({
+      requestFingerprint: identity.requestFingerprint,
+      refreshRunId: input.refreshRunId,
+      expectedRunVersion: input.expectedRunVersion,
+    });
+    const existing = await this.store.getCaptureProjectionByIdempotencyKeyHash(identity.idempotencyKeyHash);
+    if (existing) {
+      if (existing.requestFingerprint !== identity.requestFingerprint || existing.operationFingerprint !== operationFingerprint) {
+        throw new CaptureProjectionConflictError('Idempotency key is bound to a different capture operation');
+      }
+      return { projection: existing, created: false };
+    }
+    if (input.refreshRunId) {
+      const run = await this.store.get(input.refreshRunId);
+      if (!run?.capture) throw new CaptureSourceMismatchError('Refresh target is not a real URL run');
+      if (run.version !== input.expectedRunVersion) {
+        throw new VersionConflictError(`Expected version ${input.expectedRunVersion}; current version is ${run.version}`);
+      }
+      const current = run.capture.revisions.find((revision) => revision.attemptId === run.capture?.currentAttemptId);
+      if (!current || current.requestedUrl !== identity.safeRequestedUrl || current.requestFingerprint !== identity.requestFingerprint) {
+        throw new CaptureSourceMismatchError('Refresh URL does not match the existing redacted source identity');
+      }
+    }
+    const timestamp = this.now().toISOString();
+    const sourceId = `source-head-${createHash('sha256').update(identity.safeRequestedUrl).digest('hex').slice(0, 20)}`;
+    const projection = {
+      schemaVersion: 'pi.capture-projection.v1' as const,
+      id: `projection-${identity.idempotencyKeyHash.slice(0, 24)}`,
+      sourceId,
+      attemptId: identity.attemptId,
+      actor: input.actor,
+      idempotencyKeyHash: identity.idempotencyKeyHash,
+      requestFingerprint: identity.requestFingerprint,
+      operation: input.refreshRunId ? 'refresh' as const : 'initial' as const,
+      operationFingerprint,
+      requestedUrl: identity.safeRequestedUrl,
+      state: 'queued' as const,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      ...(input.refreshRunId ? {
+        refreshRunId: input.refreshRunId,
+        expectedRunVersion: input.expectedRunVersion,
+      } : {}),
+    };
+    const created = await this.store.createCaptureProjection(projection);
+    if (!created.created) return created;
+    const capturing = await this.store.markCaptureProjectionCapturing(projection.id, this.now().toISOString());
+    const operation = this.execute(projection.id, { url: input.url, idempotencyKey: input.idempotencyKey });
+    this.inFlight.set(projection.id, operation);
+    void operation.finally(() => this.inFlight.delete(projection.id));
+    return { projection: capturing, created: true };
+  }
+
+  private async execute(projectionId: string, input: CaptureInput): Promise<void> {
+    let record: CaptureRecord;
+    try {
+      record = await this.kernel.capture(input);
+    } catch (error) {
+      let code = 'capture_failed_before_manifest';
+      if (error instanceof CaptureDisabledError) code = 'capture_disabled';
+      if (error instanceof CaptureIdempotencyConflictError) code = 'idempotency_conflict';
+      if (error instanceof VersionConflictError) code = 'workflow_version_conflict';
+      await this.store.failCaptureProjection(projectionId, code, this.now().toISOString()).catch(() => undefined);
+      return;
+    }
+    try {
+      await this.store.finalizeCaptureProjection(projectionId, record);
+    } catch {
+      const committed = await this.repository.get(record.attempt.id).catch(() => undefined);
+      if (committed) await this.store.finalizeCaptureProjection(projectionId, committed).catch(() => undefined);
+    }
+  }
+
+  async reconcile(): Promise<void> {
+    const pending = (await this.store.listCaptureProjections()).filter((projection) => ['queued', 'capturing'].includes(projection.state));
+    for (const projection of pending) {
+      const record = await this.repository.get(projection.attemptId);
+      if (record) {
+        try {
+          await this.store.finalizeCaptureProjection(projection.id, record);
+        } catch { /* Keep pending so a later restart can retry manifest-only materialization. */ }
+      } else {
+        await this.store.failCaptureProjection(projection.id, 'capture_interrupted', this.now().toISOString());
+      }
+    }
+  }
+
+  async waitForIdle(projectionId: string): Promise<void> {
+    await this.inFlight.get(projectionId);
+  }
+}

--- a/studio-peninsula-insider/server/real-url-integrity.ts
+++ b/studio-peninsula-insider/server/real-url-integrity.ts
@@ -1,0 +1,57 @@
+import type { CaptureRecord } from '../shared/capture-contracts.js';
+import type { FoundryRun } from '../shared/contracts.js';
+import { assertRealUrlContentLineage } from './real-url-lineage.js';
+import { buildRealUrlRun, summarizeCapture } from './real-url-runner.js';
+
+export interface ImmutableCaptureResolver {
+  get(attemptId: string): Promise<CaptureRecord | undefined>;
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export async function validateRealUrlRunAgainstResolver(
+  run: FoundryRun,
+  resolver?: ImmutableCaptureResolver,
+): Promise<CaptureRecord | undefined> {
+  if (!run.capture) return undefined;
+  if (!resolver) throw new Error('Real URL runs require an immutable capture resolver');
+  const attemptIds = run.capture.revisions.map((revision) => revision.attemptId);
+  if (new Set(attemptIds).size !== attemptIds.length) throw new Error('Capture revision history contains duplicate attempts');
+
+  const records = await Promise.all(attemptIds.map(async (attemptId) => {
+    const record = await resolver.get(attemptId);
+    if (!record || record.attempt.id !== attemptId) throw new Error('Immutable capture manifest is unavailable');
+    return record;
+  }));
+  records.forEach((record, index) => {
+    if (!same(summarizeCapture(record), run.capture!.revisions[index])) {
+      throw new Error('Mutable capture summary does not match the immutable manifest');
+    }
+  });
+
+  const artifactRecord = records.find((record) => record.attempt.id === run.capture!.artifactAttemptId);
+  if (!artifactRecord || artifactRecord.attempt.state !== 'extracted') {
+    throw new Error('Immutable artifact capture is unavailable');
+  }
+  const baseline = buildRealUrlRun(artifactRecord, run.bundle.submittedBy, run.idempotencyKey);
+  if (!same(run.claims, baseline.claims)) throw new Error('Mutable claims do not match the immutable extraction');
+  if (!same(run.bundle.sourceItems, baseline.bundle.sourceItems)
+      || run.bundle.id !== baseline.bundle.id
+      || run.bundle.title !== baseline.bundle.title
+      || run.bundle.capturedAt !== baseline.bundle.capturedAt) {
+    throw new Error('Mutable source items do not match the immutable source revision');
+  }
+  if (run.angle.id !== baseline.angle.id
+      || run.angle.label !== baseline.angle.label
+      || run.angle.framing !== baseline.angle.framing
+      || run.artifact.angleId !== baseline.artifact.angleId) {
+    throw new Error('Artifact metadata does not match the immutable extraction');
+  }
+  for (const blocker of baseline.blockers) {
+    if (!run.blockers.includes(blocker)) throw new Error('Immutable source restriction blocker is missing');
+  }
+  assertRealUrlContentLineage(run);
+  return artifactRecord;
+}

--- a/studio-peninsula-insider/server/real-url-lineage.ts
+++ b/studio-peninsula-insider/server/real-url-lineage.ts
@@ -1,0 +1,160 @@
+import { createHash } from 'node:crypto';
+import {
+  QuickNoteSchema,
+  RealUrlContentLineageSchema,
+  type Claim,
+  type FoundryRun,
+} from '../shared/contracts.js';
+import type { CaptureRecord } from '../shared/capture-contracts.js';
+import { resolveEvidenceLocator } from './capture/extractor.js';
+
+const hash = (value: string) => createHash('sha256').update(value).digest('hex');
+
+function headlineFrom(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 140) return normalized;
+  const shortened = normalized.slice(0, 137).replace(/\s+\S*$/, '').trim();
+  return `${shortened || normalized.slice(0, 137)}...`;
+}
+
+type ReviewedSourceKind = 'web' | 'venue-site' | 'press' | 'social' | 'gov' | 'partner';
+
+interface ArtifactSourceBinding {
+  canonicalUrl: string;
+  capturedAt: string;
+  contentHash: string;
+}
+
+function addDays(value: string, days: number): string {
+  return new Date(new Date(value).getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function sourceSlug(url: string): string {
+  const hostname = new URL(url).hostname
+    .toLowerCase()
+    .replace(/^www\./, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60);
+  return hostname || 'captured-source';
+}
+
+export function buildRealUrlArtifactBinding(
+  claims: Claim[],
+  claimIds: string[],
+  source: ArtifactSourceBinding,
+  sourceKind?: ReviewedSourceKind,
+) {
+  const claimsById = new Map(claims.map((claim) => [claim.id, claim]));
+  const selected = claimIds.map((claimId) => {
+    const claim = claimsById.get(claimId);
+    if (!claim || claim.restrictedFromArtifacts || !['supported', 'approved'].includes(claim.verification) || claim.evidence.length === 0) {
+      throw new Error('Real URL copy may use only selected, supported and unrestricted immutable claims');
+    }
+    return claim;
+  });
+  const headline = selected[0] ? headlineFrom(selected[0].text) : 'Captured source requires human framing';
+  const dek = `Captured from ${new URL(source.canonicalUrl).hostname} for evidence-led human review.`;
+  const body = selected.length > 0
+    ? selected.map((claim) => claim.text).join('\n\n')
+    : 'No publishable draft was generated from this capture.';
+  const systemSegment = (value: string) => ({ source: 'system_template' as const, textHash: hash(value) });
+  const payload = QuickNoteSchema.parse({
+    headline,
+    dek,
+    section: 'note',
+    tag: 'editor-note',
+    publishedAt: source.capturedAt,
+    expiresAt: addDays(source.capturedAt, 7),
+    sources: [{
+      kind: sourceKind ?? 'unclassified-web',
+      url: source.canonicalUrl,
+      checkedAt: source.capturedAt,
+    }],
+    status: 'draft',
+    body,
+  });
+  const targetPath = `next/src/content/quick-notes/${source.capturedAt.slice(0, 10)}-${sourceSlug(source.canonicalUrl)}-${source.contentHash.slice(0, 8)}.md`;
+  const lineage = RealUrlContentLineageSchema.parse({
+    schemaVersion: 'pi.real-url-content-lineage.v1',
+    exportBindingHash: hash(JSON.stringify({ payload, targetPath, claimIds })),
+    headline: {
+      contentHash: hash(headline),
+      segments: selected[0]
+        ? [{ source: 'claim', claimId: selected[0].id, textHash: hash(headline) }]
+        : [systemSegment(headline)],
+    },
+    dek: { contentHash: hash(dek), segments: [systemSegment(dek)] },
+    body: {
+      contentHash: hash(body),
+      segments: selected.length > 0
+        ? selected.map((claim) => ({ source: 'claim' as const, claimId: claim.id, textHash: hash(claim.text) }))
+        : [systemSegment(body)],
+    },
+  });
+  return { headline, dek, body, payload, targetPath, lineage };
+}
+
+export function assertRealUrlContentLineage(run: FoundryRun): void {
+  if (!run.capture) return;
+  const dependency = run.capture.revisions.find((revision) => revision.attemptId === run.capture?.artifactAttemptId);
+  const source = dependency?.sourceRevision;
+  if (!source || !run.artifact.contentLineage) throw new Error('Real URL artifact lineage is incomplete');
+  const sourceReview = run.artifact.sourceReview;
+  if (sourceReview && (JSON.stringify(sourceReview.confirmedClaimIds) !== JSON.stringify(run.artifact.claimIds)
+      || JSON.stringify(run.angle.evidenceClaimIds) !== JSON.stringify(run.artifact.claimIds))) {
+    throw new Error('Real URL source review is not bound to the selected claims');
+  }
+  const expected = buildRealUrlArtifactBinding(run.claims, run.artifact.claimIds, {
+    canonicalUrl: source.canonicalUrl,
+    capturedAt: source.capturedAt,
+    contentHash: source.contentHash,
+  }, sourceReview?.sourceKind);
+  if (JSON.stringify(run.artifact.payload) !== JSON.stringify(expected.payload)
+      || run.artifact.targetPath !== expected.targetPath
+      || JSON.stringify(run.artifact.contentLineage) !== JSON.stringify(expected.lineage)) {
+    throw new Error('Real URL artifact does not reproduce its immutable export binding');
+  }
+}
+
+export function assertRealUrlArtifactAgainstCapture(run: FoundryRun, record: CaptureRecord): void {
+  if (!run.capture) return;
+  if (record.attempt.id !== run.capture.artifactAttemptId
+      || record.attempt.state !== 'extracted'
+      || !record.sourceRevision
+      || !record.extractionRevision) {
+    throw new Error('Patch export requires the exact immutable artifact capture');
+  }
+  const dependency = run.capture.revisions.find((revision) => revision.attemptId === run.capture?.artifactAttemptId);
+  if (!dependency?.sourceRevision || !dependency.extractionRevision
+      || dependency.requestFingerprint !== record.attempt.requestFingerprint
+      || dependency.sourceRevision.id !== record.sourceRevision.id
+      || dependency.sourceRevision.canonicalUrl !== record.sourceRevision.canonicalUrl
+      || dependency.sourceRevision.capturedAt !== record.sourceRevision.capturedAt
+      || dependency.sourceRevision.contentHash !== record.sourceRevision.contentBlobHash
+      || dependency.extractionRevision.id !== record.extractionRevision.id
+      || dependency.extractionRevision.contentHash !== record.extractionRevision.extractedTextBlobHash) {
+    throw new Error('Patch metadata does not match the immutable source and extraction');
+  }
+  const claims = new Map(run.claims.map((claim) => [claim.id, claim]));
+  for (const claimId of run.artifact.claimIds) {
+    const claim = claims.get(claimId);
+    if (!claim || claim.evidence.length !== 1) throw new Error('Exported claim lacks exact immutable evidence');
+    const evidence = claim.evidence[0];
+    if (evidence.locatorType !== 'extracted_block') throw new Error('Exported claim lacks an immutable extraction locator');
+    const resolved = resolveEvidenceLocator(record.extractionRevision, {
+      sourceRevisionId: evidence.sourceRevisionId ?? '',
+      extractionRevisionId: evidence.extractionRevisionId ?? '',
+      locatorType: 'extracted_block',
+      locator: evidence.locator,
+      excerpt: evidence.excerpt,
+      excerptHash: evidence.excerptHash,
+    });
+    if (claim.text !== resolved
+        || evidence.sourceItemId !== record.sourceRevision.id
+        || evidence.capturedAt !== record.sourceRevision.capturedAt) {
+      throw new Error('Exported claim cannot be reproduced from immutable evidence');
+    }
+  }
+  assertRealUrlContentLineage(run);
+}

--- a/studio-peninsula-insider/server/real-url-runner.ts
+++ b/studio-peninsula-insider/server/real-url-runner.ts
@@ -1,0 +1,267 @@
+import { createHash } from 'node:crypto';
+import {
+  CaptureRevisionSummarySchema,
+  ClaimSchema,
+  FoundryRunSchema,
+  type CaptureRevisionSummary,
+  type Claim,
+  type FoundryRun,
+} from '../shared/contracts.js';
+import type { CaptureRecord } from '../shared/capture-contracts.js';
+import { containsEmDash, containsPriceLanguage } from '../shared/editorial-laws.js';
+import { createEvidenceLocator } from './capture/extractor.js';
+import { evaluateQuickNoteGates } from './fixture-runner.js';
+import { buildRealUrlArtifactBinding } from './real-url-lineage.js';
+
+const hash = (value: string) => createHash('sha256').update(value).digest('hex');
+const PROMPT_PATTERN = /\b(?:ignore (?:all|any|the) previous instructions|system prompt|developer message|assistant:)\b/i;
+const MAX_CLAIMS = 12;
+
+function restrictionFor(text: string): string | undefined {
+  if (containsPriceLanguage(text)) return 'PI outputs do not publish prices.';
+  if (containsEmDash(text)) return 'PI outputs do not publish em dashes.';
+  if (PROMPT_PATTERN.test(text)) return 'Instruction-like source text remains inert and is held from artifacts.';
+  return undefined;
+}
+
+function staleReviewHistory(run: FoundryRun, supersededByAttemptId: string, staledAt: string) {
+  const history = run.reviewHistory.map((entry) => entry.validity === 'current' ? {
+    ...entry,
+    validity: 'stale' as const,
+    staledAt,
+    supersededByAttemptId,
+    staleReason: 'source_refreshed' as const,
+  } : entry);
+  if (run.review && !history.some((entry) => entry.validity === 'stale'
+    && entry.decidedAt === run.review?.decidedAt && entry.reviewer === run.review?.reviewer)) {
+    history.push({
+      ...run.review,
+      validity: 'stale',
+      staledAt,
+      supersededByAttemptId,
+      staleReason: 'source_refreshed',
+    });
+  }
+  return history;
+}
+
+export function summarizeCapture(record: CaptureRecord): CaptureRevisionSummary {
+  const source = record.sourceRevision;
+  const extraction = record.extractionRevision;
+  const restrictedBlocks = extraction?.blocks.filter((block) => restrictionFor(block.text)).length ?? 0;
+  const restrictions = [
+    'HTTPS on port 443 only; private and special-use destinations are blocked.',
+    'Only inert text extraction is retained; scripts and subresources are never executed or fetched.',
+    'Extraction is bounded to 256 text segments and 4,000 characters per segment.',
+    'Every stored query value is redacted from operator-visible URLs.',
+    ...(restrictedBlocks > 0 ? [`${restrictedBlocks} extracted block${restrictedBlocks === 1 ? ' was' : 's were'} held from draft generation.`] : []),
+  ];
+  return CaptureRevisionSummarySchema.parse({
+    attemptId: record.attempt.id,
+    requestFingerprint: record.attempt.requestFingerprint,
+    requestedUrl: record.attempt.requestedUrl,
+    state: record.attempt.state,
+    createdAt: record.attempt.createdAt,
+    completedAt: record.attempt.completedAt,
+    events: record.attempt.events.map(({ state, at }) => ({ state, at })),
+    redirects: record.attempt.redirects,
+    outcomeReason: record.attempt.outcomeReason ? { code: record.attempt.outcomeReason.code } : undefined,
+    failure: record.attempt.failure ? { stage: record.attempt.failure.stage, code: record.attempt.failure.code } : undefined,
+    sourceRevision: source ? {
+      id: source.id,
+      canonicalUrl: source.canonicalUrl,
+      capturedAt: source.capturedAt,
+      status: source.status,
+      mediaType: source.mediaType,
+      charset: source.charset,
+      contentEncoding: source.contentEncoding,
+      redirects: source.redirects.map((redirect) => ({
+        url: redirect.url,
+        status: redirect.status,
+        location: redirect.location,
+      })),
+      contentHash: source.contentBlobHash,
+      wireBytes: source.wireBytes,
+      decodedBytes: source.decodedBytes,
+    } : undefined,
+    extractionRevision: extraction ? {
+      id: extraction.id,
+      extractedAt: extraction.extractedAt,
+      extractorVersion: extraction.extractorVersion,
+      contentHash: extraction.extractedTextBlobHash,
+      blockCount: extraction.blocks.length,
+    } : undefined,
+    restrictions,
+  });
+}
+
+export function deriveRealUrlClaims(record: CaptureRecord): Claim[] {
+  if (!record.sourceRevision || !record.extractionRevision) return [];
+  return ClaimSchema.array().parse(record.extractionRevision.blocks.slice(0, MAX_CLAIMS).map((block, index) => {
+    const evidence = createEvidenceLocator(record.extractionRevision!, block.locator);
+    const restrictionReason = restrictionFor(block.text);
+    return {
+      id: `claim-${hash(`${record.extractionRevision!.id}:${block.locator}`).slice(0, 20)}`,
+      text: block.text,
+      origin: 'external_fact',
+      verification: 'supported',
+      evidence: [{
+        sourceItemId: record.sourceRevision!.id,
+        sourceRevisionId: evidence.sourceRevisionId,
+        extractionRevisionId: evidence.extractionRevisionId,
+        locatorType: evidence.locatorType,
+        locator: evidence.locator,
+        excerpt: evidence.excerpt,
+        excerptHash: evidence.excerptHash,
+        capturedAt: record.sourceRevision!.capturedAt,
+      }],
+      restrictedFromArtifacts: Boolean(restrictionReason),
+      restrictionReason,
+      order: index,
+    };
+  }));
+}
+
+export function buildRealUrlRun(
+  record: CaptureRecord,
+  actor: string,
+  workflowIdempotencyKey: string,
+): FoundryRun {
+  if (record.attempt.state !== 'extracted' || !record.sourceRevision || !record.extractionRevision) {
+    throw new Error('Only extracted captures can create a Foundry run');
+  }
+  const summary = summarizeCapture(record);
+  const claims = deriveRealUrlClaims(record);
+  const usableClaims = claims.filter((claim) => !claim.restrictedFromArtifacts).slice(0, 3);
+  const selectedClaims = usableClaims.length > 0 ? usableClaims : claims.slice(0, 1);
+  const blockers = usableClaims.length > 0 ? [] : ['No extracted block is safe for artifact generation; inspect restrictions and edit from verified evidence.'];
+  const capturedAt = record.sourceRevision.capturedAt;
+  const claimIds = usableClaims.map((claim) => claim.id);
+  const bound = buildRealUrlArtifactBinding(claims, claimIds, {
+    canonicalUrl: record.sourceRevision.canonicalUrl,
+    capturedAt,
+    contentHash: record.sourceRevision.contentBlobHash,
+  });
+  const payload = bound.payload;
+  const gateResults = evaluateQuickNoteGates(payload, claims, claimIds, { requireSourceReview: true, sourceReviewComplete: false });
+
+  return FoundryRunSchema.parse({
+    id: `run-${hash(record.attempt.id).slice(0, 24)}`,
+    idempotencyKey: workflowIdempotencyKey,
+    version: 1,
+    status: blockers.length > 0 || gateResults.some((gate) => !gate.passed) ? 'needs_revision' : 'ready_for_review',
+    createdAt: record.attempt.createdAt,
+    updatedAt: record.attempt.completedAt,
+    bundle: {
+      schemaVersion: 'pi.intake-bundle.v1',
+      id: `bundle-${record.sourceRevision.id}`,
+      title: `Captured source: ${new URL(record.sourceRevision.canonicalUrl).hostname}`,
+      submittedBy: actor,
+      capturedAt,
+      sourceItems: [{
+        id: record.sourceRevision.id,
+        kind: 'url',
+        uri: record.sourceRevision.canonicalUrl,
+        contentHash: record.sourceRevision.contentBlobHash,
+        capturedAt,
+      }],
+    },
+    claims,
+    angle: {
+      id: `angle-${record.extractionRevision.id}`,
+      label: 'Source-led quick note',
+      framing: 'A bounded first draft assembled from source assertions in the current immutable extraction; independent verification remains a human decision.',
+      evidenceClaimIds: selectedClaims.map((claim) => claim.id),
+      selectedBy: 'deterministic-real-url-policy',
+    },
+    artifact: {
+      id: `artifact-${hash(record.attempt.id).slice(0, 20)}`,
+      version: 1,
+      type: 'quick_note',
+      targetPath: bound.targetPath,
+      claimIds,
+      angleId: `angle-${record.extractionRevision.id}`,
+      payload,
+      contentLineage: bound.lineage,
+      gateResults,
+    },
+    blockers,
+    capture: {
+      mode: 'real_url',
+      currentAttemptId: record.attempt.id,
+      artifactAttemptId: record.attempt.id,
+      revisions: [summary],
+    },
+    audit: [{
+      at: record.attempt.completedAt,
+      actor,
+      type: 'real_url_capture_created',
+      detail: `Created a draft from immutable attempt ${record.attempt.id}; source HTML remained inert.`,
+    }],
+  });
+}
+
+export function refreshRealUrlRun(run: FoundryRun, record: CaptureRecord, actor: string): FoundryRun {
+  if (!run.capture) throw new Error('Only real URL runs can be refreshed');
+  if (run.capture.currentAttemptId === record.attempt.id) return run;
+  const refreshed = buildRealUrlRun(record, actor, run.idempotencyKey);
+  const staledAt = record.attempt.completedAt;
+  return FoundryRunSchema.parse({
+    ...refreshed,
+    id: run.id,
+    idempotencyKey: run.idempotencyKey,
+    version: run.version + 1,
+    createdAt: run.createdAt,
+    updatedAt: staledAt,
+    artifact: {
+      ...refreshed.artifact,
+      id: run.artifact.id,
+      version: run.artifact.version + 1,
+      targetPath: refreshed.artifact.targetPath,
+    },
+    capture: {
+      mode: 'real_url',
+      currentAttemptId: record.attempt.id,
+      artifactAttemptId: record.attempt.id,
+      revisions: [...run.capture.revisions, summarizeCapture(record)],
+    },
+    review: undefined,
+    reviewHistory: staleReviewHistory(run, record.attempt.id, staledAt),
+    audit: [...run.audit, {
+      at: staledAt,
+      actor,
+      type: 'source_refreshed',
+      detail: `Source refresh created immutable attempt ${record.attempt.id}; every dependent review decision was invalidated.`,
+    }],
+  });
+}
+
+export function staleRealUrlRunForNoStory(run: FoundryRun, record: CaptureRecord, actor: string): FoundryRun {
+  if (!run.capture) throw new Error('Only real URL runs can be refreshed');
+  if (record.attempt.state !== 'no_story' || !record.sourceRevision || !record.extractionRevision) {
+    throw new Error('No-story staleness requires a complete immutable source and extraction revision');
+  }
+  if (run.capture.currentAttemptId === record.attempt.id) return run;
+  const staledAt = record.attempt.completedAt;
+  const blocker = 'The refreshed source contained no extractable story text; the prior artifact remains visible but is stale.';
+  return FoundryRunSchema.parse({
+    ...run,
+    version: run.version + 1,
+    status: 'needs_revision',
+    updatedAt: staledAt,
+    blockers: [...new Set([...run.blockers, blocker])],
+    capture: {
+      ...run.capture,
+      currentAttemptId: record.attempt.id,
+      revisions: [...run.capture.revisions, summarizeCapture(record)],
+    },
+    review: undefined,
+    reviewHistory: staleReviewHistory(run, record.attempt.id, staledAt),
+    audit: [...run.audit, {
+      at: staledAt,
+      actor,
+      type: 'source_refreshed_no_story',
+      detail: `Source head advanced to no-story attempt ${record.attempt.id}; every dependent review decision was invalidated.`,
+    }],
+  });
+}

--- a/studio-peninsula-insider/server/review-receipts.ts
+++ b/studio-peninsula-insider/server/review-receipts.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, readFile, realpath } from 'node:fs/promises';
+import { isAbsolute, relative, resolve } from 'node:path';
+import { z } from 'zod';
+import type { FoundryRun, ReviewDecision } from '../shared/contracts.js';
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+
+const ReviewReceiptSchema = z.object({
+  schemaVersion: z.literal('pi.review-receipt.v1'),
+  runId: z.string().min(1),
+  runVersion: z.number().int().positive(),
+  artifactId: z.string().min(1),
+  artifactVersion: z.number().int().positive(),
+  decision: z.enum(['accepted', 'rejected']),
+  reviewer: z.string().min(1),
+  note: z.string().optional(),
+  decidedAt: z.string().datetime(),
+  dependency: z.union([
+    z.object({
+      mode: z.literal('real_url'),
+      currentAttemptId: z.string().min(1),
+      artifactAttemptId: z.string().min(1),
+      requestFingerprint: Sha256Schema,
+      sourceRevisionId: z.string().min(1),
+      extractionRevisionId: z.string().min(1),
+    }),
+    z.object({
+      mode: z.literal('fixture'),
+      sourceItems: z.array(z.unknown()),
+    }),
+  ]),
+  claimIds: z.array(z.string()),
+  sourceReview: z.unknown().nullable(),
+  angle: z.unknown(),
+  payload: z.unknown(),
+  contentLineage: z.unknown().nullable(),
+  targetPath: z.string().nullable(),
+  gateResults: z.array(z.unknown()),
+  blockers: z.array(z.string()),
+});
+
+export type ReviewReceipt = z.infer<typeof ReviewReceiptSchema>;
+
+const digest = (value: string | Uint8Array) => createHash('sha256').update(value).digest('hex');
+
+function contained(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return !pathFromRoot.startsWith('..') && !isAbsolute(pathFromRoot);
+}
+
+export function buildReviewReceipt(
+  run: FoundryRun,
+  input: Pick<ReviewDecision, 'decision' | 'reviewer' | 'note'> & { decidedAt: string; runVersion?: number },
+): ReviewReceipt {
+  const artifactRevision = run.capture?.revisions.find((revision) => revision.attemptId === run.capture?.artifactAttemptId);
+  const dependency = run.capture ? {
+    mode: 'real_url' as const,
+    currentAttemptId: run.capture.currentAttemptId,
+    artifactAttemptId: run.capture.artifactAttemptId,
+    requestFingerprint: artifactRevision!.requestFingerprint,
+    sourceRevisionId: artifactRevision!.sourceRevision!.id,
+    extractionRevisionId: artifactRevision!.extractionRevision!.id,
+  } : {
+    mode: 'fixture' as const,
+    sourceItems: run.bundle.sourceItems,
+  };
+  return ReviewReceiptSchema.parse({
+    schemaVersion: 'pi.review-receipt.v1',
+    runId: run.id,
+    runVersion: input.runVersion ?? run.version,
+    artifactId: run.artifact.id,
+    artifactVersion: run.artifact.version,
+    decision: input.decision,
+    reviewer: input.reviewer,
+    note: input.note,
+    decidedAt: input.decidedAt,
+    dependency,
+    claimIds: run.artifact.claimIds,
+    sourceReview: run.artifact.sourceReview ?? null,
+    angle: run.angle,
+    payload: run.artifact.payload,
+    contentLineage: run.artifact.contentLineage ?? null,
+    targetPath: run.artifact.targetPath ?? null,
+    gateResults: run.artifact.gateResults,
+    blockers: run.blockers,
+  });
+}
+
+export class FileReviewReceiptRepository {
+  private readonly root: string;
+
+  constructor(root: string, allowedRoot: string) {
+    this.root = resolve(root);
+    const resolvedAllowedRoot = resolve(allowedRoot);
+    if (!contained(resolvedAllowedRoot, this.root)) throw new Error('Review receipt root escaped the configured data root');
+  }
+
+  private pathFor(hash: string): string {
+    return resolve(this.root, `${Sha256Schema.parse(hash)}.json`);
+  }
+
+  private async syncRoot(): Promise<void> {
+    let handle;
+    try {
+      handle = await open(this.root, 'r');
+      await handle.sync();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!['EACCES', 'EINVAL', 'EISDIR', 'ENOTSUP', 'EPERM'].includes(code ?? '')) throw error;
+    } finally {
+      await handle?.close().catch(() => undefined);
+    }
+  }
+
+  async put(receipt: ReviewReceipt): Promise<string> {
+    const parsed = ReviewReceiptSchema.parse(receipt);
+    const bytes = `${JSON.stringify(parsed)}\n`;
+    const hash = digest(bytes);
+    await mkdir(this.root, { recursive: true });
+    const realRoot = await realpath(this.root);
+    if (realRoot !== this.root) throw new Error('Review receipt root must not traverse a link');
+    const path = this.pathFor(hash);
+    let handle;
+    try {
+      handle = await open(path, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+      await handle.writeFile(bytes, 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await this.syncRoot();
+      return hash;
+    } catch (error) {
+      await handle?.close().catch(() => undefined);
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      const existing = await this.get(hash);
+      if (!existing || `${JSON.stringify(existing)}\n` !== bytes) throw new Error('Review receipt hash collision');
+      return hash;
+    }
+  }
+
+  async get(hash: string): Promise<ReviewReceipt | undefined> {
+    const path = this.pathFor(hash);
+    try {
+      const metadata = await lstat(path);
+      if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
+        throw new Error('Review receipt must be a private regular file');
+      }
+      const [realRoot, realFile] = await Promise.all([realpath(this.root), realpath(path)]);
+      if (realRoot !== this.root) throw new Error('Review receipt root must not traverse a link');
+      if (!contained(realRoot, realFile)) throw new Error('Review receipt escaped its repository root');
+      const bytes = await readFile(realFile, 'utf8');
+      if (digest(bytes) !== hash) throw new Error('Review receipt content hash mismatch');
+      return ReviewReceiptSchema.parse(JSON.parse(bytes));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+  }
+}
+
+export function assertReviewReceiptMatchesCurrentRun(run: FoundryRun, receipt: ReviewReceipt): void {
+  if (!run.review) throw new Error('Current review receipt has no active review');
+  const expected = buildReviewReceipt(run, {
+    decision: run.review.decision,
+    reviewer: run.review.reviewer,
+    note: run.review.note,
+    decidedAt: run.review.decidedAt,
+    runVersion: run.version - 1,
+  });
+  if (JSON.stringify(expected) !== JSON.stringify(receipt)) {
+    throw new Error('Current review receipt does not match the exact reviewed artifact snapshot');
+  }
+}

--- a/studio-peninsula-insider/server/store.ts
+++ b/studio-peninsula-insider/server/store.ts
@@ -1,33 +1,173 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
+import { lstat, mkdir, open, readFile, realpath, rename, rm } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
-import { FoundryRunSchema, QuickNoteSchema, type ArtifactEdit, type FoundryRun, type ReviewDecision } from '../shared/contracts.js';
+import {
+  CaptureProjectionSchema,
+  FoundryRunSchema,
+  QuickNoteSchema,
+  type ArtifactEdit,
+  type CaptureProjection,
+  type FoundryRun,
+  type ReviewDecision,
+} from '../shared/contracts.js';
+import type { CaptureRecord } from '../shared/capture-contracts.js';
 import { evaluateQuickNoteGates } from './fixture-runner.js';
+import {
+  buildRealUrlRun,
+  refreshRealUrlRun,
+  staleRealUrlRunForNoStory,
+  summarizeCapture,
+} from './real-url-runner.js';
+import { assertRealUrlContentLineage, buildRealUrlArtifactBinding } from './real-url-lineage.js';
+import {
+  validateRealUrlRunAgainstResolver,
+  type ImmutableCaptureResolver,
+} from './real-url-integrity.js';
+import {
+  assertReviewReceiptMatchesCurrentRun,
+  buildReviewReceipt,
+  FileReviewReceiptRepository,
+} from './review-receipts.js';
 
 interface StoreFile {
-  schemaVersion: 'pi.foundry-file-store.v1';
+  schemaVersion: 'pi.foundry-file-store.v2';
   runs: FoundryRun[];
+  captureProjections: CaptureProjection[];
 }
 
-function normalizeDerivedStatus(run: FoundryRun): FoundryRun {
-  const hasFailedGate = run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed);
-  if (!hasFailedGate || !['ready_for_review', 'accepted'].includes(run.status)) return run;
-  return FoundryRunSchema.parse({ ...run, status: 'needs_revision', review: undefined });
+function contained(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return !pathFromRoot.startsWith('..') && !isAbsolute(pathFromRoot);
+}
+
+function staleCurrentReviews(run: FoundryRun, input: {
+  at: string;
+  reason: 'source_refreshed' | 'artifact_edited' | 'review_superseded';
+  supersededByAttemptId?: string;
+}) {
+  return run.reviewHistory.map((entry) => entry.validity === 'current' ? {
+    ...entry,
+    validity: 'stale' as const,
+    staledAt: input.at,
+    staleReason: input.reason,
+    ...(input.supersededByAttemptId ? { supersededByAttemptId: input.supersededByAttemptId } : {}),
+  } : entry);
+}
+
+function normalizeDerivedStatus(run: unknown, storeSchemaVersion: 'pi.foundry-file-store.v1' | 'pi.foundry-file-store.v2'): FoundryRun {
+  const candidate = run as Partial<FoundryRun> & { review?: Record<string, unknown>; reviewHistory?: Record<string, unknown>[] };
+  const existingHistory = Array.isArray(candidate.reviewHistory) ? candidate.reviewHistory : [];
+  let reviewHistory = candidate.review && !existingHistory.some((entry) => entry.validity === 'current'
+    && entry.decision === candidate.review?.decision
+    && entry.reviewer === candidate.review?.reviewer
+    && entry.decidedAt === candidate.review?.decidedAt)
+    ? [...existingHistory, { ...candidate.review, validity: 'current' as const }]
+    : existingHistory;
+  const hasUnsealedCurrentReview = Boolean(candidate.review && !candidate.review.receiptHash)
+    || reviewHistory.some((entry) => entry.validity === 'current' && !entry.receiptHash);
+  const hasLegacyUnsealedHistory = storeSchemaVersion === 'pi.foundry-file-store.v1'
+    && reviewHistory.some((entry) => !entry.receiptHash);
+  if (hasLegacyUnsealedHistory) {
+    const migratedAt = typeof candidate.updatedAt === 'string' ? candidate.updatedAt : new Date(0).toISOString();
+    reviewHistory = reviewHistory.map((entry) => !entry.receiptHash ? {
+      ...entry,
+      validity: 'stale' as const,
+      staledAt: typeof entry.staledAt === 'string' ? entry.staledAt : migratedAt,
+      staleReason: 'legacy_unsealed' as const,
+      supersededByAttemptId: undefined,
+    } : entry);
+  }
+  const parsed = FoundryRunSchema.parse({
+    ...candidate,
+    ...(hasUnsealedCurrentReview ? { status: 'needs_revision', review: undefined } : {}),
+    reviewHistory,
+  });
+  assertRealUrlContentLineage(parsed);
+  const hasFailedGate = parsed.blockers.length > 0 || parsed.artifact.gateResults.some((gate) => !gate.passed);
+  if (!hasFailedGate || !['ready_for_review', 'accepted'].includes(parsed.status)) return parsed;
+  const normalized = FoundryRunSchema.parse({ ...parsed, status: 'needs_revision', review: undefined });
+  assertRealUrlContentLineage(normalized);
+  return normalized;
 }
 
 export class VersionConflictError extends Error {}
+export class CaptureProjectionConflictError extends Error {}
+export class CaptureBusyError extends Error {}
+export class CaptureRefreshTargetError extends Error {}
+export class RunRefreshInProgressError extends Error {}
 
 export class FileFoundryStore {
   private mutationQueue: Promise<void> = Promise.resolve();
   private readonly filePath: string;
+  private readonly root: string;
+  private readonly immutableCaptureResolver?: ImmutableCaptureResolver;
+  private readonly reviewReceipts: FileReviewReceiptRepository;
 
-  constructor(filePath: string, allowedRoot = dirname(filePath)) {
-    const root = resolve(allowedRoot);
+  constructor(filePath: string, allowedRoot = dirname(filePath), immutableCaptureResolver?: ImmutableCaptureResolver) {
+    this.root = resolve(allowedRoot);
     this.filePath = resolve(filePath);
-    const candidate = relative(root, this.filePath);
-    if (candidate.startsWith('..') || isAbsolute(candidate)) {
+    if (!contained(this.root, this.filePath)) {
       throw new Error('Foundry store path must remain inside its configured data root');
     }
+    this.immutableCaptureResolver = immutableCaptureResolver;
+    this.reviewReceipts = new FileReviewReceiptRepository(resolve(this.root, 'review-receipts'), this.root);
+  }
+
+  hasImmutableCaptureResolver(): boolean { return Boolean(this.immutableCaptureResolver); }
+
+  private async validateRealUrlRun(run: FoundryRun): Promise<CaptureRecord | undefined> {
+    const immutableRecord = await validateRealUrlRunAgainstResolver(run, this.immutableCaptureResolver);
+    if (!run.capture) return undefined;
+    const sourceReview = run.artifact.sourceReview;
+    const expectedGates = evaluateQuickNoteGates(run.artifact.payload, run.claims, run.artifact.claimIds, {
+      requireSourceReview: true,
+      sourceReviewComplete: Boolean(sourceReview?.angleConfirmed
+        && sourceReview.confirmedClaimIds.length > 0
+        && sourceReview.confirmedClaimIds.every((claimId) => run.artifact.claimIds.includes(claimId))),
+    });
+    if (JSON.stringify(expectedGates) !== JSON.stringify(run.artifact.gateResults)) {
+      throw new Error('Mutable artifact gates do not match immutable evidence and public copy');
+    }
+    return immutableRecord;
+  }
+
+  async validateForExport(id: string): Promise<{ run: FoundryRun; immutableRecord?: CaptureRecord }> {
+    return this.mutate(async () => {
+      const data = await this.read();
+      const run = data.runs.find((candidate) => candidate.id === id);
+      if (!run) throw new Error('Run not found');
+      if (data.captureProjections.some((projection) => projection.refreshRunId === id && ['queued', 'capturing'].includes(projection.state))) {
+        throw new RunRefreshInProgressError('Source refresh is in progress');
+      }
+      await this.validateReviewReceipts(run);
+      return { run, immutableRecord: await this.validateRealUrlRun(run) };
+    });
+  }
+
+  private async validateCaptureProjection(projection: CaptureProjection): Promise<void> {
+    if (!projection.summary) return;
+    if (!this.immutableCaptureResolver) throw new Error('Terminal capture projections require an immutable capture resolver');
+    const record = await this.immutableCaptureResolver.get(projection.attemptId);
+    if (!record || JSON.stringify(summarizeCapture(record)) !== JSON.stringify(projection.summary)) {
+      throw new Error('Mutable capture projection does not match the immutable manifest');
+    }
+  }
+
+  private async validateReviewReceipts(run: FoundryRun): Promise<void> {
+    for (const entry of run.reviewHistory) {
+      if (!entry.receiptHash && entry.staleReason === 'legacy_unsealed') continue;
+      if (!entry.receiptHash) throw new Error('Review history receipt is unavailable');
+      const receipt = await this.reviewReceipts.get(entry.receiptHash);
+      if (!receipt || receipt.runId !== run.id || receipt.decision !== entry.decision
+          || receipt.reviewer !== entry.reviewer || receipt.decidedAt !== entry.decidedAt
+          || receipt.note !== entry.note) {
+        throw new Error('Review history receipt is unavailable or does not match its decision');
+      }
+    }
+    if (!run.review) return;
+    const receipt = await this.reviewReceipts.get(run.review.receiptHash);
+    if (!receipt) throw new Error('Current review receipt is unavailable');
+    assertReviewReceiptMatchesCurrentRun(run, receipt);
   }
 
   private async mutate<T>(operation: () => Promise<T>): Promise<T> {
@@ -42,44 +182,227 @@ export class FileFoundryStore {
     }
   }
 
+  private async safeExistingFile(): Promise<string> {
+    const metadata = await lstat(this.filePath);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
+      throw new Error('Foundry store must be a private regular file');
+    }
+    const [realRoot, realFile] = await Promise.all([realpath(this.root), realpath(this.filePath)]);
+    if (!contained(realRoot, realFile)) throw new Error('Foundry store escaped its configured data root');
+    return realFile;
+  }
+
   private async read(): Promise<StoreFile> {
     try {
-      const raw = await readFile(this.filePath, 'utf8');
-      const parsed = JSON.parse(raw) as StoreFile;
-      if (parsed.schemaVersion !== 'pi.foundry-file-store.v1') throw new Error('Unsupported Foundry store schema');
-      return { schemaVersion: parsed.schemaVersion, runs: parsed.runs.map((run) => normalizeDerivedStatus(FoundryRunSchema.parse(run))) };
+      const raw = await readFile(await this.safeExistingFile(), 'utf8');
+      const parsed = JSON.parse(raw) as { schemaVersion?: string; runs?: unknown[]; captureProjections?: unknown[] };
+      if (!['pi.foundry-file-store.v1', 'pi.foundry-file-store.v2'].includes(parsed.schemaVersion ?? '')) {
+        throw new Error('Unsupported Foundry store schema');
+      }
+      const storeSchemaVersion = parsed.schemaVersion as 'pi.foundry-file-store.v1' | 'pi.foundry-file-store.v2';
+      const runs = (parsed.runs ?? []).map((run) => normalizeDerivedStatus(run, storeSchemaVersion));
+      await Promise.all(runs.map((run) => this.validateRealUrlRun(run)));
+      await Promise.all(runs.map((run) => this.validateReviewReceipts(run)));
+      const captureProjections = (parsed.captureProjections ?? []).map((projection) => CaptureProjectionSchema.parse(projection));
+      await Promise.all(captureProjections.map((projection) => this.validateCaptureProjection(projection)));
+      return {
+        schemaVersion: 'pi.foundry-file-store.v2',
+        runs,
+        captureProjections,
+      };
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { schemaVersion: 'pi.foundry-file-store.v1', runs: [] };
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { schemaVersion: 'pi.foundry-file-store.v2', runs: [], captureProjections: [] };
+      }
       throw error;
     }
   }
 
-  private async write(data: StoreFile): Promise<void> {
-    await mkdir(dirname(this.filePath), { recursive: true });
-    const temporary = `${this.filePath}.${process.pid}.${randomUUID()}.tmp`;
-    const handle = await open(temporary, 'wx');
+  private async syncParent(): Promise<void> {
+    let handle;
     try {
+      handle = await open(dirname(this.filePath), 'r');
+      await handle.sync();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!['EACCES', 'EINVAL', 'EISDIR', 'ENOTSUP', 'EPERM'].includes(code ?? '')) throw error;
+    } finally {
+      await handle?.close().catch(() => undefined);
+    }
+  }
+
+  private async write(data: StoreFile): Promise<void> {
+    await mkdir(this.root, { recursive: true });
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const [realRoot, realParent] = await Promise.all([realpath(this.root), realpath(dirname(this.filePath))]);
+    if (!contained(realRoot, realParent)) throw new Error('Foundry store parent escaped its configured data root');
+    try {
+      await this.safeExistingFile();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    const temporary = `${this.filePath}.${process.pid}.${randomUUID()}.tmp`;
+    let handle;
+    try {
+      handle = await open(temporary, 'wx', 0o600);
       await handle.writeFile(`${JSON.stringify(data, null, 2)}\n`, 'utf8');
       await handle.sync();
       await handle.close();
+      handle = undefined;
       await rename(temporary, this.filePath);
+      await this.syncParent();
     } catch (error) {
-      await handle.close().catch(() => undefined);
+      await handle?.close().catch(() => undefined);
       await rm(temporary, { force: true }).catch(() => undefined);
       throw error;
     }
   }
 
-  async list(): Promise<FoundryRun[]> {
-    return (await this.read()).runs;
-  }
-
-  async get(id: string): Promise<FoundryRun | undefined> {
-    return (await this.read()).runs.find((run) => run.id === id);
-  }
-
+  async list(): Promise<FoundryRun[]> { return (await this.read()).runs; }
+  async get(id: string): Promise<FoundryRun | undefined> { return (await this.read()).runs.find((run) => run.id === id); }
   async getByIdempotencyKey(key: string): Promise<FoundryRun | undefined> {
     return (await this.read()).runs.find((run) => run.idempotencyKey === key);
+  }
+  async listCaptureProjections(): Promise<CaptureProjection[]> { return (await this.read()).captureProjections; }
+  async getCaptureProjection(id: string): Promise<CaptureProjection | undefined> {
+    return (await this.read()).captureProjections.find((projection) => projection.id === id);
+  }
+  async getCaptureProjectionByIdempotencyKeyHash(keyHash: string): Promise<CaptureProjection | undefined> {
+    return (await this.read()).captureProjections.find((projection) => projection.idempotencyKeyHash === keyHash);
+  }
+
+  async createCaptureProjection(input: CaptureProjection): Promise<{ projection: CaptureProjection; created: boolean }> {
+    return this.mutate(async () => {
+      const projection = CaptureProjectionSchema.parse(input);
+      const data = await this.read();
+      const existing = data.captureProjections.find((item) => item.idempotencyKeyHash === projection.idempotencyKeyHash);
+      if (existing) {
+        if (existing.requestFingerprint !== projection.requestFingerprint
+            || existing.operationFingerprint !== projection.operationFingerprint) {
+          throw new CaptureProjectionConflictError('Idempotency key is bound to a different capture operation');
+        }
+        return { projection: existing, created: false };
+      }
+      if (data.captureProjections.some((item) => ['queued', 'capturing'].includes(item.state))) {
+        throw new CaptureBusyError('Only one local URL capture may run at a time');
+      }
+      if (projection.operation === 'refresh') {
+        const run = data.runs.find((item) => item.id === projection.refreshRunId);
+        if (!run?.capture) throw new CaptureRefreshTargetError('Refresh target is not a real URL run');
+        if (run.version !== projection.expectedRunVersion) {
+          throw new VersionConflictError(`Expected version ${projection.expectedRunVersion}; current version is ${run.version}`);
+        }
+        const current = run.capture.revisions.find((revision) => revision.attemptId === run.capture?.currentAttemptId);
+        if (!current || current.requestFingerprint !== projection.requestFingerprint) {
+          throw new CaptureRefreshTargetError('Refresh request does not match the exact source identity');
+        }
+      }
+      data.captureProjections.unshift(projection);
+      await this.write(data);
+      return { projection, created: true };
+    });
+  }
+
+  async markCaptureProjectionCapturing(id: string, at: string): Promise<CaptureProjection> {
+    return this.mutate(async () => {
+      const data = await this.read();
+      const index = data.captureProjections.findIndex((projection) => projection.id === id);
+      if (index < 0) throw new Error('Capture projection not found');
+      const current = data.captureProjections[index];
+      if (current.summary) return current;
+      if (current.state !== 'queued') return current;
+      const updated = CaptureProjectionSchema.parse({ ...current, state: 'capturing', updatedAt: at });
+      data.captureProjections[index] = updated;
+      await this.write(data);
+      return updated;
+    });
+  }
+
+  async failCaptureProjection(id: string, code: string, at: string): Promise<CaptureProjection> {
+    return this.mutate(async () => {
+      const data = await this.read();
+      const index = data.captureProjections.findIndex((projection) => projection.id === id);
+      if (index < 0) throw new Error('Capture projection not found');
+      const current = data.captureProjections[index];
+      if (current.summary) return current;
+      const updated = CaptureProjectionSchema.parse({
+        ...current,
+        state: 'failed',
+        updatedAt: at,
+        failure: { stage: 'storage', code },
+      });
+      data.captureProjections[index] = updated;
+      await this.write(data);
+      return updated;
+    });
+  }
+
+  async finalizeCaptureProjection(id: string, record: CaptureRecord): Promise<{ projection: CaptureProjection; run?: FoundryRun }> {
+    return this.mutate(async () => {
+      const data = await this.read();
+      const projectionIndex = data.captureProjections.findIndex((projection) => projection.id === id);
+      if (projectionIndex < 0) throw new Error('Capture projection not found');
+      const projection = data.captureProjections[projectionIndex];
+      if (projection.attemptId !== record.attempt.id
+        || projection.requestFingerprint !== record.attempt.requestFingerprint
+        || projection.idempotencyKeyHash !== record.attempt.idempotencyKeyHash) {
+        throw new CaptureProjectionConflictError('Immutable capture record does not match its projection');
+      }
+      if (projection.summary) {
+        return { projection, run: projection.runId ? data.runs.find((run) => run.id === projection.runId) : undefined };
+      }
+
+      const summary = summarizeCapture(record);
+      let run: FoundryRun | undefined;
+      let materializationFailure: CaptureProjection['materializationFailure'];
+      if (projection.refreshRunId) {
+        const runIndex = data.runs.findIndex((item) => item.id === projection.refreshRunId);
+        if (runIndex < 0) {
+          materializationFailure = { code: 'refresh_target_missing' };
+        } else {
+          const current = data.runs[runIndex];
+          if (!current.capture) {
+            materializationFailure = { code: 'refresh_target_invalid' };
+          } else if (current.capture.currentAttemptId === record.attempt.id) {
+            run = current;
+          } else {
+            try {
+              if (record.attempt.state === 'extracted') run = refreshRealUrlRun(current, record, projection.actor);
+              if (record.attempt.state === 'no_story') run = staleRealUrlRunForNoStory(current, record, projection.actor);
+              if (run) {
+                await this.validateRealUrlRun(run);
+                data.runs[runIndex] = run;
+              }
+            } catch {
+              materializationFailure = { code: 'workflow_materialization_failed' };
+            }
+          }
+        }
+      } else if (record.attempt.state === 'extracted') {
+        try {
+          const candidate = buildRealUrlRun(record, projection.actor, `real-url:${projection.idempotencyKeyHash}`);
+          const materialized = data.runs.find((item) => item.idempotencyKey === candidate.idempotencyKey) ?? candidate;
+          await this.validateRealUrlRun(materialized);
+          if (!data.runs.some((item) => item.id === materialized.id)) data.runs.unshift(materialized);
+          run = materialized;
+        } catch {
+          materializationFailure = { code: 'workflow_materialization_failed' };
+        }
+      }
+
+      const updated = CaptureProjectionSchema.parse({
+        ...projection,
+        state: record.attempt.state,
+        updatedAt: record.attempt.completedAt,
+        summary,
+        runId: run?.id ?? projection.refreshRunId,
+        failure: undefined,
+        materializationFailure,
+      });
+      data.captureProjections[projectionIndex] = updated;
+      await this.write(data);
+      return { projection: updated, run };
+    });
   }
 
   async create(run: FoundryRun): Promise<FoundryRun> {
@@ -87,9 +410,11 @@ export class FileFoundryStore {
       const data = await this.read();
       const existing = data.runs.find((item) => item.idempotencyKey === run.idempotencyKey);
       if (existing) return existing;
-      data.runs.unshift(FoundryRunSchema.parse(run));
+      const parsed = FoundryRunSchema.parse(run);
+      await this.validateRealUrlRun(parsed);
+      data.runs.unshift(parsed);
       await this.write(data);
-      return run;
+      return parsed;
     });
   }
 
@@ -99,24 +424,34 @@ export class FileFoundryStore {
       const index = data.runs.findIndex((run) => run.id === id);
       if (index < 0) throw new Error('Run not found');
       const run = data.runs[index];
+      if (data.captureProjections.some((projection) => projection.refreshRunId === id && ['queued', 'capturing'].includes(projection.state))) {
+        throw new RunRefreshInProgressError('Source refresh is in progress');
+      }
       if (run.version !== decision.expectedVersion) {
         throw new VersionConflictError(`Expected version ${decision.expectedVersion}; current version is ${run.version}`);
       }
       if (decision.decision === 'accepted' && (run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed))) {
         throw new Error('Artifact has unresolved blockers or failed gates');
       }
+      if (decision.decision === 'accepted' && run.capture && run.capture.currentAttemptId !== run.capture.artifactAttemptId) {
+        throw new Error('Artifact evidence is stale against the current source head');
+      }
+      assertRealUrlContentLineage(run);
       const now = new Date().toISOString();
+      const receiptHash = await this.reviewReceipts.put(buildReviewReceipt(run, {
+        decision: decision.decision,
+        reviewer: decision.reviewer,
+        note: decision.note,
+        decidedAt: now,
+      }));
+      const review = { decision: decision.decision, reviewer: decision.reviewer, note: decision.note, decidedAt: now, receiptHash };
       const updated = FoundryRunSchema.parse({
         ...run,
         version: run.version + 1,
         status: decision.decision,
         updatedAt: now,
-        review: {
-          decision: decision.decision,
-          reviewer: decision.reviewer,
-          note: decision.note,
-          decidedAt: now,
-        },
+        review,
+        reviewHistory: [...staleCurrentReviews(run, { at: now, reason: 'review_superseded' }), { ...review, validity: 'current' }],
         audit: [...run.audit, {
           at: now,
           actor: decision.reviewer,
@@ -125,6 +460,7 @@ export class FileFoundryStore {
         }],
       });
       data.runs[index] = updated;
+      await this.validateRealUrlRun(updated);
       await this.write(data);
       return updated;
     });
@@ -136,38 +472,77 @@ export class FileFoundryStore {
       const index = data.runs.findIndex((run) => run.id === id);
       if (index < 0) throw new Error('Run not found');
       const run = data.runs[index];
+      if (data.captureProjections.some((projection) => projection.refreshRunId === id && ['queued', 'capturing'].includes(projection.state))) {
+        throw new RunRefreshInProgressError('Source refresh is in progress');
+      }
       if (run.version !== edit.expectedVersion) {
         throw new VersionConflictError(`Expected version ${edit.expectedVersion}; current version is ${run.version}`);
       }
-
-      const payload = QuickNoteSchema.parse({
-        ...run.artifact.payload,
-        headline: edit.headline,
-        dek: edit.dek,
-        body: edit.body,
-      });
+      const claimIds = edit.claimIds ?? run.artifact.claimIds;
+      const claimsById = new Map(run.claims.map((claim) => [claim.id, claim]));
+      if (claimIds.some((claimId) => !claimsById.has(claimId))) throw new Error('Selected claim does not exist');
       const now = new Date().toISOString();
-      const gateResults = evaluateQuickNoteGates(payload, run.claims, run.artifact.claimIds);
+      const sourceReview = edit.sourceKind && edit.claimIds && edit.confirmAngle ? {
+        sourceKind: edit.sourceKind,
+        confirmedClaimIds: edit.claimIds,
+        angleConfirmed: true as const,
+        confirmedBy: edit.editor,
+        confirmedAt: now,
+      } : run.artifact.sourceReview;
+      const dependency = run.capture?.revisions.find((revision) => revision.attemptId === run.capture?.artifactAttemptId);
+      const bound = run.capture && dependency?.sourceRevision
+        ? buildRealUrlArtifactBinding(run.claims, claimIds, {
+          canonicalUrl: dependency.sourceRevision.canonicalUrl,
+          capturedAt: dependency.sourceRevision.capturedAt,
+          contentHash: dependency.sourceRevision.contentHash,
+        }, sourceReview?.sourceKind)
+        : undefined;
+      if (bound && ((edit.headline !== undefined && edit.headline !== bound.headline)
+          || (edit.dek !== undefined && edit.dek !== bound.dek)
+          || (edit.body !== undefined && edit.body !== bound.body))) {
+        throw new Error('Real URL public copy must reproduce selected immutable evidence');
+      }
+      if (!bound && (!edit.headline || !edit.body)) throw new Error('Fixture artifact edits require headline and body');
+      const payload = bound?.payload ?? QuickNoteSchema.parse({
+        ...run.artifact.payload,
+        headline: edit.headline!,
+        dek: edit.dek,
+        body: edit.body!,
+      });
+      const gateResults = evaluateQuickNoteGates(payload, run.claims, claimIds, run.capture ? {
+        requireSourceReview: true,
+        sourceReviewComplete: Boolean(sourceReview?.angleConfirmed
+          && sourceReview.confirmedClaimIds.length > 0
+          && sourceReview.confirmedClaimIds.every((claimId) => claimIds.includes(claimId))),
+      } : {});
+      const staleDependency = Boolean(run.capture && run.capture.currentAttemptId !== run.capture.artifactAttemptId);
       const updated = FoundryRunSchema.parse({
         ...run,
         version: run.version + 1,
-        status: gateResults.some((gate) => !gate.passed) ? 'needs_revision' : 'ready_for_review',
+        status: staleDependency || run.blockers.length > 0 || gateResults.some((gate) => !gate.passed) ? 'needs_revision' : 'ready_for_review',
         updatedAt: now,
         review: undefined,
+        reviewHistory: staleCurrentReviews(run, { at: now, reason: 'artifact_edited' }),
+        angle: { ...run.angle, evidenceClaimIds: claimIds, selectedBy: sourceReview ? edit.editor : run.angle.selectedBy },
         artifact: {
           ...run.artifact,
           version: run.artifact.version + 1,
+          claimIds,
           payload,
+          targetPath: bound?.targetPath ?? run.artifact.targetPath,
+          contentLineage: bound?.lineage ?? run.artifact.contentLineage,
+          sourceReview,
           gateResults,
         },
         audit: [...run.audit, {
           at: now,
           actor: edit.editor,
           type: 'artifact_edited',
-          detail: `Edited artifact ${run.artifact.id}; any prior decision was invalidated.`,
+          detail: `Edited artifact ${run.artifact.id}; any prior decision was retained as stale.`,
         }],
       });
       data.runs[index] = updated;
+      await this.validateRealUrlRun(updated);
       await this.write(data);
       return updated;
     });

--- a/studio-peninsula-insider/shared/capture-contracts.ts
+++ b/studio-peninsula-insider/shared/capture-contracts.ts
@@ -4,6 +4,12 @@ const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 const ImmutableIdSchema = z.string().regex(/^[a-z][a-z0-9-]{7,127}$/);
 const IpAddressSchema = z.union([z.ipv4(), z.ipv6()]);
 
+export const AttemptRedirectSchema = z.object({
+  url: z.string().url(),
+  status: z.number().int().min(300).max(399),
+  location: z.string().url(),
+}).readonly();
+
 export const CaptureStateSchema = z.enum([
   'queued',
   'capturing',
@@ -42,6 +48,7 @@ export const CaptureAttemptSchema = z.object({
   completedAt: z.string().datetime(),
   state: CaptureStateSchema,
   events: z.array(CaptureStateEventSchema).min(2),
+  redirects: z.array(AttemptRedirectSchema).default([]),
   sourceRevisionId: ImmutableIdSchema.optional(),
   extractionRevisionId: ImmutableIdSchema.optional(),
   outcomeReason: z.object({
@@ -124,10 +131,17 @@ export const ExtractionRevisionSchema = z.object({
   attemptId: ImmutableIdSchema,
   sourceRevisionId: ImmutableIdSchema,
   extractedAt: z.string().datetime(),
-  extractorVersion: z.literal('pi.parse5-text.v1'),
+  extractorVersion: z.enum(['pi.parse5-text.v1', 'pi.parse5-text.v2']),
   sourceContentBlobHash: Sha256Schema,
   extractedTextBlobHash: Sha256Schema,
   blocks: z.array(ExtractedBlockSchema),
+}).superRefine((revision, context) => {
+  if (revision.extractorVersion === 'pi.parse5-text.v2') {
+    if (revision.blocks.length > 256) context.addIssue({ code: 'custom', path: ['blocks'], message: 'Extractor v2 block limit exceeded' });
+    revision.blocks.forEach((block, index) => {
+      if (block.text.length > 4_000) context.addIssue({ code: 'custom', path: ['blocks', index, 'text'], message: 'Extractor v2 segment limit exceeded' });
+    });
+  }
 }).readonly();
 
 export const CaptureEvidenceLocatorSchema = z.object({

--- a/studio-peninsula-insider/shared/contracts.ts
+++ b/studio-peninsula-insider/shared/contracts.ts
@@ -1,20 +1,200 @@
 import { z } from 'zod';
+import { CaptureStateSchema } from './capture-contracts.js';
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const ImmutableIdSchema = z.string().regex(/^[a-z][a-z0-9-]{7,127}$/);
+
+function hasOnlyRedactedQueryValues(value: string): boolean {
+  try {
+    return [...new URL(value).searchParams.values()].every((queryValue) => queryValue === '[redacted]');
+  } catch {
+    return false;
+  }
+}
 
 export const EvidenceLocatorSchema = z.object({
   sourceItemId: z.string().min(1),
-  locatorType: z.enum(['selector', 'paragraph', 'timecode', 'manual']),
+  sourceRevisionId: ImmutableIdSchema.optional(),
+  extractionRevisionId: ImmutableIdSchema.optional(),
+  locatorType: z.enum(['selector', 'paragraph', 'timecode', 'manual', 'extracted_block']),
   locator: z.string().min(1),
   excerpt: z.string().min(1),
-  excerptHash: z.string().regex(/^[a-f0-9]{64}$/),
+  excerptHash: Sha256Schema,
   capturedAt: z.string().datetime(),
+}).superRefine((locator, context) => {
+  if (locator.locatorType === 'extracted_block' && (!locator.sourceRevisionId || !locator.extractionRevisionId)) {
+    context.addIssue({ code: 'custom', path: ['sourceRevisionId'], message: 'Extracted evidence requires immutable revision IDs' });
+  }
 });
 
 export const SourceItemSchema = z.object({
   id: z.string().min(1),
   kind: z.enum(['url', 'text_note', 'audio_note', 'image', 'document']),
   uri: z.string().url().optional(),
-  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+  contentHash: Sha256Schema,
   capturedAt: z.string().datetime(),
+});
+
+export const CaptureRevisionSummarySchema = z.object({
+  attemptId: ImmutableIdSchema,
+  requestFingerprint: Sha256Schema,
+  requestedUrl: z.string().url(),
+  state: CaptureStateSchema,
+  createdAt: z.string().datetime(),
+  completedAt: z.string().datetime(),
+  events: z.array(z.object({
+    state: CaptureStateSchema,
+    at: z.string().datetime(),
+  })).min(2),
+  redirects: z.array(z.object({
+    url: z.string().url(),
+    status: z.number().int().min(300).max(399),
+    location: z.string().url(),
+  })),
+  outcomeReason: z.object({ code: z.string().min(1) }).optional(),
+  failure: z.object({
+    stage: z.enum(['policy', 'dns', 'transport', 'body', 'extraction', 'storage']),
+    code: z.string().min(1),
+  }).optional(),
+  sourceRevision: z.object({
+    id: ImmutableIdSchema,
+    canonicalUrl: z.string().url(),
+    capturedAt: z.string().datetime(),
+    status: z.number().int().min(200).max(299),
+    mediaType: z.enum(['text/html', 'text/plain']),
+    charset: z.enum(['utf-8', 'us-ascii']),
+    contentEncoding: z.enum(['identity', 'gzip', 'deflate', 'br']),
+    redirects: z.array(z.object({
+      url: z.string().url(),
+      status: z.number().int().min(300).max(399),
+      location: z.string().url(),
+    })),
+    contentHash: Sha256Schema,
+    wireBytes: z.number().int().nonnegative(),
+    decodedBytes: z.number().int().nonnegative(),
+  }).optional(),
+  extractionRevision: z.object({
+    id: ImmutableIdSchema,
+    extractedAt: z.string().datetime(),
+    extractorVersion: z.string().min(1),
+    contentHash: Sha256Schema,
+    blockCount: z.number().int().nonnegative(),
+  }).optional(),
+  restrictions: z.array(z.string().min(1)),
+}).superRefine((summary, context) => {
+  const urls = [
+    ['requestedUrl', summary.requestedUrl] as const,
+    ...(summary.sourceRevision ? [['sourceRevision.canonicalUrl', summary.sourceRevision.canonicalUrl] as const] : []),
+    ...summary.redirects.flatMap((redirect, index) => [
+      [`redirects.${index}.url`, redirect.url] as const,
+      [`redirects.${index}.location`, redirect.location] as const,
+    ]),
+    ...(summary.sourceRevision?.redirects.flatMap((redirect, index) => [
+      [`sourceRevision.redirects.${index}.url`, redirect.url] as const,
+      [`sourceRevision.redirects.${index}.location`, redirect.location] as const,
+    ]) ?? []),
+  ];
+  for (const [path, url] of urls) {
+    if (!hasOnlyRedactedQueryValues(url)) context.addIssue({ code: 'custom', path: path.split('.'), message: 'Operator-visible URLs require redacted query values' });
+  }
+  if (summary.state === 'extracted' && (!summary.sourceRevision || !summary.extractionRevision)) {
+    context.addIssue({ code: 'custom', path: ['state'], message: 'Extracted capture summaries require immutable revisions' });
+  }
+});
+
+export const RealUrlCaptureSchema = z.object({
+  mode: z.literal('real_url'),
+  currentAttemptId: ImmutableIdSchema,
+  artifactAttemptId: ImmutableIdSchema,
+  revisions: z.array(CaptureRevisionSummarySchema).min(1),
+});
+
+export const CaptureProjectionSchema = z.object({
+  schemaVersion: z.literal('pi.capture-projection.v1'),
+  id: ImmutableIdSchema,
+  sourceId: ImmutableIdSchema,
+  attemptId: ImmutableIdSchema,
+  actor: z.string().min(1),
+  idempotencyKeyHash: Sha256Schema,
+  requestFingerprint: Sha256Schema,
+  operation: z.enum(['initial', 'refresh']),
+  operationFingerprint: Sha256Schema,
+  requestedUrl: z.string().url(),
+  state: CaptureStateSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  runId: z.string().min(1).optional(),
+  refreshRunId: z.string().min(1).optional(),
+  expectedRunVersion: z.number().int().positive().optional(),
+  summary: CaptureRevisionSummarySchema.optional(),
+  failure: z.object({
+    stage: z.enum(['policy', 'dns', 'transport', 'body', 'extraction', 'storage']),
+    code: z.string().min(1),
+  }).optional(),
+  materializationFailure: z.object({
+    code: z.enum(['refresh_target_missing', 'refresh_target_invalid', 'workflow_materialization_failed']),
+  }).optional(),
+}).superRefine((projection, context) => {
+  const isTerminal = ['extracted', 'held', 'no_story', 'failed'].includes(projection.state);
+  const hasRefreshId = projection.refreshRunId !== undefined;
+  const hasRefreshVersion = projection.expectedRunVersion !== undefined;
+  if (hasRefreshId !== hasRefreshVersion) {
+    context.addIssue({ code: 'custom', path: ['refreshRunId'], message: 'Refresh projections require both run ID and expected version' });
+  }
+  if (projection.operation === 'refresh' && (!hasRefreshId || !hasRefreshVersion)) {
+    context.addIssue({ code: 'custom', path: ['operation'], message: 'Refresh operations require their target context' });
+  }
+  if (projection.operation === 'initial' && (hasRefreshId || hasRefreshVersion)) {
+    context.addIssue({ code: 'custom', path: ['operation'], message: 'Initial operations cannot carry refresh context' });
+  }
+  if (!hasOnlyRedactedQueryValues(projection.requestedUrl)) {
+    context.addIssue({ code: 'custom', path: ['requestedUrl'], message: 'Capture projections require redacted query values' });
+  }
+  if (projection.summary && projection.summary.attemptId !== projection.attemptId) {
+    context.addIssue({ code: 'custom', path: ['summary'], message: 'Projection summary belongs to a different attempt' });
+  }
+  if (projection.summary && (projection.summary.state !== projection.state
+      || projection.summary.requestFingerprint !== projection.requestFingerprint
+      || projection.summary.requestedUrl !== projection.requestedUrl)) {
+    context.addIssue({ code: 'custom', path: ['summary'], message: 'Projection summary does not match its request and terminal state' });
+  }
+  if (isTerminal && !projection.summary && !(projection.state === 'failed' && projection.failure)) {
+    context.addIssue({ code: 'custom', path: ['summary'], message: 'Terminal capture projections require an immutable summary' });
+  }
+  if (!isTerminal && (projection.summary || projection.failure || projection.runId || projection.materializationFailure)) {
+    context.addIssue({ code: 'custom', path: ['state'], message: 'Non-terminal projections cannot expose terminal materialization fields' });
+  }
+  if (projection.state === 'failed' && !projection.summary && !projection.failure) {
+    context.addIssue({ code: 'custom', path: ['failure'], message: 'Interrupted projections require a safe failure' });
+  }
+  if (projection.materializationFailure && !projection.summary) {
+    context.addIssue({ code: 'custom', path: ['materializationFailure'], message: 'Materialization failures require retained immutable capture summary' });
+  }
+});
+
+export const ReviewHistoryEntrySchema = z.object({
+  decision: z.enum(['accepted', 'rejected']),
+  reviewer: z.string().min(1),
+  note: z.string().optional(),
+  decidedAt: z.string().datetime(),
+  receiptHash: Sha256Schema.optional(),
+  validity: z.enum(['current', 'stale']),
+  staledAt: z.string().datetime().optional(),
+  supersededByAttemptId: ImmutableIdSchema.optional(),
+  staleReason: z.enum(['source_refreshed', 'artifact_edited', 'review_superseded', 'legacy_unsealed']).optional(),
+}).superRefine((entry, context) => {
+  if (entry.validity === 'current' && !entry.receiptHash) {
+    context.addIssue({ code: 'custom', path: ['receiptHash'], message: 'Current review decisions require an immutable receipt' });
+  }
+  if (entry.validity === 'current' && (entry.staledAt || entry.staleReason || entry.supersededByAttemptId)) {
+    context.addIssue({ code: 'custom', path: ['validity'], message: 'Current review decisions cannot have stale metadata' });
+  }
+  if (entry.validity === 'stale' && (!entry.staledAt || !entry.staleReason)) {
+    context.addIssue({ code: 'custom', path: ['staledAt'], message: 'Stale review decisions require stale metadata' });
+  }
+  if (entry.validity === 'stale' && !entry.receiptHash && entry.staleReason !== 'legacy_unsealed') {
+    context.addIssue({ code: 'custom', path: ['receiptHash'], message: 'Only explicitly migrated legacy reviews may lack an immutable receipt' });
+  }
 });
 
 export const IntakeBundleSchema = z.object({
@@ -54,7 +234,7 @@ export const QuickNoteSchema = z.object({
   verifiedAt: z.string().datetime().optional(),
   verifiedBy: z.string().optional(),
   sources: z.array(z.object({
-    kind: z.enum(['venue-site', 'phone', 'email', 'visit', 'press', 'social', 'gov', 'partner']),
+    kind: z.enum(['unclassified-web', 'web', 'venue-site', 'phone', 'email', 'visit', 'press', 'social', 'gov', 'partner']),
     url: z.string().url().optional(),
     note: z.string().optional(),
     checkedAt: z.string().datetime().optional(),
@@ -63,13 +243,45 @@ export const QuickNoteSchema = z.object({
   body: z.string().min(1),
 });
 
+const ContentLineageSegmentSchema = z.object({
+  source: z.enum(['claim', 'system_template']),
+  claimId: z.string().min(1).optional(),
+  textHash: Sha256Schema,
+}).superRefine((segment, context) => {
+  if ((segment.source === 'claim') !== Boolean(segment.claimId)) {
+    context.addIssue({ code: 'custom', path: ['claimId'], message: 'Claim lineage requires exactly one claim identity' });
+  }
+});
+
+const ContentFieldLineageSchema = z.object({
+  contentHash: Sha256Schema,
+  segments: z.array(ContentLineageSegmentSchema).min(1),
+});
+
+export const RealUrlContentLineageSchema = z.object({
+  schemaVersion: z.literal('pi.real-url-content-lineage.v1'),
+  exportBindingHash: Sha256Schema,
+  headline: ContentFieldLineageSchema,
+  dek: ContentFieldLineageSchema,
+  body: ContentFieldLineageSchema,
+});
+
 export const ArtifactSchema = z.object({
   id: z.string().min(1),
   version: z.number().int().positive(),
   type: z.literal('quick_note'),
+  targetPath: z.string().regex(/^next\/src\/content\/quick-notes\/[a-z0-9][a-z0-9-]{0,119}\.md$/).optional(),
   claimIds: z.array(z.string()),
   angleId: z.string().min(1),
   payload: QuickNoteSchema,
+  contentLineage: RealUrlContentLineageSchema.optional(),
+  sourceReview: z.object({
+    sourceKind: z.enum(['web', 'venue-site', 'press', 'social', 'gov', 'partner']),
+    confirmedClaimIds: z.array(z.string().min(1)).min(1),
+    angleConfirmed: z.literal(true),
+    confirmedBy: z.string().min(1),
+    confirmedAt: z.string().datetime(),
+  }).optional(),
   gateResults: z.array(z.object({
     gate: z.string(),
     passed: z.boolean(),
@@ -87,9 +299,20 @@ export const ReviewDecisionSchema = z.object({
 export const ArtifactEditSchema = z.object({
   editor: z.string().min(1),
   expectedVersion: z.number().int().positive(),
-  headline: z.string().min(1).max(140),
+  headline: z.string().min(1).max(140).optional(),
   dek: z.string().max(320).optional(),
-  body: z.string().min(1),
+  body: z.string().min(1).optional(),
+  sourceKind: z.enum(['web', 'venue-site', 'press', 'social', 'gov', 'partner']).optional(),
+  claimIds: z.array(z.string().min(1)).min(1).optional(),
+  confirmAngle: z.boolean().optional(),
+}).superRefine((edit, context) => {
+  const supplied = [edit.sourceKind !== undefined, edit.claimIds !== undefined, edit.confirmAngle !== undefined];
+  if (supplied.some(Boolean) && !supplied.every(Boolean)) {
+    context.addIssue({ code: 'custom', path: ['sourceKind'], message: 'Source classification, claim selection and angle confirmation must be saved together' });
+  }
+  if (edit.confirmAngle === false) {
+    context.addIssue({ code: 'custom', path: ['confirmAngle'], message: 'Angle confirmation must be explicit' });
+  }
 });
 
 export const AuditEventSchema = z.object({
@@ -116,11 +339,56 @@ export const FoundryRunSchema = z.object({
     reviewer: z.string(),
     note: z.string().optional(),
     decidedAt: z.string().datetime(),
+    receiptHash: Sha256Schema,
   }).optional(),
+  reviewHistory: z.array(ReviewHistoryEntrySchema).default([]),
+  capture: RealUrlCaptureSchema.optional(),
   audit: z.array(AuditEventSchema),
+}).superRefine((run, context) => {
+  const isReviewedStatus = run.status === 'accepted' || run.status === 'rejected';
+  if (isReviewedStatus && (!run.review || run.review.decision !== run.status)) {
+    context.addIssue({ code: 'custom', path: ['status'], message: 'Reviewed status requires a matching current immutable review decision' });
+  }
+  if (!isReviewedStatus && run.review) {
+    context.addIssue({ code: 'custom', path: ['review'], message: 'A current review decision requires matching accepted or rejected status' });
+  }
+  const currentReviews = run.reviewHistory.filter((entry) => entry.validity === 'current');
+  if (currentReviews.length > 1 || (run.review && !currentReviews.some((entry) => (
+    entry.decision === run.review?.decision && entry.reviewer === run.review?.reviewer
+    && entry.decidedAt === run.review?.decidedAt && entry.receiptHash === run.review?.receiptHash
+  ))) || (!run.review && currentReviews.length > 0)) {
+    context.addIssue({ code: 'custom', path: ['reviewHistory'], message: 'Current review history must match the active review decision' });
+  }
+  if (!run.capture) return;
+  if (!run.artifact.contentLineage) {
+    context.addIssue({ code: 'custom', path: ['artifact', 'contentLineage'], message: 'Real URL artifacts require field-level immutable evidence lineage' });
+  }
+  const current = run.capture.revisions.find((revision) => revision.attemptId === run.capture?.currentAttemptId);
+  const artifactRevision = run.capture.revisions.find((revision) => revision.attemptId === run.capture?.artifactAttemptId);
+  if (!current || !artifactRevision) {
+    context.addIssue({ code: 'custom', path: ['capture', 'currentAttemptId'], message: 'Current capture attempt is missing from revision history' });
+    return;
+  }
+  if (artifactRevision.state !== 'extracted' || !artifactRevision.sourceRevision || !artifactRevision.extractionRevision) {
+    context.addIssue({ code: 'custom', path: ['capture'], message: 'Foundry artifacts require an extracted dependency revision' });
+    return;
+  }
+  if (!run.bundle.sourceItems.some((source) => source.id === artifactRevision.sourceRevision?.id)) {
+    context.addIssue({ code: 'custom', path: ['bundle', 'sourceItems'], message: 'Bundle must reference the current immutable source revision' });
+  }
+  run.claims.flatMap((claim) => claim.evidence).forEach((locator, index) => {
+    if (locator.locatorType !== 'extracted_block') return;
+    if (locator.sourceItemId !== artifactRevision.sourceRevision?.id
+      || locator.sourceRevisionId !== artifactRevision.sourceRevision?.id
+      || locator.extractionRevisionId !== artifactRevision.extractionRevision?.id) {
+      context.addIssue({ code: 'custom', path: ['claims', index, 'evidence'], message: 'Evidence must resolve against the current immutable extraction revision' });
+    }
+  });
 });
 
 export type FoundryRun = z.infer<typeof FoundryRunSchema>;
 export type ReviewDecision = z.infer<typeof ReviewDecisionSchema>;
 export type ArtifactEdit = z.infer<typeof ArtifactEditSchema>;
 export type Claim = z.infer<typeof ClaimSchema>;
+export type CaptureRevisionSummary = z.infer<typeof CaptureRevisionSummarySchema>;
+export type CaptureProjection = z.infer<typeof CaptureProjectionSchema>;

--- a/studio-peninsula-insider/shared/editorial-laws.ts
+++ b/studio-peninsula-insider/shared/editorial-laws.ts
@@ -1,0 +1,21 @@
+const CURRENCY_TOKEN = String.raw`(?:A\$|AU\$|NZ\$|US\$|[$€£¥₹]|\b(?:AUD|USD|NZD|EUR|GBP|CAD|SGD|JPY)\b)`;
+const MONEY_AMOUNT = String.raw`\d(?:[\d,]*(?:\.\d{1,2})?)?`;
+
+const PRICE_PATTERNS = Object.freeze([
+  new RegExp(String.raw`${CURRENCY_TOKEN}\s*${MONEY_AMOUNT}`, 'i'),
+  new RegExp(String.raw`${MONEY_AMOUNT}\s*(?:${CURRENCY_TOKEN}|dollars?|cents?|euros?|pounds?|yen|rupees?|bucks?)\b`, 'i'),
+  new RegExp(String.raw`${CURRENCY_TOKEN}`, 'i'),
+  /\b(?:dollars?|cents?|euros?|pounds?|yen|rupees?|bucks?)\b/i,
+  /\b(?:price|prices|priced|pricing|cost|costs|costing)\b/i,
+  /\b(?:charge|charges|charged|charging|surcharge|surcharges)\b/i,
+  /\bfees?\b/i,
+  /\b(?:free|complimentary|gratis)\b/i,
+]);
+
+export function containsPriceLanguage(value: string): boolean {
+  return PRICE_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function containsEmDash(value: string): boolean {
+  return value.includes('—');
+}

--- a/studio-peninsula-insider/src/App.tsx
+++ b/studio-peninsula-insider/src/App.tsx
@@ -1,126 +1,354 @@
-import { useEffect, useState } from 'react';
-import type { FoundryRun } from '../shared/contracts';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CaptureProjection, FoundryRun } from '../shared/contracts';
 
 const FIXTURE_ID = 'red-hill-winter-lunch';
+const TERMINAL_CAPTURE_STATES = new Set(['extracted', 'held', 'no_story', 'failed']);
+const SOURCE_KINDS = ['web', 'venue-site', 'press', 'social', 'gov', 'partner'] as const;
+
+interface Capabilities {
+  realUrlCapture?: { enabled?: boolean };
+  externalCalls?: boolean;
+}
+
+const captureCopy: Record<string, string> = {
+  queued: 'Capture queued locally.',
+  capturing: 'Checking the public destination and capturing one page.',
+  captured: 'Source stored as an immutable revision.',
+  extracting: 'Extracting inert text. Scripts and subresources are not run.',
+  extracted: 'Evidence is ready for review.',
+  held: 'Capture held by the safety policy.',
+  no_story: 'Captured safely, but no usable story text was found.',
+  failed: 'Capture failed safely. No automatic retry was made.',
+};
+
+function safeFailureCopy(code?: string): string {
+  if (!code) return 'The source could not be processed safely.';
+  if (code.startsWith('redirect_')) return 'A redirect left the allowed public HTTPS boundary.';
+  if (['https_required', 'port_blocked', 'credentials_blocked', 'special_use_hostname', 'non_public_address', 'source_mismatch'].includes(code)) {
+    return 'This URL is outside the local capture policy.';
+  }
+  if (code.startsWith('dns_')) return 'The public destination could not be verified.';
+  if (code.includes('timeout') || ['transport_failed', 'http_status'].includes(code)) return 'The source did not respond within capture limits.';
+  if (code.includes('oversize')) return 'The response exceeded the safe capture limit.';
+  if (code.includes('media_type') || code.includes('charset')) return 'The response format is not supported by the inert extractor.';
+  return 'The source could not be processed safely.';
+}
+
+function idempotencyKey(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function safeApiError(body: unknown, fallback: string): string {
+  const error = (body as { error?: unknown } | undefined)?.error;
+  if (typeof error === 'string') return error;
+  const code = (error as { code?: unknown } | undefined)?.code;
+  return typeof code === 'string' ? `${fallback} Code: ${code}` : fallback;
+}
 
 export function App() {
-  const [run, setRun] = useState<FoundryRun | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [runs, setRuns] = useState<FoundryRun[]>([]);
+  const [activeRunId, setActiveRunId] = useState('');
+  const [captures, setCaptures] = useState<CaptureProjection[]>([]);
+  const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [operation, setOperation] = useState<'fixture' | 'capture' | 'refresh' | 'save' | 'review' | ''>('');
   const [error, setError] = useState('');
+  const [pollError, setPollError] = useState('');
+  const [url, setUrl] = useState('');
   const [draft, setDraft] = useState({ headline: '', dek: '', body: '' });
+  const [sourceKind, setSourceKind] = useState('');
+  const [selectedClaimIds, setSelectedClaimIds] = useState<string[]>([]);
+  const [angleConfirmed, setAngleConfirmed] = useState(false);
+  const urlInput = useRef<HTMLInputElement>(null);
+
+  const realUrlsEnabled = capabilities?.realUrlCapture?.enabled === true;
+  const run = runs.find((candidate) => candidate.id === activeRunId) ?? runs[0] ?? null;
+  const activeCapture = captures.find((capture) => ['queued', 'capturing'].includes(capture.state));
+
+  function upsertRun(updated: FoundryRun) {
+    setRuns((current) => [updated, ...current.filter((candidate) => candidate.id !== updated.id)]);
+    setActiveRunId(updated.id);
+  }
+
+  async function loadRuns(preferredRunId?: string) {
+    const response = await fetch('/api/foundry/runs');
+    if (!response.ok) throw new Error('The run ledger is unavailable.');
+    const data = await response.json();
+    const nextRuns: FoundryRun[] = data.runs ?? [];
+    setRuns(nextRuns);
+    setActiveRunId((current) => preferredRunId ?? current ?? nextRuns[0]?.id ?? '');
+  }
+
+  async function loadCaptures(): Promise<CaptureProjection[]> {
+    const response = await fetch('/api/foundry/captures');
+    if (!response.ok) throw new Error('Capture status is temporarily unavailable.');
+    const data = await response.json();
+    const nextCaptures: CaptureProjection[] = data.captures ?? [];
+    setCaptures(nextCaptures);
+    return nextCaptures;
+  }
 
   useEffect(() => {
-    fetch('/api/foundry/runs')
-      .then((response) => response.json())
-      .then((data) => setRun(data.runs?.[0] ?? null))
-      .catch(() => setError('The local API is not available yet.'));
+    let cancelled = false;
+    Promise.all([
+      fetch('/api/capabilities').then((response) => response.ok ? response.json() : {}),
+      fetch('/api/foundry/runs').then((response) => response.ok ? response.json() : { runs: [] }),
+    ]).then(async ([rawCapabilityData, runData]) => {
+      if (cancelled) return;
+      const capabilityData = rawCapabilityData as Capabilities;
+      setCapabilities(capabilityData);
+      const nextRuns: FoundryRun[] = runData.runs ?? [];
+      setRuns(nextRuns);
+      setActiveRunId(nextRuns[0]?.id ?? '');
+      if (capabilityData?.realUrlCapture?.enabled === true) {
+        try { await loadCaptures(); } catch { setPollError('Status is temporarily unavailable. Retrying locally.'); }
+      }
+    }).catch(() => setError('The local Workbench API is not available yet.'))
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
   }, []);
 
   useEffect(() => {
+    if (!realUrlsEnabled || !captures.some((capture) => !TERMINAL_CAPTURE_STATES.has(capture.state))) return;
+    const timer = window.setInterval(async () => {
+      try {
+        const next = await loadCaptures();
+        setPollError('');
+        const completed = next.find((capture) => capture.runId && TERMINAL_CAPTURE_STATES.has(capture.state));
+        if (completed?.runId) await loadRuns(completed.runId);
+      } catch { setPollError('Status is temporarily unavailable. Retrying locally.'); }
+    }, 1_000);
+    return () => window.clearInterval(timer);
+  }, [realUrlsEnabled, captures.map((capture) => `${capture.id}:${capture.state}`).join('|')]);
+
+  useEffect(() => {
     if (!run) return;
-    setDraft({
-      headline: run.artifact.payload.headline,
-      dek: run.artifact.payload.dek ?? '',
-      body: run.artifact.payload.body,
-    });
+    setDraft({ headline: run.artifact.payload.headline, dek: run.artifact.payload.dek ?? '', body: run.artifact.payload.body });
+    setSelectedClaimIds(run.artifact.sourceReview?.confirmedClaimIds ?? run.artifact.claimIds);
+    setSourceKind(run.artifact.sourceReview?.sourceKind ?? '');
+    setAngleConfirmed(Boolean(run.artifact.sourceReview?.angleConfirmed));
   }, [run?.id, run?.artifact.version]);
 
-  async function startRun() {
-    setBusy(true);
-    setError('');
+  async function startFixture() {
+    setOperation('fixture'); setError('');
     try {
       const response = await fetch('/api/foundry/runs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Foundry-CSRF': '1' },
         body: JSON.stringify({ fixtureId: FIXTURE_ID, actor: 'local-editor', idempotencyKey: 'fixture-red-hill-v1' }),
       });
       if (!response.ok) throw new Error('The fixture run could not start.');
-      setRun(await response.json());
+      upsertRun(await response.json());
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'The fixture run failed.'); }
+    finally { setOperation(''); }
+  }
+
+  async function submitCapture(refresh = false) {
+    if (!url.trim()) {
+      setError('Enter one HTTPS source URL.');
+      urlInput.current?.focus();
+      return;
+    }
+    setOperation(refresh ? 'refresh' : 'capture'); setError('');
+    try {
+      const requestOptions: RequestInit = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Foundry-CSRF': '1', 'Idempotency-Key': idempotencyKey(refresh ? 'refresh' : 'capture') },
+        body: JSON.stringify({ url: url.trim(), actor: 'local-editor', ...(refresh && run ? { expectedVersion: run.version } : {}) }),
+      };
+      const response = refresh && run
+        ? await fetch(`/api/foundry/runs/${run.id}/refresh`, requestOptions)
+        : await fetch('/api/foundry/captures', requestOptions);
+      const body = await response.json();
+      if (!response.ok) throw new Error(`${safeFailureCopy(body.error?.code)} Code: ${body.error?.code ?? 'capture_failed'}`);
+      setCaptures((current) => [body, ...current.filter((capture) => capture.id !== body.id)]);
+      setUrl('');
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'The fixture run failed.');
-    } finally { setBusy(false); }
+      setError(cause instanceof Error ? cause.message : 'The capture request failed safely.');
+      urlInput.current?.focus();
+    } finally { setOperation(''); }
   }
 
   async function decide(decision: 'accepted' | 'rejected') {
     if (!run) return;
-    setBusy(true);
-    setError('');
+    setOperation('review'); setError('');
     try {
       const response = await fetch(`/api/foundry/runs/${run.id}/review`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        method: 'PUT', headers: { 'Content-Type': 'application/json', 'X-Foundry-CSRF': '1' },
         body: JSON.stringify({ decision, reviewer: 'local-editor', expectedVersion: run.version }),
       });
       const body = await response.json();
-      if (!response.ok) throw new Error(body.error ?? 'Review decision failed.');
-      setRun(body);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'Review decision failed.');
-    } finally { setBusy(false); }
+      if (!response.ok) throw new Error(safeApiError(body, 'Review decision failed.'));
+      upsertRun(body);
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'Review decision failed.'); }
+    finally { setOperation(''); }
   }
 
   async function saveDraft() {
     if (!run) return;
-    setBusy(true);
-    setError('');
+    setOperation('save'); setError('');
     try {
       const response = await fetch(`/api/foundry/runs/${run.id}/artifact`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...draft, editor: 'local-editor', expectedVersion: run.version }),
+        method: 'PUT', headers: { 'Content-Type': 'application/json', 'X-Foundry-CSRF': '1' },
+        body: JSON.stringify({
+          ...(!run.capture ? draft : {}), editor: 'local-editor', expectedVersion: run.version,
+          ...(run.capture ? { sourceKind, claimIds: selectedClaimIds, confirmAngle: angleConfirmed } : {}),
+        }),
       });
       const body = await response.json();
-      if (!response.ok) throw new Error(body.error ?? 'The draft could not be saved.');
-      setRun(body);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'The draft could not be saved.');
-    } finally { setBusy(false); }
+      if (!response.ok) throw new Error(safeApiError(body, 'The draft could not be saved.'));
+      upsertRun(body);
+    } catch (cause) { setError(cause instanceof Error ? cause.message : 'The draft could not be saved.'); }
+    finally { setOperation(''); }
   }
 
   const sourceById = new Map(run?.bundle.sourceItems.map((source) => [source.id, source]) ?? []);
-  const draftDirty = Boolean(run && (
-    draft.headline !== run.artifact.payload.headline
-    || draft.dek !== (run.artifact.payload.dek ?? '')
-    || draft.body !== run.artifact.payload.body
+  const draftDirty = Boolean(run && (draft.headline !== run.artifact.payload.headline
+    || draft.dek !== (run.artifact.payload.dek ?? '') || draft.body !== run.artifact.payload.body));
+  const sourceReviewDirty = Boolean(run?.capture && (
+    sourceKind !== (run.artifact.sourceReview?.sourceKind ?? '')
+    || angleConfirmed !== Boolean(run.artifact.sourceReview?.angleConfirmed)
+    || selectedClaimIds.join('|') !== (run.artifact.sourceReview?.confirmedClaimIds ?? run.artifact.claimIds).join('|')
   ));
-  const reviewBlocked = Boolean(run && (
-    run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed)
-  ));
+  const unsaved = draftDirty || sourceReviewDirty;
+  const reviewBlocked = Boolean(run && (run.blockers.length > 0 || run.artifact.gateResults.some((gate) => !gate.passed)
+    || (run.capture && run.capture.currentAttemptId !== run.capture.artifactAttemptId)));
+  const currentRevision = useMemo(() => run?.capture?.revisions.find((revision) => revision.attemptId === run.capture?.currentAttemptId), [run]);
+  const artifactRevision = useMemo(() => run?.capture?.revisions.find((revision) => revision.attemptId === run.capture?.artifactAttemptId), [run]);
+  const latestStaleReview = run?.reviewHistory.filter((entry) => entry.validity === 'stale').at(-1);
 
   return (
     <main>
       <header className="masthead">
         <div className="wordmark"><span>Peninsula</span> <strong>Insider</strong></div>
-        <div className="environment">PRIVATE WORKBENCH · FIXTURE MODE</div>
+        <div className="environment">PRIVATE WORKBENCH · LOOPBACK ONLY · NO PUBLISH</div>
       </header>
 
       <section className="hero">
-        <p className="eyebrow">Content Foundry v0.1</p>
+        <p className="eyebrow">Content Foundry v0.2</p>
         <h1>Evidence first. One source, many useful outputs.</h1>
-        <p>Start with a frozen local fixture, inspect every claim, then make a human review decision. Nothing publishes from this screen.</p>
-        <button onClick={startRun} disabled={busy}>{run ? 'Replay fixture safely' : 'Run the first fixture'}</button>
+        <p>Capture one bounded source, inspect every claim, then make a human review decision. Nothing publishes from this screen.</p>
+      </section>
+
+      <section className="intake panel" aria-labelledby="source-intake-title">
+        <div className="panel-heading">
+          <h2 id="source-intake-title">Source intake</h2>
+          <span className={`capability ${realUrlsEnabled ? 'on' : 'off'}`}>Real URL capture {realUrlsEnabled ? 'on' : 'off'}</span>
+        </div>
+        <div className="intake-grid">
+          <div>
+            <h3>Frozen fixture</h3>
+            <p>Deterministic and offline. Replays the original review workflow without an external call.</p>
+            <button className="secondary" onClick={startFixture} disabled={Boolean(operation)}>{operation === 'fixture' ? 'Starting fixture...' : 'Run fixture'}</button>
+          </div>
+          <form onSubmit={(event) => { event.preventDefault(); void submitCapture(false); }}>
+            <h3>Real URL capture</h3>
+            <label className="url-field" htmlFor="source-url">HTTPS source URL</label>
+            <div className="url-row">
+              <input ref={urlInput} id="source-url" type="url" required inputMode="url" autoCapitalize="none" autoCorrect="off" spellCheck={false}
+                value={url} onChange={(event) => setUrl(event.target.value)} disabled={!realUrlsEnabled || Boolean(activeCapture)}
+                aria-describedby="source-url-help" aria-invalid={error.startsWith('Enter one HTTPS') || undefined} placeholder="https://example.com/page" />
+              <button type="submit" disabled={!realUrlsEnabled || Boolean(operation) || Boolean(activeCapture)}>
+                {operation === 'capture' ? 'Starting capture...' : 'Capture URL'}
+              </button>
+            </div>
+            <p id="source-url-help">{realUrlsEnabled
+              ? 'HTTPS only, port 443. One page. Redirects are checked. Saved query values are redacted.'
+              : 'Real URL capture is off. Enable FOUNDRY_REAL_URLS_ENABLED=1 only in the native loopback runtime.'}</p>
+          </form>
+        </div>
       </section>
 
       {error && <div className="notice error" role="alert">{error}</div>}
-      {!run && <section className="empty"><h2>No run yet</h2><p>The first deterministic package is ready to prove the full review spine.</p></section>}
+      {pollError && <div className="notice warning" role="status">{pollError}</div>}
+      {activeCapture && <div className="capture-live" role="status" aria-live="polite"><strong>{captureCopy[activeCapture.state]}</strong></div>}
+
+      {realUrlsEnabled && captures.length > 0 && <section className="capture-history panel" aria-labelledby="capture-history-title">
+        <div className="panel-heading"><h2 id="capture-history-title">Capture activity</h2><span>{captures.length} attempt{captures.length === 1 ? '' : 's'}</span></div>
+        <div className="capture-list">
+          {captures.map((capture) => {
+            const code = capture.materializationFailure?.code ?? capture.summary?.failure?.code ?? capture.summary?.outcomeReason?.code ?? capture.failure?.code;
+            return <article className={`capture-row state-${capture.state}`} key={capture.id}>
+              <div><span className={`pill ${capture.state}`}>{capture.state.replaceAll('_', ' ')}</span><strong>{capture.materializationFailure
+                ? 'Capture is immutable, but its workflow projection needs operator recovery.'
+                : captureCopy[capture.state]}</strong></div>
+              <p className="safe-url">{capture.requestedUrl}</p>
+              {code && <p>{safeFailureCopy(code)} <code>{code}</code></p>}
+              {!capture.summary?.sourceRevision && TERMINAL_CAPTURE_STATES.has(capture.state) && <small>No source revision was created.</small>}
+            </article>;
+          })}
+        </div>
+      </section>}
+
+      {loading && <section className="empty" role="status"><h2>Loading Workbench</h2><p>Reading the local run and capture ledgers.</p></section>}
+      {!loading && !run && <section className="empty"><h2>No run yet</h2><p>Use the frozen fixture, or enable the bounded local URL capability.</p></section>}
 
       {run && <>
+        <div className="run-select-row">
+          <label htmlFor="active-run">Visible run</label>
+          <select id="active-run" value={run.id} onChange={(event) => setActiveRunId(event.target.value)}>
+            {runs.map((candidate) => <option value={candidate.id} key={candidate.id}>{candidate.capture ? 'URL' : 'Fixture'} · {candidate.id}</option>)}
+          </select>
+        </div>
         <section className="runbar" aria-live="polite">
           <div><span>RUN</span><strong>{run.id}</strong></div>
           <div><span>STATUS</span><strong className={`status ${run.status}`}>{run.status.replaceAll('_', ' ')}</strong></div>
           <div><span>VERSION</span><strong>{run.version}</strong></div>
-          <div><span>EXTERNAL CALLS</span><strong>None</strong></div>
+          <div><span>NETWORK</span><strong>{run.capture ? 'One bounded HTTPS capture' : 'None'}</strong></div>
         </section>
+
+        {run.capture && currentRevision && artifactRevision && <section className="provenance panel" aria-labelledby="provenance-title">
+          <div className="panel-heading"><h2 id="provenance-title">Source provenance</h2><span>{run.capture.revisions.length} immutable revision{run.capture.revisions.length === 1 ? '' : 's'}</span></div>
+          {latestStaleReview && <div className="notice warning">Review stale: the source head changed after this decision. Review current evidence and approve again.</div>}
+          {run.capture.currentAttemptId !== run.capture.artifactAttemptId && <div className="notice warning">
+            The current source head contains no usable story text. The draft still depends on the previous revision and cannot be approved or downloaded.
+          </div>}
+          <dl className="provenance-grid">
+            <div><dt>Requested URL</dt><dd>{currentRevision.requestedUrl}</dd></div>
+            <div><dt>Freshness</dt><dd>Current source head</dd></div>
+            <div><dt>Captured</dt><dd>{new Date(currentRevision.completedAt).toLocaleString('en-AU')}</dd></div>
+            <div><dt>Capture attempt</dt><dd>{currentRevision.attemptId}</dd></div>
+            {currentRevision.sourceRevision && <>
+              <div><dt>Canonical URL</dt><dd>{currentRevision.sourceRevision.canonicalUrl}</dd></div>
+              <div><dt>Source revision</dt><dd>{currentRevision.sourceRevision.id}</dd></div>
+              <div><dt>Response</dt><dd>{currentRevision.sourceRevision.status} · {currentRevision.sourceRevision.mediaType} · {currentRevision.sourceRevision.decodedBytes.toLocaleString()} bytes</dd></div>
+              <div><dt>Content hash</dt><dd>{currentRevision.sourceRevision.contentHash}</dd></div>
+            </>}
+            {currentRevision.extractionRevision && <>
+              <div><dt>Extraction revision</dt><dd>{currentRevision.extractionRevision.id}</dd></div>
+              <div><dt>Extractor</dt><dd>{currentRevision.extractionRevision.extractorVersion} · {currentRevision.extractionRevision.blockCount} blocks</dd></div>
+            </>}
+            {artifactRevision.attemptId !== currentRevision.attemptId && <div><dt>Draft dependency</dt><dd>{artifactRevision.attemptId} · superseded</dd></div>}
+          </dl>
+          <details><summary>Capture timeline ({currentRevision.events.length} states)</summary>
+            <ol>{currentRevision.events.map((event, index) => <li key={`${event.state}-${index}`}><strong>{event.state.replaceAll('_', ' ')}</strong> · {new Date(event.at).toLocaleString('en-AU')}</li>)}</ol>
+          </details>
+          {currentRevision.redirects.length > 0 && <details><summary>Redirect chain ({currentRevision.redirects.length})</summary>
+            <ol>{currentRevision.redirects.map((redirect, index) => <li key={`${redirect.url}-${index}`}><code>{redirect.status}</code> {redirect.url} → {redirect.location}</li>)}</ol>
+          </details>}
+          <div className="restrictions"><h3>Restrictions</h3><ul>{currentRevision.restrictions.map((restriction) => <li key={restriction}>{restriction}</li>)}</ul></div>
+          <div className="refresh-control">
+            <p><strong>Capture new revision</strong><br />Creates a new immutable source revision. Any review tied to the current revision will become stale.</p>
+            <button className="secondary" onClick={() => void submitCapture(true)} disabled={Boolean(operation) || Boolean(activeCapture) || !url.trim()}>
+              {operation === 'refresh' ? 'Starting revision...' : 'Create revision using URL above'}
+            </button>
+          </div>
+        </section>}
 
         <div className="workspace-grid">
           <section className="panel">
-            <div className="panel-heading"><h2 className="eyebrow">Claim ledger</h2><span>{run.claims.length} claims</span></div>
+            <div className="panel-heading"><h2>Claim ledger</h2><span>{run.claims.length} claims</span></div>
+            {run.capture && <p className="trust-note">Supported means reproduced from this captured source. It does not mean independently verified.</p>}
             {run.claims.map((claim) => <article className="claim" key={claim.id}>
-              <div className="claim-top"><span className={`pill ${claim.verification}`}>{claim.verification}</span>{claim.restrictedFromArtifacts && <span className="pill restricted">held</span>}</div>
+              <div className="claim-top">
+                {run.capture && <input type="checkbox" aria-label={`Select source assertion: ${claim.text.slice(0, 80)}`}
+                  checked={selectedClaimIds.includes(claim.id)} disabled={claim.restrictedFromArtifacts}
+                  onChange={(event) => setSelectedClaimIds((current) => event.target.checked ? [...current, claim.id] : current.filter((id) => id !== claim.id))} />}
+                <span className={`pill ${claim.verification}`}>{run.capture ? 'source-supported' : claim.verification}</span>
+                {claim.restrictedFromArtifacts && <span className="pill restricted">held</span>}
+              </div>
               <p>{claim.text}</p>
               <small>{claim.origin.replaceAll('_', ' ')} · {claim.evidence.length} evidence locator{claim.evidence.length === 1 ? '' : 's'}</small>
-              {claim.evidence.length > 0 && <details className="evidence-detail">
-                <summary>Inspect evidence</summary>
+              {claim.evidence.length > 0 && <details className="evidence-detail"><summary>Inspect inert evidence</summary>
                 {claim.evidence.map((item) => {
                   const source = sourceById.get(item.sourceItemId);
                   return <div className="evidence-item" key={`${item.sourceItemId}-${item.locator}`}>
@@ -128,7 +356,8 @@ export function App() {
                     <dl>
                       <div><dt>Locator</dt><dd>{item.locatorType}: {item.locator}</dd></div>
                       <div><dt>Captured</dt><dd>{new Date(item.capturedAt).toLocaleString('en-AU')}</dd></div>
-                      <div><dt>Source</dt><dd>{source?.uri ? <a href={source.uri} target="_blank" rel="noreferrer">{source.uri}</a> : item.sourceItemId}</dd></div>
+                      {item.extractionRevisionId && <div><dt>Extraction</dt><dd>{item.extractionRevisionId}</dd></div>}
+                      <div><dt>Source</dt><dd>{source?.uri ?? item.sourceItemId}</dd></div>
                     </dl>
                   </div>;
                 })}
@@ -138,32 +367,29 @@ export function App() {
           </section>
 
           <section className="panel artifact-panel">
-            <div className="panel-heading"><h2 className="eyebrow">Quick-note draft</h2><span>Draft only</span></div>
+            <div className="panel-heading"><h2>Quick-note draft</h2><span>Draft only</span></div>
+            {run.capture && <div className="source-review">
+              <p>Real-source public copy is locked to the selected immutable assertions. Change the claim selection, then save to regenerate every factual segment.</p>
+              <label>Source classification<select value={sourceKind} onChange={(event) => setSourceKind(event.target.value)}>
+                <option value="">Choose a source type</option>{SOURCE_KINDS.map((kind) => <option value={kind} key={kind}>{kind}</option>)}
+              </select></label>
+              <label className="confirm-row"><input type="checkbox" checked={angleConfirmed} onChange={(event) => setAngleConfirmed(event.target.checked)} />
+                I confirm the selected source assertions and this source-led angle for human review.</label>
+            </div>}
             <p className="section-label">{run.artifact.payload.section} · {run.artifact.payload.tag}</p>
-            <label className="editor-field">
-              <span>Headline</span>
-              <textarea rows={2} value={draft.headline} onChange={(event) => setDraft({ ...draft, headline: event.target.value })} />
-            </label>
-            <label className="editor-field">
-              <span>Dek</span>
-              <textarea rows={3} value={draft.dek} onChange={(event) => setDraft({ ...draft, dek: event.target.value })} />
-            </label>
-            <label className="editor-field body-field">
-              <span>Body</span>
-              <textarea rows={7} value={draft.body} onChange={(event) => setDraft({ ...draft, body: event.target.value })} />
-            </label>
-            <div className="gates">
-              {run.artifact.gateResults.map((gate) => <div key={gate.gate} className={gate.passed ? 'gate pass' : 'gate fail'}>
-                <strong>{gate.passed ? 'PASS' : 'BLOCK'}</strong><span>{gate.gate.replaceAll('_', ' ')}</span>
-              </div>)}
-            </div>
-            {draftDirty && <div className="notice unsaved" role="status">Unsaved changes are not reviewed. Save them before approving a draft handoff.</div>}
+            <label className="editor-field"><span>Headline</span><textarea rows={2} value={draft.headline} readOnly={Boolean(run.capture)} onChange={(event) => setDraft({ ...draft, headline: event.target.value })} /></label>
+            <label className="editor-field"><span>Dek</span><textarea rows={3} value={draft.dek} readOnly={Boolean(run.capture)} onChange={(event) => setDraft({ ...draft, dek: event.target.value })} /></label>
+            <label className="editor-field body-field"><span>Body</span><textarea rows={7} value={draft.body} readOnly={Boolean(run.capture)} onChange={(event) => setDraft({ ...draft, body: event.target.value })} /></label>
+            <div className="gates">{run.artifact.gateResults.map((gate) => <div key={gate.gate} className={gate.passed ? 'gate pass' : 'gate fail'}>
+              <strong>{gate.passed ? 'PASS' : 'BLOCK'}</strong><span>{gate.gate.replaceAll('_', ' ')}</span>
+            </div>)}</div>
+            {unsaved && <div className="notice unsaved" role="status">Unsaved changes are not reviewed. Save them before approving a draft handoff.</div>}
             <div className="actions">
-              <button className="secondary" onClick={saveDraft} disabled={busy || !draftDirty}>Save changes</button>
-              <button className="secondary" onClick={() => decide('rejected')} disabled={busy}>Reject</button>
-              <button onClick={() => decide('accepted')} disabled={busy || draftDirty || reviewBlocked}>Approve draft handoff</button>
+              <button className="secondary" onClick={saveDraft} disabled={Boolean(operation) || !unsaved || (Boolean(run.capture) && (!sourceKind || !angleConfirmed || selectedClaimIds.length === 0))}>Save changes</button>
+              <button className="secondary" onClick={() => decide('rejected')} disabled={Boolean(operation) || Boolean(activeCapture)}>Reject</button>
+              <button onClick={() => decide('accepted')} disabled={Boolean(operation) || Boolean(activeCapture) || unsaved || reviewBlocked}>Approve draft handoff</button>
             </div>
-            {run.status === 'accepted' && !draftDirty && <a className="download" href={`/api/foundry/runs/${run.id}/patch`}>Download reviewed patch</a>}
+            {run.status === 'accepted' && !activeCapture && !unsaved && !reviewBlocked && <a className="download" href={`/api/foundry/runs/${run.id}/patch`}>Download reviewed patch</a>}
           </section>
         </div>
       </>}

--- a/studio-peninsula-insider/src/styles.css
+++ b/studio-peninsula-insider/src/styles.css
@@ -15,11 +15,11 @@
 
 * { box-sizing: border-box; }
 body { margin: 0; min-width: 320px; min-height: 100vh; }
-button, a { font: inherit; }
-button { border: 0; border-radius: 999px; background: #0b2e4a; color: white; padding: 0.8rem 1.25rem; font-weight: 700; cursor: pointer; }
-button:disabled { opacity: 0.55; cursor: wait; }
+button, a, input, select, textarea { font: inherit; }
+button { min-height: 44px; border: 0; border-radius: 999px; background: #0b2e4a; color: white; padding: 0.8rem 1.25rem; font-weight: 700; cursor: pointer; }
+button:disabled { opacity: 0.55; cursor: not-allowed; }
 button.secondary { background: transparent; color: #0b2e4a; border: 1px solid #9ca7ae; }
-button:focus-visible, a:focus-visible { outline: 3px solid #10527e; outline-offset: 3px; }
+button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, summary:focus-visible { outline: 3px solid #10527e; outline-offset: 3px; }
 
 main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding-bottom: 64px; }
 .masthead { min-height: 78px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #cfcac2; }
@@ -29,11 +29,12 @@ main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding-bottom: 64
 .environment { color: #53636e; }
 .hero { padding: 72px 0 48px; max-width: 780px; }
 .hero .eyebrow { color: #10527e; }
-h1, h2 { font-family: Sora, Figtree, sans-serif; letter-spacing: -0.045em; margin: 0; }
+h1, h2 { font-family: Sora, Figtree, sans-serif; letter-spacing: -0.04em; margin: 0; }
 h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .hero > p:not(.eyebrow) { max-width: 650px; font-size: 1.15rem; line-height: 1.65; color: #53636e; margin: 1.5rem 0; }
 .notice, .empty { padding: 24px; border-radius: 16px; border: 1px solid #cfcac2; background: #fbfaf8; }
 .notice.error { border-color: #b84135; color: #8f2f28; }
+.notice.warning { border-color: #d9a340; background: #fff7e5; color: #6d4c12; }
 .notice.unsaved { margin-top: 14px; padding: 12px 14px; border-color: #d9a340; background: #fff7e5; color: #6d4c12; font-size: 0.82rem; }
 .empty p { color: #53636e; }
 .runbar { display: grid; grid-template-columns: 1.4fr 1fr 0.6fr 1fr; gap: 1px; background: #cfcac2; border: 1px solid #cfcac2; border-radius: 14px; overflow: hidden; margin-bottom: 18px; }
@@ -44,7 +45,7 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .status.accepted { color: #1d6d54; }
 .status.needs_revision, .status.rejected, .status.failed { color: #a33c32; }
 .workspace-grid { display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.3fr); gap: 18px; align-items: start; }
-.panel { background: #fbfaf8; border: 1px solid #d7d1c8; border-radius: 18px; padding: 24px; }
+.panel { background: #fbfaf8; border: 1px solid #d7d1c8; border-radius: 16px; padding: 24px; }
 .panel-heading { display: flex; align-items: baseline; justify-content: space-between; border-bottom: 1px solid #ded9d1; padding-bottom: 14px; margin-bottom: 16px; }
 .panel-heading .eyebrow { margin: 0; color: #10527e; }
 .panel-heading > span { color: #53636e; font-size: 0.82rem; }
@@ -55,11 +56,11 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .claim-top { display: flex; gap: 6px; }
 .pill { display: inline-flex; border-radius: 999px; padding: 4px 8px; background: #e4ede8; color: #1d6d54; font-size: 0.68rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; }
 .pill.unsupported, .pill.conflicted, .pill.restricted { background: #f3dfda; color: #8f2f28; }
-.restriction { border-left: 3px solid #b84135; margin-top: 10px; padding: 8px 10px; background: #f8ebe7; color: #7b332d; font-size: 0.82rem; line-height: 1.4; }
+.restriction { border: 1px solid #d9a49d; border-radius: 8px; margin-top: 10px; padding: 8px 10px; background: #f8ebe7; color: #7b332d; font-size: 0.82rem; line-height: 1.4; }
 .evidence-detail { margin-top: 12px; border: 1px solid #ded9d1; border-radius: 10px; background: white; }
 .evidence-detail summary { cursor: pointer; padding: 10px 12px; color: #10527e; font-size: 0.78rem; font-weight: 800; }
 .evidence-item { padding: 0 12px 12px; }
-.evidence-item blockquote { margin: 4px 0 12px; padding-left: 10px; border-left: 3px solid #f5c177; color: #374b58; font: 0.92rem/1.5 Figtree, sans-serif; }
+.evidence-item blockquote { margin: 4px 0 12px; padding: 10px 12px; border: 1px solid #e6c994; border-radius: 8px; background: #fffaf0; color: #374b58; font: 0.92rem/1.5 Figtree, sans-serif; overflow-wrap: anywhere; }
 .evidence-item dl { margin: 0; display: grid; gap: 5px; font-size: 0.72rem; }
 .evidence-item dl div { display: grid; grid-template-columns: 66px minmax(0, 1fr); gap: 6px; }
 .evidence-item dt { color: #53636e; font-weight: 800; text-transform: uppercase; }
@@ -80,10 +81,76 @@ h1 { font-size: clamp(2.7rem, 7vw, 5.5rem); line-height: 0.98; }
 .actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 10px; margin-top: 24px; }
 .download { display: block; margin-top: 16px; text-align: center; color: #0b2e4a; font-weight: 800; }
 
+.intake { margin-bottom: 18px; }
+.intake-grid { display: grid; grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.25fr); gap: 24px; }
+.intake-grid > div { padding-right: 24px; border-right: 1px solid #ded9d1; }
+.intake h3, .provenance h3 { margin: 0 0 8px; font: 700 1rem/1.3 Sora, Figtree, sans-serif; }
+.intake p, .refresh-control p, .trust-note { color: #53636e; line-height: 1.5; }
+.capability { padding: 5px 9px; border-radius: 999px; font-weight: 800; font-size: 0.72rem; }
+.capability.on { background: #e4ede8; color: #225d49; }
+.capability.off { background: #e7e4de; color: #53636e; }
+.url-field { display: block; margin: 14px 0 7px; color: #53636e; font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; }
+.url-row { display: flex; gap: 10px; }
+.url-row input, .run-select-row select, .source-review select { min-height: 44px; border: 1px solid #aaa39a; border-radius: 9px; background: white; color: #14202a; padding: 0 12px; }
+.url-row input { min-width: 0; flex: 1; }
+.url-row input:disabled { background: #eeeae4; color: #687781; }
+.capture-live { margin: 14px 0; border: 1px solid #7da3bb; border-radius: 12px; background: #eaf3f7; color: #164762; padding: 14px 16px; }
+.capture-history { margin-bottom: 18px; }
+.capture-list { display: grid; gap: 10px; }
+.capture-row { display: grid; gap: 6px; padding: 14px; border: 1px solid #ded9d1; border-radius: 10px; }
+.capture-row > div { display: flex; align-items: center; gap: 10px; }
+.capture-row p, .capture-row small { margin: 0; line-height: 1.45; }
+.capture-row small { color: #53636e; }
+.safe-url { color: #374b58; overflow-wrap: anywhere; }
+.capture-row code { color: #53636e; font-size: 0.78rem; }
+.pill.queued, .pill.capturing { background: #eaf3f7; color: #164762; }
+.pill.held, .pill.no_story { background: #fff0ce; color: #6d4c12; }
+.pill.failed { background: #f3dfda; color: #8f2f28; }
+.run-select-row { display: flex; justify-content: flex-end; align-items: center; gap: 10px; margin: 20px 0 10px; }
+.run-select-row label { color: #53636e; font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.09em; }
+.run-select-row select { max-width: min(100%, 420px); }
+.provenance { margin: 0 0 18px; }
+.provenance-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; margin: 0; border: 1px solid #ded9d1; border-radius: 10px; background: #ded9d1; overflow: hidden; }
+.provenance-grid div { min-width: 0; background: white; padding: 12px; }
+.provenance-grid dt { color: #53636e; font-size: 0.68rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+.provenance-grid dd { margin: 4px 0 0; overflow-wrap: anywhere; font-size: 0.88rem; line-height: 1.45; }
+.provenance > details { margin-top: 14px; }
+.provenance > details summary { min-height: 44px; display: flex; align-items: center; color: #10527e; font-weight: 800; cursor: pointer; }
+.provenance > details li { margin: 8px 0; overflow-wrap: anywhere; }
+.restrictions { margin-top: 18px; }
+.restrictions ul { margin-bottom: 0; padding-left: 20px; color: #53636e; }
+.restrictions li { margin: 7px 0; line-height: 1.45; }
+.refresh-control { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-top: 18px; padding-top: 18px; border-top: 1px solid #ded9d1; }
+.refresh-control p { margin: 0; }
+.trust-note { margin-top: 0; padding: 10px 12px; border-radius: 8px; background: #eaf3f7; color: #164762; }
+.claim-top input, .confirm-row input { inline-size: 20px; block-size: 20px; accent-color: #10527e; }
+.source-review { display: grid; gap: 14px; padding: 14px; border: 1px solid #d6c38f; border-radius: 10px; background: #fffaf0; }
+.source-review label:not(.confirm-row) { display: grid; gap: 7px; color: #53636e; font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; }
+.source-review select { width: 100%; text-transform: none; letter-spacing: 0; }
+.confirm-row { display: flex; align-items: flex-start; gap: 10px; color: #374b58; line-height: 1.45; }
+.artifact-panel { min-width: 0; }
+
 @media (max-width: 820px) {
   .environment { display: none; }
   .hero { padding-top: 48px; }
   .runbar { grid-template-columns: 1fr 1fr; }
   .workspace-grid { grid-template-columns: 1fr; }
   .gates { grid-template-columns: 1fr; }
+  .intake-grid { grid-template-columns: 1fr; }
+  .intake-grid > div { padding: 0 0 20px; border: 0; border-bottom: 1px solid #ded9d1; }
+  .provenance-grid { grid-template-columns: 1fr; }
+  .refresh-control { align-items: stretch; flex-direction: column; }
+  .url-row { align-items: stretch; flex-direction: column; }
+  .run-select-row { align-items: stretch; flex-direction: column; }
+  .run-select-row select { max-width: none; }
+}
+
+@media (max-width: 480px) {
+  main { width: min(100% - 20px, 1180px); padding-bottom: 36px; }
+  .masthead { min-height: 64px; }
+  .hero { padding: 36px 0 30px; }
+  h1 { font-size: clamp(2.25rem, 13vw, 3.2rem); }
+  .panel { padding: 18px; }
+  .runbar { grid-template-columns: 1fr; }
+  .panel-heading { align-items: flex-start; flex-direction: column; gap: 7px; }
 }

--- a/studio-peninsula-insider/tests/capture-kernel.test.ts
+++ b/studio-peninsula-insider/tests/capture-kernel.test.ts
@@ -1,15 +1,23 @@
 import { gzipSync } from 'node:zlib';
 import { link, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { CaptureAttemptSchema, CaptureRecordSchema, type CaptureRecord } from '../shared/capture-contracts.js';
 import { ContentAddressedBlobStore, sha256 } from '../server/capture/blob-store.js';
 import { ImmutableFileStore } from '../server/capture/filesystem.js';
-import { createEvidenceLocator, resolveEvidenceLocator } from '../server/capture/extractor.js';
+import {
+  MAX_EXTRACTION_BLOCKS,
+  MAX_EXTRACTION_BLOCK_CHARS,
+  createEvidenceLocator,
+  extractBlocks,
+  resolveEvidenceLocator,
+} from '../server/capture/extractor.js';
 import { CaptureDisabledError, CaptureIdempotencyConflictError, CaptureKernel, realUrlCaptureEnabled } from '../server/capture/kernel.js';
 import { canonicalizeCaptureUrl, isPublicAddress, type DnsResolver, type ResolvedAddress } from '../server/capture/policy.js';
 import { FileCaptureRepository } from '../server/capture/repository.js';
+import { createPinnedHttpsTransport } from '../server/capture/transport.js';
 import type { CaptureTransport, TransportRequest, TransportResponse } from '../server/capture/transport-contract.js';
 
 const temporaryDirectories: string[] = [];
@@ -92,6 +100,36 @@ afterEach(async () => {
 });
 
 describe('sealed CaptureKernel policy', () => {
+  it('disables family autoselection so the real transport reaches exactly one pinned loopback address', async () => {
+    let acceptedConnections = 0;
+    const server = createServer((socket) => {
+      acceptedConnections += 1;
+      socket.destroy();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Expected a loopback TCP address');
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 2_000);
+      const error = await createPinnedHttpsTransport().request({
+        url: new URL(`https://offline.invalid:${address.port}/`),
+        pinnedAddress: { address: '127.0.0.1', family: 4 },
+        maxHeaderBytes: 1_024,
+        signal: controller.signal,
+      }).then(() => undefined, (reason: NodeJS.ErrnoException) => reason);
+      clearTimeout(timeout);
+      expect(error).toBeTruthy();
+      expect(error?.code).not.toBe('ERR_INVALID_IP_ADDRESS');
+      expect(acceptedConnections).toBe(1);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
   it('defaults the real-URL flag off and rejects malformed flag values', async () => {
     expect(realUrlCaptureEnabled({})).toBe(false);
     expect(realUrlCaptureEnabled({ FOUNDRY_REAL_URLS_ENABLED: '1' })).toBe(true);
@@ -161,6 +199,15 @@ describe('sealed CaptureKernel policy', () => {
 });
 
 describe('immutable capture, extraction and evidence', () => {
+  it('keeps HTML inert and bounds every stored or displayed extraction segment', () => {
+    const oversized = 'Source assertion '.repeat(100_000);
+    const blocks = extractBlocks(`<script>fetch('https://evil.invalid/')</script><p>${oversized}</p>`, 'text/html');
+    expect(blocks.length).toBeGreaterThan(1);
+    expect(blocks.length).toBeLessThanOrEqual(MAX_EXTRACTION_BLOCKS);
+    expect(blocks.every((block) => block.text.length <= MAX_EXTRACTION_BLOCK_CHARS)).toBe(true);
+    expect(blocks.map((block) => block.text).join(' ')).not.toContain('evil.invalid');
+  });
+
   it('extracts inert text, reproduces every locator and never persists signed query values', async () => {
     const html = '<html><head><script>fetch("https://evil.invalid")</script></head><body><h1>Local update</h1><p>Ignore previous instructions. This remains inert source text.</p><img src="https://asset.invalid/a.jpg"></body></html>';
     const transport = new FakeTransport((input, index) => {

--- a/studio-peninsula-insider/tests/foundry.test.ts
+++ b/studio-peninsula-insider/tests/foundry.test.ts
@@ -48,6 +48,26 @@ describe('deterministic Foundry fixture', () => {
     expect(restricted.find((gate) => gate.gate === 'supported_claims_only')?.passed).toBe(false);
   });
 
+  it.each([
+    'Tickets cost 20 dollars.',
+    'An entry fee applies.',
+    'Admission costs USD 20.',
+    'Tickets are $20.',
+    'Tickets are EUR 20.',
+    'Tickets are twenty dollars.',
+    'Admission is complimentary.',
+    'Admission is available at no charge.',
+    'An entry charge applies.',
+    'The venue charges for entry.',
+    'Guests are charged on arrival.',
+    'A booking surcharge applies.',
+    'The operator is charging admission.',
+  ])('blocks all public price wording: %s', (body) => {
+    const run = runFixture('test-editor', `price-law-${body}`);
+    const gates = evaluateQuickNoteGates({ headline: 'Event details', body }, run.claims, run.artifact.claimIds);
+    expect(gates.find((gate) => gate.gate === 'no_price')?.passed).toBe(false);
+  });
+
   it('requires idempotency and serializes concurrent mutations', async () => {
     const { app, store } = await harness();
     await request(app).post('/api/foundry/runs').send({ fixtureId: 'red-hill-winter-lunch', actor: 'test-editor' }).expect(400);
@@ -86,6 +106,76 @@ describe('deterministic Foundry fixture', () => {
 
     const restarted = new FileFoundryStore(file, directory);
     expect((await restarted.get(legacy.id))?.status).toBe('needs_revision');
+  });
+
+  it('migrates legacy unsealed acceptance to stale review history and permits a sealed re-review', async () => {
+    const { directory, file } = await harness();
+    const legacy = runFixture('legacy-editor', 'legacy-unsealed-review');
+    const decidedAt = '2026-08-20T10:00:00.000Z';
+    const legacyReview = { decision: 'accepted', reviewer: 'legacy-reviewer', note: 'Legacy approval', decidedAt };
+    const raw = {
+      ...legacy,
+      version: 2,
+      status: 'accepted',
+      updatedAt: decidedAt,
+      review: legacyReview,
+      reviewHistory: [{ ...legacyReview, validity: 'current' }],
+    };
+    await writeFile(file, `${JSON.stringify({ schemaVersion: 'pi.foundry-file-store.v1', runs: [raw] })}\n`, 'utf8');
+
+    const restarted = new FileFoundryStore(file, directory);
+    const migrated = await restarted.get(legacy.id);
+    expect(migrated).toMatchObject({ status: 'needs_revision', review: undefined });
+    expect(migrated?.reviewHistory).toEqual([expect.objectContaining({
+      decision: 'accepted', reviewer: 'legacy-reviewer', note: 'Legacy approval',
+      validity: 'stale', staleReason: 'legacy_unsealed', staledAt: decidedAt,
+    })]);
+    expect(migrated?.reviewHistory[0].receiptHash).toBeUndefined();
+    const resealed = await restarted.review(legacy.id, {
+      decision: 'accepted', reviewer: 'current-reviewer', expectedVersion: 2,
+    });
+    expect(resealed.status).toBe('accepted');
+    expect(resealed.review?.receiptHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(resealed.reviewHistory).toHaveLength(2);
+  });
+
+  it('migrates every receipt-less v1 stale review without changing its non-reviewed status', async () => {
+    const { directory, file } = await harness();
+    const legacy = runFixture('legacy-editor', 'legacy-unsealed-stale-review');
+    const decidedAt = '2026-08-19T10:00:00.000Z';
+    const staledAt = '2026-08-20T10:00:00.000Z';
+    const raw = {
+      ...legacy,
+      status: 'ready_for_review',
+      updatedAt: staledAt,
+      review: undefined,
+      reviewHistory: [{
+        decision: 'accepted', reviewer: 'legacy-reviewer', note: 'Superseded legacy approval', decidedAt,
+        validity: 'stale', staledAt, staleReason: 'artifact_edited',
+      }],
+    };
+    await writeFile(file, `${JSON.stringify({ schemaVersion: 'pi.foundry-file-store.v1', runs: [raw] })}\n`, 'utf8');
+
+    const migrated = await new FileFoundryStore(file, directory).get(legacy.id);
+    expect(migrated?.status).toBe('ready_for_review');
+    expect(migrated?.review).toBeUndefined();
+    expect(migrated?.reviewHistory).toEqual([expect.objectContaining({
+      decision: 'accepted', reviewer: 'legacy-reviewer', note: 'Superseded legacy approval', decidedAt,
+      validity: 'stale', staledAt, staleReason: 'legacy_unsealed',
+    })]);
+    expect(migrated?.reviewHistory[0].receiptHash).toBeUndefined();
+  });
+
+  it('fails closed when a v2 review loses its immutable receipt reference', async () => {
+    const { directory, file, store } = await harness();
+    const created = await store.create(runFixture('editor', 'v2-missing-review-receipt'));
+    await store.review(created.id, { decision: 'accepted', reviewer: 'reviewer', expectedVersion: created.version });
+    const persisted = JSON.parse(await readFile(file, 'utf8'));
+    delete persisted.runs[0].review.receiptHash;
+    delete persisted.runs[0].reviewHistory[0].receiptHash;
+    await writeFile(file, `${JSON.stringify(persisted)}\n`, 'utf8');
+
+    await expect(new FileFoundryStore(file, directory).get(created.id)).rejects.toThrow(/immutable receipt/);
   });
 
   it('versions edits, invalidates approval and blocks restricted copy', async () => {

--- a/studio-peninsula-insider/tests/real-url.test.ts
+++ b/studio-peninsula-insider/tests/real-url.test.ts
@@ -1,0 +1,924 @@
+import { createHash } from 'node:crypto';
+import { link, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import request from 'supertest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createApp } from '../server/app.js';
+import { captureRequestIdentity, type CaptureInput } from '../server/capture/kernel.js';
+import { FileCaptureRepository } from '../server/capture/repository.js';
+import { buildExtractionRevision, extractBlocks } from '../server/capture/extractor.js';
+import { loadRuntimeConfig } from '../server/config.js';
+import { buildPatch, evaluateQuickNoteGates, runFixture } from '../server/fixture-runner.js';
+import { RealUrlCoordinator, type CaptureKernelPort, type CaptureRepositoryPort } from '../server/real-url-coordinator.js';
+import { buildRealUrlArtifactBinding } from '../server/real-url-lineage.js';
+import { FileReviewReceiptRepository } from '../server/review-receipts.js';
+import { FileFoundryStore } from '../server/store.js';
+import { CaptureRecordSchema, type CaptureRecord } from '../shared/capture-contracts.js';
+
+const temporaryDirectories: string[] = [];
+const hash = (value: string | Uint8Array) => createHash('sha256').update(value).digest('hex');
+const csrf = { 'x-foundry-csrf': '1' };
+
+function recordFor(input: CaptureInput, options: {
+  state?: 'extracted' | 'no_story' | 'held' | 'failed';
+  text?: string;
+  redirect?: boolean;
+  failureCode?: string;
+} = {}): CaptureRecord {
+  const identity = captureRequestIdentity(input);
+  const state = options.state ?? 'extracted';
+  const createdAt = '2026-08-21T08:00:00.000Z';
+  const completedAt = '2026-08-21T08:00:01.000Z';
+  const redirects = options.redirect ? [{
+    url: identity.safeRequestedUrl,
+    status: 302,
+    location: 'https://private.invalid/',
+  }] : [];
+  if (state === 'failed') return CaptureRecordSchema.parse({
+    schemaVersion: 'pi.capture-manifest.v1',
+    attempt: {
+      schemaVersion: 'pi.capture-attempt.v1',
+      id: identity.attemptId,
+      idempotencyKeyHash: identity.idempotencyKeyHash,
+      requestFingerprint: identity.requestFingerprint,
+      requestedUrl: identity.safeRequestedUrl,
+      createdAt,
+      completedAt,
+      state,
+      events: [{ state: 'queued', at: createdAt }, { state: 'capturing', at: createdAt }, { state: 'failed', at: completedAt, detail: options.failureCode ?? 'non_public_address' }],
+      redirects,
+      failure: { stage: 'dns', code: options.failureCode ?? 'non_public_address', message: 'blocked 169.254.169.254 internal detail' },
+    },
+  });
+  if (state === 'held') return CaptureRecordSchema.parse({
+    schemaVersion: 'pi.capture-manifest.v1',
+    attempt: {
+      schemaVersion: 'pi.capture-attempt.v1',
+      id: identity.attemptId,
+      idempotencyKeyHash: identity.idempotencyKeyHash,
+      requestFingerprint: identity.requestFingerprint,
+      requestedUrl: identity.safeRequestedUrl,
+      createdAt,
+      completedAt,
+      state,
+      events: [{ state: 'queued', at: createdAt }, { state: 'capturing', at: createdAt }, { state: 'held', at: completedAt, detail: 'raw event secret 10.0.0.1' }],
+      redirects,
+      outcomeReason: { code: 'unsupported_media_type', detail: 'Unsafe raw detail' },
+    },
+  });
+
+  const text = state === 'no_story' ? '' : (options.text ?? 'Example Domain\n\nThis source assertion is safe for a human-reviewed note.');
+  const blocks = extractBlocks(text, 'text/plain');
+  const sourceId = `source-${hash(`${identity.attemptId}:source`).slice(0, 24)}`;
+  const extractionId = `extract-${hash(`${identity.attemptId}:extract`).slice(0, 24)}`;
+  const sourceHash = hash(text);
+  const extraction = buildExtractionRevision({
+    id: extractionId,
+    attemptId: identity.attemptId,
+    sourceRevisionId: sourceId,
+    extractedAt: completedAt,
+    sourceContentBlobHash: sourceHash,
+    extractedTextBlobHash: hash(blocks.map((block) => block.text).join('\n\n')),
+    blocks,
+  });
+  return CaptureRecordSchema.parse({
+    schemaVersion: 'pi.capture-manifest.v1',
+    attempt: {
+      schemaVersion: 'pi.capture-attempt.v1',
+      id: identity.attemptId,
+      idempotencyKeyHash: identity.idempotencyKeyHash,
+      requestFingerprint: identity.requestFingerprint,
+      requestedUrl: identity.safeRequestedUrl,
+      createdAt,
+      completedAt,
+      state,
+      events: [
+        { state: 'queued', at: createdAt },
+        { state: 'capturing', at: createdAt },
+        { state: 'captured', at: completedAt },
+        { state: 'extracting', at: completedAt },
+        { state, at: completedAt },
+      ],
+      redirects,
+      sourceRevisionId: sourceId,
+      extractionRevisionId: extractionId,
+      outcomeReason: state === 'no_story' ? { code: 'no_extractable_text', detail: 'No extractable text' } : undefined,
+    },
+    sourceRevision: {
+      schemaVersion: 'pi.source-revision.v1',
+      id: sourceId,
+      attemptId: identity.attemptId,
+      requestedUrl: identity.safeRequestedUrl,
+      canonicalUrl: identity.safeRequestedUrl,
+      capturedAt: completedAt,
+      status: 200,
+      mediaType: 'text/plain',
+      charset: 'utf-8',
+      contentEncoding: 'identity',
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      redirects: [],
+      resolvedAddresses: ['93.184.216.34'],
+      selectedAddress: '93.184.216.34',
+      remoteAddress: '93.184.216.34',
+      wireBlobHash: sourceHash,
+      contentBlobHash: sourceHash,
+      wireBytes: Buffer.byteLength(text),
+      decodedBytes: Buffer.byteLength(text),
+    },
+    extractionRevision: extraction,
+  });
+}
+
+class FakeKernel implements CaptureKernelPort {
+  calls = 0;
+  constructor(private readonly factory: (input: CaptureInput, call: number) => Promise<CaptureRecord> | CaptureRecord) {}
+  async capture(input: CaptureInput): Promise<CaptureRecord> {
+    this.calls += 1;
+    return this.factory(input, this.calls);
+  }
+}
+
+class FakeRepository implements CaptureRepositoryPort {
+  constructor(readonly records = new Map<string, CaptureRecord>()) {}
+  async get(attemptId: string) { return this.records.get(attemptId); }
+}
+
+async function harness(kernel: FakeKernel, repository = new FakeRepository()) {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-real-url-'));
+  temporaryDirectories.push(directory);
+  const file = join(directory, 'runs.json');
+  const store = new FileFoundryStore(file, directory, repository);
+  const committingKernel: CaptureKernelPort = {
+    capture: async (input) => {
+      const record = await kernel.capture(input);
+      repository.records.set(record.attempt.id, record);
+      return record;
+    },
+  };
+  const coordinator = new RealUrlCoordinator(store, committingKernel, repository);
+  const app = createApp(store, { realUrlsEnabled: true, coordinator });
+  return { directory, file, store, coordinator, app, repository };
+}
+
+async function waitForTerminal(coordinator: RealUrlCoordinator, projectionId: string) {
+  await coordinator.waitForIdle(projectionId);
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe('local real URL vertical slice', () => {
+  it('fails closed when disabled and requires loopback when enabled', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pi-real-url-off-'));
+    temporaryDirectories.push(directory);
+    const store = new FileFoundryStore(join(directory, 'runs.json'), directory);
+    const app = createApp(store);
+    const capabilities = await request(app).get('/api/capabilities').expect(200);
+    expect(capabilities.body.realUrlCapture.enabled).toBe(false);
+    expect(capabilities.body.externalCalls).toBe(false);
+    await request(app).post('/api/foundry/captures').send({ url: 'https://example.com/' }).expect(404);
+    expect(() => loadRuntimeConfig({ NODE_ENV: 'test', FOUNDRY_REAL_URLS_ENABLED: '1', FOUNDRY_HOST: '0.0.0.0' })).toThrow(/native loopback/);
+    expect(() => loadRuntimeConfig({ NODE_ENV: 'production', FOUNDRY_REAL_URLS_ENABLED: '1' })).toThrow(/disabled in production/);
+    expect(() => loadRuntimeConfig({ NODE_ENV: 'test', FOUNDRY_REAL_URLS_ENABLED: 'yes' })).toThrow(/must be 0 or 1/);
+    expect(() => createApp(store, {
+      realUrlsEnabled: true,
+      coordinator: {} as RealUrlCoordinator,
+    })).toThrow(/immutable manifest validation/);
+  });
+
+  it('requires loopback Host, same origin and a CSRF header before capture', async () => {
+    const { store, coordinator } = await harness(new FakeKernel((input) => recordFor(input)));
+    const app = createApp(store, { realUrlsEnabled: true, coordinator, expectedHost: '127.0.0.1:4310' });
+    const body = { url: 'https://example.com/', actor: 'editor', idempotencyKey: 'origin-gate' };
+    await request(app).post('/api/foundry/captures').set('Host', 'evil.example').set(csrf).send(body).expect(403);
+    await request(app).post('/api/foundry/captures').set('Host', '127.0.0.1:4310').set('Origin', 'https://evil.example').set(csrf).send(body).expect(403);
+    await request(app).post('/api/foundry/captures').set('Host', '127.0.0.1:4310').send(body).expect(403);
+    await request(app).get('/api/health').set('Host', '127.0.0.1:4310').expect(200);
+    for (const path of ['/api/health', '/api/capabilities', '/api/foundry/captures', '/api/foundry/runs', '/']) {
+      await request(app).get(path).set('Host', 'evil.example').expect(403);
+    }
+    await request(app).get('/api/health').set('Host', '127.0.0.1:9999').expect(403);
+    await request(app).post('/api/foundry/runs').set('Host', '127.0.0.1:4310').send({ fixtureId: 'red-hill-winter-lunch' }).expect(403);
+  });
+
+  it('binds each idempotency key to one URL and allows only one active capture', async () => {
+    let release!: (record: CaptureRecord) => void;
+    const deferred = new Promise<CaptureRecord>((resolve) => { release = resolve; });
+    const kernel = new FakeKernel(() => deferred);
+    const { app, coordinator } = await harness(kernel);
+    const first = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'one-key',
+    }).expect(202);
+    await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'one-key',
+    }).expect(200);
+    await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.org/', actor: 'editor', idempotencyKey: 'one-key',
+    }).expect(409).expect(({ body }) => expect(body.error.code).toBe('idempotency_conflict'));
+    await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.org/', actor: 'editor', idempotencyKey: 'second-key',
+    }).expect(409).expect(({ body }) => expect(body.error.code).toBe('capture_busy'));
+    release(recordFor({ url: 'https://example.com/', idempotencyKey: 'one-key' }));
+    await waitForTerminal(coordinator, first.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${first.body.id}`).expect(200)).body;
+    const run = (await request(app).get(`/api/foundry/runs/${projection.runId}`).expect(200)).body;
+    await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'one-key', expectedVersion: run.version,
+    }).expect(409).expect(({ body }) => expect(body.error.code).toBe('idempotency_conflict'));
+    expect(kernel.calls).toBe(1);
+  });
+
+  it('persists capturing before outbound completion, then materializes one run', async () => {
+    let release!: (record: CaptureRecord) => void;
+    const deferred = new Promise<CaptureRecord>((resolve) => { release = resolve; });
+    const kernel = new FakeKernel(() => deferred);
+    const { app, store, coordinator } = await harness(kernel);
+    const started = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/?token=secret', actor: 'editor', idempotencyKey: 'persisted-capturing',
+    }).expect(202);
+    expect(started.body.state).toBe('capturing');
+    expect((await store.getCaptureProjection(started.body.id))?.state).toBe('capturing');
+    release(recordFor({ url: 'https://example.com/?token=secret', idempotencyKey: 'persisted-capturing' }));
+    await waitForTerminal(coordinator, started.body.id);
+    const terminal = await request(app).get(`/api/foundry/captures/${started.body.id}`).expect(200);
+    expect(terminal.body.state).toBe('extracted');
+    expect(terminal.body.requestedUrl).not.toContain('secret');
+    expect(terminal.text).not.toContain('93.184.216.34');
+    expect(await store.list()).toHaveLength(1);
+    expect(kernel.calls).toBe(1);
+  });
+
+  it('keeps safe held, no-story and redirect-private outcomes visible without leaking internals', async () => {
+    const kernel = new FakeKernel((input, call) => call === 1
+      ? recordFor(input, { state: 'held' })
+      : call === 2
+        ? recordFor(input, { state: 'no_story' })
+        : recordFor(input, { state: 'failed', redirect: true, failureCode: 'redirect_non_public_address' }));
+    const { app, coordinator } = await harness(kernel);
+    for (const key of ['held-outcome', 'no-story-outcome', 'redirect-private-outcome']) {
+      const started = await request(app).post('/api/foundry/captures').set(csrf).send({
+        url: 'https://example.com/', actor: 'editor', idempotencyKey: key,
+      }).expect(202);
+      await waitForTerminal(coordinator, started.body.id);
+    }
+    const listed = await request(app).get('/api/foundry/captures').expect(200);
+    expect(listed.body.captures.map((item: { state: string }) => item.state).sort()).toEqual(['failed', 'held', 'no_story']);
+    expect(listed.text).toContain('redirect_non_public_address');
+    expect(listed.text).toContain('https://private.invalid/');
+    expect(listed.text).not.toContain('169.254.169.254');
+    expect(listed.text).not.toContain('raw event secret');
+    expect(listed.text).not.toContain('10.0.0.1');
+    expect(listed.text).not.toContain('Unsafe raw detail');
+    expect(listed.body.captures.every((item: { runId?: string }) => !item.runId)).toBe(true);
+  });
+
+  it('marks ordinary price, fee, currency-code and symbol assertions restricted at ingestion', async () => {
+    const kernel = new FakeKernel((input) => recordFor(input, {
+      text: 'Tickets cost 20 dollars.\n\nAn entry fee applies.\n\nAdmission costs AUD 20.\n\nTickets are $20.\n\nAdmission is available at no charge.\n\nA booking surcharge applies.',
+    }));
+    const { app, coordinator } = await harness(kernel);
+    const started = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'restricted-price-copy',
+    }).expect(202);
+    await waitForTerminal(coordinator, started.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${started.body.id}`)).body;
+    const run = (await request(app).get(`/api/foundry/runs/${projection.runId}`)).body;
+    expect(run.claims).toHaveLength(6);
+    expect(run.claims.every((claim: { restrictedFromArtifacts: boolean; restrictionReason?: string }) => claim.restrictedFromArtifacts
+      && claim.restrictionReason === 'PI outputs do not publish prices.')).toBe(true);
+    expect(run.artifact.claimIds).toEqual([]);
+  });
+
+  it('requires human source classification and claim/angle confirmation before review and patch', async () => {
+    const kernel = new FakeKernel((input) => recordFor(input));
+    const { app, coordinator, repository } = await harness(kernel);
+    const started = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/?signature=top-secret', actor: 'editor', idempotencyKey: 'reviewed-url',
+    }).expect(202);
+    await waitForTerminal(coordinator, started.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${started.body.id}`).expect(200)).body;
+    const created = (await request(app).get(`/api/foundry/runs/${projection.runId}`).expect(200)).body;
+    expect(created.status).toBe('needs_revision');
+    expect(created.artifact.gateResults.find((gate: { gate: string }) => gate.gate === 'human_source_review').passed).toBe(false);
+    for (const unsupported of [
+      { headline: 'The venue seats 500 guests' },
+      { dek: 'It opens seven days a week.' },
+      { body: 'The venue seats 500 guests and opens seven days a week.' },
+    ]) {
+      await request(app).put(`/api/foundry/runs/${created.id}/artifact`).set(csrf).send({
+        editor: 'editor', expectedVersion: created.version,
+        sourceKind: 'web', claimIds: created.artifact.claimIds, confirmAngle: true,
+        ...unsupported,
+      }).expect(400).expect(({ body, text }) => {
+        expect(body.error.code).toBe('request_failed');
+        expect(text).not.toContain(Object.values(unsupported)[0]);
+      });
+    }
+    const edited = await request(app).put(`/api/foundry/runs/${created.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: created.version,
+      sourceKind: 'web', claimIds: created.artifact.claimIds, confirmAngle: true,
+    }).expect(200);
+    expect(edited.body.status).toBe('ready_for_review');
+    const accepted = await request(app).put(`/api/foundry/runs/${created.id}/review`).set(csrf).send({
+      decision: 'accepted', reviewer: 'editor', expectedVersion: edited.body.version,
+    }).expect(200);
+    const patch = await request(app).get(`/api/foundry/runs/${created.id}/patch`).expect(200);
+    expect(patch.text).toContain('kind: web');
+    expect(patch.text).toContain('url: "https://example.com/?signature=%5Bredacted%5D"');
+    expect(patch.text).not.toContain('top-secret');
+    expect(accepted.body.reviewHistory.at(-1).validity).toBe('current');
+    expect(() => buildPatch({
+      ...accepted.body,
+      artifact: {
+        ...accepted.body.artifact,
+        payload: { ...accepted.body.artifact.payload, body: 'The venue seats 500 guests.' },
+      },
+    }, repository.records.get(accepted.body.capture.artifactAttemptId))).toThrow(/binding/i);
+  });
+
+  it('rejects persisted real-source copy that no longer matches immutable lineage at review', async () => {
+    const kernel = new FakeKernel((input) => recordFor(input));
+    const { app, coordinator, file } = await harness(kernel);
+    const started = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'tampered-lineage',
+    }).expect(202);
+    await waitForTerminal(coordinator, started.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${started.body.id}`)).body;
+    const created = (await request(app).get(`/api/foundry/runs/${projection.runId}`)).body;
+    const edited = (await request(app).put(`/api/foundry/runs/${created.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: created.version,
+      sourceKind: 'web', claimIds: [created.artifact.claimIds[0]], confirmAngle: true,
+    }).expect(200)).body;
+    const persisted = JSON.parse(await readFile(file, 'utf8'));
+    persisted.runs[0].artifact.payload.body = 'Unsupported persisted factual copy.';
+    await writeFile(file, `${JSON.stringify(persisted)}\n`, 'utf8');
+    await request(app).put(`/api/foundry/runs/${created.id}/review`).set(csrf).send({
+      decision: 'accepted', reviewer: 'editor', expectedVersion: edited.version,
+    }).expect(400).expect(({ body, text }) => {
+      expect(body.error.code).toBe('request_failed');
+      expect(text).not.toContain('Unsupported persisted factual copy');
+    });
+  });
+
+  it('rejects forged export metadata, immutable summaries, source items, claims and evidence on every persisted path', async () => {
+    const kernel = new FakeKernel((input) => recordFor(input, {
+      text: 'First immutable source assertion.\n\nSecond immutable source assertion.',
+    }));
+    const { app, coordinator, file, directory, repository } = await harness(kernel);
+    const started = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'immutable-integrity',
+    }).expect(202);
+    await waitForTerminal(coordinator, started.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${started.body.id}`)).body;
+    const created = (await request(app).get(`/api/foundry/runs/${projection.runId}`)).body;
+    const edited = (await request(app).put(`/api/foundry/runs/${created.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: created.version,
+      sourceKind: 'web', claimIds: [created.artifact.claimIds[0]], confirmAngle: true,
+    }).expect(200)).body;
+    await request(app).put(`/api/foundry/runs/${created.id}/review`).set(csrf).send({
+      decision: 'accepted', reviewer: 'editor', expectedVersion: edited.version,
+    }).expect(200);
+    const original = JSON.parse(await readFile(file, 'utf8'));
+    const findRun = (data: typeof original) => data.runs.find((run: { id: string }) => run.id === created.id);
+
+    const flagOffStore = new FileFoundryStore(file, directory, repository);
+    const flagOffApp = createApp(flagOffStore);
+    await request(flagOffApp).get('/api/capabilities').expect(200).expect(({ body }) => {
+      expect(body.realUrlCapture.enabled).toBe(false);
+      expect(body.externalCalls).toBe(false);
+    });
+    await request(flagOffApp).get('/api/foundry/runs').expect(200)
+      .expect(({ body }) => expect(body.runs.some((run: { id: string }) => run.id === created.id)).toBe(true));
+    await request(flagOffApp).get('/api/foundry/captures').expect(404);
+
+    const unavailableResolver: CaptureRepositoryPort = { get: async () => { throw new Error('resolver unavailable internal detail'); } };
+    const unavailableStore = new FileFoundryStore(file, directory, unavailableResolver);
+    const unavailableApp = createApp(unavailableStore, {
+      realUrlsEnabled: true,
+      coordinator: new RealUrlCoordinator(unavailableStore, new FakeKernel(() => { throw new Error('must not capture'); }), unavailableResolver),
+    });
+    await request(unavailableApp).get(`/api/foundry/runs/${created.id}/patch`).expect(400).expect(({ body, text }) => {
+      expect(body.error.code).toBe('request_failed');
+      expect(text).not.toContain('resolver unavailable internal detail');
+    });
+
+    const projectionForgery = structuredClone(original);
+    projectionForgery.captureProjections.find((item: { id: string }) => item.id === started.body.id)
+      .summary.sourceRevision.contentHash = hash('fabricated-projection');
+    await writeFile(file, `${JSON.stringify(projectionForgery)}\n`, 'utf8');
+    await expect(new FileFoundryStore(file, directory, repository).getCaptureProjection(started.body.id))
+      .rejects.toThrow(/capture projection/);
+
+    const metadataForgery = structuredClone(original);
+    const forgedMetadata = findRun(metadataForgery);
+    forgedMetadata.artifact.payload = {
+      ...forgedMetadata.artifact.payload,
+      section: 'eat', tag: 'event',
+      publishedAt: '2039-01-01T00:00:00.000Z', expiresAt: '2039-01-08T00:00:00.000Z',
+      verifiedAt: '2039-01-01T00:00:00.000Z', verifiedBy: 'attacker',
+      sources: [{ kind: 'partner', url: 'https://attacker.example/fabricated-source', checkedAt: '2039-01-01T00:00:00.000Z', note: 'fabricated' }],
+    };
+    forgedMetadata.artifact.targetPath = 'next/src/content/quick-notes/2039-01-01-fabricated-source.md';
+    forgedMetadata.artifact.contentLineage.exportBindingHash = hash(JSON.stringify({
+      payload: forgedMetadata.artifact.payload,
+      targetPath: forgedMetadata.artifact.targetPath,
+      claimIds: forgedMetadata.artifact.claimIds,
+    }));
+    await writeFile(file, `${JSON.stringify(metadataForgery)}\n`, 'utf8');
+    const metadataStore = new FileFoundryStore(file, directory, repository);
+    const metadataApp = createApp(metadataStore, {
+      realUrlsEnabled: true,
+      coordinator: new RealUrlCoordinator(metadataStore, new FakeKernel(() => { throw new Error('must not capture'); }), repository),
+    });
+    await expect(metadataStore.get(created.id)).rejects.toThrow(/export binding/);
+    await request(metadataApp).put(`/api/foundry/runs/${created.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: 3, sourceKind: 'web', claimIds: created.artifact.claimIds, confirmAngle: true,
+    }).expect(400).expect(({ body }) => expect(body.error.code).toBe('request_failed'));
+    await request(metadataApp).put(`/api/foundry/runs/${created.id}/review`).set(csrf).send({
+      decision: 'accepted', reviewer: 'editor', expectedVersion: 3,
+    }).expect(400).expect(({ body }) => expect(body.error.code).toBe('request_failed'));
+    await request(metadataApp).get(`/api/foundry/runs/${created.id}/patch`).expect(400)
+      .expect(({ body }) => expect(body.error.code).toBe('request_failed'));
+
+    const sourceReviewForgery = structuredClone(original);
+    const forgedReview = findRun(sourceReviewForgery);
+    forgedReview.artifact.sourceReview = {
+      ...forgedReview.artifact.sourceReview,
+      sourceKind: 'partner', confirmedBy: 'attacker', confirmedAt: '2039-01-01T00:00:00.000Z',
+    };
+    const reviewDependency = forgedReview.capture.revisions.find((revision: { attemptId: string }) => revision.attemptId === forgedReview.capture.artifactAttemptId);
+    const reviewBinding = buildRealUrlArtifactBinding(forgedReview.claims, forgedReview.artifact.claimIds, {
+      canonicalUrl: reviewDependency.sourceRevision.canonicalUrl,
+      capturedAt: reviewDependency.sourceRevision.capturedAt,
+      contentHash: reviewDependency.sourceRevision.contentHash,
+    }, 'partner');
+    forgedReview.artifact.payload = reviewBinding.payload;
+    forgedReview.artifact.targetPath = reviewBinding.targetPath;
+    forgedReview.artifact.contentLineage = reviewBinding.lineage;
+    forgedReview.artifact.gateResults = evaluateQuickNoteGates(
+      forgedReview.artifact.payload, forgedReview.claims, forgedReview.artifact.claimIds,
+      { requireSourceReview: true, sourceReviewComplete: true },
+    );
+    await writeFile(file, `${JSON.stringify(sourceReviewForgery)}\n`, 'utf8');
+    await expect(new FileFoundryStore(file, directory, repository).get(created.id)).rejects.toThrow(/review receipt/);
+
+    const statusOnlyForgery = structuredClone(original);
+    const statusOnly = findRun(statusOnlyForgery);
+    statusOnly.status = 'accepted';
+    statusOnly.review = undefined;
+    statusOnly.reviewHistory = [];
+    await writeFile(file, `${JSON.stringify(statusOnlyForgery)}\n`, 'utf8');
+    const statusOnlyStore = new FileFoundryStore(file, directory, repository);
+    const statusOnlyApp = createApp(statusOnlyStore, {
+      realUrlsEnabled: true,
+      coordinator: new RealUrlCoordinator(statusOnlyStore, new FakeKernel(() => { throw new Error('must not capture'); }), repository),
+    });
+    await expect(statusOnlyStore.get(created.id)).rejects.toThrow(/matching current immutable review/);
+    await request(statusOnlyApp).get(`/api/foundry/runs/${created.id}/patch`).expect(400)
+      .expect(({ body }) => expect(body.error.code).toBe('invalid_request'));
+
+    await writeFile(file, `${JSON.stringify(original)}\n`, 'utf8');
+    const rejectedStore = new FileFoundryStore(file, directory, repository);
+    const rejectedRun = await rejectedStore.review(created.id, {
+      decision: 'rejected', reviewer: 'second-reviewer', expectedVersion: findRun(original).version,
+    });
+    const rejectedStatusForgery = JSON.parse(await readFile(file, 'utf8'));
+    findRun(rejectedStatusForgery).status = 'accepted';
+    await writeFile(file, `${JSON.stringify(rejectedStatusForgery)}\n`, 'utf8');
+    const forgedRejectedStore = new FileFoundryStore(file, directory, repository);
+    const forgedRejectedApp = createApp(forgedRejectedStore, {
+      realUrlsEnabled: true,
+      coordinator: new RealUrlCoordinator(forgedRejectedStore, new FakeKernel(() => { throw new Error('must not capture'); }), repository),
+    });
+    expect(rejectedRun.status).toBe('rejected');
+    await expect(forgedRejectedStore.get(created.id)).rejects.toThrow(/matching current immutable review/);
+    await request(forgedRejectedApp).get(`/api/foundry/runs/${created.id}/patch`).expect(400)
+      .expect(({ body }) => expect(body.error.code).toBe('invalid_request'));
+
+    const claimSwitchForgery = structuredClone(original);
+    const switched = findRun(claimSwitchForgery);
+    const alternateClaim = switched.claims.find((claim: { id: string; restrictedFromArtifacts?: boolean }) => !switched.artifact.claimIds.includes(claim.id)
+      && !claim.restrictedFromArtifacts);
+    expect(alternateClaim).toBeTruthy();
+    if (!alternateClaim) throw new Error('Expected an alternate immutable claim');
+    switched.artifact.claimIds = [alternateClaim.id];
+    switched.angle.evidenceClaimIds = [alternateClaim.id];
+    switched.artifact.sourceReview.confirmedClaimIds = [alternateClaim.id];
+    const switchDependency = switched.capture.revisions.find((revision: { attemptId: string }) => revision.attemptId === switched.capture.artifactAttemptId);
+    const switchBinding = buildRealUrlArtifactBinding(switched.claims, switched.artifact.claimIds, {
+      canonicalUrl: switchDependency.sourceRevision.canonicalUrl,
+      capturedAt: switchDependency.sourceRevision.capturedAt,
+      contentHash: switchDependency.sourceRevision.contentHash,
+    }, switched.artifact.sourceReview.sourceKind);
+    switched.artifact.payload = switchBinding.payload;
+    switched.artifact.targetPath = switchBinding.targetPath;
+    switched.artifact.contentLineage = switchBinding.lineage;
+    switched.artifact.gateResults = evaluateQuickNoteGates(
+      switched.artifact.payload, switched.claims, switched.artifact.claimIds,
+      { requireSourceReview: true, sourceReviewComplete: true },
+    );
+    await writeFile(file, `${JSON.stringify(claimSwitchForgery)}\n`, 'utf8');
+    const switchedStore = new FileFoundryStore(file, directory, repository);
+    await expect(switchedStore.get(created.id)).rejects.toThrow(/review receipt/);
+    const switchedApp = createApp(switchedStore, {
+      realUrlsEnabled: true,
+      coordinator: new RealUrlCoordinator(switchedStore, new FakeKernel(() => { throw new Error('must not capture'); }), repository),
+    });
+    await request(switchedApp).get(`/api/foundry/runs/${created.id}/patch`).expect(400)
+      .expect(({ body }) => expect(body.error.code).toBe('request_failed'));
+
+    for (const mutate of [
+      (run: typeof forgedMetadata) => { run.claims[0].evidence[0].locator = 'block:999999'; },
+      (run: typeof forgedMetadata) => { run.claims[0].evidence[0].excerpt = 'Fabricated excerpt.'; },
+      (run: typeof forgedMetadata) => { run.claims[0].evidence[0].excerptHash = hash('Fabricated excerpt.'); },
+    ]) {
+      const evidenceForgery = structuredClone(original);
+      mutate(findRun(evidenceForgery));
+      await writeFile(file, `${JSON.stringify(evidenceForgery)}\n`, 'utf8');
+      await expect(new FileFoundryStore(file, directory, repository).get(created.id)).rejects.toThrow(/immutable extraction/);
+    }
+
+    const ledgerForgery = structuredClone(original);
+    const forgedLedger = findRun(ledgerForgery);
+    const claim = forgedLedger.claims.find((item: { id: string }) => item.id === forgedLedger.artifact.claimIds[0]);
+    claim.text = 'The venue seats 500 guests.';
+    claim.evidence[0].locator = 'block:999999';
+    claim.evidence[0].excerpt = claim.text;
+    claim.evidence[0].excerptHash = hash(claim.text);
+    const artifactDependency = forgedLedger.capture.revisions.find((revision: { attemptId: string }) => revision.attemptId === forgedLedger.capture.artifactAttemptId);
+    const rebound = buildRealUrlArtifactBinding(forgedLedger.claims, forgedLedger.artifact.claimIds, {
+      canonicalUrl: artifactDependency.sourceRevision.canonicalUrl,
+      capturedAt: artifactDependency.sourceRevision.capturedAt,
+      contentHash: artifactDependency.sourceRevision.contentHash,
+    }, forgedLedger.artifact.sourceReview.sourceKind);
+    forgedLedger.artifact.payload = rebound.payload;
+    forgedLedger.artifact.targetPath = rebound.targetPath;
+    forgedLedger.artifact.contentLineage = rebound.lineage;
+    await writeFile(file, `${JSON.stringify(ledgerForgery)}\n`, 'utf8');
+    const ledgerStore = new FileFoundryStore(file, directory, repository);
+    await expect(ledgerStore.get(created.id)).rejects.toThrow(/immutable extraction/);
+    const ledgerApp = createApp(ledgerStore, {
+      realUrlsEnabled: true,
+      coordinator: new RealUrlCoordinator(ledgerStore, new FakeKernel(() => { throw new Error('must not capture'); }), repository),
+    });
+    await request(ledgerApp).get(`/api/foundry/runs/${created.id}/patch`).expect(400)
+      .expect(({ body }) => expect(body.error.code).toBe('request_failed'));
+
+    const summaryForgery = structuredClone(original);
+    const forgedSummary = findRun(summaryForgery);
+    const summaryDependency = forgedSummary.capture.revisions.find((revision: { attemptId: string }) => revision.attemptId === forgedSummary.capture.artifactAttemptId);
+    summaryDependency.sourceRevision.canonicalUrl = 'https://attacker.example/fabricated-source';
+    summaryDependency.sourceRevision.capturedAt = '2039-01-01T00:00:00.000Z';
+    summaryDependency.sourceRevision.contentHash = hash('fabricated-source');
+    summaryDependency.extractionRevision.contentHash = hash('fabricated-extraction');
+    forgedSummary.bundle.sourceItems[0] = {
+      ...forgedSummary.bundle.sourceItems[0],
+      uri: summaryDependency.sourceRevision.canonicalUrl,
+      contentHash: summaryDependency.sourceRevision.contentHash,
+      capturedAt: summaryDependency.sourceRevision.capturedAt,
+    };
+    const summaryBinding = buildRealUrlArtifactBinding(forgedSummary.claims, forgedSummary.artifact.claimIds, {
+      canonicalUrl: summaryDependency.sourceRevision.canonicalUrl,
+      capturedAt: summaryDependency.sourceRevision.capturedAt,
+      contentHash: summaryDependency.sourceRevision.contentHash,
+    }, forgedSummary.artifact.sourceReview.sourceKind);
+    forgedSummary.artifact.payload = summaryBinding.payload;
+    forgedSummary.artifact.targetPath = summaryBinding.targetPath;
+    forgedSummary.artifact.contentLineage = summaryBinding.lineage;
+    await writeFile(file, `${JSON.stringify(summaryForgery)}\n`, 'utf8');
+    await expect(new FileFoundryStore(file, directory, repository).get(created.id)).rejects.toThrow(/immutable manifest/);
+  });
+
+  it('refresh creates a new immutable revision and retains the prior review as stale', async () => {
+    const kernel = new FakeKernel((input, call) => recordFor(input, { text: call === 1 ? 'First source assertion.' : 'Second source assertion.' }));
+    const { app, coordinator, directory } = await harness(kernel);
+    const first = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'refresh-first',
+    }).expect(202);
+    await waitForTerminal(coordinator, first.body.id);
+    const firstProjection = (await request(app).get(`/api/foundry/captures/${first.body.id}`)).body;
+    let run = (await request(app).get(`/api/foundry/runs/${firstProjection.runId}`)).body;
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: run.version,
+      headline: run.artifact.payload.headline, dek: run.artifact.payload.dek, body: run.artifact.payload.body,
+      sourceKind: 'web', claimIds: run.artifact.claimIds, confirmAngle: true,
+    })).body;
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/review`).set(csrf).send({ decision: 'accepted', reviewer: 'editor', expectedVersion: run.version })).body;
+    const firstReceiptHash = run.review.receiptHash;
+    const refreshed = await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'refresh-second', expectedVersion: run.version,
+    }).expect(202);
+    await waitForTerminal(coordinator, refreshed.body.id);
+    const current = (await request(app).get(`/api/foundry/runs/${run.id}`).expect(200)).body;
+    expect(current.capture.revisions).toHaveLength(2);
+    expect(current.capture.currentAttemptId).toBe(current.capture.artifactAttemptId);
+    expect(current.review).toBeUndefined();
+    expect(current.reviewHistory.at(-1)).toMatchObject({
+      validity: 'stale', staleReason: 'source_refreshed', receiptHash: firstReceiptHash,
+    });
+    expect(JSON.parse(await readFile(join(directory, 'review-receipts', `${firstReceiptHash}.json`), 'utf8'))).toMatchObject({
+      runId: run.id, decision: 'accepted', reviewer: 'editor',
+    });
+    await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(400);
+
+    let reviewedAgain = (await request(app).put(`/api/foundry/runs/${run.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: current.version,
+      headline: current.artifact.payload.headline, dek: current.artifact.payload.dek, body: current.artifact.payload.body,
+      sourceKind: 'web', claimIds: current.artifact.claimIds, confirmAngle: true,
+    }).expect(200)).body;
+    reviewedAgain = (await request(app).put(`/api/foundry/runs/${run.id}/review`).set(csrf).send({
+      decision: 'accepted', reviewer: 'editor', expectedVersion: reviewedAgain.version,
+    }).expect(200)).body;
+    const third = await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'refresh-third', expectedVersion: reviewedAgain.version,
+    }).expect(202);
+    await waitForTerminal(coordinator, third.body.id);
+    const afterThird = (await request(app).get(`/api/foundry/runs/${run.id}`).expect(200)).body;
+    expect(afterThird.reviewHistory).toHaveLength(2);
+    expect(afterThird.reviewHistory.every((entry: { validity: string }) => entry.validity === 'stale')).toBe(true);
+    expect(afterThird.reviewHistory.map((entry: { decidedAt: string }) => entry.decidedAt)).toEqual([
+      run.reviewHistory.at(-1).decidedAt,
+      reviewedAgain.reviewHistory.at(-1).decidedAt,
+    ]);
+  });
+
+  it('rejects refreshes for a different logical URL before another network call', async () => {
+    const kernel = new FakeKernel((input) => recordFor(input));
+    const { app, coordinator } = await harness(kernel);
+    const first = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/?id=1', actor: 'editor', idempotencyKey: 'source-match-first',
+    }).expect(202);
+    await waitForTerminal(coordinator, first.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${first.body.id}`)).body;
+    const run = (await request(app).get(`/api/foundry/runs/${projection.runId}`)).body;
+    await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send({
+      url: 'https://example.com/?id=2', actor: 'editor', idempotencyKey: 'source-match-second', expectedVersion: run.version,
+    }).expect(400).expect(({ body }) => expect(body.error.code).toBe('source_mismatch'));
+    expect(kernel.calls).toBe(1);
+  });
+
+  it('binds refresh idempotency to exact operation context and locks run mutations in flight', async () => {
+    let releaseRefresh!: (record: CaptureRecord) => void;
+    const refreshDeferred = new Promise<CaptureRecord>((resolve) => { releaseRefresh = resolve; });
+    const kernel = new FakeKernel((input, call) => call === 1 ? recordFor(input) : refreshDeferred);
+    const { app, coordinator } = await harness(kernel);
+    const first = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/?id=1', actor: 'editor', idempotencyKey: 'refresh-context-first',
+    }).expect(202);
+    await waitForTerminal(coordinator, first.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${first.body.id}`)).body;
+    let run = (await request(app).get(`/api/foundry/runs/${projection.runId}`)).body;
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: run.version,
+      sourceKind: 'web', claimIds: run.artifact.claimIds, confirmAngle: true,
+    }).expect(200)).body;
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/review`).set(csrf).send({
+      decision: 'accepted', reviewer: 'editor', expectedVersion: run.version,
+    }).expect(200)).body;
+    const refreshBody = {
+      url: 'https://example.com/?id=1', actor: 'editor', idempotencyKey: 'refresh-context-second', expectedVersion: run.version,
+    };
+    const refresh = await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send(refreshBody).expect(202);
+    const exactRetry = await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send(refreshBody).expect(200);
+    expect(exactRetry.body.id).toBe(refresh.body.id);
+    await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send({ ...refreshBody, expectedVersion: run.version + 1 })
+      .expect(409).expect(({ body }) => expect(body.error.code).toBe('idempotency_conflict'));
+    await request(app).put(`/api/foundry/runs/${run.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: run.version,
+      sourceKind: 'web', claimIds: run.artifact.claimIds, confirmAngle: true,
+    }).expect(409).expect(({ body }) => expect(body.error.code).toBe('source_refresh_in_progress'));
+    await request(app).put(`/api/foundry/runs/${run.id}/review`).set(csrf).send({
+      decision: 'rejected', reviewer: 'editor', expectedVersion: run.version,
+    }).expect(409).expect(({ body }) => expect(body.error.code).toBe('source_refresh_in_progress'));
+    await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(409)
+      .expect(({ body }) => expect(body.error.code).toBe('source_refresh_in_progress'));
+    releaseRefresh(recordFor({ url: refreshBody.url, idempotencyKey: refreshBody.idempotencyKey }, { text: 'Second immutable assertion.' }));
+    await waitForTerminal(coordinator, refresh.body.id);
+    const completedRetry = await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send(refreshBody).expect(200);
+    expect(completedRetry.body.id).toBe(refresh.body.id);
+    expect((await request(app).get(`/api/foundry/runs/${run.id}`)).body.capture.revisions).toHaveLength(2);
+    expect(kernel.calls).toBe(2);
+  });
+
+  it('a no-story refresh advances the source head, keeps the prior artifact dependency, and blocks patch', async () => {
+    const kernel = new FakeKernel((input, call) => recordFor(input, call === 1 ? {} : { state: 'no_story' }));
+    const { app, coordinator } = await harness(kernel);
+    const first = await request(app).post('/api/foundry/captures').set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'no-story-first',
+    }).expect(202);
+    await waitForTerminal(coordinator, first.body.id);
+    const projection = (await request(app).get(`/api/foundry/captures/${first.body.id}`)).body;
+    let run = (await request(app).get(`/api/foundry/runs/${projection.runId}`)).body;
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/artifact`).set(csrf).send({
+      editor: 'editor', expectedVersion: run.version,
+      headline: run.artifact.payload.headline, dek: run.artifact.payload.dek, body: run.artifact.payload.body,
+      sourceKind: 'web', claimIds: run.artifact.claimIds, confirmAngle: true,
+    })).body;
+    run = (await request(app).put(`/api/foundry/runs/${run.id}/review`).set(csrf).send({ decision: 'accepted', reviewer: 'editor', expectedVersion: run.version })).body;
+    const refreshed = await request(app).post(`/api/foundry/runs/${run.id}/refresh`).set(csrf).send({
+      url: 'https://example.com/', actor: 'editor', idempotencyKey: 'no-story-second', expectedVersion: run.version,
+    }).expect(202);
+    await waitForTerminal(coordinator, refreshed.body.id);
+    const current = (await request(app).get(`/api/foundry/runs/${run.id}`)).body;
+    expect(current.capture.currentAttemptId).not.toBe(current.capture.artifactAttemptId);
+    expect(current.capture.revisions.at(-1).state).toBe('no_story');
+    expect(current.status).toBe('needs_revision');
+    expect(current.reviewHistory.at(-1).validity).toBe('stale');
+    await request(app).get(`/api/foundry/runs/${run.id}/patch`).expect(400);
+  });
+
+  it('reconciles manifest-before-mapping once and marks missing manifests interrupted without refetch', async () => {
+    const kernel = new FakeKernel(() => { throw new Error('must not refetch'); });
+    const { store, repository, file } = await harness(kernel);
+    const input = { url: 'https://example.com/', idempotencyKey: 'crash-manifest' };
+    const identity = captureRequestIdentity(input);
+    const timestamp = '2026-08-21T08:00:00.000Z';
+    await store.createCaptureProjection({
+      schemaVersion: 'pi.capture-projection.v1', id: `projection-${identity.idempotencyKeyHash.slice(0, 24)}`,
+      sourceId: `source-head-${hash(identity.safeRequestedUrl).slice(0, 20)}`, attemptId: identity.attemptId,
+      actor: 'editor', idempotencyKeyHash: identity.idempotencyKeyHash, requestFingerprint: identity.requestFingerprint,
+      operation: 'initial', operationFingerprint: hash('crash-manifest-operation'),
+      requestedUrl: identity.safeRequestedUrl, state: 'queued', createdAt: timestamp, updatedAt: timestamp,
+    });
+    await store.markCaptureProjectionCapturing(`projection-${identity.idempotencyKeyHash.slice(0, 24)}`, timestamp);
+    repository.records.set(identity.attemptId, recordFor(input));
+    const recovered = new RealUrlCoordinator(store, kernel, repository);
+    await recovered.reconcile();
+    await recovered.reconcile();
+    expect((await store.list()).length).toBe(1);
+    expect((await store.getCaptureProjection(`projection-${identity.idempotencyKeyHash.slice(0, 24)}`))?.state).toBe('extracted');
+    expect(kernel.calls).toBe(0);
+
+    const missingInput = { url: 'https://example.org/', idempotencyKey: 'crash-no-manifest' };
+    const missing = captureRequestIdentity(missingInput);
+    await store.createCaptureProjection({
+      schemaVersion: 'pi.capture-projection.v1', id: `projection-${missing.idempotencyKeyHash.slice(0, 24)}`,
+      sourceId: `source-head-${hash(missing.safeRequestedUrl).slice(0, 20)}`, attemptId: missing.attemptId,
+      actor: 'editor', idempotencyKeyHash: missing.idempotencyKeyHash, requestFingerprint: missing.requestFingerprint,
+      operation: 'initial', operationFingerprint: hash('crash-missing-operation'),
+      requestedUrl: missing.safeRequestedUrl, state: 'queued', createdAt: timestamp, updatedAt: timestamp,
+    });
+    await recovered.reconcile();
+    expect((await store.getCaptureProjection(`projection-${missing.idempotencyKeyHash.slice(0, 24)}`))?.failure?.code).toBe('capture_interrupted');
+    expect(kernel.calls).toBe(0);
+    expect(JSON.parse(await readFile(file, 'utf8')).schemaVersion).toBe('pi.foundry-file-store.v2');
+  });
+
+  it('recovers a real immutable manifest across the capture and projection stores without refetch', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pi-real-crash-'));
+    temporaryDirectories.push(directory);
+    const repository = new FileCaptureRepository(directory);
+    const store = new FileFoundryStore(join(directory, 'runs.json'), directory, repository);
+    const kernel = new FakeKernel(() => { throw new Error('must not refetch'); });
+    const input = { url: 'https://example.com/', idempotencyKey: 'real-repository-crash' };
+    const identity = captureRequestIdentity(input);
+    const projectionId = `projection-${identity.idempotencyKeyHash.slice(0, 24)}`;
+    const timestamp = '2026-08-21T08:00:00.000Z';
+    await store.createCaptureProjection({
+      schemaVersion: 'pi.capture-projection.v1', id: projectionId,
+      sourceId: `source-head-${hash(identity.safeRequestedUrl).slice(0, 20)}`, attemptId: identity.attemptId,
+      actor: 'editor', idempotencyKeyHash: identity.idempotencyKeyHash, requestFingerprint: identity.requestFingerprint,
+      operation: 'initial', operationFingerprint: hash('real-repository-operation'),
+      requestedUrl: identity.safeRequestedUrl, state: 'queued', createdAt: timestamp, updatedAt: timestamp,
+    });
+    await store.markCaptureProjectionCapturing(projectionId, timestamp);
+    await repository.save(recordFor(input));
+    const restarted = new RealUrlCoordinator(store, kernel, repository);
+    await restarted.reconcile();
+    await restarted.reconcile();
+    expect((await store.getCaptureProjection(projectionId))?.state).toBe('extracted');
+    expect(await store.list()).toHaveLength(1);
+    expect(kernel.calls).toBe(0);
+  });
+
+  it('materializes a terminal refresh after a legacy version race and retains summaries for missing targets', async () => {
+    const kernel = new FakeKernel((input) => recordFor(input));
+    const repository = new FakeRepository();
+    const { app, coordinator, store, file } = await harness(kernel, repository);
+    const initialInput = { url: 'https://example.com/?id=1', idempotencyKey: 'legacy-race-initial' };
+    const first = await request(app).post('/api/foundry/captures').set(csrf).send({
+      ...initialInput, actor: 'editor',
+    }).expect(202);
+    await waitForTerminal(coordinator, first.body.id);
+    const initialProjection = (await request(app).get(`/api/foundry/captures/${first.body.id}`)).body;
+    const run = (await store.get(initialProjection.runId))!;
+
+    const refreshInput = { url: initialInput.url, idempotencyKey: 'legacy-race-refresh' };
+    const refreshIdentity = captureRequestIdentity(refreshInput);
+    const refreshProjectionId = `projection-${refreshIdentity.idempotencyKeyHash.slice(0, 24)}`;
+    const timestamp = '2026-08-21T09:00:00.000Z';
+    await store.createCaptureProjection({
+      schemaVersion: 'pi.capture-projection.v1', id: refreshProjectionId,
+      sourceId: initialProjection.sourceId, attemptId: refreshIdentity.attemptId,
+      actor: 'editor', idempotencyKeyHash: refreshIdentity.idempotencyKeyHash,
+      requestFingerprint: refreshIdentity.requestFingerprint,
+      operation: 'refresh', operationFingerprint: hash('legacy-refresh-operation'),
+      requestedUrl: refreshIdentity.safeRequestedUrl, state: 'queued', createdAt: timestamp, updatedAt: timestamp,
+      refreshRunId: run.id, expectedRunVersion: run.version,
+    });
+    await store.markCaptureProjectionCapturing(refreshProjectionId, timestamp);
+    const raced = JSON.parse(await readFile(file, 'utf8'));
+    raced.runs[0].version += 1;
+    await writeFile(file, `${JSON.stringify(raced)}\n`, 'utf8');
+    repository.records.set(refreshIdentity.attemptId, recordFor(refreshInput, { text: 'Recovered immutable assertion.' }));
+    const restarted = new RealUrlCoordinator(store, new FakeKernel(() => { throw new Error('must not refetch'); }), repository);
+    await restarted.reconcile();
+    await restarted.reconcile();
+    const recoveredProjection = await store.getCaptureProjection(refreshProjectionId);
+    expect(recoveredProjection?.state).toBe('extracted');
+    expect(recoveredProjection?.summary?.sourceRevision).toBeTruthy();
+    expect(recoveredProjection?.materializationFailure).toBeUndefined();
+    const recoveredRun = (await store.get(run.id))!;
+    expect(recoveredRun.version).toBe(run.version + 2);
+    expect(recoveredRun.capture?.revisions).toHaveLength(2);
+
+    const orphanInput = { url: initialInput.url, idempotencyKey: 'missing-target-refresh' };
+    const orphanIdentity = captureRequestIdentity(orphanInput);
+    const orphanProjectionId = `projection-${orphanIdentity.idempotencyKeyHash.slice(0, 24)}`;
+    await store.createCaptureProjection({
+      schemaVersion: 'pi.capture-projection.v1', id: orphanProjectionId,
+      sourceId: initialProjection.sourceId, attemptId: orphanIdentity.attemptId,
+      actor: 'editor', idempotencyKeyHash: orphanIdentity.idempotencyKeyHash,
+      requestFingerprint: orphanIdentity.requestFingerprint,
+      operation: 'refresh', operationFingerprint: hash('missing-target-operation'),
+      requestedUrl: orphanIdentity.safeRequestedUrl, state: 'queued', createdAt: timestamp, updatedAt: timestamp,
+      refreshRunId: recoveredRun.id, expectedRunVersion: recoveredRun.version,
+    });
+    await store.markCaptureProjectionCapturing(orphanProjectionId, timestamp);
+    const orphaned = JSON.parse(await readFile(file, 'utf8'));
+    orphaned.runs = [];
+    await writeFile(file, `${JSON.stringify(orphaned)}\n`, 'utf8');
+    repository.records.set(orphanIdentity.attemptId, recordFor(orphanInput, { text: 'Terminal orphan assertion.' }));
+    await restarted.reconcile();
+    await restarted.reconcile();
+    const retained = await store.getCaptureProjection(orphanProjectionId);
+    expect(retained?.state).toBe('extracted');
+    expect(retained?.summary?.sourceRevision).toBeTruthy();
+    expect(retained?.materializationFailure?.code).toBe('refresh_target_missing');
+    expect(kernel.calls).toBe(1);
+  });
+
+  it('rejects mutable store hardlinks, directories and escaping junctions', async () => {
+    const hardlinkRoot = await mkdtemp(join(tmpdir(), 'pi-foundry-hardlink-'));
+    const outside = await mkdtemp(join(tmpdir(), 'pi-foundry-outside-'));
+    temporaryDirectories.push(hardlinkRoot, outside);
+    const file = join(hardlinkRoot, 'runs.json');
+    const store = new FileFoundryStore(file, hardlinkRoot);
+    await store.create(runFixture('editor', 'store-hardlink'));
+    await link(file, join(hardlinkRoot, 'mirror.json'));
+    await expect(store.list()).rejects.toThrow(/private regular file/);
+
+    const directoryRoot = await mkdtemp(join(tmpdir(), 'pi-foundry-directory-'));
+    temporaryDirectories.push(directoryRoot);
+    await mkdir(join(directoryRoot, 'runs.json'));
+    await expect(new FileFoundryStore(join(directoryRoot, 'runs.json'), directoryRoot).list()).rejects.toThrow(/private regular file/);
+
+    await writeFile(join(outside, 'runs.json'), '{"schemaVersion":"pi.foundry-file-store.v2","runs":[],"captureProjections":[]}', 'utf8');
+    const junctionRoot = await mkdtemp(join(tmpdir(), 'pi-foundry-junction-'));
+    temporaryDirectories.push(junctionRoot);
+    await symlink(outside, join(junctionRoot, 'escape'), process.platform === 'win32' ? 'junction' : 'dir');
+    await expect(new FileFoundryStore(join(junctionRoot, 'escape', 'runs.json'), junctionRoot).list()).rejects.toThrow(/escaped/);
+  });
+
+  it('fails closed when immutable review receipts are missing or changed into links and non-files', async () => {
+    const reviewedFixture = async (prefix: string) => {
+      const root = await mkdtemp(join(tmpdir(), prefix));
+      temporaryDirectories.push(root);
+      const store = new FileFoundryStore(join(root, 'runs.json'), root);
+      const created = await store.create(runFixture('editor', `${prefix}-fixture`));
+      const reviewed = await store.review(created.id, {
+        decision: 'accepted', reviewer: 'reviewer', expectedVersion: created.version,
+      });
+      const receiptHash = reviewed.review!.receiptHash;
+      return { root, store, runId: created.id, receiptPath: join(root, 'review-receipts', `${receiptHash}.json`) };
+    };
+
+    const hardlinked = await reviewedFixture('pi-review-hardlink-');
+    await link(hardlinked.receiptPath, join(hardlinked.root, 'receipt-mirror.json'));
+    await expect(hardlinked.store.get(hardlinked.runId)).rejects.toThrow(/private regular file/);
+
+    const linked = await reviewedFixture('pi-review-junction-');
+    const outside = await mkdtemp(join(tmpdir(), 'pi-review-outside-'));
+    temporaryDirectories.push(outside);
+    const outsideReceipts = join(outside, 'receipts');
+    await mkdir(outsideReceipts);
+    const outsideReceipt = join(outsideReceipts, linked.receiptPath.split(/[\\/]/).at(-1)!);
+    await writeFile(outsideReceipt, await readFile(linked.receiptPath));
+    await rm(join(linked.root, 'review-receipts'), { recursive: true });
+    await symlink(outsideReceipts, join(linked.root, 'review-receipts'), process.platform === 'win32' ? 'junction' : 'dir');
+    await expect(linked.store.get(linked.runId)).rejects.toThrow(/must not traverse a link/);
+
+    const nonFile = await reviewedFixture('pi-review-directory-');
+    await rm(nonFile.receiptPath);
+    await mkdir(nonFile.receiptPath);
+    await expect(nonFile.store.get(nonFile.runId)).rejects.toThrow(/private regular file/);
+
+    const missing = await reviewedFixture('pi-review-missing-');
+    await rm(missing.receiptPath);
+    await expect(missing.store.get(missing.runId)).rejects.toThrow(/receipt is unavailable/);
+
+    expect(() => new FileReviewReceiptRepository(join(outside, 'escape'), linked.root)).toThrow(/escaped/);
+  });
+});

--- a/studio-peninsula-insider/vite.config.ts
+++ b/studio-peninsula-insider/vite.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
   server: {
     port: 4311,
     proxy: {
-      '/api': 'http://127.0.0.1:4310',
+      '/api': {
+        target: 'http://127.0.0.1:4310',
+        changeOrigin: true,
+        // The browser request is same-origin with Vite. Present the trusted
+        // loopback proxy origin to the API's second same-origin check.
+        headers: { Origin: 'http://127.0.0.1:4310' },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- add a disabled-by-default, loopback-only real URL capture workflow around the immutable CaptureKernel
- derive evidence-led Quick Notes from sealed source and extraction revisions, with human source classification and review
- seal accepted and rejected artifact snapshots in content-addressed review receipts before patch export
- preserve the fixture workflow and fail closed for production, hostile hosts, active refreshes, stale evidence, restricted copy, and missing immutable provenance

## Security boundary

- one human-submitted HTTPS page; no crawl, automatic retry, provider/model call, CMS write, publication, or team-network exposure
- exact DNS pinning with validated remote-address equality; URL query values are never persisted
- source HTML remains inert; persisted projections expose safe codes rather than raw transport or address details
- FOUNDRY_REAL_URLS_ENABLED remains 0 by default

## Verification

- capture boundary, typecheck, 66 tests, client/server build, and audit pass
- Node 22 full suite passes with network disabled
- hardened isolated container is non-root, read-only, cap-drop ALL, no-new-privileges, loopback-only, and flag-off
- browser verification passes at 320px with labelled controls and no application errors
- independent security review passed all receipt, provenance, idempotency, refresh, SSRF, legacy migration, and tamper regressions
- one post-fix local canary to https://example.com/ completed with one request, immutable attempt/source/extraction revisions, three evidence-backed claims, generic-web confirmation, accepted sealed review receipt, patch export, and git apply --check

Stacked on the immutable URL capture kernel in #324.

Closes #325