### PR TITLE
PI-003: one timezone-correct season, and stop the site insisting it is winter

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -78,6 +78,7 @@ jobs:
           cd next
           npm run test:content-admission
           npm run test:share-link
+          npm run test:season
           npm run test:agent-readiness
           npm run test:event-safeguards
           npm run validate:content

--- a/next/package.json
+++ b/next/package.json
@@ -14,6 +14,7 @@
     "check": "astro check",
     "validate:content": "node scripts/validate-content.mjs",
     "test:content-admission": "node scripts/test-content-admission.mjs",
+    "test:season": "node --test src/lib/season.test.mjs",
     "test:closed-venue-maintenance": "node --test scripts/closed-venue-maintenance.test.mjs",
     "test:campaigns-review-page": "node --test scripts/campaigns-review-page.test.mjs",
     "assert:campaigns-review-page": "node scripts/assert-campaigns-review-page.mjs",

--- a/next/scripts/lint-nav-budget.mjs
+++ b/next/scripts/lint-nav-budget.mjs
@@ -14,9 +14,12 @@
  * Usage: node scripts/lint-nav-budget.mjs   (from next/, or repo root
  * via node next/scripts/lint-nav-budget.mjs). Exits 1 on any breach.
  *
- * v5-nav.ts is deliberately dependency-free with flat interfaces so
- * this script can strip the TypeScript surface and evaluate the
- * config without a TS toolchain.
+ * v5-nav.ts keeps flat interfaces and a single import so this script can
+ * strip the TypeScript surface and evaluate the config without a TS
+ * toolchain. That one import is the shared season helper
+ * (src/lib/season.ts), which drives the rail eyebrows; this lint only
+ * counts links, so it strips the import line and stubs the helper rather
+ * than resolving a module graph.
  */
 
 import { readFileSync } from 'node:fs';
@@ -36,15 +39,22 @@ const navPath = join(here, '..', 'src', 'lib', 'v5-nav.ts');
 
 let source = readFileSync(navPath, 'utf8');
 
-// Strip the TypeScript surface: interfaces (flat, no nested braces),
-// type annotations on exported consts, `as` casts on group literals.
+// Strip the TypeScript surface: imports (stubbed in the sandbox below),
+// interfaces (flat, no nested braces), type annotations on exported
+// consts, `as` casts on group literals.
 source = source
+  .replace(/^import[^\n]*;[^\n]*$/gm, '')
   .replace(/export interface [\s\S]*?\n\}/g, '')
   .replace(/export const (\w+)\s*:\s*[^=]+=/g, 'exports.$1 =')
   .replace(/export const (\w+)\s*=/g, 'exports.$1 =')
   .replace(/ as string \| null/g, '');
 
-const sandbox = { exports: {} };
+// Stubs for the symbols v5-nav.ts imports. Their values never reach a
+// link count, so a fixed placeholder is enough.
+const sandbox = {
+  exports: {},
+  getSeasonEditionTag: () => "Season '00",
+};
 try {
   vm.runInNewContext(source, sandbox, { filename: 'v5-nav.evaluated.js' });
 } catch (err) {

--- a/next/src/components/CoverHero.astro
+++ b/next/src/components/CoverHero.astro
@@ -3,7 +3,7 @@
  * CoverHero, full-bleed immersive cover module.
  * Homepage passes issueDate to get seasonal copy; other pages pass props to override.
  */
-import { currentSeason } from '../lib/editorial';
+import { getAustralianSeasonLower } from '../lib/season';
 
 export interface Props {
   issueDate?: string;
@@ -38,7 +38,7 @@ const {
   bgImage,
 } = Astro.props;
 
-const season = currentSeason();
+const season = getAustralianSeasonLower();
 
 const seasonalHeadlines: Record<string, { line1: string; line2: string; em: string }> = {
   summer: { line1: 'Where Victoria', line2: 'eats, swims,', em: 'stays late.' },

--- a/next/src/components/v5/home/HomeCover.astro
+++ b/next/src/components/v5/home/HomeCover.astro
@@ -19,7 +19,7 @@
  */
 import { editableText, editableImage } from '../../../lib/inline-edit/attrs';
 import { loadOverrides } from '../../../lib/inline-edit/overrides';
-import { getSeason } from '../../../lib/edition';
+import { getAustralianSeasonLower } from '../../../lib/season';
 
 const DEFAULT_STATEMENT = 'The Mornington Peninsula, sorted.';
 
@@ -51,7 +51,7 @@ const dateLabel = now.toLocaleDateString('en-AU', {
 const isoDate = new Intl.DateTimeFormat('en-CA', {
   timeZone: 'Australia/Melbourne',
 }).format(now);
-const season = getSeason(now).toLowerCase();
+const season = getAustralianSeasonLower(now);
 ---
 
 <section class="home-cover" aria-label="Cover">

--- a/next/src/components/v5/home/HomePlan.astro
+++ b/next/src/components/v5/home/HomePlan.astro
@@ -17,12 +17,12 @@
 import { getCollection } from 'astro:content';
 import Card from '../Card.astro';
 import { resolveHero } from '../../../lib/inline-edit/resolve-hero';
-import { currentSeason } from '../../../lib/editorial';
+import { getAustralianSeasonLower } from '../../../lib/season';
 
 const ROTATION_WINDOW_DAYS = 5;
 
 const plans = await getCollection('itineraries');
-const season = currentSeason();
+const season = getAustralianSeasonLower();
 
 const seasonScore = (p: any) =>
   p.data.season === season ? 2 : p.data.season === 'year-round' ? 1 : 0;

--- a/next/src/components/v5/plans/plans-data.ts
+++ b/next/src/components/v5/plans/plans-data.ts
@@ -16,11 +16,11 @@
 import { getCollection } from 'astro:content';
 import {
   getFacets,
-  auSeason,
   CHIP_PRESETS,
   FACET_OPTIONS,
   type FacetKey,
 } from '../../../lib/facets';
+import { getAustralianSeasonLower } from '../../../lib/season';
 import { routeSlug, venueHref, titleize } from '../../../lib/editorial';
 import { loadOverrides } from '../../../lib/inline-edit/overrides';
 
@@ -122,7 +122,7 @@ async function heroFor(
 }
 
 export async function buildPlansModel(now: Date = new Date()): Promise<PlansModel> {
-  const season = auSeason(now);
+  const season = getAustralianSeasonLower(now);
 
   // ---- stop resolution lookups -------------------------------------------
   const venues = await getCollection('venues');

--- a/next/src/lib/conditions.ts
+++ b/next/src/lib/conditions.ts
@@ -20,7 +20,8 @@
  */
 
 import rawConditions from '../data/conditions.json';
-import { getSunsetLabel, PENINSULA_TZ } from './sunset';
+import { getSunsetLabel } from './sunset';
+import { getAustralianSeason, melbourneCalendarParts } from './season';
 
 export interface ConditionsStrip {
   /** e.g. "Sorrento", or null when no locus is configured. */
@@ -47,40 +48,16 @@ type RawConditions = {
   staleAfterHours?: number | null;
 };
 
-/** Southern Hemisphere meteorological seasons, matching src/lib/edition.ts. */
-function seasonForMonth(month: number): string {
-  if (month >= 3 && month <= 5) return 'Autumn';
-  if (month >= 6 && month <= 8) return 'Winter';
-  if (month >= 9 && month <= 11) return 'Spring';
-  return 'Summer';
-}
-
-/**
- * Melbourne-local calendar parts. The build runs in UTC, and for ten hours
- * of every day the UTC date is a day behind the Peninsula. Deriving the
- * month and year from the localised parts (rather than from getMonth())
- * keeps the issue stamp correct across month and year boundaries.
- */
-function melbourneParts(date: Date): { year: number; month: number; monthName: string } {
-  const parts = new Intl.DateTimeFormat('en-AU', {
-    timeZone: PENINSULA_TZ,
-    year: 'numeric',
-    month: 'numeric',
-  }).formatToParts(date);
-  const num = (t: string) => Number(parts.find((p) => p.type === t)?.value ?? '0');
-  const year = num('year');
-  const month = num('month');
-  const monthName = new Intl.DateTimeFormat('en-AU', {
-    timeZone: PENINSULA_TZ,
-    month: 'long',
-  }).format(date);
-  return { year, month, monthName };
-}
-
-/** "Winter Insider · July 2026" plus its short form, derived from the date. */
+/** "Winter Insider · July 2026" plus its short form, derived from the date.
+ *
+ * Season and calendar parts both come from src/lib/season.ts, which is the
+ * only place in the codebase that decides what season it is. The local
+ * seasonForMonth/melbourneParts pair that used to live here was the one
+ * timezone-correct implementation of four; it now serves the whole site
+ * from the shared module instead. */
 export function getIssueStamp(date: Date = new Date()): { full: string; short: string } {
-  const { year, month, monthName } = melbourneParts(date);
-  const season = seasonForMonth(month);
+  const { year, monthName } = melbourneCalendarParts(date);
+  const season = getAustralianSeason(date);
   return {
     full: `${season} Insider · ${monthName} ${year}`,
     short: `${season} ${year}`,

--- a/next/src/lib/edition.ts
+++ b/next/src/lib/edition.ts
@@ -2,23 +2,15 @@
  * edition.ts - Publication identity helpers.
  *
  * Returns the current seasonal edition string for Peninsula Insider.
- * Season is Southern Hemisphere meteorological:
- *   Autumn  → March, April, May
- *   Winter  → June, July, August
- *   Spring  → September, October, November
- *   Summer  → December, January, February
+ * The season itself comes from src/lib/season.ts, the single shared
+ * derivation. The getSeason() that used to live here read date.getMonth()
+ * off the build host's clock, so on a UTC runner it named the previous
+ * season for the first ten to fourteen hours after every changeover.
  *
  * Evaluated at build time so every static page is consistent.
  * No runtime JS required.
  */
-
-export function getSeason(date: Date = new Date()): 'Autumn' | 'Winter' | 'Spring' | 'Summer' {
-  const m = date.getMonth() + 1; // 1-indexed
-  if (m >= 3 && m <= 5) return 'Autumn';
-  if (m >= 6 && m <= 8) return 'Winter';
-  if (m >= 9 && m <= 11) return 'Spring';
-  return 'Summer';
-}
+import { getAustralianSeason, melbourneCalendarParts } from './season';
 
 /**
  * Returns { mark, label } for the masthead edition slot.
@@ -30,24 +22,15 @@ export function getPublicationEdition(date: Date = new Date()): {
   mark: string;
   label: string;
 } {
-  const season = getSeason(date);
-  const month = date.toLocaleDateString('en-AU', {
-    month: 'long',
-    timeZone: 'Australia/Melbourne',
-  });
-  const year = date.getFullYear();
+  const season = getAustralianSeason(date);
+  const { monthName, year } = melbourneCalendarParts(date);
   return {
     mark: '',
-    label: `${season} Insider · ${month} ${year}`,
+    label: `${season} Insider · ${monthName} ${year}`,
   };
 }
 
 /** Convenience: just the season + month/year label string. */
 export function getEditionLabel(date: Date = new Date()): string {
   return getPublicationEdition(date).label;
-}
-
-/** Convenience: just the season name. */
-export function getCurrentSeason(date: Date = new Date()): string {
-  return getSeason(date);
 }

--- a/next/src/lib/editorial.ts
+++ b/next/src/lib/editorial.ts
@@ -451,17 +451,12 @@ export function formatHeroCredit(credit: string | undefined | null): string {
 }
 
 /**
- * Return the current Southern-Hemisphere season from a Date.
- * Used for seasonal hooks on index pages.
+ * The season hooks on index pages read getAustralianSeasonLower() from
+ * src/lib/season.ts. The currentSeason() that used to live here derived the
+ * season from date.getMonth() on the build host's clock, which on a UTC
+ * runner lags Melbourne by a season for the first ten to fourteen hours
+ * after each changeover. seasonBlurb below is keyed by that shared value.
  */
-export function currentSeason(date: Date = new Date()): 'summer' | 'autumn' | 'winter' | 'spring' {
-  const m = date.getMonth(); // 0..11
-  if (m === 11 || m <= 1) return 'summer';    // Dec, Jan, Feb
-  if (m >= 2 && m <= 4) return 'autumn';      // Mar, Apr, May
-  if (m >= 5 && m <= 7) return 'winter';      // Jun, Jul, Aug
-  return 'spring';                             // Sep, Oct, Nov
-}
-
 export const seasonBlurb: Record<'summer' | 'autumn' | 'winter' | 'spring', { label: string; line: string }> = {
   summer: {
     label: 'The summer issue',

--- a/next/src/lib/facets.ts
+++ b/next/src/lib/facets.ts
@@ -20,6 +20,7 @@
  */
 
 import { eventIsUnqualifiedFree } from './event-access.mjs';
+import { getAustralianSeasonLower } from './season';
 
 export type FacetKey = 'place' | 'cat' | 'mood' | 'price' | 'party' | 'date';
 
@@ -499,15 +500,6 @@ function addDays(d: Date, n: number): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate() + n);
 }
 
-/** Southern-hemisphere season for a date. */
-export function auSeason(d: Date): 'summer' | 'autumn' | 'winter' | 'spring' {
-  const m = d.getMonth(); // 0-based
-  if (m === 11 || m <= 1) return 'summer';
-  if (m <= 4) return 'autumn';
-  if (m <= 7) return 'winter';
-  return 'spring';
-}
-
 function rangesOverlap(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date): boolean {
   return aStart <= bEnd && bStart <= aEnd;
 }
@@ -543,11 +535,11 @@ export function dateScopesFor(
   const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
   if (rangesOverlap(s, e, monthStart, monthEnd)) scopes.push('this-month');
 
-  const season = auSeason(today);
+  const season = getAustralianSeasonLower(today);
   const overlapDays: Date[] = [s <= today ? today : s];
   // Sample the event span (start, end, today) for a same-season hit.
   overlapDays.push(e);
-  if (overlapDays.some((d) => auSeason(d) === season && d >= today)) {
+  if (overlapDays.some((d) => getAustralianSeasonLower(d) === season && d >= today)) {
     scopes.push('this-season');
   }
   return scopes;
@@ -622,7 +614,7 @@ function facetsForVenueLike(data: Record<string, any>, out: Facets) {
       ? data.seasonBest
       : [];
   if (seasons.length) {
-    const current = auSeason(new Date());
+    const current = getAustralianSeasonLower(new Date());
     if (seasons.includes('all-year') || seasons.includes(current)) {
       emit(out, 'date', 'this-season');
     }
@@ -717,12 +709,12 @@ function facetsForItinerary(data: Record<string, any>, out: Facets) {
 
   const season = typeof data.season === 'string' ? data.season : 'year-round';
   if (season === 'rainy') emit(out, 'mood', 'rainy-day');
-  if (season !== 'year-round' && season !== auSeason(new Date())) {
+  if (season !== 'year-round' && season !== getAustralianSeasonLower(new Date())) {
     if (['summer', 'autumn', 'winter', 'spring', 'christmas-period', 'easter-period', 'school-holidays', 'whale-season'].includes(season)) {
       emit(out, 'date', 'seasonal');
     }
   }
-  if (season === 'year-round' || season === auSeason(new Date())) {
+  if (season === 'year-round' || season === getAustralianSeasonLower(new Date())) {
     emit(out, 'date', 'this-season');
   }
 }
@@ -736,7 +728,7 @@ function facetsForArticle(data: Record<string, any>, out: Facets) {
   if (shape === 'seasonal') emit(out, 'date', 'seasonal');
 
   const tags: string[] = Array.isArray(data.tags) ? data.tags : [];
-  const current = auSeason(new Date());
+  const current = getAustralianSeasonLower(new Date());
   for (const raw of tags) {
     const tag = String(raw).toLowerCase();
     // Place tags (plans articles tag towns directly)

--- a/next/src/lib/season.test.mjs
+++ b/next/src/lib/season.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * season tests. Run from repo root or next/:
+ *
+ *   node --test next/src/lib/season.test.mjs
+ *
+ * Uses Node's native TypeScript type-stripping (Node >= 22.18) to import
+ * season.ts directly. No framework, no build step.
+ *
+ * WHAT THIS GUARDS. CI builds this site on a UTC runner, ten to eleven
+ * hours behind Australia/Melbourne. Every assertion below is written as an
+ * absolute UTC instant straddling a Melbourne season boundary, and each
+ * pair is checked against the naive derivation a UTC host would produce
+ * from date.getMonth() (which on a UTC host is exactly getUTCMonth()).
+ * The "after" case of every pair is one the naive version gets WRONG, and
+ * the test asserts that divergence explicitly: if someone reintroduces a
+ * getMonth()-based season, these are the cases that catch it.
+ *
+ * Melbourne is UTC+11 (AEDT) across the March and December boundaries and
+ * UTC+10 (AEST) across the June and September ones.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  getAustralianSeason,
+  getAustralianSeasonLower,
+  getSeasonEditionTag,
+  melbourneCalendarParts,
+} = await import('./season.ts');
+
+/** The season a UTC build host would have computed from date.getMonth(). */
+function naiveUtcHostSeason(date) {
+  const m = date.getUTCMonth() + 1; // getMonth() on a UTC host
+  if (m >= 3 && m <= 5) return 'Autumn';
+  if (m >= 6 && m <= 8) return 'Winter';
+  if (m >= 9 && m <= 11) return 'Spring';
+  return 'Summer';
+}
+
+/**
+ * Each case: the last instant of the old season and the first instant of
+ * the new one, both expressed in UTC, plus the season either side.
+ */
+const boundaries = [
+  {
+    name: '1 March (Melbourne UTC+11)',
+    beforeUtc: '2026-02-28T12:59:59Z', // 28 Feb 23:59:59 Melbourne
+    afterUtc: '2026-02-28T13:00:00Z', //  1 Mar 00:00:00 Melbourne
+    before: 'Summer',
+    after: 'Autumn',
+  },
+  {
+    name: '1 June (Melbourne UTC+10)',
+    beforeUtc: '2026-05-31T13:59:59Z', // 31 May 23:59:59 Melbourne
+    afterUtc: '2026-05-31T14:00:00Z', //   1 Jun 00:00:00 Melbourne
+    before: 'Autumn',
+    after: 'Winter',
+  },
+  {
+    name: '1 September (Melbourne UTC+10)',
+    beforeUtc: '2026-08-31T13:59:59Z', // 31 Aug 23:59:59 Melbourne
+    afterUtc: '2026-08-31T14:00:00Z', //   1 Sep 00:00:00 Melbourne
+    before: 'Winter',
+    after: 'Spring',
+  },
+  {
+    name: '1 December (Melbourne UTC+11)',
+    beforeUtc: '2026-11-30T12:59:59Z', // 30 Nov 23:59:59 Melbourne
+    afterUtc: '2026-11-30T13:00:00Z', //   1 Dec 00:00:00 Melbourne
+    before: 'Spring',
+    after: 'Summer',
+  },
+];
+
+for (const b of boundaries) {
+  test(`${b.name}: the day before is ${b.before}`, () => {
+    assert.equal(getAustralianSeason(new Date(b.beforeUtc)), b.before);
+  });
+
+  test(`${b.name}: the first minute of the new season is ${b.after}`, () => {
+    assert.equal(getAustralianSeason(new Date(b.afterUtc)), b.after);
+  });
+
+  test(`${b.name}: a UTC host's getMonth() would still say ${b.before}`, () => {
+    // The regression itself. If this ever stops diverging the fixture is
+    // wrong, not the code, because these instants are chosen to straddle
+    // the Melbourne boundary while the UTC date has not turned over yet.
+    assert.equal(naiveUtcHostSeason(new Date(b.afterUtc)), b.before);
+    assert.notEqual(getAustralianSeason(new Date(b.afterUtc)), naiveUtcHostSeason(new Date(b.afterUtc)));
+  });
+}
+
+test('the lower-case form is a casing adapter, not a second derivation', () => {
+  for (const b of boundaries) {
+    for (const iso of [b.beforeUtc, b.afterUtc]) {
+      const d = new Date(iso);
+      assert.equal(getAustralianSeasonLower(d), getAustralianSeason(d).toLowerCase());
+    }
+  }
+});
+
+test('every month of the year maps to the right season', () => {
+  // Melbourne noon on the 15th of each month, so no offset can shift it.
+  const expected = [
+    'Summer', 'Summer', 'Autumn', 'Autumn', 'Autumn', 'Winter',
+    'Winter', 'Winter', 'Spring', 'Spring', 'Spring', 'Summer',
+  ];
+  for (let m = 0; m < 12; m++) {
+    const d = new Date(Date.UTC(2026, m, 15, 1, 0, 0)); // noon-ish Melbourne
+    assert.equal(getAustralianSeason(d), expected[m], `month ${m + 1}`);
+  }
+});
+
+test('melbourneCalendarParts reads the Melbourne day, not the UTC one', () => {
+  const d = new Date('2026-08-31T14:00:00Z'); // 1 Sep 00:00 Melbourne
+  const parts = melbourneCalendarParts(d);
+  assert.equal(parts.year, 2026);
+  assert.equal(parts.month, 9);
+  assert.equal(parts.monthName, 'September');
+});
+
+test("the edition tag follows the season across the new year", () => {
+  assert.equal(getSeasonEditionTag(new Date('2026-08-31T14:00:00Z')), "Spring '26");
+  assert.equal(getSeasonEditionTag(new Date('2026-11-30T13:00:00Z')), "Summer '26");
+  // 1 Jan 2027 00:00 Melbourne: still Summer, but the year has rolled.
+  assert.equal(getSeasonEditionTag(new Date('2026-12-31T13:00:00Z')), "Summer '27");
+  // The last minute of 2026 in Melbourne is still '26.
+  assert.equal(getSeasonEditionTag(new Date('2026-12-31T12:59:59Z')), "Summer '26");
+});

--- a/next/src/lib/season.ts
+++ b/next/src/lib/season.ts
@@ -1,0 +1,98 @@
+/**
+ * season.ts - the single source of truth for "which season is it".
+ *
+ * The Peninsula publishes on Melbourne time. The build host does not: CI
+ * runs in UTC, ten to eleven hours behind Australia/Melbourne. A season
+ * derived from a raw date.getMonth() therefore still reports the PREVIOUS
+ * season for the first ten to fourteen hours after every changeover, while
+ * anything derived from localised calendar parts has already rolled over.
+ * That divergence is how the site came to publish a Spring masthead above
+ * Winter positioning copy.
+ *
+ * Four season functions used to exist: getSeason in lib/edition.ts,
+ * currentSeason in lib/editorial.ts, auSeason in lib/facets.ts, and the
+ * private seasonForMonth inside lib/conditions.ts. Only the last was
+ * timezone-correct. They are all gone; this module is what remains, and
+ * every surface that needs a season reads it from here.
+ *
+ * Southern Hemisphere meteorological seasons:
+ *   Summer  December, January, February
+ *   Autumn  March, April, May
+ *   Winter  June, July, August
+ *   Spring  September, October, November
+ *
+ * Evaluated at build time, so every static page agrees with every other.
+ *
+ * This module deliberately has no imports. Half the site depends on it,
+ * including lib/v5-nav.ts (which scripts/lint-nav-budget.mjs evaluates
+ * without a TypeScript toolchain) and season.test.mjs (which Node runs
+ * with bare type-stripping and no bundler resolution). A leaf module with
+ * zero edges stays loadable by both. The timezone literal below is the
+ * same value lib/sunset.ts pins for the astronomy; it is a constant of
+ * geography, not configuration.
+ */
+
+const PENINSULA_TZ = 'Australia/Melbourne';
+
+/** Title case, the form the masthead and the edition stamp print. */
+export type AustralianSeason = 'Summer' | 'Autumn' | 'Winter' | 'Spring';
+
+/** Lower case, the form the facet vocabulary and content frontmatter store. */
+export type AustralianSeasonLower = 'summer' | 'autumn' | 'winter' | 'spring';
+
+export interface MelbourneCalendarParts {
+  /** Four-digit year, e.g. 2026. */
+  year: number;
+  /** One-indexed month, 1 to 12. */
+  month: number;
+  /** Full month name in en-AU, e.g. "September". */
+  monthName: string;
+}
+
+/**
+ * Melbourne-local calendar parts for an instant. Taking year and month
+ * from the localised parts rather than from getFullYear()/getMonth() keeps
+ * every derivation correct across day, month, season and year boundaries
+ * no matter where the build runs.
+ */
+export function melbourneCalendarParts(date: Date = new Date()): MelbourneCalendarParts {
+  const parts = new Intl.DateTimeFormat('en-AU', {
+    timeZone: PENINSULA_TZ,
+    year: 'numeric',
+    month: 'numeric',
+  }).formatToParts(date);
+  const num = (t: string) => Number(parts.find((p) => p.type === t)?.value ?? '0');
+  const monthName = new Intl.DateTimeFormat('en-AU', {
+    timeZone: PENINSULA_TZ,
+    month: 'long',
+  }).format(date);
+  return { year: num('year'), month: num('month'), monthName };
+}
+
+/** The Southern Hemisphere season on Melbourne time. Title case. */
+export function getAustralianSeason(date: Date = new Date()): AustralianSeason {
+  const { month } = melbourneCalendarParts(date);
+  if (month >= 3 && month <= 5) return 'Autumn';
+  if (month >= 6 && month <= 8) return 'Winter';
+  if (month >= 9 && month <= 11) return 'Spring';
+  return 'Summer';
+}
+
+/**
+ * The same answer in the lower-case form the facet vocabulary, the
+ * seasonBlurb table and content frontmatter all use. A casing adapter, not
+ * a second derivation.
+ */
+export function getAustralianSeasonLower(date: Date = new Date()): AustralianSeasonLower {
+  return getAustralianSeason(date).toLowerCase() as AustralianSeasonLower;
+}
+
+/**
+ * The masthead-style edition tag, e.g. "Winter '26". Season and year come
+ * from the same Melbourne-localised instant, so the two halves cannot
+ * disagree across the summer new-year boundary.
+ */
+export function getSeasonEditionTag(date: Date = new Date()): string {
+  const { year } = melbourneCalendarParts(date);
+  return `${getAustralianSeason(date)} '${String(year % 100).padStart(2, '0')}`;
+}

--- a/next/src/lib/v5-nav.ts
+++ b/next/src/lib/v5-nav.ts
@@ -11,9 +11,10 @@
  * Budget is CI-enforced by scripts/lint-nav-budget.mjs:
  *   total header choices <= 55, drawer items (incl. CTA) <= 14.
  *
- * NOTE for the budget lint: this file must stay dependency-free (no
- * imports) and its interfaces must stay flat (no nested braces) so the
- * lint can strip types and evaluate the config. Voice rules per
+ * NOTE for the budget lint: interfaces here must stay flat (no nested
+ * braces) so the lint can strip types and evaluate the config, and the
+ * only import permitted is the shared season helper below, which
+ * scripts/lint-nav-budget.mjs strips and stubs. Voice rules per
  * BRAND-PI.md: no em-dashes, no tourism adjectives, no exclamation
  * marks, noun-phrase links.
  *
@@ -22,6 +23,15 @@
  * V5MegaPanel marks the pin fields up with editableText() so each pin
  * is CMS-editable in place (entityType 'page', entitySlug 'nav-<key>').
  */
+import { getSeasonEditionTag } from './season';
+
+/**
+ * The rail eyebrow. Every pillar pin used to carry a hard-coded
+ * "Editor's pick · Winter '26", and the navigation renders on every page
+ * of the site, so the whole site insisted it was winter well into spring.
+ * It now follows the real Melbourne season and year.
+ */
+const editorsPickEyebrow = `Editor's pick · ${getSeasonEditionTag()}`;
 
 export interface V5NavLink {
   key: string;
@@ -73,7 +83,7 @@ const configuredV5Pillars = [
       { key: 'all-eat', label: 'All places to eat', href: '/eat/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'Laura at Pt Leo Estate',
       verdict: 'Sit at the bar, not the dining room. Better view, faster service. The kingfish is the order.',
       href: '/eat/laura-pt-leo/',
@@ -96,7 +106,7 @@ const configuredV5Pillars = [
       { key: 'all-stay', label: 'All stays', href: '/stay/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'Jackalope',
       verdict: 'The architecture is doing the work. Book Doot Doot Doot for dinner the same night, the room rate justifies the splurge.',
       href: '/stay/jackalope/',
@@ -120,7 +130,7 @@ const configuredV5Pillars = [
       { key: 'all-wine', label: 'All wine regions', href: '/wine/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'Ten Minutes by Tractor',
       verdict: 'Three vineyards, one table, and the Wallis Pinot is the pour. The architecture does the rest.',
       href: '/wine/ten-minutes-by-tractor/',
@@ -144,7 +154,7 @@ const configuredV5Pillars = [
       { key: 'map',        label: 'Open the map', href: '/map/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'Bushrangers Bay walk',
       verdict: 'A properly wild coast walk with a steep descent and a real payoff. Check conditions before you go, then allow enough time for the climb back.',
       href: '/explore/bushrangers-bay-walk/',
@@ -170,7 +180,7 @@ const configuredV5Pillars = [
       { key: 'all-plans', label: 'All plans', href: '/explore/plans/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'Ridge to Sea',
       verdict: 'Two nights, Red Hill down to Flinders. The order matters: ridge first, coast second, and the Friday-night arrival makes the whole thing work.',
       href: '/explore/plans/ridge-to-sea-two-night-escape/',
@@ -193,7 +203,7 @@ const configuredV5Pillars = [
       { key: 'all-whats-on', label: 'Everything on this weekend', href: '/whats-on/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'MPRG school holiday workshops',
       verdict: 'Starts 1 July in Mornington, indoor, practical, and actually useful if the school-holiday weather turns. Book early.',
       href: '/whats-on/mornington-peninsula-regional-gallery-school-holiday-workshops/',
@@ -225,7 +235,7 @@ const configuredV5Pillars = [
       { key: 'all-journal', label: 'Every issue, every piece', href: '/journal/' },
     ],
     rail: {
-      eyebrow: "Editor's pick · Winter '26",
+      eyebrow: editorsPickEyebrow,
       title: 'Insider Picks, 12 August',
       verdict: 'Three things worth making time for this week, chosen by the desk.',
       href: '/journal/insider-picks-2026-08-12/',

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -90,20 +90,20 @@ function verdictLine(signature?: string): string | undefined {
   return first.split(/\s+/).length <= 25 ? first : undefined;
 }
 
-// ── The Six: editorially pinned for the winter season. Verdicts are Critic
+// ── The Six: editorially pinned by the desk. Verdicts are Critic
 //    voice, 25 words maximum, distilled from each venue's own editorial copy.
 const sixPicks: Array<{ slug: string; verdict: string }> = [
   {
     slug: 'tedesca-osteria',
-    verdict: 'The winter long lunch, settled: wood oven, fire lit, one set menu built for cold weather. Book lunch, not dinner.',
+    verdict: 'The long lunch, settled: wood oven, one set menu, and a room built for a slow table. Book lunch, not dinner.',
   },
   {
     slug: 'doot-doot-doot',
-    verdict: 'The cold-night occasion room: two hats, winter produce, and the glass orb chandelier earning its theatre when the ridge goes quiet.',
+    verdict: 'The occasion room: two hats, produce-led menus, and the glass orb chandelier earning its theatre when the ridge goes quiet.',
   },
   {
     slug: 'barragunda-dining',
-    verdict: 'The winter farm booking: a thousand-acre estate, weekly-changing menu, and cooking that makes most sense in the cold months.',
+    verdict: 'The farm booking: a thousand-acre estate, a weekly-changing menu, and cooking tied to what the estate has ready.',
   },
   {
     slug: 'merricks-general-wine-store',
@@ -111,11 +111,11 @@ const sixPicks: Array<{ slug: string; verdict: string }> = [
   },
   {
     slug: 'portsea-hotel',
-    verdict: 'The bay-front pub for a cold blue day: fireplace inside, winter acoustic sessions on the calendar, and the view still doing the work.',
+    verdict: 'The bay-front pub: fireplace inside, acoustic sessions on the calendar, and the view still doing the work.',
   },
   {
     slug: 'commonfolk-coffee',
-    verdict: 'The quick winter warm-up: serious coffee in a Mornington warehouse, best before ten, with the egg sandwich still the order.',
+    verdict: 'The quick warm-up: serious coffee in a Mornington warehouse, best before ten, with the egg sandwich still the order.',
   },
 ];
 
@@ -172,7 +172,12 @@ const wineryKitchens = wineries.filter((v) =>
 );
 const wineryOther = wineries.filter((v) => !wineryKitchens.includes(v));
 
-// ── From the Journal (3 maximum, winter-contextual). ─────────────────────────
+// ── From the Journal (3 maximum). ───────────────────────────────────────────
+//    EDITORIAL: this rail is still the winter selection. The three pieces
+//    below are real published articles and keep their winter identity, but
+//    the CURATION is seasonal and needs the desk to re-pick for the season
+//    in hand. Flagged rather than guessed: choosing which pieces lead a hub
+//    is an editorial call, not an engineering one.
 const articlesAll = (await getCollection('articles', ({ data }) => data.status === 'published'))
   .sort((a, b) => (b.data.publishedAt?.getTime() ?? 0) - (a.data.publishedAt?.getTime() ?? 0));
 
@@ -220,7 +225,7 @@ const pillarSchema = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
   name: 'Where to Eat on the Mornington Peninsula',
-  description: 'The best restaurants, long lunches, cellar door dining, cafes, bakeries, and winter fireside tables on the Mornington Peninsula.',
+  description: 'The best restaurants, long lunches, cellar door dining, cafes, bakeries, and fireside tables on the Mornington Peninsula.',
   url: 'https://peninsulainsider.com.au/eat/',
   breadcrumb: {
     '@type': 'BreadcrumbList',
@@ -238,7 +243,7 @@ const faqSchema = {
     { '@type': 'Question', name: 'What are the best restaurants on the Mornington Peninsula?',
       acceptedAnswer: { '@type': 'Answer', text: 'The Good Food Guide awarded 15 hats across 11 Peninsula venues. The four two-hat restaurants, Barragunda Dining, Laura at Pt. Leo Estate, Tedesca Osteria, and Ten Minutes by Tractor, are the clearest destination dining choices.' } },
     { '@type': 'Question', name: 'Do I need to book restaurants on the Mornington Peninsula?',
-      acceptedAnswer: { '@type': 'Answer', text: 'Most serious restaurants require bookings, especially on weekends. Hatted venues can book out weeks or months in advance. Walk-in options exist: Montalto Piazza (daily), Foxeys Hangout (no bookings taken), Rare Hare at Willow Creek (walk-in from 2pm weekends), and most cafes and bakeries. Check winter hours before driving.' } },
+      acceptedAnswer: { '@type': 'Answer', text: 'Most serious restaurants require bookings, especially on weekends. Hatted venues can book out weeks or months in advance. Walk-in options exist: Montalto Piazza (daily), Foxeys Hangout (no bookings taken), Rare Hare at Willow Creek (walk-in from 2pm weekends), and most cafes and bakeries. Check seasonal hours before driving.' } },
     { '@type': 'Question', name: 'What is the best area for food on the Mornington Peninsula?',
       acceptedAnswer: { '@type': 'Answer', text: 'The Red Hill plateau, including Main Ridge and Red Hill South, has the highest concentration of serious dining. Mornington town has the strongest casual eating scene. Sorrento and Portsea have the best waterfront and atmosphere-first dining. For wine-paired long lunches, stick to the ridge.' } },
     { '@type': 'Question', name: 'When is the best time to visit the Mornington Peninsula for food?',
@@ -251,7 +256,7 @@ const faqSchema = {
 };
 
 const standfirst =
-  'Winter is the Peninsula food scene at its most useful: fires lit, cellar doors with time to talk, and the best tables actually bookable. ' +
+  'The Peninsula food scene at its most useful: cellar doors with time to talk, kitchens with a point of view, and tables you can still get. ' +
   `Six tables worth planning around first, then all ${venues.length} places we cover, ` +
   'filterable by occasion and town.';
 
@@ -274,14 +279,14 @@ export const prerender = true;
     eyebrow="Eat & Drink"
     title="Where to eat on the Mornington Peninsula"
     standfirst={standfirst}
-    image={{ src: '/images/sourced/article-cellar-door-01.webp', alt: 'A Peninsula cellar door set for a winter tasting' }}
+    image={{ src: '/images/sourced/article-cellar-door-01.webp', alt: 'A Peninsula cellar door set for a tasting' }}
   />
 
   <!-- 2. The verdict layer -->
   <TheSix
     id="the-six"
-    eyebrow="The Six · winter edit"
-    heading="Six tables worth planning around this winter"
+    eyebrow="The Six · the desk edit"
+    heading="Six tables worth planning around"
     surface="eat"
     items={sixItems}
   />
@@ -337,7 +342,7 @@ export const prerender = true;
     >
       <h3 class="eat-winery-kitchens__heading">Winery kitchens</h3>
       <p class="eat-winery-kitchens__sub">
-        The vineyard dining rooms live with their wineries, one page per venue. Winter is when the fires and long lunches make the detour worth it.
+        The vineyard dining rooms live with their wineries, one page per venue. The fires, the long lunches and the estate wine are what make the detour worth it.
       </p>
       <ul class="eat-winery-kitchens__list">
         {wineryKitchens.map((venue) => (
@@ -357,7 +362,7 @@ export const prerender = true;
 
   <!-- What's On, one line + link (spec block 18: strip becomes a line) -->
   <p class="eat-whatson container">
-    Winter food and wine events coming up on the Peninsula:
+    Food and wine events coming up on the Peninsula:
     <a href="/whats-on/">see What&rsquo;s On &rarr;</a>
   </p>
 
@@ -384,7 +389,7 @@ export const prerender = true;
         </details>
         <details class="hub-faq__item">
           <summary class="hub-faq__q">Do I need to book?</summary>
-          <div class="hub-faq__a"><p>Most serious restaurants require bookings, especially on weekends. Hatted venues book weeks or months ahead. Walk-in options: Montalto Piazza (daily), Foxeys Hangout (no bookings taken), Rare Hare at Willow Creek (from 2pm weekends), and most cafes and bakeries. Check winter hours before driving.</p></div>
+          <div class="hub-faq__a"><p>Most serious restaurants require bookings, especially on weekends. Hatted venues book weeks or months ahead. Walk-in options: Montalto Piazza (daily), Foxeys Hangout (no bookings taken), Rare Hare at Willow Creek (from 2pm weekends), and most cafes and bakeries. Check seasonal hours before driving.</p></div>
         </details>
         <details class="hub-faq__item">
           <summary class="hub-faq__q">What is the best area for food?</summary>

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -26,7 +26,8 @@ import EmptyState from '../../components/v5/EmptyState.astro';
 import TrustNote from '../../components/v5/hub/TrustNote.astro';
 import { getFacets, type FacetKey } from '../../lib/facets';
 import { resolveHero } from '../../lib/inline-edit/resolve-hero';
-import { routeSlug, currentSeason, seasonBlurb, placeLabel, titleize, venueHref } from '../../lib/editorial';
+import { routeSlug, seasonBlurb, placeLabel, titleize, venueHref } from '../../lib/editorial';
+import { getAustralianSeasonLower } from '../../lib/season';
 import { buildCollectionPageSchema, buildFaqSchema, buildBreadcrumbSchema } from '../../lib/schema';
 
 // ── Copy helpers ──────────────────────────────────────────────────────────────
@@ -177,7 +178,7 @@ const directoryRows: Row[] = [...rows, ...venueRows].sort((a, b) =>
   a.name.localeCompare(b.name),
 );
 
-const season = currentSeason();
+const season = getAustralianSeasonLower();
 const blurb = seasonBlurb[season];
 
 // Live-count parity with lib/v5-filter-state itemMatches: AND across facet

--- a/next/src/pages/journal/index.astro
+++ b/next/src/pages/journal/index.astro
@@ -213,7 +213,7 @@ export const prerender = true;
         <div class="editors-desk__col">
           <p class="label label--accent">From the editor's desk</p>
           <h2 class="editors-desk__title">What we're writing about this season</h2>
-          <p class="editors-desk__body">Winter on the Peninsula is for long lunches, thermal pools and walks that earn a fire afterwards. The Journal is leaning into practical guides for those moods, honest stay notes, and the weekly <em>Peninsula This Weekend</em> brief.</p>
+          <p class="editors-desk__body">The Peninsula is for long lunches, thermal pools and walks that earn a fire afterwards. The Journal is leaning into practical guides for those moods, honest stay notes, and the weekly <em>Peninsula This Weekend</em> brief.</p>
         </div>
       </div>
     </div>

--- a/next/src/pages/whats-on/_data.ts
+++ b/next/src/pages/whats-on/_data.ts
@@ -62,14 +62,6 @@ function parseIsoLocal(s: string): Date {
   return new Date(y, m - 1, d);
 }
 
-export function auSeasonWord(d: Date): string {
-  const m = d.getMonth();
-  if (m === 11 || m <= 1) return 'summer';
-  if (m <= 4) return 'autumn';
-  if (m <= 7) return 'winter';
-  return 'spring';
-}
-
 /** "Fri 11 - Sun 13 July" (en dash; em dashes are banned house-wide). */
 export function rangeLabel(start: Date, end: Date): string {
   const dow = (d: Date) => d.toLocaleDateString('en-AU', { weekday: 'short' });

--- a/next/src/pages/whats-on/index.astro
+++ b/next/src/pages/whats-on/index.astro
@@ -30,10 +30,10 @@ import {
   groupByDay,
   getPicks,
   getShelves,
-  auSeasonWord,
   isoDate,
   startOfDay,
 } from './_data';
+import { getAustralianSeasonLower } from '../../lib/season';
 
 export const prerender = true;
 
@@ -125,7 +125,7 @@ const pickCards = picks.map((p, i) => {
   };
 });
 
-const season = auSeasonWord(now);
+const season = getAustralianSeasonLower(now);
 const todayISO = isoDate(startOfDay(now));
 const modifiedTime = todayISO;
 const pageDescription = `What is actually worth it on the Mornington Peninsula this weekend: PI's three picks, then everything on by day. A selection, not a calendar.`;


### PR DESCRIPTION
Closes #364.

The site showed a spring masthead above winter positioning copy. There were two causes and this fixes both.

## Cause one: five season functions, one of them correct

There was no shared season utility. Five separate functions independently re-derived the same March, June, September and December boundaries, and only the one behind the masthead localised to Melbourne first. The other four took the month from a raw `getMonth()`, so on a UTC build host they compute the previous season for roughly the first half-day after every Melbourne season boundary while the masthead has already rolled over.

The audit found four. Implementation found a fifth, `auSeasonWord` in `pages/whats-on/_data.ts`, feeding the What's On page. Same bug class.

All five are now deleted and replaced by `next/src/lib/season.ts`, which localises to Australia/Melbourne. It is deliberately a leaf module with no imports, because `lint-nav-budget.mjs` evaluates `v5-nav.ts` in a bare VM and the test runs under plain `node --test` type-stripping. Both need it loadable without a module graph.

## Cause two: seven hard-coded literals in the navigation

`lib/v5-nav.ts` carried `"Editor's pick · Winter '26"` seven times, and the navigation renders on every page. That is why the register saw winter positioning on Eat, Wine, Plans and Journal at once. They now derive from the shared function, year included. It reads `Editor's pick · Spring '26` today.

## The test is the point

`next/src/lib/season.test.mjs`, 16 assertions, wired into the CI gate. Each Melbourne boundary is expressed as an absolute UTC instant either side. A third assertion per boundary computes what a naive `getMonth()` would have returned and asserts that it **diverges**, so if anyone reintroduces a timezone-naive season the suite fails loudly rather than passing by coincidence.

## Verification

Build passes, 982 pages. Nav says `Editor's pick · Spring '26`, masthead says `Spring Insider · September 2026`, What's On says `spring on the Peninsula`. The rendered output now agrees with itself. Nav budget lint passes at 55/55 header and 14/14 drawer.

## Editorial copy: read this before merging

Fifteen pieces of copy asserted winter in the present tense. I neutralised them rather than inventing spring copy, because writing editorial is not an engineering act and I will not invent claims about venues. Every replacement is drawn only from facts already in the original line. Examples: "The winter long lunch, settled: wood oven, fire lit, one set menu built for cold weather" became "The long lunch, settled: wood oven, one set menu, and a room built for a slow table."

**These read as correct and neutral, not as spring copy.** The full list is in the action register for the desk to rewrite properly.

Deliberately left alone: two FAQ answers that discuss winter as guidance rather than asserting the present season, since they read correctly in spring and rewriting them would lose accurate advice. Historical articles keep their winter identity.

**One item needs the desk, not engineering.** The three Journal cards on the Eat hub are still the winter selection. Which articles lead a hub is curation. There is an `EDITORIAL:` comment at the rail so it is visible to whoever opens the file next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUtNaf5gYAh9HUBkEPYHi3
