### PR TITLE
feat(foundry): add fail-closed team-mode identity boundary

### DIFF
--- a/studio-peninsula-insider/server/app.ts
+++ b/studio-peninsula-insider/server/app.ts
@@ -20,6 +20,14 @@ import {
   RunRefreshInProgressError,
   VersionConflictError,
 } from './store.js';
+import {
+  createTeamWorkbench,
+  isProtectedTeamMethod,
+  resolveTeamWorkbenchConfig,
+  type TeamWorkbench,
+  type TeamWorkbenchConfig,
+  type TeamWorkbenchIdentityOptions,
+} from './team-workbench.js';
 
 const CreateRunBaseSchema = z.object({
   actor: z.string().min(1).default('local-editor'),
@@ -84,8 +92,14 @@ export function createApp(store: FileFoundryStore, options: {
   realUrlsEnabled?: boolean;
   coordinator?: RealUrlCoordinator;
   expectedHost?: string;
+  teamWorkbench?: TeamWorkbenchConfig;
+  identity?: TeamWorkbenchIdentityOptions;
 } = {}) {
   const realUrlsEnabled = options.realUrlsEnabled ?? false;
+  const team: TeamWorkbench = createTeamWorkbench(
+    options.teamWorkbench ?? resolveTeamWorkbenchConfig({}),
+    options.identity ?? {},
+  );
   if (realUrlsEnabled && !options.coordinator) throw new Error('Real URL capture requires the sealed coordinator');
   if (realUrlsEnabled && !store.hasImmutableCaptureResolver()) throw new Error('Real URL capture requires immutable manifest validation');
   const app = express();
@@ -115,6 +129,12 @@ export function createApp(store: FileFoundryStore, options: {
     response.setHeader('Cache-Control', 'no-store');
     next();
   });
+  if (team.requireVerifiedIdentity) {
+    const identityGuard = team.requireVerifiedIdentity;
+    app.use('/api', (request, response, next) => (
+      isProtectedTeamMethod(request.method) ? identityGuard(request, response, next) : next()
+    ));
+  }
   if (realUrlsEnabled) {
     const mutationGuard = requireSafeLocalMutation(options.expectedHost);
     app.use('/api', (request, response, next) => (
@@ -128,6 +148,9 @@ export function createApp(store: FileFoundryStore, options: {
     recipes: ['quick_note_v1', 'url_article_v1', 'newsletter_social_v1', 'explainer_preproduction_v1', 'podcast_preproduction_v1', 'short_video_preproduction_v1'],
     artifactTypes: ['quick_note', 'article_draft', 'article_metadata', 'ask_answer', 'internal_link_plan', 'seo_metadata_proposal', 'insider_note_issue', 'insider_note_subject_set', 'linkedin_post', 'instagram_caption', 'instagram_first_comment', 'instagram_carousel_script', 'social_media_brief', 'explainer_core', 'explainer_faq', 'explainer_carousel', 'explainer_voiceover', 'explainer_visualisation', 'podcast_evidence_dossier', 'podcast_angle', 'podcast_run_sheet', 'podcast_interview_guide', 'podcast_script', 'podcast_show_notes', 'podcast_chapters', 'video_hooks', 'video_script', 'video_shot_list', 'video_scenes', 'video_overlays', 'video_subtitles', 'video_thumbnail', 'video_platform_captions'],
     publicationAdapters: ['downloadable_patch'],
+    directReleaseAdapters: [],
+    teamMode: team.capabilities.mode,
+    teamWorkbench: team.capabilities,
     externalCalls: realUrlsEnabled,
     providerCalls: false,
     modelCalls: false,

--- a/studio-peninsula-insider/server/config.ts
+++ b/studio-peninsula-insider/server/config.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, relative, resolve } from 'node:path';
 import { realUrlCaptureEnabled } from './capture/kernel.js';
+import { resolveTeamWorkbenchConfig, TEAM_MODE_ENV_VAR, type TeamWorkbenchConfig } from './team-workbench.js';
 
 export interface RuntimeConfig {
   dataFile: string;
@@ -9,6 +10,7 @@ export interface RuntimeConfig {
   port: number;
   expectedHost: string;
   realUrlsEnabled: boolean;
+  teamWorkbench: TeamWorkbenchConfig;
   staticDir?: string;
 }
 
@@ -35,6 +37,13 @@ export function loadRuntimeConfig(environment = process.env): RuntimeConfig {
     throw new Error('Real URL capture requires native loopback FOUNDRY_HOST=127.0.0.1');
   }
 
+  // Team mode is an authenticated-session boundary, not a public deployment
+  // gate. It stays on loopback until a verified external session exists.
+  const teamWorkbench = resolveTeamWorkbenchConfig(environment);
+  if (teamWorkbench.teamModeEnabled && host !== '127.0.0.1') {
+    throw new Error(`${TEAM_MODE_ENV_VAR}=enabled requires native loopback FOUNDRY_HOST=127.0.0.1`);
+  }
+
   const port = Number(environment.FOUNDRY_PORT ?? 4310);
   if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('FOUNDRY_PORT must be a valid TCP port');
   const expectedHost = environment.FOUNDRY_EXPECTED_HOST ?? `127.0.0.1:${port}`;
@@ -52,6 +61,7 @@ export function loadRuntimeConfig(environment = process.env): RuntimeConfig {
     port,
     expectedHost,
     realUrlsEnabled,
+    teamWorkbench,
     staticDir: environment.FOUNDRY_STATIC_DIR ? resolve(environment.FOUNDRY_STATIC_DIR) : undefined,
   };
 }

--- a/studio-peninsula-insider/server/index.ts
+++ b/studio-peninsula-insider/server/index.ts
@@ -25,6 +25,9 @@ createApp(store, {
   realUrlsEnabled: config.realUrlsEnabled,
   coordinator,
   expectedHost: config.expectedHost,
+  // No server-owned verifier exists yet, so requesting team mode here fails
+  // closed at startup rather than serving unauthenticated mutations.
+  teamWorkbench: config.teamWorkbench,
 }).listen(config.port, config.host, () => {
   const displayHost = config.host === '0.0.0.0' ? '127.0.0.1' : config.host;
   console.log(`Peninsula Insider Workbench listening on http://${displayHost}:${config.port}`);

--- a/studio-peninsula-insider/server/team-workbench.ts
+++ b/studio-peninsula-insider/server/team-workbench.ts
@@ -1,0 +1,187 @@
+import type express from 'express';
+import { z } from 'zod';
+
+export const TEAM_MODE_ENV_VAR = 'PI_FOUNDRY_TEAM_MODE';
+export const TEAM_MODE_ENABLED_VALUE = 'enabled';
+
+export type TeamWorkbenchMode = 'local' | 'team';
+
+export interface TeamWorkbenchConfig {
+  readonly mode: TeamWorkbenchMode;
+  readonly teamModeEnabled: boolean;
+  readonly testOnlyIdentityAllowed: boolean;
+}
+
+/**
+ * Team mode is opt-in through one exact literal. Every other value, including
+ * 'true', '1', 'ENABLED' and an unset variable, resolves to the local default.
+ */
+export function resolveTeamWorkbenchConfig(environment: NodeJS.ProcessEnv = process.env): TeamWorkbenchConfig {
+  const mode: TeamWorkbenchMode = environment[TEAM_MODE_ENV_VAR] === TEAM_MODE_ENABLED_VALUE ? 'team' : 'local';
+  const runtime = environment.NODE_ENV ?? 'development';
+  return Object.freeze({
+    mode,
+    teamModeEnabled: mode === 'team',
+    testOnlyIdentityAllowed: runtime === 'test' || environment.VITEST === 'true',
+  });
+}
+
+/**
+ * Identity-bearing request headers are trivially forgeable by any client that
+ * can reach the loopback service, so team mode refuses requests carrying them
+ * rather than reading them.
+ */
+export const UNTRUSTED_IDENTITY_HEADERS: readonly string[] = Object.freeze([
+  'x-foundry-actor',
+  'x-foundry-identity',
+  'x-foundry-user',
+  'x-actor',
+  'x-user',
+  'x-user-id',
+  'x-user-email',
+  'x-remote-user',
+  'x-forwarded-user',
+  'x-forwarded-email',
+  'x-auth-request-user',
+  'x-auth-request-email',
+  'x-authenticated-user',
+  'x-on-behalf-of',
+]);
+
+/** Body fields that record who acted. In team mode the server owns their value. */
+const IDENTITY_BODY_FIELDS: readonly string[] = Object.freeze(['actor', 'reviewer', 'editor', 'confirmedBy']);
+
+const IdentityClaimSchema = z.object({
+  actorId: z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:@-]*$/),
+  displayName: z.string().min(1).max(200).optional(),
+}).strict();
+
+export type TeamIdentityClaim = z.infer<typeof IdentityClaimSchema>;
+
+export type VerifiedIdentitySource = 'server_owned_verifier' | 'test_injected_identity';
+
+export interface VerifiedTeamIdentity {
+  readonly actorId: string;
+  readonly displayName: string;
+  readonly verifiedBy: VerifiedIdentitySource;
+}
+
+export type TeamIdentityVerifier = (
+  request: express.Request,
+) => TeamIdentityClaim | null | undefined | Promise<TeamIdentityClaim | null | undefined>;
+
+export interface TeamWorkbenchIdentityOptions {
+  /** Server-owned verification. The only identity source accepted outside tests. */
+  readonly verifyIdentity?: TeamIdentityVerifier;
+  /** Test-only injected identity. Rejected unless the runtime is a test runtime. */
+  readonly testOnlyIdentity?: TeamIdentityVerifier;
+}
+
+const verifiedIdentities = new WeakMap<express.Request, VerifiedTeamIdentity>();
+
+export function getVerifiedIdentity(request: express.Request): VerifiedTeamIdentity | undefined {
+  return verifiedIdentities.get(request);
+}
+
+/** Team mode protects every method that is not a plain GET read. */
+export function isProtectedTeamMethod(method: string): boolean {
+  return method.toUpperCase() !== 'GET';
+}
+
+export interface TeamWorkbenchCapabilities {
+  readonly mode: TeamWorkbenchMode;
+  readonly enabled: boolean;
+  readonly identitySource: 'server_verified_middleware' | 'test_injected_identity' | 'local_single_operator';
+  readonly trustsIdentityHeaders: false;
+  readonly protectedMethods: 'all_non_get' | 'none';
+  readonly sharedTenancy: false;
+  readonly remoteAccess: false;
+}
+
+export interface TeamWorkbench {
+  readonly config: TeamWorkbenchConfig;
+  readonly capabilities: TeamWorkbenchCapabilities;
+  /** Undefined in local mode, where no identity gate is mounted at all. */
+  readonly requireVerifiedIdentity?: express.RequestHandler;
+}
+
+function deny(response: express.Response, status: number, code: string) {
+  return response.status(status).json({ error: { code } });
+}
+
+export function createTeamWorkbench(
+  config: TeamWorkbenchConfig,
+  options: TeamWorkbenchIdentityOptions = {},
+): TeamWorkbench {
+  const { verifyIdentity, testOnlyIdentity } = options;
+  if (testOnlyIdentity && !config.testOnlyIdentityAllowed) {
+    throw new Error('The injected Workbench identity callback is test-only');
+  }
+  if (verifyIdentity && testOnlyIdentity) {
+    throw new Error('Configure either the server-owned identity verifier or the test-only identity callback');
+  }
+
+  if (config.mode === 'local') {
+    if (verifyIdentity || testOnlyIdentity) throw new Error('Workbench identity verification requires team mode');
+    return Object.freeze({
+      config,
+      capabilities: Object.freeze({
+        mode: 'local' as const,
+        enabled: false,
+        identitySource: 'local_single_operator' as const,
+        trustsIdentityHeaders: false as const,
+        protectedMethods: 'none' as const,
+        sharedTenancy: false as const,
+        remoteAccess: false as const,
+      }),
+    });
+  }
+
+  const verifier = verifyIdentity ?? testOnlyIdentity;
+  if (!verifier) throw new Error('Team mode requires a server-owned verified identity middleware');
+  const verifiedBy: VerifiedIdentitySource = verifyIdentity ? 'server_owned_verifier' : 'test_injected_identity';
+
+  const requireVerifiedIdentity: express.RequestHandler = (request, response, next) => {
+    for (const header of UNTRUSTED_IDENTITY_HEADERS) {
+      if (request.get(header) !== undefined) return deny(response, 403, 'untrusted_identity_header');
+    }
+    void (async () => {
+      let claim: TeamIdentityClaim;
+      try {
+        const resolved = await verifier(request);
+        if (resolved === null || resolved === undefined) return deny(response, 401, 'team_identity_required');
+        claim = IdentityClaimSchema.parse(resolved);
+      } catch {
+        return deny(response, 401, 'team_identity_unverified');
+      }
+      const identity: VerifiedTeamIdentity = Object.freeze({
+        actorId: claim.actorId,
+        displayName: claim.displayName ?? claim.actorId,
+        verifiedBy,
+      });
+      verifiedIdentities.set(request, identity);
+      if (request.body && typeof request.body === 'object' && !Array.isArray(request.body)) {
+        const body = request.body as Record<string, unknown>;
+        body.actor = identity.actorId;
+        for (const field of IDENTITY_BODY_FIELDS) {
+          if (field in body) body[field] = identity.actorId;
+        }
+      }
+      return next();
+    })();
+  };
+
+  return Object.freeze({
+    config,
+    capabilities: Object.freeze({
+      mode: 'team' as const,
+      enabled: true,
+      identitySource: verifyIdentity ? ('server_verified_middleware' as const) : ('test_injected_identity' as const),
+      trustsIdentityHeaders: false as const,
+      protectedMethods: 'all_non_get' as const,
+      sharedTenancy: false as const,
+      remoteAccess: false as const,
+    }),
+    requireVerifiedIdentity,
+  });
+}

--- a/studio-peninsula-insider/tests/team-workbench.test.ts
+++ b/studio-peninsula-insider/tests/team-workbench.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import request from 'supertest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createApp } from '../server/app.js';
+import { loadRuntimeConfig } from '../server/config.js';
+import { FileFoundryStore } from '../server/store.js';
+import {
+  createTeamWorkbench,
+  resolveTeamWorkbenchConfig,
+  TEAM_MODE_ENV_VAR,
+  UNTRUSTED_IDENTITY_HEADERS,
+  type TeamIdentityVerifier,
+} from '../server/team-workbench.js';
+import type { ArtifactVersion, FoundryRun } from '../shared/contracts.js';
+
+const temporaryDirectories: string[] = [];
+
+const TEAM_ENV: NodeJS.ProcessEnv = { [TEAM_MODE_ENV_VAR]: 'enabled', NODE_ENV: 'test' };
+const teamConfig = () => resolveTeamWorkbenchConfig(TEAM_ENV);
+
+/** The test-only identity injection interface: an in-process verified claim. */
+const injectIdentity = (actorId: string): TeamIdentityVerifier => () => ({ actorId, displayName: 'Team Editor' });
+
+async function harness(options: Parameters<typeof createApp>[1] = {}) {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-team-workbench-'));
+  temporaryDirectories.push(directory);
+  const store = new FileFoundryStore(join(directory, 'runs.json'), directory);
+  return { directory, store, app: createApp(store, options) };
+}
+
+function createRun(app: ReturnType<typeof createApp>, key: string, body: Record<string, unknown> = {}) {
+  return request(app).post('/api/foundry/runs')
+    .set('Idempotency-Key', key)
+    .send({ fixtureId: 'red-hill-winter-lunch', actor: 'body-supplied-editor', ...body });
+}
+
+function completed(run: FoundryRun, type: ArtifactVersion['type']): ArtifactVersion {
+  const artifact = run.artifactPack.completed.find((candidate) => candidate.type === type);
+  if (!artifact) throw new Error(`Missing ${type}`);
+  return artifact;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe('Team Workbench mode resolution', () => {
+  it('defaults to local single-operator mode and preserves fixture behaviour', async () => {
+    expect(resolveTeamWorkbenchConfig({})).toMatchObject({ mode: 'local', teamModeEnabled: false });
+    for (const raw of ['', 'true', '1', 'ENABLED', 'Enabled', 'team', 'enabled ']) {
+      expect(resolveTeamWorkbenchConfig({ [TEAM_MODE_ENV_VAR]: raw }).mode).toBe('local');
+    }
+    expect(resolveTeamWorkbenchConfig({ [TEAM_MODE_ENV_VAR]: 'enabled' }).mode).toBe('team');
+
+    const { app, store } = await harness();
+    const created = (await createRun(app, 'local-default-mode').expect(201)).body as FoundryRun;
+    expect(created.audit[0]?.actor).toBe('body-supplied-editor');
+    expect((await store.list()).length).toBe(1);
+
+    const capabilities = (await request(app).get('/api/capabilities').expect(200)).body;
+    expect(capabilities.teamMode).toBe('local');
+    expect(capabilities.teamWorkbench).toEqual({
+      mode: 'local',
+      enabled: false,
+      identitySource: 'local_single_operator',
+      trustsIdentityHeaders: false,
+      protectedMethods: 'none',
+      sharedTenancy: false,
+      remoteAccess: false,
+    });
+    expect(capabilities.directReleaseAdapters).toEqual([]);
+    expect(capabilities.publicationAdapters).toEqual(['downloadable_patch']);
+    expect(capabilities).toMatchObject({ publishing: false, sending: false, scheduling: false, recording: false, rendering: false, productionMutation: false });
+  });
+
+  it('resolves team mode from the non-secret toggle and refuses a public bind', () => {
+    expect(loadRuntimeConfig({ NODE_ENV: 'test' }).teamWorkbench.mode).toBe('local');
+    expect(loadRuntimeConfig(TEAM_ENV).teamWorkbench).toMatchObject({ mode: 'team', teamModeEnabled: true });
+    expect(() => loadRuntimeConfig({ ...TEAM_ENV, FOUNDRY_HOST: '0.0.0.0' })).toThrow(/loopback/);
+    expect(() => loadRuntimeConfig({ ...TEAM_ENV, NODE_ENV: 'production' })).toThrow(/disabled in production/);
+  });
+
+  it('keeps the test-only identity injector out of non-test runtimes', () => {
+    const developmentTeam = resolveTeamWorkbenchConfig({ [TEAM_MODE_ENV_VAR]: 'enabled', NODE_ENV: 'development' });
+    expect(developmentTeam.testOnlyIdentityAllowed).toBe(false);
+    expect(() => createTeamWorkbench(developmentTeam, { testOnlyIdentity: injectIdentity('sneaky-editor') }))
+      .toThrow(/test-only/);
+    expect(() => createTeamWorkbench(resolveTeamWorkbenchConfig({}), { verifyIdentity: injectIdentity('editor') }))
+      .toThrow(/requires team mode/);
+    expect(() => createTeamWorkbench(teamConfig(), { verifyIdentity: injectIdentity('a'), testOnlyIdentity: injectIdentity('b') }))
+      .toThrow(/either the server-owned identity verifier or the test-only/);
+  });
+});
+
+describe('Team mode authenticated-session boundary', () => {
+  it('fails closed when team mode is requested without verified identity', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pi-team-workbench-'));
+    temporaryDirectories.push(directory);
+    const store = new FileFoundryStore(join(directory, 'runs.json'), directory);
+    expect(() => createApp(store, { teamWorkbench: teamConfig() })).toThrow(/verified identity/);
+
+    const unresolved = await harness({ teamWorkbench: teamConfig(), identity: { testOnlyIdentity: () => null } });
+    expect((await createRun(unresolved.app, 'team-no-identity').expect(401)).body)
+      .toEqual({ error: { code: 'team_identity_required' } });
+
+    const failing = await harness({
+      teamWorkbench: teamConfig(),
+      identity: { testOnlyIdentity: () => { throw new Error('session lookup failed'); } },
+    });
+    expect((await createRun(failing.app, 'team-verifier-error').expect(401)).body)
+      .toEqual({ error: { code: 'team_identity_unverified' } });
+
+    // A malformed claim is not an identity either.
+    const malformed = await harness({
+      teamWorkbench: teamConfig(),
+      identity: { testOnlyIdentity: () => ({ actorId: '' }) as never },
+    });
+    await createRun(malformed.app, 'team-malformed-claim').expect(401);
+
+    expect(await unresolved.store.list()).toEqual([]);
+    expect(await failing.store.list()).toEqual([]);
+    expect(await malformed.store.list()).toEqual([]);
+
+    // Reads stay available; only mutations are gated.
+    await request(unresolved.app).get('/api/foundry/runs').expect(200);
+    const capabilities = (await request(unresolved.app).get('/api/capabilities').expect(200)).body;
+    expect(capabilities.teamWorkbench).toEqual({
+      mode: 'team',
+      enabled: true,
+      identitySource: 'test_injected_identity',
+      trustsIdentityHeaders: false,
+      protectedMethods: 'all_non_get',
+      sharedTenancy: false,
+      remoteAccess: false,
+    });
+    expect(capabilities.directReleaseAdapters).toEqual([]);
+  });
+
+  it('rejects spoofed identity headers rather than reading them', async () => {
+    const { app, store } = await harness({
+      teamWorkbench: teamConfig(),
+      identity: { testOnlyIdentity: injectIdentity('verified-editor') },
+    });
+    for (const [index, header] of UNTRUSTED_IDENTITY_HEADERS.entries()) {
+      const response = await createRun(app, `spoof-${index}`).set(header, 'editor-in-chief').expect(403);
+      expect(response.body).toEqual({ error: { code: 'untrusted_identity_header' } });
+    }
+    expect(await store.list()).toEqual([]);
+
+    // The same request without the forged header is accepted by the verifier.
+    const created = (await createRun(app, 'spoof-control').expect(201)).body as FoundryRun;
+    expect(created.audit[0]?.actor).toBe('verified-editor');
+  });
+
+  it('accepts a verified injected identity and owns the recorded actor', async () => {
+    const { app, store } = await harness({
+      teamWorkbench: teamConfig(),
+      identity: { testOnlyIdentity: injectIdentity('verified-editor') },
+    });
+    const run = (await createRun(app, 'team-verified-create', { actor: 'impersonated-editor' }).expect(201)).body as FoundryRun;
+    expect(run.audit[0]?.actor).toBe('verified-editor');
+
+    const quickNote = completed(run, 'quick_note');
+    const reviewed = (await request(app).put(`/api/foundry/runs/${run.id}/review`).send({
+      artifactId: quickNote.id,
+      decision: 'accepted',
+      reviewer: 'impersonated-editor',
+      expectedVersion: run.version,
+      expectedArtifactVersion: quickNote.version,
+    }).expect(200)).body as FoundryRun;
+    expect(reviewed.audit.some((entry) => entry.actor === 'verified-editor')).toBe(true);
+    expect(reviewed.audit.every((entry) => entry.actor !== 'impersonated-editor')).toBe(true);
+
+    const persisted = await store.get(run.id);
+    expect(persisted?.audit.every((entry) => entry.actor !== 'impersonated-editor')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope

First implementation slice for the Peninsula Insider Team Workbench.

- Adds an explicit opt-in, fail-closed team-mode configuration.
- Requires a server-owned verified identity callback for every non-GET API mutation in team mode.
- Rejects spoofable identity headers and test-only identity injection outside test runtimes.
- Leaves the default fixture/local Workbench unchanged.
- Does not add Supabase calls, credentials, database mutation, network exposure, or any direct release/publish/send/schedule/record/render capability.

## Verification

- `npm test -- --run tests/team-workbench.test.ts` — 6 passed
- `npm run typecheck` — passed

Human/engineering review remains required before integration or any team-network/auth provider rollout.