### PR TITLE
fix(play): remove the Prize partner label

### DIFF
--- a/next/scripts/lint-no-pricing.mjs
+++ b/next/scripts/lint-no-pricing.mjs
@@ -43,9 +43,9 @@ const ALLOW = new Set([
   'lib/sanity/phase5-adapters.ts',
   'lib/sanity/queries.ts', // GROQ query definitions — data-layer field selection only, not rendered
   // Where in the Peninsula is PI? promo config. The one dollar figure is the
-  // prize-draw value (our own promotion, labelled "Prize partner" wherever it
-  // renders), never a venue price. Trade-promotion terms require the prize
-  // value to be stated. Templates only ever render PLAY.draw.prize.
+  // prize-draw value of our own promotion, never a venue price; trade-promotion
+  // terms require the prize value to be stated. Templates only ever render
+  // PLAY.draw.prize.
   'lib/play.ts',
 ]);
 

--- a/next/src/components/play/PlayBeacon.astro
+++ b/next/src/components/play/PlayBeacon.astro
@@ -43,7 +43,7 @@ const href = playUrl('masthead');
       <p class="v5-play__copy">
         Case {PLAY.case.id}: {PLAY.case.title}. Ask the locals, read the land, find her before sunset. {PRIZE_LINE}
       </p>
-      <p class="v5-play__fine">Prize partner. Free to play, no account.</p>
+      <p class="v5-play__fine">Free to play, no account.</p>
     </div>
   </div>
 )}

--- a/next/src/components/play/PlayCard.astro
+++ b/next/src/components/play/PlayCard.astro
@@ -32,7 +32,7 @@ const href = playUrl(surface);
           ? 'She took her coffee to go from Mornington pier and was gone. Ask the locals, search the scenes, read the land. Find her before sunset and the route you solved is a real day out you can save to your trip.'
           : 'A painted Peninsula, three witnesses a stop, and the sun for a clock. Find PI before sunset and her route becomes a day you can drive.'}
       </p>
-      <p class="play-card__prize">{PRIZE_LINE}{' '}<span class="play-card__sponsor">Prize partner.</span></p>
+      <p class="play-card__prize">{PRIZE_LINE}</p>
       <p class="play-card__actions">
         <a class="pi-btn pi-btn--solid" href={href} data-evt="pi_play_promo" data-surface={surface} data-position="cta">Play Case {PLAY.case.id}</a>
         <span class="play-card__fine">Six to ten minutes. Free, no account.</span>
@@ -81,7 +81,6 @@ const href = playUrl(surface);
   }
   .play-card__dek { margin: 0 0 var(--space-3); font-size: var(--fs-400); line-height: 1.5; }
   .play-card__prize { margin: 0 0 var(--space-4); font-size: var(--fs-300); font-weight: var(--fw-semibold); }
-  .play-card__sponsor { font-weight: 400; color: var(--soft); }
   .play-card__actions { margin: 0; display: flex; align-items: center; gap: var(--space-4); flex-wrap: wrap; }
   .play-card__fine { font-size: var(--fs-200); color: var(--soft); }
   @media (max-width: 767px) {

--- a/next/src/components/play/PlayRibbon.astro
+++ b/next/src/components/play/PlayRibbon.astro
@@ -5,8 +5,7 @@
  * Renders nothing unless this place or venue plays a part in the current
  * case (PLAY.case) or is the draw's prize partner. Data-driven from lib/play,
  * so Case 02 re-points every ribbon with one config edit and no template
- * work. The prize-partner variant carries the sponsor label per the site's
- * advertising firewall (label, never absence).
+ * work.
  */
 import { PLAY, playRole, playUrl } from '../../lib/play';
 
@@ -28,10 +27,7 @@ const copy = role === 'found'
   <aside class:list={['play-ribbon', `play-ribbon--${role}`]} aria-label="Where in the Peninsula is PI?">
     <img class="play-ribbon__mark" src="/images/play/pi-mark-still-96.png" srcset="/images/play/pi-mark-still-96.png 1x, /images/play/pi-mark-still-192.png 2x" width="40" height="37" alt="" loading="lazy" decoding="async" />
     <div class="play-ribbon__text">
-      <p class="play-ribbon__eyebrow">
-        Where in the Peninsula is PI?
-        {role === 'prize' && <span class="play-ribbon__sponsor">Prize partner</span>}
-      </p>
+      <p class="play-ribbon__eyebrow">Where in the Peninsula is PI?</p>
       <p class="play-ribbon__lead">{copy.lead} <span class="play-ribbon__body">{copy.body}</span></p>
     </div>
     <a
@@ -68,12 +64,6 @@ const copy = role === 'found'
     text-transform: uppercase;
     color: var(--sand-text);
     font-weight: var(--fw-semibold);
-    display: flex; gap: var(--space-2); flex-wrap: wrap;
-  }
-  .play-ribbon__sponsor {
-    color: var(--soft);
-    font-weight: 500;
-    letter-spacing: 0.06em;
   }
   .play-ribbon__lead { margin: 0; font-size: var(--fs-300); line-height: 1.4; font-weight: var(--fw-semibold); }
   .play-ribbon__body { font-weight: 400; color: var(--soft, #5B6770); }


### PR DESCRIPTION
Removes the words "Prize partner" from the masthead beacon card, the prize-venue ribbon and both play cards, per James. The prize line ("Find her and go in the draw for $250 at Doot Doot Doot, Jackalope.") is unchanged. Full site build green in a clean worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)