### PR TITLE
fix(content): remove permanently closed Ouest France Bistro from Insider Picks

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -14,6 +14,7 @@
     "check": "astro check",
     "validate:content": "node scripts/validate-content.mjs",
     "test:content-admission": "node scripts/test-content-admission.mjs",
+    "test:closed-venue-maintenance": "node --test scripts/closed-venue-maintenance.test.mjs",
     "test:campaigns-review-page": "node --test scripts/campaigns-review-page.test.mjs",
     "assert:campaigns-review-page": "node scripts/assert-campaigns-review-page.mjs",
     "test:partner-portal-dashboard": "node --test scripts/partner-portal-dashboard.test.mjs",

--- a/next/scripts/closed-venue-maintenance.test.mjs
+++ b/next/scripts/closed-venue-maintenance.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = (path) => new URL(path, import.meta.url);
+
+async function text(path) {
+  return readFile(source(path), 'utf8');
+}
+
+test('Ouest France Bistro is permanently closed and excluded from public routes', async () => {
+  const venue = JSON.parse(await text('../src/content/venues/ouest-france-bistro.json'));
+  const eatRoute = await text('../src/pages/eat/[slug].astro');
+  const eatHub = await text('../src/pages/eat/index.astro');
+
+  assert.equal(venue.status, 'permanently_closed');
+  assert.equal(venue.sitemapExclude, true);
+  assert.equal(venue.bookingUrl, undefined);
+  assert.match(eatRoute, /venue\.data\.status !== 'permanently_closed'/);
+  assert.match(eatHub, /v\.data\.status !== 'permanently_closed'/);
+});
+
+test('published Insider Picks do not recommend Ouest France Bistro', async () => {
+  const picks = await Promise.all([
+    text('../src/content/articles/insider-picks-2026-08-09.md'),
+    text('../src/content/articles/insider-picks-2026-09-13.md'),
+  ]);
+
+  for (const pick of picks) {
+    assert.doesNotMatch(pick, /Ouest France Bistro/i);
+  }
+});
+
+test('active venue records do not link to Ouest France Bistro', async () => {
+  const venue = JSON.parse(await text('../src/content/venues/peninsula-fresh-organics.json'));
+
+  assert.doesNotMatch(JSON.stringify(venue.pairWith ?? []), /Ouest France Bistro/i);
+});
+
+test('closed venue pages suppress booking and contact actions', async () => {
+  const template = await text('../src/components/VenueDetailTemplate.astro');
+
+  assert.match(template, /\(data\.bookingUrl \|\| data\.phone\) && !isClosed/);
+});

--- a/next/src/components/VenueDetailTemplate.astro
+++ b/next/src/components/VenueDetailTemplate.astro
@@ -258,7 +258,7 @@ const hoursSchema = hasOpeningHours && isCanonicalSurface && section !== 'wine'
       label: `${data.name} - name`,
     })}>{data.name}</h1>
     {isClosed && (
-      <p class="venue-detail__closed-notice">This cellar door is permanently closed. The page is preserved for historical reference.</p>
+      <p class="venue-detail__closed-notice">This venue is closed. The page is preserved for historical reference.</p>
     )}
     <p class="venue-detail__signature" {...editableText({
       entityType: 'venue', entitySlug: venueSlug, fieldPath: 'signature',
@@ -278,7 +278,7 @@ const hoursSchema = hasOpeningHours && isCanonicalSurface && section !== 'wine'
       </p>
     )}
 
-    {(data.bookingUrl || data.phone) && (
+    {(data.bookingUrl || data.phone) && !isClosed && (
       <div class="venue-detail__booking-bar">
         {data.bookingUrl && (
           <a href={data.bookingUrl} target="_blank" rel="noopener noreferrer" class="pi-btn pi-btn--solid pi-btn--lg">

--- a/next/src/content/articles/insider-picks-2026-08-09.md
+++ b/next/src/content/articles/insider-picks-2026-08-09.md
@@ -1,12 +1,12 @@
 ---
-title: "Stonier Fire & Wine Lunch, a Winter Whale Watch Window, and Buckwheat Galettes in Mornington"
-dek: Stonier Wines fires up a winter lunch in Merricks, the whale migration corridor off Cape Schanck peaks in August, and Ouest France Bistro's buckwheat galette with ham and gruyère earns a Saturday morning detour.
+title: "Stonier Fire & Wine Lunch and a Winter Whale Watch Window"
+dek: Stonier Wines fires up a winter lunch in Merricks, and the whale migration corridor off Cape Schanck peaks in August.
 author: "editorial"
 houseByline: true
 publishedAt: 2026-08-09
 heroImage:
   src: "/images/sourced/place-mornington-01.webp"
-  alt: "Mornington, Victoria Bathing boxes on the beach - representative image for Ouest France Bistro"
+  alt: "Mornington, Victoria bathing boxes on the beach"
   credit: "Simon Yeo"
   license: "wikimedia-cc-by"
 format: "insider-edit"
@@ -30,8 +30,7 @@ faq:
     answer: "Check availability and book through stonier.com.au/visit. The lunch runs today, Sunday 9 August 2026, so book immediately if you haven't already - seats go fast."
   - question: "When is the best time to spot whales from Cape Schanck in winter?"
     answer: "August is the peak month for humpback and southern right whales moving through Bass Strait. Arrive at the Cape Schanck boardwalk by mid-morning on a calm, clear day for the best sightlines. No booking required - Parks Victoria manages the site and the boardwalk is open daily."
-  - question: "What are Ouest France Bistro's opening hours?"
-    answer: "Ouest France Bistro is on Blight Street, Mornington. They open early on weekdays and Saturdays; check their current hours directly as winter trading can vary. The buckwheat galette service runs through the morning menu."
+
 ---
 
 **Stonier Fire & Wine Winter Lunch, Merricks - today only**
@@ -50,14 +49,6 @@ Follow this with coffee and something warm at Georgie Bass in Flinders, fifteen 
 
 ---
 
-**Ouest France Bistro, Mornington - buckwheat galette on a winter Saturday**
-
-Ouest France is easy to walk past. It sits on Blight Street rather than Main Street, the awning is blue-and-white and quietly done, and the interior is small enough that a full house looks like eight people. The buckwheat galette with ham and gruyère is the order - a properly made Breton-style galette with enough structural integrity that it doesn't collapse mid-bite, which sounds like a low bar and isn't. The café grew from a crêperie into something more considered, and the breakfast menu now runs a jambon-beurre alongside the galettes. Go early on Saturday, before ten if you can manage it, because tables move quickly and the kitchen runs at its best pace in the first hour of service. Blight Street, Mornington; check current hours before you go.
-
-Pair a post-breakfast walk along the Mornington foreshore with a stop at Commonfolk Coffee on the way back if you want a second coffee roasted in-house.
-
----
-
 ### This Weekend's Key Details
 
 **Stonier Fire & Wine Winter Lunch**
@@ -69,8 +60,3 @@ Bookings essential: stonier.com.au/visit
 Cape Schanck Road, Cape Schanck
 Open daily - August is peak window; aim for mid-morning on a clear day
 No booking required; parks.vic.gov.au
-
-**Ouest France Bistro**
-Blight Street, Mornington
-Saturday mornings recommended; arrive before 10am
-Check current winter trading hours directly

--- a/next/src/content/articles/insider-picks-2026-09-13.md
+++ b/next/src/content/articles/insider-picks-2026-09-13.md
@@ -1,12 +1,12 @@
 ---
-title: "Insider Picks: 13 September 2026"
-dek: "Ouest France Bistro's buckwheat galette on a spring Saturday, spider orchids along the Moorooduc Plains grassland loop, and the final Red Hill truffle hunt window before season close."
+title: "Insider Picks: Spider Orchids and Red Hill Truffles, 13 September 2026"
+dek: "Spider orchids along the Moorooduc Plains grassland loop and the final Red Hill truffle hunt window before season close."
 author: "editorial"
 houseByline: true
 publishedAt: 2026-09-13
 heroImage:
   src: "/images/sourced/place-mornington-01.webp"
-  alt: "Mornington, Victoria Bathing boxes on the beach - representative image for Ouest France Bistro"
+  alt: "Mornington, Victoria bathing boxes on the beach"
   credit: "Simon Yeo"
   license: "wikimedia-cc-by"
 format: "insider-edit"
@@ -26,24 +26,10 @@ clusterLinks:
   - label: "Best Walks on the Mornington Peninsula"
     href: "/explore/best-walks/"
 faq:
-  - question: "Where is Ouest France Bistro and when does it open?"
-    answer: "Ouest France Bistro is in Mornington. It opens early on Saturdays - arrive before 9am for the best experience. Check their socials for current hours."
   - question: "When does the Red Hill Truffles hunt season close?"
     answer: "The 2026 truffle hunt season at Red Hill Truffles in Main Ridge runs until 30 September 2026. Bookings are essential and Saturday slots in mid-September fill fast - book at redhilltruffles.com/hunts."
   - question: "Where are the spider orchids on the Moorooduc Plains?"
     answer: "The Moorooduc Plains Flora and Fauna Reserve is off Moorooduc Road near Moorooduc. The grassland loop trails are publicly accessible. Orchids typically peak mid-September; wear shoes you can get muddy and go on a morning after recent rain for the best display."
----
-
-## EAT - Ouest France Bistro, Mornington
-
-The buckwheat galette at Ouest France Bistro is one of the Peninsula's most quietly accomplished breakfasts, and Saturday morning in spring is when it makes the most sense to go.
-
-The bistro sits on a side street in Mornington and is easy to walk past. Inside, the format is properly Breton: dark buckwheat crêpe, ham, gruyère, egg, folded at the corners. The jambon-beurre breakfast runs alongside it. Neither dish tries to do more than it should. The coffee is sharp, the room is small, and the blue-and-white awning marks the door. Spring brings the first outdoor table weather of the year - the side-street position means no wind, full morning sun by nine.
-
-Go on Saturday, arrive before 9:30am. The galette with ham and gruyère is the order. Counter service, so no booking required for breakfast - though the room fills fast once the market crowd arrives.
-
-Pair a post-breakfast walk down to Mornington Harbour with a stop at Commonfolk Coffee if you want a second coffee from the roastery.
-
 ---
 
 ## EXPERIENCE - Spider Orchids, Moorooduc Plains Flora and Fauna Reserve
@@ -71,9 +57,6 @@ Johnny Ripe bakery in Main Ridge is five minutes away; a pie in the garden befor
 ---
 
 ## Quick Reference
-
-**Ouest France Bistro**
-Side-street Mornington (check Google Maps for the exact address). Open early Saturday and Sunday mornings. No booking required for breakfast. Order the buckwheat galette with ham and gruyère.
 
 **Moorooduc Plains Flora and Fauna Reserve**
 Moorooduc Road, Moorooduc. Publicly accessible, no booking. Best visited mid-September mornings after rain. Forty-minute grassland loop. Wear boots.

--- a/next/src/content/venues/ouest-france-bistro.json
+++ b/next/src/content/venues/ouest-france-bistro.json
@@ -11,21 +11,10 @@
   "address": "5 Blake St, Mornington VIC 3931",
   "phone": "+61 3 5975 1500",
   "website": "https://www.ouestfrance.com.au",
+  "status": "permanently_closed",
   "priceBand": "$$",
-  "signature": "A properly Breton bistro on a Mornington side street, buckwheat galettes, jambon-beurre, and some of the best coffee on the strip behind a blue-and-white awning.",
-  "editorNote": "Ouest France started as a crêperie and grew into something much more interesting: a small, properly Breton-feeling bistro tucked into a side street off Mornington's Main, with a blue-and-white awning that you walk past without noticing until someone points it out. The galettes are genuine, proper buckwheat, proper garnishes, and the breakfast menu leans honest French: croissants, jambon-beurre, eggs and country bread.\n\nThe coffee is better than most of the more-visible Main Street cafés, which is reason enough for a morning detour. The room is small and fills quickly on weekends, but the owners keep the pace civil even when there is a queue at the door. This is the kind of place that earns its position in a town that otherwise does coffee and brunch as a commodity.\n\nGo early on Saturday. Order the galette with ham and gruyère and a second coffee. The side street is the point.",
-  "whyWeGo": "Started as a crêperie and grew into something much more interesting, a small Breton-feeling bistro you walk past without noticing until someone points it out.",
-  "bestFor": [
-    "Morning stop",
-    "Brunch",
-    "Couples",
-    "Solo travellers"
-  ],
-  "ifOnlyOneThing": "Go early on Saturday and order the buckwheat galette with ham and gruyère.",
-  "pairWith": [
-    "Garagiste",
-    "Sourdough Kitchen"
-  ],
+  "signature": "Ouest France Bistro in Mornington is permanently closed.",
+  "editorNote": "Ouest France Bistro in Mornington is permanently closed. This record is retained for historical reference and is excluded from public venue listings and routes.",
   "tags": {
     "mood": [
       "slow"
@@ -46,10 +35,9 @@
   },
   "gallery": [],
   "featuredPartner": false,
-  "lastVerified": "2026-04-09",
+  "lastVerified": "2026-09-12",
   "publishedAt": "2026-04-09",
-  "bookingUrl": "https://www.ouestfrance.com.au",
-  "bookingProvider": "direct",
+  "sitemapExclude": true,
   "knownFor": [
     "Breton Buckwheat Galettes",
     "Jambon-Beurre Breakfast",

--- a/next/src/content/venues/peninsula-fresh-organics.json
+++ b/next/src/content/venues/peninsula-fresh-organics.json
@@ -28,8 +28,7 @@
   ],
   "ifOnlyOneThing": "Go early and buy what was picked that morning, then cook dinner with it.",
   "pairWith": [
-    "Circe Wines",
-    "Ouest France Bistro"
+    "Circe Wines"
   ],
   "tags": {
     "mood": [


### PR DESCRIPTION
## Release scope

Publishes the approved Ouest France Bistro closure removal from Max task [1218425673059014](https://app.asana.com/1/233540066981051/project/1218200694561476/task/1218425673059014).

- Reviewed head: `c9c408070dfa8234f7cf38b5c8298a2987861f24`
- Verified base: `d7660ae49d9d6b33d503c376c73cedbac5e56649`
- Public verification: https://peninsulainsider.com.au/eat/ouest-france-bistro/
- Boundaries: no email, social, CRM, DNS, billing or unrelated production changes
- Rollback: revert this pull request and verify deployment provenance plus https://peninsulainsider.com.au/eat/ouest-france-bistro/

Local targeted test `npm run test:closed-venue-maintenance` and the full production build passed in an isolated worktree before this PR was opened.
