### PR TITLE
ops(play): draw script, pi-draw-enter source, game briefs

### DIFF
--- a/docs/game/where-is-pi-higgsfield-brief.md
+++ b/docs/game/where-is-pi-higgsfield-brief.md
@@ -1,0 +1,227 @@
+# Where in the Peninsula is PI? Build brief for Higgsfield (game type)
+
+Version 1, 2026-09-11. Owner: James. Paste everything below the line into a fresh Higgsfield build session as the opening message. It is written to pre-answer every gate in Higgsfield's game pipeline (profile, experience formula, STYLE FORMULA, asset manifest, thresholds, six-function contract) so the builder has nothing left to invent except execution.
+
+Why this shape: the two 9 September prototypes (`find-the-insider-lab`, `insider-beyond-the-map`) drifted because their briefs left room. One became a 3D Babylon RPG in a fictional "Lantern Cove", the other an evidence puzzle in a fictional "Bay Steps" behind an invitation cookie, and both spent more words on compliance hedging than on the Peninsula. Everything below closes those gaps: real places only, 2D painted scenes, public URL, authored case data, locked style.
+
+---
+
+## 0. Decisions already made (do not re-ask)
+
+- `create_website` with `type: "game"`, `category: "adventure"`, `subdomain: "where-is-pi"`. No template.
+- `meta: { game: "Where in the Peninsula is PI?", minPlayers: 1, maxPlayers: 4 }`. Solo is the primary mode; 2 to 4 seats share one notebook (Search Party). Never block solo play on other players.
+- Do NOT publish to the Higgsfield community feed. Deploy only.
+- Public URL, anonymous play, no sign-in, no invitation cookie, no gate of any kind. Progress persists in the room; the room id is generated client-side and remembered in localStorage.
+- 2D only. Painted scene backgrounds, DOM and CSS, no WebGL, no Babylon, no 3D anywhere.
+- Real Mornington Peninsula places only, drawn from the slug lists in section 6. No invented towns, coves, studios or villages. Invented characters (witnesses) are fine; invented geography is not.
+- The STYLE FORMULA in section 5 is approved. Skip the approval gate and use it byte-identical.
+- Keep design notes to `design/plan.md` and `design/assets.csv`. No compliance essays, no external-review documents, no "not tested" disclaimers inside the game UI.
+
+## 1. The game in one breath
+
+PI is the Peninsula Insider's in-house local: the friend with better taste who is always twenty minutes ahead of you. Every case starts with where she was last seen. You ask witnesses, search painted scenes for what she left behind, and read the land itself to work out where she went next. The sun is the clock. Catch her before it sets and she tells you what to order. The route you deduced becomes a real Peninsula day out.
+
+Experience formula: **The player feels like a local who is finally in on the secret, because every clue rewards knowing the Peninsula and every solved case hands them a real day they could drive tomorrow.**
+
+## 2. Game profile
+
+| Axis | Choice |
+|---|---|
+| Time | Pause-at-will. A case clock advances only on player actions (travel, ask, search). No real-time countdown. |
+| Space | Discrete: a hand-drawn map of the Peninsula with 37 real towns as nodes; 3 to 5 visited per case. |
+| Agency | One investigator (solo) or a shared notebook (Search Party). |
+| Conflict | Versus the sunset and versus authored misdirection. Never versus other players. |
+| Content | Authored cases as data. Case 01 is fully written in section 7. |
+| Outcome | Found her before sunset (rank awarded) / Sunset (she has moved on; case can be replayed). |
+| Players | Solo primary. Co-op 2 to 4 shares one notebook and one clock. |
+| Session | 6 to 10 minutes per case. |
+| Engagement | Discovery first, story second. |
+| Platforms | Mobile browser first, desktop second. Touch, pointer, keyboard (physical key codes). |
+| Language | English. Every player-visible string lives in one `STRINGS` object inside the case data. |
+
+## 3. Loops and verbs
+
+Core loop (one stop): arrive at a place → talk to up to 3 witnesses → search the scene (3 or 4 hotspots) → read the notebook → choose the next place on the map.
+
+Verbs (all server-validated in `logic.js`):
+
+- **Travel** to a place. Costs clock minutes based on real distance (section 8). A wrong place costs the minutes plus a 40 minute penalty and returns one flavour line from a witness who has not seen her.
+- **Ask** a witness. Costs 10 minutes. Each witness has one line. One witness per stop points to the correct next place, one gives a "tell" about PI (what she is drinking, whether she has the dog, bay side or ocean side), one is a decoy that points to a plausible wrong place.
+- **Search** a hotspot in the painted scene. Costs 15 minutes. Returns a clue that either confirms the next place or adds a tell.
+- **Hint**. Free the first time, then costs 30 minutes each. Reveals the relevant witness line.
+- **Name the venue**. At the final stop the player picks one of three real venues. Tells decide it. Correct: found her. Wrong: one more try, then sunset.
+- **Restart**. Always available.
+
+Loops: knowledge narrows the map (positive), but every stop still requires the player to choose (counterweight). A wrong turn is never fatal on its own; three wrong turns in one case will usually cost the sunset. Comeback path: the free hint plus the notebook always contain enough to finish.
+
+Information map: player sees the map, the current scene, revealed witness lines, revealed hotspot clues, notebook tells, clock and sunset time. Hidden until earned: unrevealed witness lines and hotspot text. Server-only, never in `viewFor`: the correct route, the correct final venue, decoy flags, and the unrevealed text of any witness or hotspot. In Search Party every seat sees the same notebook; the seat that took the action is recorded on each entry.
+
+## 4. Interface
+
+Three regions, stacked on mobile, side by side on desktop:
+
+1. **The scene.** One painted 16:9 background per place. Hotspots are absolutely positioned buttons over the painting (min 44px touch target) drawn as small amber ink circles that pulse once when the scene opens. Witnesses stand along the bottom edge of the scene as cel-shaded sprites; tap to ask.
+2. **The notebook.** Kraft paper panel. Three sections: Tells (bullets), Clues (bullets, each tagged with the place it came from), Stamps (one rubber stamp per place visited; the final stamp is PI's own mark when found). The clock is a small sun icon travelling along an arc at the top of the notebook with the time in words ("Mid-morning", "Golden hour", "Last light").
+3. **The map.** Hand-drawn Peninsula outline authored as inline SVG from the coordinates in section 6 (not a generated image). Visited places are stamped, the current place glows amber, all other places are tappable. Bay side and ocean side are labelled.
+
+Entry path: launch → title card with "Last seen" line → one tap "Open the case" → first scene. Return visits open on the current scene with the notebook showing the current goal. Preferences (reduce motion, high contrast, text size) sit behind one icon and apply immediately.
+
+End card: "Found her" or "Sunset". Shows the route as a stamped strip, the rank, PI's sign-off line, and two buttons: "Save PI's route" (links to the route on peninsulainsider.com.au, section 9) and "Share" (copies the emoji trail, e.g. `Where in the Peninsula is PI? Case 01 ☕→🌊→🍓→🍷 Found her at golden hour`).
+
+Ranks by minutes remaining at the catch: Daytripper (0 to 29), Weekender (30 to 89), Sea-changer (90 to 149), Local (150 to 239), Insider (240+).
+
+## 5. STYLE FORMULA (approved, use byte-identical in every asset prompt)
+
+Soft impressionist gouache with visible broken brushwork over clean anime cel-shaded characters, delicate ink contours only on figures and objects, never on landscapes. Rounded readable silhouettes, wind-shaped tea-tree and moonah, weathered timber, basalt shelves. Environments in cream sand, sea-glass teal, eucalypt sage and dusk violet; PI and witnesses in warm terracotta and ivory that pop against them; clues and interactive objects carry one copper-amber glow. Luminous Australian golden-hour light, dappled shade, quiet magical-realist whimsy. High contrast between elements and backgrounds, consistent flat frontal perspective across every scene.
+
+STYLE TOKEN: `impressionist gouache over anime cel characters, cream sand and sea-glass teal, terracotta figures, copper-amber clue glow, golden-hour light`
+
+Rules the formula does not carry: whimsy is light, weather, wind and animals only (gulls that gossip, a ferry leaving a trail of light, glowing footprints). Never invent spirits, totems or "old stories" of place; this is Bunurong Country and none of that is ours to generate. Landscapes are painted from the real place descriptions in section 6, not from photographs, and not from Mediterranean or tropical references.
+
+PI herself: mid-30s, sun hat, terracotta linen, canvas tote, a small scruffy dog on a rope lead. She is always leaving the frame, never facing the player, until the final card.
+
+Type in the UI: a warm humanist serif for headings, a clean sans for body, a mono for the clock and stamps. Cream page, ink text, terracotta primary button, eucalypt for confirmed clues. No gradients, no dark scrims, no film grain.
+
+## 6. Real-world data the builder must use
+
+Place nodes (slug, name, lat, lng). These are the only travel destinations. Coordinates drive the map and the travel-minute formula.
+
+```
+mornington -38.2170 145.0390 | mount-eliza -38.1880 145.0920 | mount-martha -38.2760 145.0180
+safety-beach -38.3120 144.9960 | dromana -38.3340 144.9640 | mccrae -38.3510 144.9260
+rosebud -38.3560 144.9060 | capel-sound -38.3620 144.8770 | tootgarook -38.3730 144.8550
+rye -38.3730 144.8220 | blairgowrie -38.3600 144.7770 | sorrento -38.3390 144.7430
+portsea -38.3190 144.7100 | point-nepean -38.3070 144.6600 | st-andrews-beach -38.4180 144.8230
+fingal -38.4180 144.8600 | cape-schanck -38.4939 144.8881 | boneo -38.4030 144.8850
+flinders -38.4770 145.0180 | shoreham -38.4300 145.0500 | point-leo -38.4160 145.0720
+merricks -38.3900 145.0900 | merricks-beach -38.4040 145.0950 | merricks-north -38.3700 145.0800
+balnarring -38.3720 145.1240 | somers -38.3940 145.1590 | bittern -38.3400 145.1740
+crib-point -38.3630 145.2040 | stony-point -38.3740 145.2180 | hastings -38.3080 145.1860
+tyabb -38.2600 145.1870 | moorooduc -38.2350 145.1050 | tuerong -38.2600 145.0900
+red-hill -38.3619 145.0543 | red-hill-south -38.3900 145.0350 | main-ridge -38.4050 145.0090
+arthurs-seat -38.3550 144.9550
+```
+
+Region labels for the map: Mornington Bay Coast, Peninsula Tip, Ocean Coast, Red Hill Wine Country, Western Port.
+
+Place intros to paint from (short forms):
+
+- Mornington: Main Street runs down to the pier and bathing boxes; Saturday market; morning coffee culture; boats in the harbour.
+- Cape Schanck: where the Peninsula runs out of land; the 1859 lighthouse on the last headland; a boardwalk down through tea-tree to a basalt beach that vanishes at high tide; open ocean to the horizon; best in the last two hours of light.
+- Main Ridge: high hinterland on the ridge; strawberry farm, dairy, orchards, gravel roads under big gums, mist in the mornings.
+- Red Hill: misty basalt plateau; a general store, a monthly market, vineyard restaurants that don't advertise from the highway; the winery restaurant cluster (Ten Minutes by Tractor, Montalto, Paringa Estate) has no peer in the state.
+- Sorrento: limestone village at the tip; the ferry to Queenscliff; back beach ocean baths; gelato on the main street.
+
+Venue and experience slugs that may appear as clue references or final-venue candidates (all real, all have pages on peninsulainsider.com.au at `/eat/`, `/drink/`, `/stay/`, `/explore/` sections; the builder only needs the slug and name):
+
+`commonfolk-coffee` Commonfolk Coffee (Mornington) · `mornington-main-street-market` · `the-rocks-mornington` · `cape-schanck-boardwalk` · `cape-schanck-lighthouse-walk` · `bushrangers-bay-walk` · `sunny-ridge-strawberry-farm` Sunny Ridge Strawberry Farm (Main Ridge) · `main-ridge-dairy` Main Ridge Dairy · `ten-minutes-by-tractor` Ten Minutes by Tractor (Red Hill) · `montalto` Montalto (Red Hill) · `montalto-sculpture-trail` · `paringa-estate` Paringa Estate (Red Hill) · `red-hill-bakery` · `red-hill-market` · `sorrento-ferry` · `sorrento-gelato` · `sorrento-ocean-baths` · `flinders-general-store` · `laura-pt-leo` Laura (Point Leo) · `pt-leo-estate` · `peninsula-hot-springs` · `jetty-road-brewery` (Dromana) · `arthurs-seat-lookout`
+
+## 7. Case 01, fully authored: "Took her coffee to go"
+
+Season: spring. Sunset 19:40. Case opens 08:10 at Mornington.
+
+Correct route: `mornington` → `cape-schanck` → `main-ridge` → `red-hill`. Final venue: **Montalto** (tells: she wanted a walk before lunch, and a view).
+
+**Title card.** "Last seen: Mornington pier, Saturday 8:10am. Flat white, takeaway. The dog was with her." Button: "Open the case".
+
+**Stop 1, Mornington (scene: pier and bathing boxes, low morning sun, market stalls setting up).**
+- Witness, barista (correct): "Took her coffee to go. Asked me which way the wind was blowing. I said south-westerly, straight off the Strait. She smiled like that was the answer."
+- Witness, newsagent (tell): "Bought a postcard. Lighthouse on it. And a lead for the dog, the old one had frayed."
+- Witness, fisherman (decoy, points to Sorrento): "Reckon she was for the ferry. Everyone's for the ferry on a Saturday."
+- Hotspots: the coffee cup lid in the bin (clue: "Lid marked with a compass rose drawn in biro. The needle points south, past the vineyards, to open ocean."), the market noticeboard (tell: "A torn flyer for a sculpture walk. One corner missing, as if someone took the map."), the dog's water bowl outside the cafe (flavour: "Still wet. She wasn't here long."), the pier end (flavour: "Gulls arguing over nothing. One of them looks smug.").
+- Wrong turn lines: Sorrento: "Ferry deckhand: 'Had a woman with a dog? Mate, half the boat has a dog.' No sign of her." Rosebud: "Foreshore kiosk: 'Haven't seen her. Try somewhere with a view.'"
+
+**Stop 2, Cape Schanck (scene: lighthouse on the headland, boardwalk through tea-tree, big ocean, late morning light).**
+- Witness, park ranger (correct): "Went down the boardwalk with the dog, came back up with a punnet in her hand. Said she'd earned strawberries."
+- Witness, photographer (tell): "Asked me where the light would be good at one o'clock. I said the ridge. Wanted somewhere with a view for lunch, she said."
+- Witness, tourist (decoy, points to Flinders): "Someone said the best fish and chips are in Flinders. She might have gone that way?"
+- Hotspots: boot prints on the boardwalk (clue: "Two sets going down, two coming back. Small dog prints beside them, heading for the car park and the hinterland road."), the lighthouse sign (flavour: "1859. She'd have read it. She reads everything."), a strawberry-punnet sticker on the bin (clue: "Sunny Ridge, Main Ridge. Printed this morning."), the lookout bench (tell: "A pencil sketch left under a stone: a sculpture on a hill, three lines, unfinished.").
+- Wrong turn: Flinders: "General store: 'Not today. You want the ridge, not the coast.'"
+
+**Stop 3, Main Ridge (scene: strawberry rows under big gums, gravel road, dairy gate, midday dapple).**
+- Witness, strawberry picker (correct): "Ate three before she paid. Asked how far to the sculpture trail. Ten minutes, I told her, if you don't stop for cheese."
+- Witness, dairy hand (tell): "Bought a goat's cheese and asked for it wrapped twice. Picnic, she said. Somewhere with a table and a view."
+- Witness, cyclist (decoy, points to Arthurs Seat): "Told her the Eagle at Arthurs Seat has the best view on the Peninsula. She said 'the second best'."
+- Hotspots: the honesty box (clue: "A five-dollar note folded into a tiny boat. Written on the hull: 'lunch, 1pm, walk first'."), a strawberry stem on the fence (flavour), the dairy chalkboard (tell: "Someone has drawn a small sculpture next to the word 'Montalto' and then rubbed it out. Badly."), the gum tree (flavour: "A kookaburra. Not laughing. Judging.").
+- Wrong turn: Arthurs Seat: "Chairlift attendant: 'View's great. She's not here.'"
+
+**Stop 4, Red Hill (scene: vineyard rows on the plateau, misty gullies, a long table under a tree, golden light).**
+- Final venue choice from three: Ten Minutes by Tractor, Montalto, Paringa Estate.
+- Notebook tells at this point should read: postcard with a lighthouse; wanted a walk before lunch; wanted a view; a sculpture, three times.
+- Correct: Montalto. Found card: PI at the end of the sculpture trail, dog asleep, one glass poured. Her line: "Took you long enough. Sit at the outside table. Better view, and the kingfish is the order." Stamp: PI's mark.
+- Wrong first pick: "The host at the door: 'Sculpture trail? That's next door.' 40 minutes gone." Second wrong pick: Sunset.
+
+**Sunset card.** "Last light on the ridge. She's moved on. Her tab's still open somewhere." Button: "Try again".
+
+Optional Search Party lines: when a second seat joins, the notebook shows "Two of you now. She'll be harder to miss."
+
+## 8. Numbers fixed before code
+
+- Travel minutes between places = round(haversine km × 1.6) + 10. Wrong place adds 40.
+- Ask 10 min, search 15 min, hint 0 then 30 min each, wrong final venue 40 min.
+- Case 01 par: 08:10 start; correct route with all correct witnesses and two searches per stop finishes about 14:30, leaving roughly 310 minutes: Insider rank. Three wrong turns and every hotspot: about 19:10, still a Local. The numbers are in one `TUNING` object; do not hard-code them elsewhere.
+- Interactive nodes per scene: at most 8. DOM only, target 60fps on a mid-range phone, no layout thrash (render from a single view object, diff by version).
+- Touch targets 44px minimum. Text scale option 100 / 125 / 150 percent.
+- Reduce-motion preference disables the hotspot pulse, the sun arc animation and scene crossfades.
+- Every action acknowledges within one frame with a disabled state on the tapped control, then re-enables on the next server view.
+
+## 9. Website integration (phase 1 minimum)
+
+- Every place, venue and experience the game names carries its real slug. The end card's "Save PI's route" button opens `https://peninsulainsider.com.au/plan/?pi-case=01&route=mornington,cape-schanck,main-ridge,red-hill&venue=montalto` in a new tab. The website side (ours, not Higgsfield's) reads those parameters and writes the route into the visitor's saved trip. The game only builds the URL.
+- Each stamp in the notebook links to the place page: `https://peninsulainsider.com.au/places/<slug>/`.
+- The Share button copies the emoji trail plus the game URL.
+- Nothing else touches the website in phase 1. No accounts, no prizes, no cookies.
+
+## 10. Six-function contract, mapped
+
+`meta`: as in section 0.
+
+`setup(players)`: `{ version: 1, caseId: "01", seed: 17, clock: 490, sunset: 1180, at: "mornington", route: ["mornington"], revealed: { witnesses: [], hotspots: [] }, notebook: { tells: [], clues: [], stamps: ["mornington"] }, wrongTurns: 0, hints: 0, finalAttempts: 0, status: "playing", seats: players }`. Clock values are minutes since midnight.
+
+`validateAction(state, playerId, action)`: refuse unknown seats, refuse everything when `status !== "playing"` except `restart`, refuse `travel` to the current place or to a slug not in the place list, refuse `ask`/`search` for ids not at the current place or already revealed, refuse `guess` unless `at` is the final place of the case, refuse `hint` when nothing is left to reveal at this stop. Any action that would push `clock` past `sunset` is allowed and resolves to `status: "sunset"` in `applyAction` (the player gets to see the last thing happen).
+
+`applyAction`: pure, copies state, advances clock, appends notebook entries with `{ text, place, by: playerId }`, sets `status` to `found` or `sunset`, computes rank at `found`. Randomness only from `seed` (used for which flavour gull line shows; nothing that affects the outcome).
+
+`isGameOver`: `{ over: status !== "playing", winner: status === "found" ? "all" : null }`. Do not let the platform's "over" state block `restart`.
+
+`viewFor(state, playerId)`: return clock, sunset, at, route, stamps, revealed witness and hotspot text, notebook, status, rank, and for the current place the list of witness and hotspot ids with `revealed` booleans and their labels only. Never return unrevealed text, the correct route, decoy flags, or the final venue.
+
+Case content lives in a `CASES` constant inside `logic.js` (no imports allowed there). Keep it as plain JSON so future cases can be generated and dropped in.
+
+## 11. Asset manifest (design/assets.csv)
+
+| id | role | type | description | ratio | source |
+|---|---|---|---|---|---|
+| bg-mornington | scene background | image | Mornington pier and bathing boxes, morning market setting up, low sun | 16:9 | generate |
+| bg-cape-schanck | scene background | image | Cape Schanck lighthouse headland, boardwalk through tea-tree, open ocean | 16:9 | generate |
+| bg-main-ridge | scene background | image | Main Ridge strawberry rows under big gums, gravel road, midday dapple | 16:9 | generate |
+| bg-red-hill | scene background | image | Red Hill vineyard plateau, misty gullies, long table under a tree, golden hour | 16:9 | generate |
+| spr-pi | character sprite | image | woman in sun hat and terracotta linen walking away with small scruffy dog on rope lead | 1:1 | generate |
+| spr-witness-a | character sprite | image | barista in apron holding takeaway cup | 1:1 | generate |
+| spr-witness-b | character sprite | image | park ranger in wide hat with binoculars | 1:1 | generate |
+| spr-witness-c | character sprite | image | strawberry picker with punnet | 1:1 | generate |
+| cover | launch cover | image | PI walking off along the Cape Schanck boardwalk at golden hour, dog ahead, notebook in foreground | 3:2 | generate |
+| icon | app icon | image | rubber-stamp compass rose with a sun hat brim | 1:1 | generate |
+| amb-bay | ambience loop | audio | calm bay water, gulls, distant market | 12s | generate |
+| amb-ocean | ambience loop | audio | wind off the Strait, gannets, surf below cliffs | 12s | generate |
+| amb-ridge | ambience loop | audio | hinterland dusk, magpies, leaves | 12s | generate |
+| sfx-stamp | feedback | audio | rubber stamp thunk | 1s | generate |
+
+The map is inline SVG authored from the coordinates in section 6, not a generated image. Sprites are generated on a magenta key and keyed out. All backgrounds ship at 1280×720. The four remaining Case 01 witnesses (newsagent, fisherman, photographer, tourist, dairy hand, cyclist) reuse the three witness sprites with a CSS hue shift on the apron or hat; do not generate more than ten images.
+
+## 12. Copy rules (non-negotiable)
+
+- No em-dashes anywhere in the game, not in UI, not in witness lines. Use commas, full stops, colons.
+- PI never greets the player and never speaks about herself in the third person. She speaks once, at the end.
+- Sentences 8 to 18 words by default; witnesses may use 3 to 6 word sentences for punch.
+- Name real things: tables, roads, the order. Never "a charming eatery".
+- Bunurong acknowledgement on the title card footer: "Peninsula Insider acknowledges the Bunurong people, Traditional Owners of the lands and waters of the Mornington Peninsula." Nothing else about culture or history is invented.
+
+## 13. Done means
+
+- Case 01 plays start to finish on a phone in under ten minutes, both outcomes reachable.
+- Two tabs on the same room share one notebook and one clock; a third tab still plays.
+- `viewFor` never leaks the answer (assert in `tests/logic.test.ts`: the correct route and venue never appear in any view before `found`).
+- Reduce-motion, contrast and text-scale options work before the first tap.
+- `app-meta.json` filled with the generated cover and a real `og_title`.
+- Handover: the live URL, the four background paintings and the PI sprite as files, and `design/plan.md` under one page.

--- a/docs/game/where-is-pi-higgsfield-prompt.md
+++ b/docs/game/where-is-pi-higgsfield-prompt.md
@@ -1,0 +1,117 @@
+Build me a browser game called **Where in the Peninsula is PI?** for Peninsula Insider, an editorial guide to the Mornington Peninsula in Victoria, Australia. Create it as `type: "game"`, `category: "adventure"`, `subdomain: "where-is-pi"`, no template. Do not publish it to the community feed; deploy only. Use my unlimited generations for every image and audio asset.
+
+The decisions below are final. Do not re-ask them, do not soften them, and do not add a sign-in gate, an invitation cookie, a 3D engine, fictional places, or compliance disclaimers inside the game. The only planning files are `design/plan.md` (one page) and `design/assets.csv`.
+
+## The idea
+
+PI is Peninsula Insider's in-house local: the friend with better taste who is always twenty minutes ahead of you. This is Where in the World is Carmen Sandiego, but there is no crime. PI has simply gone for the day, and you are chasing her across real Peninsula towns. At each stop you ask three witnesses, search a painted scene for what she left behind, and read the land to work out where she went next. The sun is the clock. Catch her before it sets and she tells you what to order. The route you deduced becomes a real day out someone could drive tomorrow.
+
+Experience formula: the player feels like a local who is finally in on the secret, because every clue rewards knowing the Peninsula and every solved case hands them a real day.
+
+The whole thing should feel like stepping into a painting: whimsical, luminous, a little magical, never techie.
+
+## Profile
+
+Pause-at-will (the clock advances only on player actions). Discrete space: a hand-drawn map with 37 real towns as nodes, 3 to 5 visited per case. Solo is the primary mode; 2 to 4 seats may share one notebook and one clock ("Search Party") but solo must never wait on anyone. Conflict is versus the sunset and authored misdirection, never versus other players. Content is authored case data; Case 01 is written in full below. Outcome: Found her (rank awarded) or Sunset (replayable). Session 6 to 10 minutes. Engagement: discovery first, story second. Mobile browser first, desktop second; touch, pointer and keyboard on physical key codes. All player-visible strings in one STRINGS object.
+
+`meta: { game: "Where in the Peninsula is PI?", minPlayers: 1, maxPlayers: 4 }`
+
+## Verbs (all validated on the server)
+
+- **Travel** to a place on the map. Costs `round(haversine_km * 1.6) + 10` minutes. A wrong place costs that plus 40 and returns one flavour line from someone who has not seen her.
+- **Ask** a witness (10 min). Each stop has three: one points to the correct next place, one gives a "tell" about PI (what she is carrying, what she wants from lunch), one is a decoy pointing to a plausible wrong place.
+- **Search** a hotspot in the scene (15 min). Three or four per scene. Returns a clue that confirms the next place or adds a tell.
+- **Hint**: free once, then 30 min each. Reveals the correct witness line for the current stop.
+- **Name the venue** at the final stop: choose one of three real venues. The tells decide it. Wrong once costs 40 min; wrong twice is Sunset.
+- **Restart**, always available, including after game over.
+
+Keep every number in one TUNING object. Case 01 starts 08:10, sunset 19:40. Ranks by minutes left when she is found: Daytripper 0 to 29, Weekender 30 to 89, Sea-changer 90 to 149, Local 150 to 239, Insider 240 and up.
+
+## Screen
+
+Three regions: stacked on mobile, side by side on desktop.
+
+1. **The scene.** One painted 16:9 background per place. Hotspots are 44px-minimum buttons positioned over the painting, drawn as small copper-amber ink circles that pulse once when the scene opens. Witnesses stand along the bottom edge as cel-shaded sprites; tap to ask. Witness lines appear as hand-lettered speech on torn paper.
+2. **The notebook.** Kraft paper. Sections: Tells, Clues (each tagged with the place it came from), Stamps (one rubber stamp per place visited; the last stamp is PI's own mark when found). The clock is a small sun travelling along an arc across the top of the notebook, with the time in words: Early, Mid-morning, Midday, Afternoon, Golden hour, Last light. The sky colour of the current scene shifts with the clock (pale dawn, white noon, terracotta golden hour, violet dusk) using a CSS tint over the painting.
+3. **The map.** The Peninsula outline authored as inline SVG from the coordinates below (not a generated image). Visited places are stamped, the current place glows amber, the rest are tappable. Label the bay side and the ocean side and the five regions.
+
+Entry: title card ("Last seen" line, one button "Open the case") then straight into the first scene. On return, open on the current scene with the notebook showing the current goal. Preferences behind one icon: reduce motion, high contrast, text scale 100/125/150. Reduce motion kills the pulse, the sun animation and crossfades.
+
+End card: "Found her" or "Sunset". Shows the route as a stamped strip, the rank, PI's sign-off, and two buttons. "Save PI's route" opens `https://peninsulainsider.com.au/plan/?pi-case=01&route=<comma-separated place slugs>&venue=<venue slug>` in a new tab. "Share" copies: `Where in the Peninsula is PI? Case 01 ☕→🌊→🍓→🍷 Found her at golden hour` plus the game URL. Every stamp links to `https://peninsulainsider.com.au/places/<slug>/`.
+
+## STYLE FORMULA (approved; insert byte-identical into every asset prompt, skip the approval gate)
+
+Soft impressionist gouache with visible broken brushwork over clean anime cel-shaded characters, delicate ink contours only on figures and objects, never on landscapes. Rounded readable silhouettes, wind-shaped tea-tree and moonah, weathered timber, basalt shelves. Environments in cream sand, sea-glass teal, eucalypt sage and dusk violet; PI and witnesses in warm terracotta and ivory that pop against them; clues and interactive objects carry one copper-amber glow. Luminous Australian golden-hour light, dappled shade, quiet magical-realist whimsy. High contrast between elements and backgrounds, consistent flat frontal perspective across every scene.
+
+STYLE TOKEN: `impressionist gouache over anime cel characters, cream sand and sea-glass teal, terracotta figures, copper-amber clue glow, golden-hour light`
+
+Whimsy is light, weather, wind and animals only: gulls that gossip, a ferry leaving a trail of light, footprints that glow faintly, pollen in the air. Never invent spirits, totems or "old stories" of place; this is Bunurong Country and none of that is ours to make up. Paint landscapes from the place descriptions below, never from Mediterranean or tropical references, and never from photographs. PI: mid-30s, wide sun hat, terracotta linen, canvas tote, small scruffy dog on a rope lead, always walking out of frame until the final card. UI type: a warm humanist serif for headings, clean sans for body, mono for the clock and stamps. Cream page, ink text, terracotta primary button, eucalypt for confirmed clues. No gradients, no dark scrims, no film grain.
+
+## Real places (the only travel nodes; slug, lat, lng)
+
+mornington -38.2170 145.0390; mount-eliza -38.1880 145.0920; mount-martha -38.2760 145.0180; safety-beach -38.3120 144.9960; dromana -38.3340 144.9640; mccrae -38.3510 144.9260; rosebud -38.3560 144.9060; capel-sound -38.3620 144.8770; tootgarook -38.3730 144.8550; rye -38.3730 144.8220; blairgowrie -38.3600 144.7770; sorrento -38.3390 144.7430; portsea -38.3190 144.7100; point-nepean -38.3070 144.6600; st-andrews-beach -38.4180 144.8230; fingal -38.4180 144.8600; cape-schanck -38.4939 144.8881; boneo -38.4030 144.8850; flinders -38.4770 145.0180; shoreham -38.4300 145.0500; point-leo -38.4160 145.0720; merricks -38.3900 145.0900; merricks-beach -38.4040 145.0950; merricks-north -38.3700 145.0800; balnarring -38.3720 145.1240; somers -38.3940 145.1590; bittern -38.3400 145.1740; crib-point -38.3630 145.2040; stony-point -38.3740 145.2180; hastings -38.3080 145.1860; tyabb -38.2600 145.1870; moorooduc -38.2350 145.1050; tuerong -38.2600 145.0900; red-hill -38.3619 145.0543; red-hill-south -38.3900 145.0350; main-ridge -38.4050 145.0090; arthurs-seat -38.3550 144.9550.
+
+Regions: Mornington Bay Coast, Peninsula Tip, Ocean Coast, Red Hill Wine Country, Western Port.
+
+Paint from these: Mornington, Main Street running down to the pier and painted bathing boxes, Saturday market setting up, boats in the harbour. Cape Schanck, where the Peninsula runs out of land, the 1859 lighthouse on the last headland, a boardwalk down through tea-tree to a basalt beach, open ocean to the horizon. Main Ridge, high hinterland, strawberry rows under big gums, a dairy gate, gravel roads, morning mist. Red Hill, a misty basalt plateau of vineyards, a general store, winery restaurants that do not advertise from the highway, a long table under a tree.
+
+Real venues and experiences (use these slugs and names only): commonfolk-coffee (Commonfolk Coffee, Mornington), mornington-main-street-market, cape-schanck-boardwalk, cape-schanck-lighthouse-walk, sunny-ridge-strawberry-farm (Sunny Ridge Strawberry Farm, Main Ridge), main-ridge-dairy (Main Ridge Dairy), ten-minutes-by-tractor (Ten Minutes by Tractor, Red Hill), montalto (Montalto, Red Hill), montalto-sculpture-trail, paringa-estate (Paringa Estate, Red Hill), sorrento-ferry, arthurs-seat-lookout, flinders-general-store.
+
+## Case 01: "Took her coffee to go"
+
+Correct route: mornington → cape-schanck → main-ridge → red-hill. Final venue: **montalto** (tells: she wanted a walk before lunch, a view, and a sculpture keeps appearing).
+
+Title card: "Last seen: Mornington pier, Saturday 8:10am. Flat white, takeaway. The dog was with her."
+
+**Mornington** (scene: pier and bathing boxes, low morning sun, market stalls going up)
+- Barista, correct: "Took her coffee to go. Asked me which way the wind was blowing. I said south-westerly, straight off the Strait. She smiled like that was the answer."
+- Newsagent, tell: "Bought a postcard. Lighthouse on it. And a new lead for the dog, the old one had frayed."
+- Fisherman, decoy (Sorrento): "Reckon she was for the ferry. Everyone's for the ferry on a Saturday."
+- Hotspots: coffee lid in the bin, clue: "A compass rose drawn on the lid in biro. The needle points south, past the vineyards, to open ocean." Market noticeboard, tell: "A torn flyer for a sculpture walk. One corner missing, as if someone took the map." Dog bowl outside the cafe, flavour: "Still wet. She wasn't here long." Pier end, flavour: "Gulls arguing over nothing. One of them looks smug."
+- Wrong turns: Sorrento: "Ferry deckhand: 'Woman with a dog? Mate, half the boat has a dog.'" Rosebud: "Kiosk: 'Haven't seen her. Try somewhere with a view.'"
+
+**Cape Schanck** (scene: lighthouse headland, boardwalk through tea-tree, big ocean, late morning)
+- Ranger, correct: "Went down the boardwalk with the dog, came back up with a punnet in her hand. Said she'd earned strawberries."
+- Photographer, tell: "Asked me where the light would be good at one o'clock. I said the ridge. She wanted somewhere with a view for lunch."
+- Tourist, decoy (Flinders): "Someone said the best fish and chips are in Flinders. She might have gone that way?"
+- Hotspots: boot prints on the boardwalk, clue: "Two sets going down, two coming back, small dog prints beside them, heading for the car park and the hinterland road." Punnet sticker on the bin, clue: "Sunny Ridge, Main Ridge. Printed this morning." Lookout bench, tell: "A pencil sketch under a stone: a sculpture on a hill, three lines, unfinished." Lighthouse sign, flavour: "1859. She'd have read it. She reads everything."
+- Wrong turn, Flinders: "General store: 'Not today. You want the ridge, not the coast.'"
+
+**Main Ridge** (scene: strawberry rows under big gums, gravel road, dairy gate, midday dapple)
+- Picker, correct: "Ate three before she paid. Asked how far to the sculpture trail. Ten minutes, I told her, if you don't stop for cheese."
+- Dairy hand, tell: "Bought a goat's cheese and asked for it wrapped twice. Picnic, she said. Somewhere with a table and a view."
+- Cyclist, decoy (Arthurs Seat): "Told her the Eagle at Arthurs Seat has the best view on the Peninsula. She said 'the second best'."
+- Hotspots: honesty box, clue: "A five-dollar note folded into a tiny boat. On the hull: 'lunch, 1pm, walk first'." Dairy chalkboard, tell: "Someone drew a small sculpture next to the word Montalto, then rubbed it out. Badly." Fence, flavour: "One strawberry stem. Evidence of a crime she'd admit to." Gum tree, flavour: "A kookaburra. Not laughing. Judging."
+- Wrong turn, Arthurs Seat: "Chairlift attendant: 'View's great. She's not here.'"
+
+**Red Hill** (scene: vineyard rows on the plateau, misty gullies, a long table under a tree, golden light). Choose from Ten Minutes by Tractor, Montalto, Paringa Estate.
+- Correct, Montalto. Found card: PI at the end of the sculpture trail, dog asleep, one glass poured. Her only line in the game: "Took you long enough. Sit at the outside table. Better view, and the kingfish is the order."
+- Wrong first pick: "The host at the door: 'Sculpture trail? That's next door.'" Second wrong pick: Sunset.
+
+Sunset card: "Last light on the ridge. She's moved on. Her tab's still open somewhere." When a second seat joins a room, the notebook shows: "Two of you now. She'll be harder to miss."
+
+## The six functions
+
+`setup(players)`: `{ version: 1, caseId: "01", seed: 17, clock: 490, sunset: 1180, at: "mornington", route: ["mornington"], revealed: { witnesses: [], hotspots: [] }, notebook: { tells: [], clues: [], stamps: ["mornington"] }, wrongTurns: 0, hints: 0, finalAttempts: 0, status: "playing", seats: players }` (clock in minutes since midnight).
+
+`validateAction`: refuse unknown seats; refuse everything except restart when status is not playing; refuse travel to the current place or an unknown slug; refuse ask/search for ids not at the current place or already revealed; refuse guess unless at the case's final place; refuse hint when nothing is left to reveal here. Actions that push the clock past sunset are allowed and resolve to status sunset in applyAction, so the player sees the last thing happen.
+
+`applyAction`: pure, copy state, advance clock, append notebook entries as `{ text, place, by: playerId }`, set status found or sunset, compute rank on found. Randomness only from seed and only for flavour lines, never outcomes.
+
+`isGameOver`: `{ over: status !== "playing", winner: status === "found" ? "all" : null }`, and restart must still work afterwards.
+
+`viewFor`: return clock, sunset, at, route, stamps, revealed witness and hotspot text, notebook, status, rank, and for the current place the witness and hotspot ids with labels and revealed booleans only. Never return unrevealed text, the correct route, decoy flags or the final venue. Add a test in `tests/logic.test.ts` asserting that no view before found contains "cape-schanck", "main-ridge", "red-hill" or "montalto" as the answer.
+
+Case content lives in a CASES constant inside `logic.js` as plain JSON so future cases can be dropped in.
+
+## Assets (design/assets.csv, ten images maximum)
+
+Backgrounds 16:9 at 1280×720: bg-mornington, bg-cape-schanck, bg-main-ridge, bg-red-hill as described above. Sprites 1:1 on a magenta key: spr-pi (woman in sun hat and terracotta linen walking away with a small scruffy dog on a rope lead), spr-witness-a (barista in apron with takeaway cup), spr-witness-b (park ranger in wide hat with binoculars), spr-witness-c (strawberry picker with punnet). Cover 3:2: PI walking off along the Cape Schanck boardwalk at golden hour, dog ahead, notebook in the foreground. Icon 1:1: rubber-stamp compass rose with a sun-hat brim. Reuse the three witness sprites for the other six witnesses with a CSS hue shift on apron or hat. Audio: amb-bay (calm bay water, gulls, distant market, 12s loop), amb-ocean (wind off the Strait, gannets, surf below cliffs, 12s), amb-ridge (hinterland dusk, magpies, leaves, 12s), sfx-stamp (rubber stamp thunk). The map is inline SVG, not an image.
+
+## Copy rules
+
+No em-dashes anywhere. PI never greets the player and never refers to herself in the third person; she speaks once, at the end. Sentences 8 to 18 words, witnesses may use 3 to 6 word sentences for punch. Name real things. Title card footer: "Peninsula Insider acknowledges the Bunurong people, Traditional Owners of the lands and waters of the Mornington Peninsula." Nothing else about culture or history is invented.
+
+## Done means
+
+Case 01 plays start to finish on a phone in under ten minutes with both outcomes reachable. Two tabs on the same room share one notebook and clock; a third tab still plays. The viewFor leak test passes. Preferences work before the first tap. `app-meta.json` carries the generated cover and a real `og_title`. Hand back the live URL, the four background paintings and the PI sprite as files, and a one-page `design/plan.md`.

--- a/ops/scripts/pi_draw.py
+++ b/ops/scripts/pi_draw.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+pi_draw.py - run (or rehearse) the "Where in the Peninsula is PI?" prize draw.
+
+The ledger is pi.draw_entries in Supabase (service role only). A draw is one
+weighted random pick over all valid entries in a window, recorded once in
+pi.draw_results with the seed used, so anyone can re-run it and get the same
+winner.
+
+    # Rehearsal (default): prints the pool and the would-be winner, writes nothing.
+    python ops/scripts/pi_draw.py --period 2026-10
+
+    # The real draw: records the result. Refuses to run twice for one period.
+    python ops/scripts/pi_draw.py --period 2026-10 --commit \
+        --partner "Doot Doot Doot, Jackalope" --prize "$250 to dine"
+
+    # Redraw (winner unreachable after 14 days): excludes the first winner.
+    python ops/scripts/pi_draw.py --period 2026-10 --commit --redraw --exclude <entry uuid>
+
+Env: SUPABASE_URL (default: the PI project) and SUPABASE_SERVICE_ROLE_KEY.
+Nothing here touches Beehiiv; contact the winner by hand, then announce.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_URL = "https://tjjhpvslpysfklwpqmgz.supabase.co"
+
+
+def rest(method: str, path: str, body=None, prefer: str | None = None):
+    url = os.environ.get("SUPABASE_URL", DEFAULT_URL).rstrip("/") + "/rest/v1/" + path
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not key:
+        sys.exit("SUPABASE_SERVICE_ROLE_KEY is not set (service role, never the anon key).")
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Accept-Profile": "pi",
+        "Content-Profile": "pi",
+    }
+    if prefer:
+        headers["Prefer"] = prefer
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        sys.exit(f"{method} {path} -> {e.code}: {e.read().decode()[:400]}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Run the PI prize draw for one window.")
+    ap.add_argument("--period", required=True, help="draw window key, e.g. 2026-10")
+    ap.add_argument("--commit", action="store_true", help="record the result (default is a rehearsal)")
+    ap.add_argument("--partner", default="Doot Doot Doot, Jackalope")
+    ap.add_argument("--prize", default="$250 to dine")
+    ap.add_argument("--redraw", action="store_true", help="replace an unclaimed result for this period")
+    ap.add_argument("--exclude", action="append", default=[], help="entry uuid to exclude (repeatable)")
+    ap.add_argument("--seed", help="override the seed (rehearsals only; the real draw derives it)")
+    args = ap.parse_args()
+
+    existing = rest("GET", f"draw_results?period=eq.{urllib.parse.quote(args.period)}&select=*")
+    if existing and args.commit and not args.redraw:
+        sys.exit(f"A result already exists for {args.period} (drawn {existing[0]['drawn_at']}). Use --redraw to replace it.")
+
+    rows = rest(
+        "GET",
+        "draw_entries?select=id,email,first_name,case_id,entries,rank,seats,created_at"
+        f"&period=eq.{urllib.parse.quote(args.period)}&consent_marketing=eq.true&order=created_at.asc",
+    ) or []
+    rows = [r for r in rows if r["id"] not in set(args.exclude)]
+    if not rows:
+        sys.exit(f"No eligible entries for {args.period}.")
+
+    # One person, many rows: weight = total entries across their cases.
+    people: dict[str, dict] = {}
+    for r in rows:
+        p = people.setdefault(r["email"], {"email": r["email"], "name": r["first_name"], "weight": 0, "rows": []})
+        p["weight"] += int(r["entries"] or 1)
+        p["rows"].append(r)
+    pool = sorted(people.values(), key=lambda p: p["email"])
+    total_entries = sum(p["weight"] for p in pool)
+
+    # Seed: deterministic from the frozen pool (ids in order) plus the period,
+    # so the draw is reproducible from the ledger alone. Recorded in draw_results.
+    fingerprint = args.period + "|" + ",".join(sorted(r["id"] for r in rows))
+    seed = args.seed if (args.seed and not args.commit) else hashlib.sha256(fingerprint.encode()).hexdigest()[:16]
+    rng = random.Random(seed)
+    winner = rng.choices(pool, weights=[p["weight"] for p in pool], k=1)[0]
+    # Attribute the win to the person's earliest entry row.
+    winner_row = sorted(winner["rows"], key=lambda r: r["created_at"])[0]
+
+    print(f"Window {args.period}: {len(pool)} people, {total_entries} weighted entries, {len(rows)} rows")
+    for p in pool:
+        print(f"  {p['weight']:>3}  {p['name'] or ''} <{p['email']}>  cases {','.join(r['case_id'] for r in p['rows'])}")
+    print(f"Seed {seed}")
+    print(f"{'WINNER' if args.commit else 'Would win'}: {winner['name']} <{winner['email']}>  entry {winner_row['id']}")
+
+    if not args.commit:
+        print("Rehearsal only. Re-run with --commit to record.")
+        return
+
+    result = {
+        "period": args.period,
+        "partner": args.partner,
+        "prize": args.prize,
+        "seed": seed,
+        "winner_entry": winner_row["id"],
+        "total_entries": total_entries,
+        "total_people": len(pool),
+        "drawn_at": datetime.now(timezone.utc).isoformat(),
+        "notes": ("redraw; excluded " + ", ".join(args.exclude)) if args.redraw else None,
+    }
+    if existing and args.redraw:
+        rest("PATCH", f"draw_results?period=eq.{urllib.parse.quote(args.period)}", result, prefer="return=minimal")
+    else:
+        rest("POST", "draw_results", [result], prefer="return=minimal")
+    print("Recorded in pi.draw_results. Contact the winner by email within two business days.")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/functions/pi-draw-enter/index.ts
+++ b/supabase/functions/pi-draw-enter/index.ts
@@ -1,0 +1,267 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+/**
+ * pi-draw-enter — records a prize-draw entry for "Where in the Peninsula is PI?"
+ *
+ * Flow: validate → (optional Turnstile) → verify the game room really reached
+ * `found` (read-only route on play.peninsulainsider.com.au) → write the entry to
+ * pi.draw_entries (the legal ledger, service role) → best-effort upsert of the
+ * subscriber in Beehiiv with game custom fields (the marketing list).
+ *
+ * Secrets used: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (injected),
+ * BEEHIIV_API_KEY (already set for pi-newsletter-subscribe),
+ * TURNSTILE_SECRET (optional; when set, a token is required), DRAW_SALT (optional).
+ */
+
+const DRAW = {
+  period: "2026-10",
+  // 11:59pm AEDT, Sunday 11 October 2026.
+  closesAt: Date.parse("2026-10-11T12:59:59Z"),
+  partner: "Doot Doot Doot, Jackalope",
+  prize: "$250 to dine",
+};
+
+const GAME_ORIGIN = "https://play.peninsulainsider.com.au";
+const BEEHIIV_PUB_ID = "pub_91e9b723-53c4-456e-a857-9faa2d61864b";
+const BEEHIIV = `https://api.beehiiv.com/v2/publications/${BEEHIIV_PUB_ID}`;
+const ALLOWED_ORIGINS = [GAME_ORIGIN, "https://peninsulainsider.com.au", "https://www.peninsulainsider.com.au"];
+const CUSTOM_FIELDS = ["pi_player", "pi_entries", "pi_last_case", "pi_best_rank", "pi_period"];
+
+function corsHeaders(origin: string | null) {
+  const allow = origin && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    "Access-Control-Allow-Origin": allow,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    Vary: "Origin",
+  };
+}
+
+function json(data: unknown, status = 200, origin: string | null = null) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders(origin) },
+  });
+}
+
+async function sha256(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// ── Supabase (PostgREST, service role, schema pi) ───────────────────────────
+
+function rest(path: string, init: RequestInit & { prefer?: string } = {}) {
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const headers: Record<string, string> = {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+    "Accept-Profile": "pi",
+    "Content-Profile": "pi",
+  };
+  if (init.prefer) headers["Prefer"] = init.prefer;
+  return fetch(`${url}/rest/v1/${path}`, { ...init, headers });
+}
+
+// ── Beehiiv (best effort; the ledger row is the source of truth) ────────────
+
+let fieldsEnsured = false;
+
+async function ensureCustomFields(apiKey: string) {
+  if (fieldsEnsured) return;
+  const headers = { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+  const res = await fetch(`${BEEHIIV}/custom_fields?limit=100`, { headers });
+  if (!res.ok) throw new Error(`custom_fields list ${res.status}`);
+  const existing = new Set(((await res.json()).data ?? []).map((f: { display: string }) => f.display));
+  for (const name of CUSTOM_FIELDS) {
+    if (existing.has(name)) continue;
+    const c = await fetch(`${BEEHIIV}/custom_fields`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ kind: "string", display: name }),
+    });
+    if (!c.ok) console.warn(`custom field ${name}: ${c.status} ${await c.text()}`);
+  }
+  fieldsEnsured = true;
+}
+
+async function upsertBeehiiv(
+  apiKey: string,
+  email: string,
+  fields: Record<string, string>,
+): Promise<string | null> {
+  await ensureCustomFields(apiKey);
+  const headers = { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+  const custom_fields = Object.entries(fields).map(([name, value]) => ({ name, value }));
+  const created = await fetch(`${BEEHIIV}/subscriptions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      email,
+      reactivate_existing: false,
+      send_welcome_email: true,
+      utm_source: "play.peninsulainsider.com.au",
+      utm_medium: "game",
+      utm_campaign: `where-is-pi-draw-${DRAW.period}`,
+      referring_site: GAME_ORIGIN,
+      custom_fields,
+    }),
+  });
+  if (!created.ok) throw new Error(`subscription create ${created.status} ${await created.text()}`);
+  const id: string | undefined = (await created.json()).data?.id;
+  if (!id) return null;
+  // Existing subscribers keep their record; make sure the game fields land either way.
+  const patched = await fetch(`${BEEHIIV}/subscriptions/${id}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ custom_fields }),
+  });
+  if (!patched.ok) console.warn(`subscription patch ${patched.status} ${await patched.text()}`);
+  // Tags are plan-dependent on Beehiiv; try, never fail the entry on it.
+  const tagged = await fetch(`${BEEHIIV}/subscriptions/${id}/tags`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ tags: ["where-is-pi"] }),
+  });
+  if (!tagged.ok) console.warn(`subscription tags ${tagged.status}`);
+  return id;
+}
+
+// ── handler ─────────────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request) => {
+  const origin = req.headers.get("origin");
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders(origin) });
+  if (req.method !== "POST") return json({ ok: false, message: "Method not allowed." }, 405, origin);
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ ok: false, message: "Invalid request body." }, 400, origin);
+  }
+
+  const email = String(body.email ?? "").trim().toLowerCase();
+  const name = String(body.name ?? "").trim().replace(/\s+/g, " ").slice(0, 40);
+  const room = String(body.room ?? "").trim();
+  const home = body.home === "local" || body.home === "visitor" ? String(body.home) : null;
+  const consent = body.consent === true;
+  const turnstile = typeof body.turnstile === "string" ? body.turnstile : null;
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return json({ ok: false, message: "Please enter a valid email address." }, 400, origin);
+  if (!name) return json({ ok: false, message: "Please tell us your first name." }, 400, origin);
+  if (!consent) return json({ ok: false, message: "Tick the box to enter the draw." }, 400, origin);
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(room)) return json({ ok: false, message: "That game could not be found." }, 400, origin);
+  if (Date.now() > DRAW.closesAt) return json({ ok: false, message: "This draw window has closed." }, 410, origin);
+
+  const turnstileSecret = Deno.env.get("TURNSTILE_SECRET");
+  if (turnstileSecret) {
+    if (!turnstile) return json({ ok: false, message: "Please complete the check and try again." }, 400, origin);
+    const v = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ secret: turnstileSecret, response: turnstile, remoteip: req.headers.get("cf-connecting-ip") ?? undefined }),
+    });
+    const vj = await v.json().catch(() => ({ success: false }));
+    if (!vj.success) return json({ ok: false, message: "Please complete the check and try again." }, 400, origin);
+  }
+
+  // Only a room that really reached `found` can enter.
+  let result: { status?: string; caseId?: string | null; rank?: string | null; minutesLeft?: number | null; seats?: number; route?: string[] };
+  try {
+    const r = await fetch(`${GAME_ORIGIN}/api/rooms/${room}/result`, { headers: { Accept: "application/json" } });
+    if (!r.ok) throw new Error(`room ${r.status}`);
+    result = await r.json();
+  } catch (err) {
+    console.error("room verify failed:", err);
+    return json({ ok: false, message: "We could not confirm your game. Try again in a moment." }, 502, origin);
+  }
+  if (result.status !== "found" || !result.caseId) return json({ ok: false, message: "Find PI first, then come back for the draw." }, 403, origin);
+
+  const seats = Math.max(1, Number(result.seats ?? 1));
+  const party = seats >= 2;
+  const entries = party ? 2 : 1;
+  const ip = req.headers.get("cf-connecting-ip") ?? req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "";
+  const ipHash = ip ? (await sha256((Deno.env.get("DRAW_SALT") ?? "pi") + ip)).slice(0, 32) : null;
+  const now = new Date().toISOString();
+
+  // Ledger row. Duplicates (same period + case + email) are ignored, not errors.
+  let already = false;
+  try {
+    const ins = await rest("draw_entries?on_conflict=period,case_id,email", {
+      method: "POST",
+      prefer: "resolution=ignore-duplicates,return=representation",
+      body: JSON.stringify([{
+        period: DRAW.period,
+        case_id: String(result.caseId),
+        room_id: room,
+        email,
+        first_name: name,
+        home,
+        rank: result.rank ?? null,
+        minutes_left: typeof result.minutesLeft === "number" ? result.minutesLeft : null,
+        seats,
+        bonus: { party },
+        entries,
+        consent_marketing: true,
+        consent_at: now,
+        source: String(body.source ?? "where-is-pi"),
+        ip_hash: ipHash,
+        user_agent: (req.headers.get("user-agent") ?? "").slice(0, 200),
+      }]),
+    });
+    if (!ins.ok) throw new Error(`insert ${ins.status} ${await ins.text()}`);
+    const rows = await ins.json();
+    already = !Array.isArray(rows) || rows.length === 0;
+  } catch (err) {
+    console.error("ledger write failed:", err);
+    return json({ ok: false, message: "We could not record your entry. Try again in a moment." }, 502, origin);
+  }
+
+  // Total entries this window for this email.
+  let total = entries;
+  try {
+    const q = await rest(`draw_entries?select=entries&period=eq.${DRAW.period}&email=eq.${encodeURIComponent(email)}`);
+    if (q.ok) {
+      const rows: { entries: number }[] = await q.json();
+      total = rows.reduce((n, r) => n + (r.entries ?? 0), 0) || entries;
+    }
+  } catch (err) {
+    console.warn("entry count failed:", err);
+  }
+
+  // Marketing list (never blocks the entry).
+  const apiKey = Deno.env.get("BEEHIIV_API_KEY");
+  if (apiKey) {
+    try {
+      const id = await upsertBeehiiv(apiKey, email, {
+        pi_player: "yes",
+        pi_entries: String(total),
+        pi_last_case: String(result.caseId),
+        pi_best_rank: String(result.rank ?? ""),
+        pi_period: DRAW.period,
+      });
+      if (id) {
+        await rest(`draw_entries?period=eq.${DRAW.period}&case_id=eq.${encodeURIComponent(String(result.caseId))}&email=eq.${encodeURIComponent(email)}`, {
+          method: "PATCH",
+          prefer: "return=minimal",
+          body: JSON.stringify({ beehiiv_subscription_id: id }),
+        });
+      }
+    } catch (err) {
+      console.error("beehiiv upsert failed:", err);
+    }
+  } else {
+    console.warn("BEEHIIV_API_KEY not set; entry recorded without list sync");
+  }
+
+  return json({
+    ok: true,
+    already,
+    entries: total,
+    period: DRAW.period,
+    message: already ? "This case is already entered for that email." : "You are in.",
+  }, 200, origin);
+});


### PR DESCRIPTION
Ops files from today's game build that were sitting uncommitted in the working checkout:

- `ops/scripts/pi_draw.py`: the monthly draw. Rehearsal by default; weighted by entries per person; seed derived from the frozen pool so any re-run reproduces the winner; writes `pi.draw_results` once per period, `--redraw --exclude <id>` for an unclaimed prize. Logic rehearsed on a fixture (weighting, determinism, single record). Needs `SUPABASE_SERVICE_ROLE_KEY` for the PI project (`tjjhpvslpysfklwpqmgz`); the ops box only holds the Mission Control key.
- `supabase/functions/pi-draw-enter/index.ts`: source of the deployed edge function (v3), so the deployed code is in git.
- `docs/game/`: the Higgsfield build brief and paste-ready prompt.

No site source touched; the deploy workflow does not trigger on these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)