### PR TITLE
fix(plan): bind the PI-route save once

### DIFF
--- a/next/src/pages/plan/index.astro
+++ b/next/src/pages/plan/index.astro
@@ -193,8 +193,18 @@ const piIndex = { places: piPlaces, venues: piVenues };
     if (btn) btn.lastChild!.textContent = " Save PI's route to my trip";
     const mine = document.querySelector<HTMLAnchorElement>('[data-plan-toolbar] a');
     if (mine) { mine.href = '/me/trip/'; mine.textContent = 'My trip'; }
-    btn?.addEventListener('click', () => {
-      const day = Store.tripAddDay(`PI's route · Case ${route.caseId}`);
+    // init() runs on DOMContentLoaded and again on astro:page-load; bind once.
+    if (!btn || btn.dataset.piBound) return true;
+    btn.dataset.piBound = '1';
+    const dayLabel = `PI's route · Case ${route.caseId}`;
+    if (Store.tripDays().some((d) => d.label === dayLabel)) {
+      btn.setAttribute('disabled', '');
+      btn.lastChild!.textContent = ' Already in my trip';
+      return true;
+    }
+    btn.addEventListener('click', () => {
+      if (Store.tripDays().some((d) => d.label === dayLabel)) return;
+      const day = Store.tripAddDay(dayLabel);
       for (const it of route.items) {
         Store.tripAdd({ kind: it.kind, slug: it.slug, title: it.title, href: it.href, meta: { image_url: it.image_url, pi_case: route.caseId } }, { dayId: day.id });
       }


### PR DESCRIPTION
Follow-up to #355. `init()` runs on both `DOMContentLoaded` and `astro:page-load`, so the "Save PI's route to my trip" handler was bound twice and created the trip day twice on one click. Now bound once (dataset guard) and a second save of the same case is refused with "Already in my trip".

Verified: `astro build` green in a clean worktree (980 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)