### PR TITLE
ci: add provenance-bound PI deployment event producer

### DIFF
--- a/.github/workflows/pi-post-deploy-qa-event.yml
+++ b/.github/workflows/pi-post-deploy-qa-event.yml
@@ -1,0 +1,75 @@
+name: PI production deploy event
+
+on:
+  deployment_status:
+
+permissions:
+  actions: read
+  contents: read
+  deployments: read
+
+concurrency:
+  group: pi-production-deploy-event-${{ github.event.deployment.id }}
+  cancel-in-progress: false
+
+jobs:
+  emit:
+    if: >-
+      github.repository == 'richmondjw/peninsula-insider' &&
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'github-pages' &&
+      github.event.deployment_status.environment == 'github-pages' &&
+      github.event.deployment.ref == 'gh-pages'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PI_EVENT_ENDPOINT: https://hooks.optiflows.com.au/pi/deployment
+      PI_EVENT_HMAC_SECRET: ${{ secrets.PI_RUNTIME_EVENT_HMAC_SECRET }}
+      PI_DEPLOYMENT_ID: ${{ github.event.deployment.id }}
+      PI_DEPLOYMENT_STATUS_ID: ${{ github.event.deployment_status.id }}
+      PI_DEPLOYMENT_ENVIRONMENT: ${{ github.event.deployment.environment }}
+      PI_DEPLOYMENT_STATUS_ENVIRONMENT: ${{ github.event.deployment_status.environment }}
+      PI_DEPLOYMENT_STATUS_STATE: ${{ github.event.deployment_status.state }}
+      PI_DEPLOYMENT_REF: ${{ github.event.deployment.ref }}
+      PI_DEPLOYMENT_ARTIFACT_SHA: ${{ github.event.deployment.sha }}
+      PI_DEPLOYED_AT: ${{ github.event.deployment_status.created_at }}
+      PI_REPOSITORY: ${{ github.repository }}
+      PI_DELIVERY_ID: deployment-status-${{ github.event.deployment_status.id }}
+      GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout the provenance validator from main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate live provenance and sign bounded event
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${#PI_EVENT_HMAC_SECRET}" -ge 32
+          test "$PI_REPOSITORY" = "richmondjw/peninsula-insider"
+          test "$PI_DEPLOYMENT_ENVIRONMENT" = "github-pages"
+          test "$PI_DEPLOYMENT_STATUS_ENVIRONMENT" = "github-pages"
+          test "$PI_DEPLOYMENT_REF" = "gh-pages"
+          test "${#PI_DEPLOYMENT_ARTIFACT_SHA}" -eq 40
+          node ops/scripts/pi-deploy-event-provenance.mjs
+
+      - name: Deliver once to the dedicated PI endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t signed < "$RUNNER_TEMP/pi-runtime-event/headers"
+          test "${#signed[@]}" -eq 2
+          curl --silent --show-error --fail-with-body \
+            --request POST \
+            --header 'content-type: application/json' \
+            --header "x-pi-timestamp: ${signed[0]}" \
+            --header "x-pi-signature: ${signed[1]}" \
+            --header "x-pi-delivery-id: $PI_DELIVERY_ID" \
+            --data-binary "@$RUNNER_TEMP/pi-runtime-event/event.json" \
+            --output "$RUNNER_TEMP/pi-runtime-event/response.json" \
+            "$PI_EVENT_ENDPOINT"
+          test -s "$RUNNER_TEMP/pi-runtime-event/response.json"

--- a/.github/workflows/pi-post-deploy-qa-event.yml
+++ b/.github/workflows/pi-post-deploy-qa-event.yml
@@ -74,6 +74,6 @@ jobs:
             --write-out '%{http_code}' \
             "$PI_EVENT_ENDPOINT" \
             > "$RUNNER_TEMP/pi-runtime-event/response.status"
-          node ops/scripts/pi-deploy-event-provenance.mjs --validate-ack \
+          node ops/scripts/pi-deploy-event-provenance.mjs --validate-ack production \
             "$RUNNER_TEMP/pi-runtime-event/response.status" \
             "$RUNNER_TEMP/pi-runtime-event/response.json"

--- a/.github/workflows/pi-post-deploy-qa-event.yml
+++ b/.github/workflows/pi-post-deploy-qa-event.yml
@@ -63,7 +63,7 @@ jobs:
           set -euo pipefail
           mapfile -t signed < "$RUNNER_TEMP/pi-runtime-event/headers"
           test "${#signed[@]}" -eq 2
-          curl --silent --show-error --fail-with-body \
+          curl --silent --show-error \
             --request POST \
             --header 'content-type: application/json' \
             --header "x-pi-timestamp: ${signed[0]}" \
@@ -71,5 +71,9 @@ jobs:
             --header "x-pi-delivery-id: $PI_DELIVERY_ID" \
             --data-binary "@$RUNNER_TEMP/pi-runtime-event/event.json" \
             --output "$RUNNER_TEMP/pi-runtime-event/response.json" \
-            "$PI_EVENT_ENDPOINT"
-          test -s "$RUNNER_TEMP/pi-runtime-event/response.json"
+            --write-out '%{http_code}' \
+            "$PI_EVENT_ENDPOINT" \
+            > "$RUNNER_TEMP/pi-runtime-event/response.status"
+          node ops/scripts/pi-deploy-event-provenance.mjs --validate-ack \
+            "$RUNNER_TEMP/pi-runtime-event/response.status" \
+            "$RUNNER_TEMP/pi-runtime-event/response.json"

--- a/ops/scripts/pi-deploy-event-provenance.mjs
+++ b/ops/scripts/pi-deploy-event-provenance.mjs
@@ -1,0 +1,175 @@
+import { createHmac } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE_SHA = /^[0-9a-f]{40}$/;
+const RUN_ID = /^[1-9][0-9]{1,30}$/;
+const MAX_BUILD_TO_DEPLOY_MS = 15 * 60 * 1000;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function instant(value, label) {
+  const parsed = new Date(value);
+  invariant(!Number.isNaN(parsed.getTime()), `${label} is not an ISO timestamp`);
+  return parsed;
+}
+
+export function validateDeploymentProvenance({
+  repository,
+  deployment,
+  deploymentStatus,
+  deploymentManifest,
+  releaseManifest,
+  artifactCommit,
+  buildRun,
+}) {
+  invariant(repository === 'richmondjw/peninsula-insider', 'repository is not approved');
+  invariant(deployment?.environment === 'github-pages', 'deployment environment is not github-pages');
+  invariant(deployment?.ref === 'gh-pages', 'deployment ref is not gh-pages');
+  invariant(SOURCE_SHA.test(deployment?.sha || ''), 'deployment artifact SHA is invalid');
+  invariant(deploymentStatus?.state === 'success', 'deployment status is not successful');
+  invariant(deploymentStatus?.environment === 'github-pages', 'deployment-status environment is not github-pages');
+
+  invariant(SOURCE_SHA.test(deploymentManifest?.sourceSha || ''), 'deployment manifest sourceSha is invalid');
+  invariant(SOURCE_SHA.test(releaseManifest?.sourceSha || ''), 'release manifest sourceSha is invalid');
+  invariant(deploymentManifest.sourceSha === releaseManifest.sourceSha, 'live manifest sourceSha mismatch');
+  invariant(deploymentManifest.sourceSha !== deployment.sha, 'gh-pages artifact SHA cannot be the source SHA');
+  invariant(RUN_ID.test(String(deploymentManifest?.runId || '')), 'deployment manifest runId is invalid');
+  invariant(String(deploymentManifest.runId) === String(releaseManifest?.buildRunId || ''), 'live manifest build run mismatch');
+  invariant(releaseManifest?.schemaVersion === 1, 'release manifest schema drift');
+  invariant(releaseManifest?.verification?.expectedDeploymentSha === deploymentManifest.sourceSha, 'release verification source SHA drift');
+
+  invariant(artifactCommit?.sha === deployment.sha, 'artifact commit SHA does not match deployment');
+  const sourceFromCommit = String(artifactCommit?.commit?.message || '').match(/^deploy: ([0-9a-f]{40})(?:\s|—|-)/)?.[1];
+  invariant(sourceFromCommit === deploymentManifest.sourceSha, 'gh-pages commit does not bind the live source SHA');
+
+  invariant(String(buildRun?.id || '') === String(deploymentManifest.runId), 'build run id does not match live manifests');
+  invariant(buildRun?.name === 'Build and Deploy — Peninsula Insider', 'build workflow name drift');
+  invariant(buildRun?.path === '.github/workflows/build-and-deploy.yml', 'build workflow path drift');
+  invariant(buildRun?.head_branch === 'main', 'build run was not sourced from main');
+  invariant(buildRun?.head_sha === deploymentManifest.sourceSha, 'build run source SHA mismatch');
+  invariant(buildRun?.status === 'completed' && buildRun?.conclusion === 'success', 'build run did not complete successfully');
+  invariant(['push', 'schedule', 'workflow_dispatch'].includes(buildRun?.event), 'build trigger is not approved');
+
+  const statusAt = instant(deploymentStatus.created_at, 'deployment status created_at');
+  const deploymentGeneratedAt = instant(deploymentManifest.generatedAt, 'deployment manifest generatedAt');
+  const releaseGeneratedAt = instant(releaseManifest.generatedAt, 'release manifest generatedAt');
+  const commitAt = instant(artifactCommit?.commit?.committer?.date, 'artifact commit date');
+  const buildCompletedAt = instant(buildRun.updated_at, 'build run updated_at');
+  for (const [label, value] of [
+    ['deployment manifest', deploymentGeneratedAt],
+    ['release manifest', releaseGeneratedAt],
+    ['artifact commit', commitAt],
+    ['build completion', buildCompletedAt],
+  ]) {
+    const delta = statusAt.getTime() - value.getTime();
+    invariant(delta >= -60_000 && delta <= MAX_BUILD_TO_DEPLOY_MS, `${label} is outside the deployment temporal bound`);
+  }
+
+  return {
+    sourceSha: deploymentManifest.sourceSha,
+    artifactSha: deployment.sha,
+    buildRunId: String(deploymentManifest.runId),
+    deployedAt: statusAt.toISOString(),
+    deploymentManifestGeneratedAt: deploymentGeneratedAt.toISOString(),
+    releaseManifestGeneratedAt: releaseGeneratedAt.toISOString(),
+    artifactCommitAt: commitAt.toISOString(),
+    buildCompletedAt: buildCompletedAt.toISOString(),
+  };
+}
+
+async function fetchJson(url, { token } = {}) {
+  const headers = { accept: 'application/json', 'cache-control': 'no-cache' };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+    headers['x-github-api-version'] = '2022-11-28';
+  }
+  const response = await fetch(url, { headers, redirect: 'error' });
+  if (!response.ok) throw new Error(`provenance fetch failed HTTP ${response.status}: ${new URL(url).origin}${new URL(url).pathname}`);
+  return response.json();
+}
+
+export async function emitSignedDeploymentEvent(env = process.env) {
+  invariant(env.PI_REPOSITORY === 'richmondjw/peninsula-insider', 'repository is not approved');
+  invariant(Buffer.byteLength(env.PI_EVENT_HMAC_SECRET || '') >= 32, 'event HMAC secret must contain at least 32 bytes');
+  invariant(env.GITHUB_TOKEN, 'GITHUB_TOKEN is required for provenance validation');
+  const deployment = {
+    id: env.PI_DEPLOYMENT_ID,
+    environment: env.PI_DEPLOYMENT_ENVIRONMENT,
+    ref: env.PI_DEPLOYMENT_REF,
+    sha: String(env.PI_DEPLOYMENT_ARTIFACT_SHA || '').toLowerCase(),
+  };
+  const deploymentStatus = {
+    id: env.PI_DEPLOYMENT_STATUS_ID,
+    state: env.PI_DEPLOYMENT_STATUS_STATE,
+    environment: env.PI_DEPLOYMENT_STATUS_ENVIRONMENT,
+    created_at: env.PI_DEPLOYED_AT,
+  };
+  const cacheKey = encodeURIComponent(String(deploymentStatus.id || deployment.id));
+  const [deploymentManifest, releaseManifest] = await Promise.all([
+    fetchJson(`https://peninsulainsider.com.au/deployment.json?pi_deployment=${cacheKey}`),
+    fetchJson(`https://peninsulainsider.com.au/release-manifest.json?pi_deployment=${cacheKey}`),
+  ]);
+  invariant(RUN_ID.test(String(deploymentManifest?.runId || '')), 'deployment manifest runId is invalid');
+  const [artifactCommit, buildRun] = await Promise.all([
+    fetchJson(`https://api.github.com/repos/${env.PI_REPOSITORY}/commits/${deployment.sha}`, { token: env.GITHUB_TOKEN }),
+    fetchJson(`https://api.github.com/repos/${env.PI_REPOSITORY}/actions/runs/${deploymentManifest.runId}`, { token: env.GITHUB_TOKEN }),
+  ]);
+  const provenance = validateDeploymentProvenance({
+    repository: env.PI_REPOSITORY,
+    deployment,
+    deploymentStatus,
+    deploymentManifest,
+    releaseManifest,
+    artifactCommit,
+    buildRun,
+  });
+  const event = {
+    schema_version: '1.0',
+    event: 'production_deploy_succeeded',
+    repository: env.PI_REPOSITORY,
+    environment: 'github-pages',
+    deployment_ref: 'gh-pages',
+    status: 'succeeded',
+    deployment_id: String(deployment.id),
+    deployment_status_id: String(deploymentStatus.id),
+    revision: provenance.sourceSha,
+    deployment_artifact_revision: provenance.artifactSha,
+    build_run_id: provenance.buildRunId,
+    deployed_at: provenance.deployedAt,
+    provenance: {
+      deployment_manifest_source_sha: provenance.sourceSha,
+      release_manifest_source_sha: provenance.sourceSha,
+      build_run_head_sha: provenance.sourceSha,
+      deployment_manifest_generated_at: provenance.deploymentManifestGeneratedAt,
+      release_manifest_generated_at: provenance.releaseManifestGeneratedAt,
+      artifact_commit_at: provenance.artifactCommitAt,
+      build_completed_at: provenance.buildCompletedAt,
+    },
+    check_definitions: [
+      { url: 'https://peninsulainsider.com.au/', expected_status: 200 },
+      { url: 'https://peninsulainsider.com.au/deployment.json', expected_status: 200 },
+      { url: 'https://peninsulainsider.com.au/release-manifest.json', expected_status: 200 },
+    ],
+  };
+  const body = JSON.stringify(event);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = `sha256=${createHmac('sha256', env.PI_EVENT_HMAC_SECRET).update(`${timestamp}.${body}`).digest('hex')}`;
+  const root = path.join(env.RUNNER_TEMP, 'pi-runtime-event');
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  await writeFile(path.join(root, 'event.json'), body, { mode: 0o600, flag: 'wx' });
+  await writeFile(path.join(root, 'headers'), `${timestamp}\n${signature}\n`, { mode: 0o600, flag: 'wx' });
+  return { event, root };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  emitSignedDeploymentEvent().then(({ event }) => {
+    process.stdout.write(`${JSON.stringify({ status: 'signed', source_revision: event.revision, artifact_revision: event.deployment_artifact_revision, build_run_id: event.build_run_id })}\n`);
+  }).catch((error) => {
+    process.stderr.write(`${JSON.stringify({ status: 'rejected', error: String(error?.message || error).slice(0, 500) })}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/ops/scripts/pi-deploy-event-provenance.mjs
+++ b/ops/scripts/pi-deploy-event-provenance.mjs
@@ -123,7 +123,12 @@ export function buildDeploymentEvent({ env, deployment, deploymentStatus, proven
   };
 }
 
-export function validateAdapterAcknowledgement(httpStatus, rawBody) {
+export function validateAdapterAcknowledgement(httpStatus, rawBody, phase) {
+  const expectedByPhase = {
+    production: 'invoked_succeeded',
+    'disabled-fixture': 'ignored_binding_disabled',
+  };
+  invariant(Object.hasOwn(expectedByPhase, phase), 'adapter acknowledgement phase is invalid');
   invariant(String(httpStatus).trim() === '202', 'adapter acknowledgement HTTP status must be 202');
   let acknowledgement;
   try {
@@ -136,10 +141,7 @@ export function validateAdapterAcknowledgement(httpStatus, rawBody) {
     'adapter acknowledgement shape drift',
   );
   invariant(acknowledgement.replayed === false, 'adapter acknowledgement must be a newly admitted delivery');
-  invariant(
-    ['ignored_binding_disabled', 'invoked_succeeded'].includes(acknowledgement.status),
-    'adapter acknowledgement status is not accepted',
-  );
+  invariant(acknowledgement.status === expectedByPhase[phase], `adapter acknowledgement status is not valid for ${phase}`);
   return acknowledgement;
 }
 
@@ -202,8 +204,8 @@ export async function emitSignedDeploymentEvent(env = process.env) {
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const operation = process.argv[2] === '--validate-ack'
-    ? Promise.all([readFile(process.argv[3], 'utf8'), readFile(process.argv[4], 'utf8')])
-      .then(([status, body]) => ({ acknowledgement: validateAdapterAcknowledgement(status, body) }))
+    ? Promise.all([readFile(process.argv[4], 'utf8'), readFile(process.argv[5], 'utf8')])
+      .then(([status, body]) => ({ acknowledgement: validateAdapterAcknowledgement(status, body, process.argv[3]) }))
     : emitSignedDeploymentEvent();
   operation.then(({ event, acknowledgement }) => {
     if (acknowledgement) {

--- a/ops/scripts/pi-deploy-event-provenance.mjs
+++ b/ops/scripts/pi-deploy-event-provenance.mjs
@@ -1,5 +1,5 @@
 import { createHmac } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -81,6 +81,68 @@ export function validateDeploymentProvenance({
   };
 }
 
+export function buildDeploymentEvent({ env, deployment, deploymentStatus, provenance }) {
+  const sourceShaFragment = `"sourceSha": "${provenance.sourceSha}"`;
+  return {
+    schema_version: '1.0',
+    event: 'production_deploy_succeeded',
+    repository: env.PI_REPOSITORY,
+    environment: 'github-pages',
+    deployment_ref: 'gh-pages',
+    status: 'succeeded',
+    deployment_id: String(deployment.id),
+    deployment_status_id: String(deploymentStatus.id),
+    revision: provenance.sourceSha,
+    deployment_artifact_revision: provenance.artifactSha,
+    build_run_id: provenance.buildRunId,
+    deployed_at: provenance.deployedAt,
+    provenance: {
+      deployment_manifest_source_sha: provenance.sourceSha,
+      release_manifest_source_sha: provenance.sourceSha,
+      build_run_head_sha: provenance.sourceSha,
+      deployment_manifest_generated_at: provenance.deploymentManifestGeneratedAt,
+      release_manifest_generated_at: provenance.releaseManifestGeneratedAt,
+      artifact_commit_at: provenance.artifactCommitAt,
+      build_completed_at: provenance.buildCompletedAt,
+    },
+    check_definitions: [
+      { id: 'homepage', url: 'https://peninsulainsider.com.au/', expected_status: 200 },
+      {
+        id: 'deployment-provenance',
+        url: 'https://peninsulainsider.com.au/deployment.json',
+        expected_status: 200,
+        required_text: sourceShaFragment,
+      },
+      {
+        id: 'release-provenance',
+        url: 'https://peninsulainsider.com.au/release-manifest.json',
+        expected_status: 200,
+        required_text: sourceShaFragment,
+      },
+    ],
+  };
+}
+
+export function validateAdapterAcknowledgement(httpStatus, rawBody) {
+  invariant(String(httpStatus).trim() === '202', 'adapter acknowledgement HTTP status must be 202');
+  let acknowledgement;
+  try {
+    acknowledgement = JSON.parse(rawBody);
+  } catch {
+    throw new Error('adapter acknowledgement is not JSON');
+  }
+  invariant(
+    JSON.stringify(Object.keys(acknowledgement).sort()) === JSON.stringify(['replayed', 'status']),
+    'adapter acknowledgement shape drift',
+  );
+  invariant(acknowledgement.replayed === false, 'adapter acknowledgement must be a newly admitted delivery');
+  invariant(
+    ['ignored_binding_disabled', 'invoked_succeeded'].includes(acknowledgement.status),
+    'adapter acknowledgement status is not accepted',
+  );
+  return acknowledgement;
+}
+
 async function fetchJson(url, { token } = {}) {
   const headers = { accept: 'application/json', 'cache-control': 'no-cache' };
   if (token) {
@@ -127,34 +189,7 @@ export async function emitSignedDeploymentEvent(env = process.env) {
     artifactCommit,
     buildRun,
   });
-  const event = {
-    schema_version: '1.0',
-    event: 'production_deploy_succeeded',
-    repository: env.PI_REPOSITORY,
-    environment: 'github-pages',
-    deployment_ref: 'gh-pages',
-    status: 'succeeded',
-    deployment_id: String(deployment.id),
-    deployment_status_id: String(deploymentStatus.id),
-    revision: provenance.sourceSha,
-    deployment_artifact_revision: provenance.artifactSha,
-    build_run_id: provenance.buildRunId,
-    deployed_at: provenance.deployedAt,
-    provenance: {
-      deployment_manifest_source_sha: provenance.sourceSha,
-      release_manifest_source_sha: provenance.sourceSha,
-      build_run_head_sha: provenance.sourceSha,
-      deployment_manifest_generated_at: provenance.deploymentManifestGeneratedAt,
-      release_manifest_generated_at: provenance.releaseManifestGeneratedAt,
-      artifact_commit_at: provenance.artifactCommitAt,
-      build_completed_at: provenance.buildCompletedAt,
-    },
-    check_definitions: [
-      { url: 'https://peninsulainsider.com.au/', expected_status: 200 },
-      { url: 'https://peninsulainsider.com.au/deployment.json', expected_status: 200 },
-      { url: 'https://peninsulainsider.com.au/release-manifest.json', expected_status: 200 },
-    ],
-  };
+  const event = buildDeploymentEvent({ env, deployment, deploymentStatus, provenance });
   const body = JSON.stringify(event);
   const timestamp = String(Math.floor(Date.now() / 1000));
   const signature = `sha256=${createHmac('sha256', env.PI_EVENT_HMAC_SECRET).update(`${timestamp}.${body}`).digest('hex')}`;
@@ -166,7 +201,15 @@ export async function emitSignedDeploymentEvent(env = process.env) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  emitSignedDeploymentEvent().then(({ event }) => {
+  const operation = process.argv[2] === '--validate-ack'
+    ? Promise.all([readFile(process.argv[3], 'utf8'), readFile(process.argv[4], 'utf8')])
+      .then(([status, body]) => ({ acknowledgement: validateAdapterAcknowledgement(status, body) }))
+    : emitSignedDeploymentEvent();
+  operation.then(({ event, acknowledgement }) => {
+    if (acknowledgement) {
+      process.stdout.write(`${JSON.stringify({ status: 'acknowledged', adapter_status: acknowledgement.status })}\n`);
+      return;
+    }
     process.stdout.write(`${JSON.stringify({ status: 'signed', source_revision: event.revision, artifact_revision: event.deployment_artifact_revision, build_run_id: event.build_run_id })}\n`);
   }).catch((error) => {
     process.stderr.write(`${JSON.stringify({ status: 'rejected', error: String(error?.message || error).slice(0, 500) })}\n`);

--- a/ops/scripts/pi-deploy-event-provenance.test.mjs
+++ b/ops/scripts/pi-deploy-event-provenance.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import {
@@ -92,14 +93,23 @@ test('emits deterministic d792-compatible checks pinned to the source revision',
 
 test('requires the exact newly-admitted adapter acknowledgement', () => {
   assert.deepEqual(
-    validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false}'),
+    validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false}', 'disabled-fixture'),
     { status: 'ignored_binding_disabled', replayed: false },
   );
   assert.deepEqual(
-    validateAdapterAcknowledgement('202', '{"status":"invoked_succeeded","replayed":false}'),
+    validateAdapterAcknowledgement('202', '{"status":"invoked_succeeded","replayed":false}', 'production'),
     { status: 'invoked_succeeded', replayed: false },
   );
-  assert.throws(() => validateAdapterAcknowledgement('200', '{"status":"invoked_succeeded","replayed":false}'), /must be 202/);
-  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"processing","replayed":true}'), /newly admitted/);
-  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false,"extra":1}'), /shape drift/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false}', 'production'), /not valid for production/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"invoked_succeeded","replayed":false}', 'disabled-fixture'), /not valid for disabled-fixture/);
+  assert.throws(() => validateAdapterAcknowledgement('200', '{"status":"invoked_succeeded","replayed":false}', 'production'), /must be 202/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"processing","replayed":true}', 'production'), /newly admitted/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false,"extra":1}', 'disabled-fixture'), /shape drift/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"invoked_succeeded","replayed":false}', 'unknown'), /phase is invalid/);
+});
+
+test('production workflow selects only the production acknowledgement phase', async () => {
+  const workflow = await readFile(new URL('../../.github/workflows/pi-post-deploy-qa-event.yml', import.meta.url), 'utf8');
+  assert.match(workflow, /--validate-ack production/);
+  assert.doesNotMatch(workflow, /--validate-ack disabled-fixture/);
 });

--- a/ops/scripts/pi-deploy-event-provenance.test.mjs
+++ b/ops/scripts/pi-deploy-event-provenance.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { validateDeploymentProvenance } from './pi-deploy-event-provenance.mjs';
+import {
+  buildDeploymentEvent, validateAdapterAcknowledgement, validateDeploymentProvenance,
+} from './pi-deploy-event-provenance.mjs';
 
 const SOURCE = '5b9a7f14d42a6b9db1f12fc38a94209a8825ebb3';
 const ARTIFACT = '7496a0d1d2df86e496148994bf207b6270b8ac0a';
@@ -70,4 +72,34 @@ test('rejects non-pages environments, refs, failed runs and stale provenance', (
   const stale = fixture();
   stale.deploymentManifest.generatedAt = '2026-08-25T20:24:28Z';
   assert.throws(() => validateDeploymentProvenance(stale), /temporal bound/);
+});
+
+test('emits deterministic d792-compatible checks pinned to the source revision', () => {
+  const value = fixture();
+  const provenance = validateDeploymentProvenance(value);
+  const event = buildDeploymentEvent({
+    env: { PI_REPOSITORY: value.repository },
+    deployment: value.deployment,
+    deploymentStatus: value.deploymentStatus,
+    provenance,
+  });
+  assert.deepEqual(event.check_definitions, [
+    { id: 'homepage', url: 'https://peninsulainsider.com.au/', expected_status: 200 },
+    { id: 'deployment-provenance', url: 'https://peninsulainsider.com.au/deployment.json', expected_status: 200, required_text: `"sourceSha": "${SOURCE}"` },
+    { id: 'release-provenance', url: 'https://peninsulainsider.com.au/release-manifest.json', expected_status: 200, required_text: `"sourceSha": "${SOURCE}"` },
+  ]);
+});
+
+test('requires the exact newly-admitted adapter acknowledgement', () => {
+  assert.deepEqual(
+    validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false}'),
+    { status: 'ignored_binding_disabled', replayed: false },
+  );
+  assert.deepEqual(
+    validateAdapterAcknowledgement('202', '{"status":"invoked_succeeded","replayed":false}'),
+    { status: 'invoked_succeeded', replayed: false },
+  );
+  assert.throws(() => validateAdapterAcknowledgement('200', '{"status":"invoked_succeeded","replayed":false}'), /must be 202/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"processing","replayed":true}'), /newly admitted/);
+  assert.throws(() => validateAdapterAcknowledgement('202', '{"status":"ignored_binding_disabled","replayed":false,"extra":1}'), /shape drift/);
 });

--- a/ops/scripts/pi-deploy-event-provenance.test.mjs
+++ b/ops/scripts/pi-deploy-event-provenance.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validateDeploymentProvenance } from './pi-deploy-event-provenance.mjs';
+
+const SOURCE = '5b9a7f14d42a6b9db1f12fc38a94209a8825ebb3';
+const ARTIFACT = '7496a0d1d2df86e496148994bf207b6270b8ac0a';
+
+function fixture() {
+  return {
+    repository: 'richmondjw/peninsula-insider',
+    deployment: { id: 6092420891, environment: 'github-pages', ref: 'gh-pages', sha: ARTIFACT },
+    deploymentStatus: { id: 17326998599, state: 'success', environment: 'github-pages', created_at: '2026-08-25T21:25:21Z' },
+    deploymentManifest: { sourceSha: SOURCE, runId: '32900519849', generatedAt: '2026-08-25T21:24:28.722Z' },
+    releaseManifest: {
+      schemaVersion: 1, sourceSha: SOURCE, buildRunId: '32900519849', generatedAt: '2026-08-25T21:24:29.107Z',
+      verification: { expectedDeploymentSha: SOURCE },
+    },
+    artifactCommit: {
+      sha: ARTIFACT,
+      commit: { message: `deploy: ${SOURCE} — approved source`, committer: { date: '2026-08-25T21:24:38Z' } },
+    },
+    buildRun: {
+      id: 32900519849, name: 'Build and Deploy — Peninsula Insider', path: '.github/workflows/build-and-deploy.yml',
+      event: 'push', status: 'completed', conclusion: 'success', head_branch: 'main', head_sha: SOURCE,
+      updated_at: '2026-08-25T21:24:44Z',
+    },
+  };
+}
+
+test('accepts the observed GitHub Pages chain and returns source separate from artifact', () => {
+  const result = validateDeploymentProvenance(fixture());
+  assert.equal(result.sourceSha, SOURCE);
+  assert.equal(result.artifactSha, ARTIFACT);
+  assert.notEqual(result.sourceSha, result.artifactSha);
+});
+
+test('never mistakes the gh-pages artifact commit for the source revision', () => {
+  const value = fixture();
+  value.deploymentManifest.sourceSha = ARTIFACT;
+  value.releaseManifest.sourceSha = ARTIFACT;
+  value.releaseManifest.verification.expectedDeploymentSha = ARTIFACT;
+  value.buildRun.head_sha = ARTIFACT;
+  value.artifactCommit.commit.message = `deploy: ${ARTIFACT} — forged`;
+  assert.throws(() => validateDeploymentProvenance(value), /artifact SHA cannot be the source SHA/);
+});
+
+test('rejects manifest, commit and build-run provenance mismatches', () => {
+  const manifestMismatch = fixture();
+  manifestMismatch.releaseManifest.sourceSha = 'a'.repeat(40);
+  assert.throws(() => validateDeploymentProvenance(manifestMismatch), /manifest sourceSha mismatch/);
+  const commitMismatch = fixture();
+  commitMismatch.artifactCommit.commit.message = `deploy: ${'a'.repeat(40)} — wrong`;
+  assert.throws(() => validateDeploymentProvenance(commitMismatch), /commit does not bind/);
+  const runMismatch = fixture();
+  runMismatch.buildRun.head_sha = 'a'.repeat(40);
+  assert.throws(() => validateDeploymentProvenance(runMismatch), /build run source SHA mismatch/);
+});
+
+test('rejects non-pages environments, refs, failed runs and stale provenance', () => {
+  const wrongEnvironment = fixture();
+  wrongEnvironment.deployment.environment = 'production';
+  assert.throws(() => validateDeploymentProvenance(wrongEnvironment), /github-pages/);
+  const wrongRef = fixture();
+  wrongRef.deployment.ref = 'main';
+  assert.throws(() => validateDeploymentProvenance(wrongRef), /gh-pages/);
+  const failedRun = fixture();
+  failedRun.buildRun.conclusion = 'failure';
+  assert.throws(() => validateDeploymentProvenance(failedRun), /successfully/);
+  const stale = fixture();
+  stale.deploymentManifest.generatedAt = '2026-08-25T20:24:28Z';
+  assert.throws(() => validateDeploymentProvenance(stale), /temporal bound/);
+});


### PR DESCRIPTION
Adds a fail-closed deployment_status producer for the observed GitHub Pages chain. It distinguishes the gh-pages artifact SHA from the source main SHA and requires agreement across deployment status, artifact commit, live deployment/release manifests, and the successful source build run before signing. Kept draft because endpoint, secret, sidecar and binding are intentionally not active. Verification: 4/4 provenance tests.