### PR TITLE
DELI-760: Add immutable release evidence

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -110,6 +110,17 @@ jobs:
         run: |
           node --input-type=module -e "import { writeFileSync } from 'node:fs'; writeFileSync('next/dist/deployment.json', JSON.stringify({ sourceSha: process.env.SOURCE_SHA, runId: process.env.BUILD_RUN_ID, generatedAt: new Date().toISOString() }, null, 2) + '\n')"
 
+      - name: Write immutable release manifest
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          BUILD_RUN_ID: ${{ github.run_id }}
+          RELEASE_TRIGGER: ${{ github.event_name }}
+          RELEASE_ACTOR: ${{ github.actor }}
+        run: |
+          cd next
+          npm run test:release-contract
+          npm run release:manifest
+
       - name: Prune internal surfaces from deploy output (T-006)
         # v5 hygiene (2026-07-11, T-006): the editorial admin surface
         # (next/src/pages/admin + public/admin/media-registry.json) must not

--- a/next/package.json
+++ b/next/package.json
@@ -31,6 +31,8 @@
     "search:audit": "node scripts/audit-search-links.mjs",
     "audit:agent-readiness": "node scripts/audit-agent-readiness.mjs",
     "test:agent-readiness": "node --test scripts/test-agent-readiness.mjs scripts/test-live-agent-readiness.mjs",
+    "test:release-contract": "node --test scripts/release-manifest.test.mjs",
+    "release:manifest": "node scripts/release-manifest.mjs",
     "bf:lint": "node ../scripts/bf-import/verify-lint.mjs",
     "bf:lint:strict": "node ../scripts/bf-import/verify-lint.mjs --strict",
     "pdfs": "node scripts/render-pdfs.mjs",

--- a/next/scripts/release-manifest.mjs
+++ b/next/scripts/release-manifest.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFile, writeFile, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const nextRoot = resolve(here, '..');
+
+export async function sha256(path) {
+  const body = await readFile(path);
+  return createHash('sha256').update(body).digest('hex');
+}
+
+async function existingArtifact(distDir, relativePath) {
+  const path = join(distDir, relativePath);
+  try {
+    const info = await stat(path);
+    if (!info.isFile()) return null;
+    return { path: `/${relativePath.replaceAll('\\', '/')}`, bytes: info.size, sha256: await sha256(path) };
+  } catch {
+    return null;
+  }
+}
+
+export async function buildReleaseManifest({
+  distDir,
+  sourceSha,
+  runId,
+  trigger,
+  actor,
+  generatedAt = new Date().toISOString(),
+}) {
+  if (!/^[0-9a-f]{7,64}$/i.test(sourceSha || '')) throw new Error('SOURCE_SHA must be a Git SHA');
+  if (!runId) throw new Error('BUILD_RUN_ID is required');
+
+  const critical = [
+    'index.html',
+    'sitemap.xml',
+    'sitemap-index.xml',
+    'whats-on/upcoming.json',
+    'llms.txt',
+    'feed.xml',
+  ];
+  const artifacts = (await Promise.all(critical.map((path) => existingArtifact(distDir, path))))
+    .filter(Boolean)
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  if (!artifacts.some((item) => item.path === '/index.html')) {
+    throw new Error('release manifest requires dist/index.html');
+  }
+
+  const releaseId = `${sourceSha.slice(0, 12)}-${runId}`;
+  return {
+    schemaVersion: 1,
+    releaseId,
+    sourceSha,
+    buildRunId: String(runId),
+    generatedAt,
+    trigger: trigger || 'unknown',
+    authority: {
+      mode: 'github-protected-release',
+      actor: actor || 'unknown',
+      note: 'Approval remains the protected branch/merge decision; this manifest is evidence, not authority.',
+    },
+    artifacts,
+    verification: {
+      state: 'awaiting_external_verification',
+      expectedDeploymentSha: sourceSha,
+    },
+  };
+}
+
+async function main() {
+  const distDir = resolve(process.env.PI_DIST_DIR || join(nextRoot, 'dist'));
+  const output = resolve(process.env.PI_RELEASE_MANIFEST || join(distDir, 'release-manifest.json'));
+  const manifest = await buildReleaseManifest({
+    distDir,
+    sourceSha: process.env.SOURCE_SHA,
+    runId: process.env.BUILD_RUN_ID,
+    trigger: process.env.RELEASE_TRIGGER,
+    actor: process.env.RELEASE_ACTOR,
+  });
+  await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  process.stdout.write(`${JSON.stringify({ releaseId: manifest.releaseId, output, artifacts: manifest.artifacts.length })}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`[release-manifest] ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/next/scripts/release-manifest.test.mjs
+++ b/next/scripts/release-manifest.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildReleaseManifest } from './release-manifest.mjs';
+
+test('release manifest binds critical output hashes to the source release', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'pi-release-'));
+  try {
+    await mkdir(join(dir, 'whats-on'), { recursive: true });
+    await writeFile(join(dir, 'index.html'), '<html>PI</html>');
+    await writeFile(join(dir, 'sitemap.xml'), '<urlset/>');
+    await writeFile(join(dir, 'whats-on', 'upcoming.json'), '{"events":[]}');
+    const result = await buildReleaseManifest({
+      distDir: dir,
+      sourceSha: '9c29fe33b3a018aa58fb4316463dbe0fd6c7465c',
+      runId: '12345',
+      trigger: 'push',
+      actor: 'james',
+      generatedAt: '2026-08-25T00:00:00.000Z',
+    });
+    assert.equal(result.releaseId, '9c29fe33b3a0-12345');
+    assert.equal(result.verification.state, 'awaiting_external_verification');
+    assert.deepEqual(result.artifacts.map((item) => item.path), [
+      '/index.html',
+      '/sitemap.xml',
+      '/whats-on/upcoming.json',
+    ]);
+    assert.match(result.artifacts[0].sha256, /^[0-9a-f]{64}$/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('release manifest fails closed without the public root', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'pi-release-empty-'));
+  try {
+    await assert.rejects(
+      () => buildReleaseManifest({ distDir: dir, sourceSha: 'abcdef1', runId: '1' }),
+      /requires dist\/index\.html/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Introduces a deterministic release manifest for Peninsula Insider deployments. The manifest binds the source SHA and GitHub run to hashes of critical public artifacts and remains awaiting external verification until the live site is checked. Includes contract tests and runs in the existing deployment workflow.\n\nVerification:\n- npm run test:release-contract\n- npm run build (960 pages; all existing gates passed)\n\nNo production deployment or content change is included.