### PR TITLE
Gate the What's On freshness safeguards that had no enforcement

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -78,6 +78,7 @@ jobs:
           cd next
           npm run test:content-admission
           npm run test:agent-readiness
+          npm run test:event-safeguards
           npm run validate:content
 
       - name: Build

--- a/.github/workflows/content-freshness.yml
+++ b/.github/workflows/content-freshness.yml
@@ -97,6 +97,26 @@ jobs:
           path: reports/event-source-freshness.json
           if-no-files-found: ignore
 
+      - name: Audit What's On safeguards
+        # Report-only here on purpose. The same script runs with --assert inside
+        # `npm run build`, but only over defects an author introduces. Verification
+        # age is the one safeguard metric that climbs on its own with the calendar,
+        # so this daily pass - where re-checking the source is the actual fix - is
+        # where it belongs. Blocking a deploy on it would stop publishing for a
+        # reason no deploy could ever clear.
+        continue-on-error: true
+        run: |
+          cd next
+          npm run audit:event-safeguards
+
+      - name: Upload What's On safeguard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-safeguards-${{ github.run_id }}
+          path: ops/reports/events/event-safeguards.json
+          if-no-files-found: ignore
+
       - name: Commit and push freshness diff
         run: |
           git add next/src/content/events next/src/content/quick-notes

--- a/.github/workflows/content-gate.yml
+++ b/.github/workflows/content-gate.yml
@@ -57,6 +57,7 @@ jobs:
           cd next
           npm run test:content-admission
           npm run test:agent-readiness
+          npm run test:event-safeguards
 
       - name: Content admission gate
         # Placeholder markers + real Astro collection-schema validation

--- a/next/package.json
+++ b/next/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && npm run lint:coordinates && astro build && npm run lint:no-hidden-pages && npm run lint:seo-architecture && npm run lint:filter-chips && npm run audit:agent-readiness && npm run assert:link-graph",
+    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && npm run lint:coordinates && astro build && npm run lint:no-hidden-pages && npm run lint:seo-architecture && npm run lint:filter-chips && npm run audit:agent-readiness && npm run assert:link-graph && npm run assert:event-safeguards",
     "build:search": "npm run build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
@@ -50,7 +50,10 @@
     "image-intelligence:pilot": "node scripts/image-intelligence-pilot.mjs pilot",
     "test:image-intelligence": "node --test scripts/image-intelligence/pilot-core.test.mjs",
     "audit:link-graph": "node scripts/audit-link-graph.mjs --dist dist --json ../ops/reports/seo/link-graph.json",
-    "assert:link-graph": "node scripts/audit-link-graph.mjs --dist dist --assert --json ../ops/reports/seo/link-graph.json"
+    "assert:link-graph": "node scripts/audit-link-graph.mjs --dist dist --assert --json ../ops/reports/seo/link-graph.json",
+    "audit:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json",
+    "test:event-safeguards": "node --test scripts/audit-event-safeguards.test.mjs",
+    "assert:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json --assert"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/next/scripts/audit-event-safeguards.mjs
+++ b/next/scripts/audit-event-safeguards.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/**
+ * audit-event-safeguards.mjs — the What's On safeguard gate.
+ *
+ * Five safeguards are meant to stand between the event corpus and a reader:
+ * source last-verified expiry, duplicate records, recurring-event validity,
+ * applicable dates/seasons, and cancellations. Three of them were already
+ * enforced in code when this script was written (2026-08-29):
+ *
+ *   - recurring validity + applicable seasons : whats-on/_data.ts ruleFor()
+ *     derives ONE occurrence rule per event and refuses to invent a cadence
+ *     from a stale nextOccurrence.
+ *   - cancellations : the `cancelled` flag plus isCancelledEvent() /
+ *     loadLiveEvents() in whats-on/_data.ts withdraw a record from every
+ *     "what is on" surface while keeping the URL and its EventCancelled
+ *     JSON-LD alive.
+ *
+ * The other two had no enforcement at all. `lastCheckedDate` was a write-only
+ * field — 56 live events carried it (or didn't) and nothing in the build, the
+ * page render or CI ever read it, so 13 events were publishing with no
+ * verification date and 31 with one over 90 days old. Nothing anywhere looked
+ * for duplicate event records either. This script closes both.
+ *
+ * Report-only by default. `--assert` compares against the ratchet baseline in
+ * ops/reports/events/event-safeguards-baseline.json and exits 1 on regression,
+ * matching the contract audit-link-graph.mjs uses. A ratchet, not a hard
+ * threshold: seeding the baseline with today's real numbers means the gate can
+ * never be satisfied by making the corpus worse, but also never blocks a
+ * deploy over debt it inherited. Tighten the baseline as the corpus is
+ * re-verified.
+ *
+ * Usage:
+ *   node scripts/audit-event-safeguards.mjs [--json out.json] [--assert]
+ *                                           [--baseline path] [--update-baseline]
+ *                                           [--today YYYY-MM-DD]
+ *                                           [--events-dir path]
+ *
+ * --today pins "now" so the time-driven verification-age numbers can be tested
+ * against a future date instead of only against the day the test happens to run.
+ */
+
+import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const DEFAULT_EVENTS_DIR = path.join(REPO, 'next', 'src', 'content', 'events');
+const DEFAULT_BASELINE = path.join(REPO, 'ops', 'reports', 'events', 'event-safeguards-baseline.json');
+
+/** Past this age a verification date is not evidence of anything. */
+const STALE_DAYS = 90;
+const LIVE_STATUSES = new Set(['published', 'scheduled']);
+
+const args = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : fallback;
+};
+const JSON_OUT = getArg('--json', null);
+const BASELINE = path.resolve(getArg('--baseline', DEFAULT_BASELINE));
+const ASSERT = args.includes('--assert');
+const UPDATE_BASELINE = args.includes('--update-baseline');
+const TODAY_OVERRIDE = getArg('--today', null);
+// Fixture directory override. Only the test harness passes this; production
+// callers audit the real corpus.
+const EVENTS_DIR = path.resolve(getArg('--events-dir', DEFAULT_EVENTS_DIR));
+
+/**
+ * Which metrics the --assert ratchet is allowed to fail on.
+ *
+ * Only defects an author can introduce. `staleVerificationDate` is deliberately
+ * NOT here: it counts records whose lastCheckedDate has aged past STALE_DAYS, so
+ * it climbs on its own with the calendar. Asserting on it would wire the passage
+ * of time into `npm run build` — this corpus would have crossed its own baseline
+ * of 31 on 2026-09-02 and blocked every deploy from then on without a single
+ * content change. Verification age is real debt, but it is surfaced by the daily
+ * content-freshness workflow, where re-verifying the record is the fix. A deploy
+ * gate is the wrong instrument for debt that accrues by doing nothing.
+ */
+const ASSERTED_METRICS = new Set([
+  'missingVerificationDate',
+  'duplicateTitleGroups',
+  'duplicateVenueDateGroups',
+  'unresolvableRecurrence',
+  'cancelledWithoutProvenance',
+]);
+
+const normalise = (value) =>
+  String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+const parseDate = (value) => {
+  if (!value) return null;
+  const d = new Date(String(value).slice(0, 10));
+  return Number.isNaN(d.getTime()) ? null : d;
+};
+
+/**
+ * Mirrors isLiveEvent() in components/v5/home/home-data.ts, which is the
+ * broadest admission test any surface applies (whats-on/_data.ts is stricter:
+ * it admits `published` only). Measuring the broader set means a record that
+ * reaches ANY surface is covered by this gate.
+ *
+ * A cancelled record is excluded for the same reason the surfaces exclude it:
+ * it is deliberately withdrawn from "what is on", so it is not the corpus this
+ * gate measures. Its own provenance is checked separately below.
+ */
+function isLive(data, file) {
+  if (file.includes('archive')) return false;
+  if (!LIVE_STATUSES.has(data.status ?? 'published')) return false;
+  if (data.cancelled === true) return false;
+  if (data.skipThis === true) return false;
+  return true;
+}
+
+async function main() {
+  const files = (await readdir(EVENTS_DIR, { recursive: true }))
+    .filter((f) => f.endsWith('.json'));
+
+  const live = [];
+  const cancelled = [];
+  for (const rel of files) {
+    const abs = path.join(EVENTS_DIR, rel);
+    let data;
+    try {
+      data = JSON.parse(await readFile(abs, 'utf8'));
+    } catch (error) {
+      console.error(`  UNREADABLE ${rel}: ${error.message}`);
+      process.exitCode = 1;
+      continue;
+    }
+    if (data.cancelled === true) cancelled.push({ file: rel, data });
+    if (isLive(data, rel)) live.push({ file: rel, data });
+  }
+
+  const today = new Date(
+    TODAY_OVERRIDE ? TODAY_OVERRIDE : new Date().toISOString().slice(0, 10)
+  );
+  if (Number.isNaN(today.getTime())) {
+    console.error(`  FAIL: --today ${TODAY_OVERRIDE} is not a valid YYYY-MM-DD date`);
+    process.exit(2);
+  }
+
+  // ── 1. source last-verified expiry ────────────────────────────────────────
+  const missingVerification = [];
+  const staleVerification = [];
+  for (const { file, data } of live) {
+    const checked = parseDate(data.lastCheckedDate);
+    if (!checked) {
+      missingVerification.push(file);
+      continue;
+    }
+    const ageDays = Math.round((today - checked) / 86400000);
+    if (ageDays > STALE_DAYS) staleVerification.push({ file, lastCheckedDate: String(data.lastCheckedDate).slice(0, 10), ageDays });
+  }
+  staleVerification.sort((a, b) => b.ageDays - a.ageDays);
+
+  // ── 2. duplicates ─────────────────────────────────────────────────────────
+  // Two independent keys. Title alone misses re-imports that were retitled;
+  // venue+date alone misses a series duplicated across two source feeds.
+  const byTitle = new Map();
+  const byVenueDate = new Map();
+  const titleByFile = new Map(live.map(({ file, data }) => [file, data.title ?? '']));
+  for (const { file, data } of live) {
+    const title = normalise(data.title);
+    if (title) {
+      if (!byTitle.has(title)) byTitle.set(title, []);
+      byTitle.get(title).push(file);
+    }
+    const venue = normalise(
+      data.venueName ?? data.locationName ?? (typeof data.venue === 'object' ? data.venue?.name : data.venue)
+    );
+    const start = String(data.startDate ?? '').slice(0, 10);
+    if (venue && start) {
+      const key = `${venue}@${start}`;
+      if (!byVenueDate.has(key)) byVenueDate.set(key, []);
+      byVenueDate.get(key).push(file);
+    }
+  }
+  const groupsOf = (map) =>
+    [...map.entries()].filter(([, files]) => files.length > 1).map(([key, files]) => ({ key, files }));
+  const duplicateTitles = groupsOf(byTitle);
+
+  // Venue+date alone is not a duplicate signal. A gallery runs two exhibitions
+  // from the same opening date and a bathhouse runs three classes from the same
+  // day; the first version of this check reported all five as defects, which is
+  // how a gate teaches people to ignore it. Require the titles to actually
+  // resemble each other before calling it a duplicate.
+  const TITLE_OVERLAP_MIN = 0.6;
+  // Compare on what *distinguishes* the events. The venue is already the group
+  // key and most titles repeat it, so leaving those tokens in scored "Sound
+  // Healing Sessions" against "Yoga (Complimentary)" at 0.6 on the strength of
+  // "peninsula hot springs" alone.
+  const distinctiveTokens = (file, venueKey) => {
+    const venueWords = new Set(venueKey.split(' ').filter(Boolean));
+    return new Set(
+      normalise(titleByFile.get(file))
+        .split(' ')
+        .filter((t) => t && !venueWords.has(t))
+    );
+  };
+  const similar = (a, b, venueKey) => {
+    const [x, y] = [distinctiveTokens(a, venueKey), distinctiveTokens(b, venueKey)];
+    if (!x.size || !y.size) return false;
+    let shared = 0;
+    for (const t of x) if (y.has(t)) shared += 1;
+    return shared / Math.min(x.size, y.size) >= TITLE_OVERLAP_MIN;
+  };
+  const duplicateVenueDates = groupsOf(byVenueDate)
+    .map(({ key, files }) => {
+      const venueKey = key.slice(0, key.lastIndexOf('@'));
+      return {
+        key,
+        files: files.filter((f, i) => files.some((g, j) => i !== j && similar(f, g, venueKey))),
+      };
+    })
+    .filter((g) => g.files.length > 1);
+
+  // ── 3/4. recurring validity + applicable dates ────────────────────────────
+  // Can the record state its own cadence? ruleFor() in whats-on/_data.ts needs
+  // a weekday for a weekly series and a weekday + ordinal for a monthly one.
+  // Without them it cannot derive a repeating rule and falls back to publishing
+  // the single date recompute-occurrence.py guessed — day-of-month arithmetic
+  // that is simply wrong for "last Saturday" or "full moon" cadences, and that
+  // renders nowhere at all on the day that guess is not refreshed.
+  //
+  // Deliberately time-independent. An earlier revision skipped any record whose
+  // nextOccurrence was still in the future, which meant the daily cron rolling
+  // that date forward permanently masked the defect: the count read 0 today and
+  // 3 the moment the clock moved. A safeguard that only reports a problem once
+  // it is already live is not a safeguard. Judge the record, not the calendar.
+  const DAY = /\b(sun|mon|tues?|wed(?:nes)?|thur?s?|fri|sat(?:ur)?)(?:day)?s?\b/i;
+  const NTH = /\b(first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\b/i;
+  const unresolvableRecurrence = [];
+  for (const { file, data } of live) {
+    const recur = data.recurrence ?? 'one-off';
+    if (recur !== 'weekly' && recur !== 'monthly') continue;
+    const note = [data.recurrenceNote, data.title, data.summary].filter(Boolean).join(' ');
+    const start = parseDate(data.startDate);
+    // Weekly: explicit prose, or the series start date as the weekday anchor.
+    if (recur === 'weekly' && (DAY.test(data.recurrenceNote ?? '') || start)) continue;
+    // Monthly: needs both the weekday and which one ("third Saturday").
+    if (recur === 'monthly' && DAY.test(note) && NTH.test(note)) continue;
+    unresolvableRecurrence.push({
+      file,
+      recurrence: recur,
+      recurrenceNote: data.recurrenceNote ?? null,
+      nextOccurrence: data.nextOccurrence ? String(data.nextOccurrence).slice(0, 10) : null,
+    });
+  }
+
+  // ── 5. cancellations ──────────────────────────────────────────────────────
+  // A cancelled record must carry the provenance that justifies the notice,
+  // otherwise the page tells a reader an event is off without saying who says so.
+  const cancelledWithoutProvenance = cancelled
+    .filter(({ data }) => !data.cancellationSourceUrl && !data.cancellationNote)
+    .map(({ file }) => file);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    asOf: today.toISOString().slice(0, 10),
+    staleAfterDays: STALE_DAYS,
+    assertedMetrics: [...ASSERTED_METRICS],
+    totals: {
+      liveEvents: live.length,
+      cancelledEvents: cancelled.length,
+      missingVerificationDate: missingVerification.length,
+      staleVerificationDate: staleVerification.length,
+      duplicateTitleGroups: duplicateTitles.length,
+      duplicateVenueDateGroups: duplicateVenueDates.length,
+      unresolvableRecurrence: unresolvableRecurrence.length,
+      cancelledWithoutProvenance: cancelledWithoutProvenance.length,
+    },
+    missingVerificationDate: missingVerification.sort(),
+    staleVerificationDate: staleVerification,
+    duplicateTitleGroups: duplicateTitles,
+    duplicateVenueDateGroups: duplicateVenueDates,
+    unresolvableRecurrence,
+    cancelledWithoutProvenance,
+  };
+
+  const t = report.totals;
+  console.log(`Event safeguard audit — ${t.liveEvents} live events, ${t.cancelledEvents} cancelled`);
+  console.log('');
+  console.log(`  Source verification            (as of ${report.asOf})`);
+  console.log(`    no lastCheckedDate .......... ${t.missingVerificationDate}   [gated]`);
+  console.log(`    stale (> ${STALE_DAYS}d) ............... ${t.staleVerificationDate}   [report-only, ages with the calendar]`);
+  console.log('  Duplicates');
+  console.log(`    same normalised title ....... ${t.duplicateTitleGroups}   [gated]`);
+  console.log(`    same venue + start date ..... ${t.duplicateVenueDateGroups}   [gated]`);
+  console.log('  Recurrence & cancellation');
+  console.log(`    unresolvable recurrence ..... ${t.unresolvableRecurrence}   [gated]`);
+  console.log(`    cancelled w/o provenance .... ${t.cancelledWithoutProvenance}   [gated]`);
+  console.log('');
+
+  for (const g of [...duplicateTitles, ...duplicateVenueDates]) {
+    console.log(`    DUPLICATE  ${g.key}`);
+    for (const f of g.files) console.log(`               ${f}`);
+  }
+  for (const u of unresolvableRecurrence) {
+    console.log(`    NO RULE    ${u.file} (${u.recurrence}) note=${JSON.stringify(u.recurrenceNote)}`);
+  }
+  for (const f of cancelledWithoutProvenance) {
+    console.log(`    NO SOURCE  ${f} is cancelled with neither a note nor a source URL`);
+  }
+
+  if (JSON_OUT) {
+    const out = path.resolve(JSON_OUT);
+    await mkdir(path.dirname(out), { recursive: true });
+    await writeFile(out, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(`  report -> ${path.relative(REPO, out)}`);
+  }
+
+  if (UPDATE_BASELINE) {
+    await mkdir(path.dirname(BASELINE), { recursive: true });
+    await writeFile(
+      BASELINE,
+      `${JSON.stringify(
+        {
+          updatedAt: report.generatedAt,
+          staleAfterDays: STALE_DAYS,
+          assertedMetrics: [...ASSERTED_METRICS],
+          ceilings: t,
+        },
+        null,
+        2
+      )}\n`
+    );
+    console.log(`  baseline -> ${path.relative(REPO, BASELINE)}`);
+    return;
+  }
+
+  if (!ASSERT) return;
+
+  let baseline;
+  try {
+    baseline = JSON.parse(await readFile(BASELINE, 'utf8'));
+  } catch (error) {
+    // Fail closed. A missing or corrupt baseline must not read as "no regression".
+    console.error(`\n  FAIL: cannot read baseline ${path.relative(REPO, BASELINE)} — ${error.message}`);
+    console.error('  Seed it with: npm run audit:event-safeguards -- --update-baseline');
+    process.exit(1);
+  }
+
+  const failures = [];
+  for (const [metric, ceiling] of Object.entries(baseline.ceilings ?? {})) {
+    if (!ASSERTED_METRICS.has(metric)) continue;
+    const actual = t[metric];
+    if (typeof actual === 'number' && actual > ceiling) {
+      failures.push(`${metric}: ${actual} > baseline ${ceiling}`);
+    }
+  }
+
+  if (failures.length) {
+    console.error('\n  FAIL: event safeguard regression against the ratchet baseline');
+    for (const f of failures) console.error(`    ${f}`);
+    console.error('\n  Fix the records, or re-seed deliberately with --update-baseline.');
+    process.exit(1);
+  }
+  console.log('  PASS: no regression against the ratchet baseline.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/next/scripts/audit-event-safeguards.test.mjs
+++ b/next/scripts/audit-event-safeguards.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * Tests for the What's On safeguard gate.
+ *
+ * The gate runs inside `npm run build`, so a false failure blocks every deploy
+ * and a false pass lets a defective event record reach readers. Both directions
+ * are asserted here against fixture corpora rather than the live content.
+ *
+ * The time-travel cases are the reason this file exists. The first revision of
+ * the gate asserted on metrics that climb with the calendar, so it would have
+ * passed on the day it shipped and blocked the deploy pipeline four days later
+ * with no content change at all.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+const SCRIPT = new URL('./audit-event-safeguards.mjs', import.meta.url).pathname;
+
+const BASE = {
+  slug: 'a-market',
+  title: 'A Market',
+  summary: 'A market on the Peninsula.',
+  category: 'market',
+  status: 'published',
+  recurrence: 'one-off',
+  startDate: '2026-12-05',
+  endDate: '2026-12-05',
+  venueName: 'Somewhere Hall',
+  lastCheckedDate: '2026-08-20',
+  publishedAt: '2026-01-01',
+};
+
+/** Write an events fixture plus a zeroed baseline, and audit it. */
+async function audit(records, { today = '2026-08-29', ceilings = {} } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'pi-safeguards-'));
+  try {
+    const events = join(dir, 'events');
+    await mkdir(events, { recursive: true });
+    for (const [name, record] of Object.entries(records)) {
+      await writeFile(join(events, `${name}.json`), JSON.stringify(record, null, 2));
+    }
+    const baseline = join(dir, 'baseline.json');
+    await writeFile(
+      baseline,
+      JSON.stringify({
+        ceilings: {
+          missingVerificationDate: 0,
+          duplicateTitleGroups: 0,
+          duplicateVenueDateGroups: 0,
+          unresolvableRecurrence: 0,
+          cancelledWithoutProvenance: 0,
+          ...ceilings,
+        },
+      })
+    );
+    const args = [SCRIPT, '--assert', '--events-dir', events, '--baseline', baseline, '--today', today];
+    try {
+      const { stdout } = await run(process.execPath, args);
+      return { code: 0, out: stdout };
+    } catch (error) {
+      return { code: error.code ?? 1, out: `${error.stdout ?? ''}${error.stderr ?? ''}` };
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('a clean corpus passes the gate', async () => {
+  const { code } = await audit({ a: BASE });
+  assert.equal(code, 0);
+});
+
+test('two records with the same title are reported as duplicates', async () => {
+  const { code, out } = await audit({
+    a: BASE,
+    b: { ...BASE, slug: 'a-market-2', title: 'A  MARKET' },
+  });
+  assert.equal(code, 1);
+  assert.match(out, /duplicateTitleGroups: 1 > baseline 0/);
+});
+
+test('same venue and date with near-identical titles is a duplicate', async () => {
+  const { code, out } = await audit({
+    a: { ...BASE, title: 'Sunday Farmers Market' },
+    b: { ...BASE, slug: 'b', title: 'Sunday Farmers Market Day' },
+  });
+  assert.equal(code, 1);
+  assert.match(out, /duplicateVenueDateGroups: 1 > baseline 0/);
+});
+
+test('same venue and date with genuinely different events is not a duplicate', async () => {
+  // A bathhouse runs several unrelated classes from one opening date. Flagging
+  // these is how a gate teaches people to ignore it.
+  const { code } = await audit({
+    a: { ...BASE, title: 'Sound Healing Sessions' },
+    b: { ...BASE, slug: 'b', title: 'Complimentary Morning Yoga' },
+  });
+  assert.equal(code, 0);
+});
+
+test('a live record with no lastCheckedDate fails the gate', async () => {
+  const record = { ...BASE };
+  delete record.lastCheckedDate;
+  const { code, out } = await audit({ a: record });
+  assert.equal(code, 1);
+  assert.match(out, /missingVerificationDate: 1 > baseline 0/);
+});
+
+test('a monthly record that cannot state its cadence fails the gate', async () => {
+  const { code, out } = await audit({
+    a: { ...BASE, recurrence: 'monthly', recurrenceNote: 'Monthly' },
+  });
+  assert.equal(code, 1);
+  assert.match(out, /unresolvableRecurrence: 1 > baseline 0/);
+});
+
+test('a monthly record with weekday and ordinal resolves', async () => {
+  const { code } = await audit({
+    a: { ...BASE, recurrence: 'monthly', recurrenceNote: 'Third Saturday of every month' },
+  });
+  assert.equal(code, 0);
+});
+
+test('a weekly record anchored only by its start date resolves', async () => {
+  const { code } = await audit({ a: { ...BASE, recurrence: 'weekly' } });
+  assert.equal(code, 0);
+});
+
+test('a cancelled record with no note and no source fails the gate', async () => {
+  const { code, out } = await audit({
+    a: { ...BASE, cancelled: true },
+  });
+  assert.equal(code, 1);
+  assert.match(out, /cancelledWithoutProvenance: 1 > baseline 0/);
+});
+
+test('a cancelled record carrying its provenance passes', async () => {
+  const { code } = await audit({
+    a: {
+      ...BASE,
+      cancelled: true,
+      cancellationNote: 'The organiser withdrew the event.',
+      cancellationSourceUrl: 'https://example.com/notice',
+    },
+  });
+  assert.equal(code, 0);
+});
+
+test('archived and editor-skipped records are outside the measured corpus', async () => {
+  const stale = { ...BASE, lastCheckedDate: undefined };
+  delete stale.lastCheckedDate;
+  const { code } = await audit({
+    a: BASE,
+    b: { ...stale, slug: 'b', title: 'B', status: 'archived' },
+    c: { ...stale, slug: 'c', title: 'C', skipThis: true },
+  });
+  assert.equal(code, 0);
+});
+
+test('verification age does not fail the gate, however far the clock moves', async () => {
+  // The regression this file was written for. lastCheckedDate is 2026-08-20;
+  // by 2030 it is years past the 90-day staleness line. That is real debt for
+  // the freshness workflow to work through, but it must never block a deploy,
+  // because no author action caused it and no author action inside this build
+  // can clear it.
+  for (const today of ['2026-09-02', '2026-12-01', '2027-08-29', '2030-01-01']) {
+    const { code, out } = await audit({ a: BASE }, { today });
+    assert.equal(code, 0, `gate failed at --today ${today}:\n${out}`);
+  }
+});
+
+test('verification age is still reported even though it is not gated', async () => {
+  const { code, out } = await audit({ a: BASE }, { today: '2027-08-29' });
+  assert.equal(code, 0);
+  assert.match(out, /stale \(> 90d\) \.+ 1 {3}\[report-only/);
+});
+
+test('the gate fails closed when the baseline is missing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'pi-safeguards-nobaseline-'));
+  try {
+    const events = join(dir, 'events');
+    await mkdir(events, { recursive: true });
+    await writeFile(join(events, 'a.json'), JSON.stringify(BASE));
+    await assert.rejects(() =>
+      run(process.execPath, [
+        SCRIPT, '--assert',
+        '--events-dir', events,
+        '--baseline', join(dir, 'does-not-exist.json'),
+      ])
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/ops/reports/events/event-safeguards-baseline.json
+++ b/ops/reports/events/event-safeguards-baseline.json
@@ -1,0 +1,21 @@
+{
+  "updatedAt": "2026-08-29T03:39:19.320Z",
+  "staleAfterDays": 90,
+  "assertedMetrics": [
+    "missingVerificationDate",
+    "duplicateTitleGroups",
+    "duplicateVenueDateGroups",
+    "unresolvableRecurrence",
+    "cancelledWithoutProvenance"
+  ],
+  "ceilings": {
+    "liveEvents": 56,
+    "cancelledEvents": 1,
+    "missingVerificationDate": 13,
+    "staleVerificationDate": 31,
+    "duplicateTitleGroups": 0,
+    "duplicateVenueDateGroups": 0,
+    "unresolvableRecurrence": 3,
+    "cancelledWithoutProvenance": 0
+  }
+}

--- a/ops/reports/events/event-safeguards.json
+++ b/ops/reports/events/event-safeguards.json
@@ -1,0 +1,217 @@
+{
+  "generatedAt": "2026-08-29T03:43:28.594Z",
+  "asOf": "2026-08-29",
+  "staleAfterDays": 90,
+  "assertedMetrics": [
+    "missingVerificationDate",
+    "duplicateTitleGroups",
+    "duplicateVenueDateGroups",
+    "unresolvableRecurrence",
+    "cancelledWithoutProvenance"
+  ],
+  "totals": {
+    "liveEvents": 56,
+    "cancelledEvents": 1,
+    "missingVerificationDate": 13,
+    "staleVerificationDate": 31,
+    "duplicateTitleGroups": 0,
+    "duplicateVenueDateGroups": 0,
+    "unresolvableRecurrence": 3,
+    "cancelledWithoutProvenance": 0
+  },
+  "missingVerificationDate": [
+    "archibald-prize-2026-facing-modernity-mitchelton-winery-mprg-art-trip.json",
+    "arj-barker-live-at-barlow.json",
+    "author-talk-vikki-petraitis-mornington-library.json",
+    "breast-foot-forward-annual-community-walk-and-run-2026.json",
+    "enchanting-kirtan-sacred-music-meditation-experience-mornington.json",
+    "glamping-tents-horror-movie-campout-back-from-the-dead-tour-2026.json",
+    "high-tea-at-mornington-botanical-rose-gardens.json",
+    "nancye-wynne-bolton-ola-golf-day-2026.json",
+    "pst-art-exhibition-opening-night-2026.json",
+    "pub-carols-thursday-17th-december.json",
+    "red-hill-market-first-saturday.json",
+    "saturday-pottery-class.json",
+    "the-wellness-experience-celebrating-women-s-health-week.json"
+  ],
+  "staleVerificationDate": [
+    {
+      "file": "bass-flinders-gin-masterclass.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "crib-point-community-market.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "emu-plains-market.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "flinders-truffles-winter-truffle-hunt-season.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "foxeys-hangout-vegetable-feast-morning-sun-vineyard.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "hastings-thursday-street-market.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "heart-of-the-community-market-rosebud.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "hill-ridge-community-market-september-2026-restart.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "mornington-christmas-festival-main-street-christmas-parade.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "mornington-tourist-railway-santa-specials.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "mornington-wednesday-market-main-street-market.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "mt-eliza-farmers-market.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "national-works-on-paper-2026-nwop.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "peninsula-hot-springs-daily-studio-yoga.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "peninsula-hot-springs-hot-springs-yoga-complimentary.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "peninsula-hot-springs-sound-healing-sessions.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "peninsula-summer-music-festival-2027-save-the-date.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "peninsula-summer-music-festival-2027.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "polperro-cellar-table-private-dining-experience.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "pt-leo-estate-sculpture-park.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "red-hill-brewery-secret-stash-weekend.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "red-hill-truffles-winter-truffle-hunt-season.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "restore-pamper-retreat-at-polperro-farmhouse.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "sound-circle-full-moon-sound-journey-at-peninsula-hot-springs.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "ten-minutes-by-tractor-terroir-masterclass.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "the-bloody-long-walk-mornington-peninsula-2026.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "tootgarook-primary-school-market.json",
+      "lastCheckedDate": "2026-05-04",
+      "ageDays": 117
+    },
+    {
+      "file": "mornington-racecourse-market.json",
+      "lastCheckedDate": "2026-05-06",
+      "ageDays": 115
+    },
+    {
+      "file": "boneo-community-market.json",
+      "lastCheckedDate": "2026-05-17",
+      "ageDays": 104
+    },
+    {
+      "file": "emu-plains-market-balnarring.json",
+      "lastCheckedDate": "2026-05-17",
+      "ageDays": 104
+    },
+    {
+      "file": "pearcedale-community-market.json",
+      "lastCheckedDate": "2026-05-17",
+      "ageDays": 104
+    }
+  ],
+  "duplicateTitleGroups": [],
+  "duplicateVenueDateGroups": [],
+  "unresolvableRecurrence": [
+    {
+      "file": "emu-plains-market.json",
+      "recurrence": "monthly",
+      "recurrenceNote": "Monthly October–April (day market); June and August also listed; no July, May or September",
+      "nextOccurrence": "2026-09-17"
+    },
+    {
+      "file": "peninsula-hot-springs-sound-healing-sessions.json",
+      "recurrence": "monthly",
+      "recurrenceNote": "Monthly",
+      "nextOccurrence": "2026-09-01"
+    },
+    {
+      "file": "sound-circle-full-moon-sound-journey-at-peninsula-hot-springs.json",
+      "recurrence": "monthly",
+      "recurrenceNote": "Monthly (full moon dates, check Eventbrite for specific dates)",
+      "nextOccurrence": "2026-09-01"
+    }
+  ],
+  "cancelledWithoutProvenance": []
+}


### PR DESCRIPTION
Audit of the five What's On freshness safeguards named in Asana 1217965540940904, across the repo and live production, plus the minimum fix for the two that had no enforcement.

## Audit result

| Safeguard | State | Evidence |
|---|---|---|
| Cancellations | Working | `main-street-mornington-festival-2026` live: `EventCancelled` JSON-LD, sourced on-page notice, absent from hub and `feed.json`, page still indexable |
| Recurring validity | Working | `ruleFor()` in `whats-on/_data.ts`; live feed 52 events, 0 with a lapsed rule end |
| Applicable dates/seasons | Working | `applicableMonths()` season and month-range windows |
| Duplicate events | **No enforcement** | Nothing anywhere looked for duplicate records |
| Source last-verified expiry | **No enforcement** | `lastCheckedDate` was write-only: 13 live events carry none, 31 are over 90 days old (oldest 117) |

`src/lib/freshness.ts` already formats a `lastCheckedDate` into "Reviewed May 2026" for venue surfaces, but no event surface calls it, and nothing read the field in the build, the render path or CI.

## Change

`audit-event-safeguards.mjs` measures all five. With `--assert` it ratchets against a baseline inside `npm run build`, and fails closed if the baseline is missing.

The ratchet covers only defects an author introduces. Two metrics age with the calendar instead:

- **`staleVerificationDate` is report-only.** Gated at its baseline of 31 it would have crossed on **2026-09-02** and blocked every deploy from then on, reaching 42 by late October, with no content change at all. It now surfaces in the daily content-freshness workflow, where re-checking the source is the fix a deploy could never perform.
- **`unresolvableRecurrence` now judges the record, not the calendar.** The daily cron rolling `nextOccurrence` forward was masking it: the count read 0 today and 3 the moment the clock moved.

## Inherited debt this pins

Ceilings are today's real numbers, so the gate cannot be satisfied by making the corpus worse, and cannot block a deploy over debt it inherited. Tighten as records are re-verified.

- 13 live events with no `lastCheckedDate`
- 3 monthly records whose prose cannot state a cadence, so the published date is only the cron's day-of-month guess — wrong for a "full moon" or "last Saturday" cadence:
  - `emu-plains-market` — "Monthly October–April (day market); June and August also listed"
  - `peninsula-hot-springs-sound-healing-sessions` — "Monthly"
  - `sound-circle-full-moon-sound-journey-at-peninsula-hot-springs` — "Monthly (full moon dates, check Eventbrite)"

Fixing those three is editorial: it needs the cadence confirmed against the organiser.

## Tests

`audit-event-safeguards.test.mjs`, 14 cases, both directions against fixture corpora — including the time-travel cases at +4d, +3mo, +1y and +3y that found the deploy-blocking defect, and the near-identical-title guard that keeps one venue's unrelated same-day classes from reading as duplicates.

- `npm run test:event-safeguards` — 14/14 pass; wired into `content-gate` and `build-and-deploy`
- `npm run build` — exit 0 end-to-end with the gate in the chain

## Not deployed

Branch only. This changes what can block the deploy pipeline, which is outside event publishing authority; merging is James's call.

## Also found, not fixed (out of scope)

`eat/[slug]`, `wine/[slug]` and `stay/[slug]` read the raw events collection with no `status` and no `cancelled` filter, and pass every weekly/monthly/ongoing record unconditionally. Latent, not currently firing — 0 records affected today — but it contradicts the comment on `isCancelledEvent` in `_data.ts` claiming those surfaces share the test. Worth a follow-up card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)