### PR TITLE
Security: validate shared-plan payloads at the decode boundary

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           cd next
           npm run test:content-admission
+          npm run test:share-link
           npm run test:agent-readiness
           npm run test:event-safeguards
           npm run validate:content

--- a/next/package.json
+++ b/next/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "description": "Astro rebuild of Peninsula Insider \u2014 atomic content layer, JSON-first authoring, editorial-grade design system. Phase 1 scaffold per roadmap-2026-04-09.md.",
+  "description": "Astro rebuild of Peninsula Insider — atomic content layer, JSON-first authoring, editorial-grade design system. Phase 1 scaffold per roadmap-2026-04-09.md.",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
@@ -58,7 +58,8 @@
     "assert:link-graph": "node scripts/audit-link-graph.mjs --dist dist --assert --json ../ops/reports/seo/link-graph.json",
     "audit:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json",
     "test:event-safeguards": "node --test scripts/audit-event-safeguards.test.mjs",
-    "assert:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json --assert"
+    "assert:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json --assert",
+    "test:share-link": "node --test src/lib/saves/share-link.test.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/next/src/lib/saves/share-link.test.mjs
+++ b/next/src/lib/saves/share-link.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Peninsula Insider - shared-plan payload safety.
+ *
+ * A shared plan is decoded from a URL that anyone can craft and send to a
+ * reader. decodePlan is the trust boundary, so these tests assert that a
+ * hostile payload cannot survive it.
+ *
+ * Why the boundary and not the render site: a recipient can fork a shared
+ * plan into their own saved list. Sanitising only on render would let a bad
+ * href be persisted and then re-rendered later from a surface that trusts
+ * its own stored data.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { encodePlan, decodePlan } from './share-link.ts';
+
+/** Encode an arbitrary object as a payload, bypassing encodePlan's typing. */
+function payload(items) {
+  const json = JSON.stringify({ v: 1, ts: Date.now(), items });
+  return Buffer.from(json, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+const good = {
+  kind: 'venue',
+  slug: 'pt-leo-estate',
+  title: 'Pt. Leo Estate',
+  href: '/wine/pt-leo-estate/',
+};
+
+test('a well-formed plan round-trips', () => {
+  const plan = decodePlan(encodePlan([{ ...good, savedAt: 1 }]));
+  assert.equal(plan.items.length, 1);
+  assert.equal(plan.items[0].href, '/wine/pt-leo-estate/');
+});
+
+test('executable and smuggling schemes are rejected', () => {
+  // These are the shapes an HTML escaper does not touch: they contain none of
+  // the characters it replaces, so they survive escaping and stay clickable.
+  const schemes = [
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    '  javascript:alert(1)',
+    'data:text/html,<script></script>',
+    'vbscript:msgbox',
+    'blob:https://evil.test/x',
+    'file:///etc/passwd',
+  ];
+  for (const href of schemes) {
+    const plan = decodePlan(payload([{ ...good, href }]));
+    assert.equal(plan.items.length, 0, `should have dropped: ${href}`);
+  }
+});
+
+test('off-site and protocol-relative links are rejected', () => {
+  for (const href of ['//evil.test/x', 'https://evil.test/x', 'http://evil.test/x', 'evil.test']) {
+    const plan = decodePlan(payload([{ ...good, href }]));
+    assert.equal(plan.items.length, 0, `should have dropped: ${href}`);
+  }
+});
+
+test('control characters in a href are rejected', () => {
+  // Embedded NUL, tab, newline and DEL are used to break a parser's scheme
+  // detection, so a href carrying any of them is refused outright. Built from
+  // char codes so the bytes cannot be lost passing through an editor.
+  const codes = [0x00, 0x09, 0x0a, 0x0d, 0x1f, 0x7f];
+  for (const code of codes) {
+    const href = '/eat/a' + String.fromCharCode(code) + 'b/';
+    const plan = decodePlan(payload([{ ...good, href }]));
+    const hex = code.toString(16).padStart(4, '0');
+    assert.equal(plan.items.length, 0, `should have dropped href containing U+${hex}`);
+  }
+});
+
+test('an unknown kind is rejected', () => {
+  const plan = decodePlan(payload([{ ...good, kind: 'restaurant' }]));
+  assert.equal(plan.items.length, 0);
+});
+
+test('one bad item drops out without losing the good ones', () => {
+  // The whole page used to throw on a malformed item, leaving the recipient
+  // with a blank plan and no empty state.
+  const plan = decodePlan(
+    payload([good, { ...good, slug: 'x', href: 'javascript:alert(1)' }, { ...good, slug: 'y' }]),
+  );
+  assert.equal(plan.items.length, 2);
+  assert.deepEqual(
+    plan.items.map((i) => i.slug),
+    ['pt-leo-estate', 'y'],
+  );
+});
+
+test('missing required fields are rejected', () => {
+  const cases = [
+    { ...good, kind: undefined },
+    { ...good, slug: '' },
+    { ...good, title: '' },
+    { ...good, href: undefined },
+    'not-an-object',
+    null,
+  ];
+  for (const item of cases) {
+    const plan = decodePlan(payload([item]));
+    assert.equal(plan.items.length, 0);
+  }
+});
+
+test('image sources allow site-relative and https, reject the rest', () => {
+  // Saved covers are sometimes absolute URLs on the storage host, so the
+  // stricter href rule would have stripped every shared image.
+  const kept = ['/images/a.jpg', 'https://tjjhpvslpysfklwpqmgz.supabase.co/storage/v1/x.jpg'];
+  for (const image_url of kept) {
+    const plan = decodePlan(payload([{ ...good, image_url }]));
+    assert.equal(plan.items[0].image_url, image_url, `should have kept: ${image_url}`);
+  }
+
+  const dropped = ['javascript:alert(1)', 'data:image/svg+xml,<svg onload=alert(1)>', '//evil.test/x.jpg', 'http://evil.test/x.jpg'];
+  for (const image_url of dropped) {
+    const plan = decodePlan(payload([{ ...good, image_url }]));
+    assert.equal(plan.items.length, 1, 'the item itself is still valid');
+    assert.equal(plan.items[0].image_url, undefined, `should have dropped: ${image_url}`);
+  }
+});
+
+test('a malformed envelope returns null rather than throwing', () => {
+  assert.equal(decodePlan(null), null);
+  assert.equal(decodePlan(''), null);
+  assert.equal(decodePlan('not-base64!!'), null);
+  assert.equal(decodePlan(payload('not-an-array')), null);
+});

--- a/next/src/lib/saves/share-link.ts
+++ b/next/src/lib/saves/share-link.ts
@@ -47,14 +47,116 @@ export function encodePlan(items: SavedItem[]): string {
   return base64UrlEncode(json);
 }
 
-/** Decode a payload back to a SharedPlan. Returns null on malformed input. */
+/**
+ * A shared plan arrives from an untrusted URL. Anyone can craft one and send
+ * the link to a reader. Everything below treats the payload as hostile.
+ *
+ * The kinds a shared item may claim. Mirrors SaveKind in ./store.
+ */
+const SHARED_KINDS = new Set([
+  'article',
+  'venue',
+  'place',
+  'event',
+  'experience',
+  'itinerary',
+  'tour',
+  'tour-operator',
+  'tour-package',
+]);
+
+/**
+ * Saved hrefs are always site-relative paths built by us (`/eat/foo/`), so a
+ * shared href may only ever be one of those.
+ *
+ * This is an allowlist on purpose. HTML-escaping a href does not make it safe:
+ * `javascript:` and `data:` URLs contain none of the characters an escaper
+ * replaces, so they survive it intact and stay clickable. Blocking a list of
+ * bad schemes is also the wrong shape, because it fails open on whatever is
+ * not on the list. Requiring a single leading slash accepts exactly what we
+ * generate and rejects every scheme, plus protocol-relative `//evil.test`
+ * links that would otherwise leave the site.
+ */
+function safeInternalHref(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const href = value.trim();
+  if (!href.startsWith('/')) return null;
+  if (href.startsWith('//')) return null;
+  // Control characters can be used to break a parser's scheme detection.
+  if (/[\u0000-\u001F\u007F]/.test(href)) return null;
+  return href;
+}
+
+/**
+ * Images are a separate case from links. Saved covers are sometimes absolute
+ * URLs on the Supabase storage host rather than site-relative paths, so the
+ * href rule above would strip every shared image.
+ *
+ * A src still must not carry a scheme that can execute or smuggle content, so
+ * this allows exactly two shapes: a site-relative path, or an https URL.
+ * That rejects javascript:, data:, blob: and plain http.
+ */
+function safeImageSrc(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const src = value.trim();
+  if (/[\u0000-\u001F\u007F]/.test(src)) return undefined;
+  if (src.startsWith('//')) return undefined;
+  if (src.startsWith('/')) return src;
+  if (src.startsWith('https://')) return src;
+  return undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Validate one item. Returns null for anything malformed, so a single bad
+ * entry drops out instead of throwing and blanking the whole page.
+ */
+function sanitiseSharedItem(raw: unknown): SharedItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const it = raw as Record<string, unknown>;
+
+  if (typeof it.kind !== 'string' || !SHARED_KINDS.has(it.kind)) return null;
+  if (typeof it.slug !== 'string' || !it.slug) return null;
+  if (typeof it.title !== 'string' || !it.title) return null;
+
+  const href = safeInternalHref(it.href);
+  if (!href) return null;
+
+  return {
+    kind: it.kind as SharedItem['kind'],
+    slug: it.slug,
+    section: optionalString(it.section),
+    title: it.title,
+    dek: optionalString(it.dek),
+    image_url: safeImageSrc(it.image_url),
+    href,
+  };
+}
+
+/**
+ * Decode a payload back to a SharedPlan. Returns null on malformed input.
+ *
+ * Every item is validated here, at the trust boundary, rather than at each
+ * render site. That matters because a recipient can fork a shared plan into
+ * their own store: sanitising only on render would let a hostile href be
+ * persisted and then re-rendered later from a surface that trusts its own
+ * saved data.
+ */
 export function decodePlan(encoded: string | null | undefined): SharedPlan | null {
   if (!encoded) return null;
   try {
     const json = base64UrlDecode(encoded);
     const parsed = JSON.parse(json);
     if (!parsed || parsed.v !== 1 || !Array.isArray(parsed.items)) return null;
-    return parsed as SharedPlan;
+
+    const items = parsed.items
+      .map(sanitiseSharedItem)
+      .filter((it: SharedItem | null): it is SharedItem => it !== null);
+
+    return { v: 1, ts: typeof parsed.ts === 'number' ? parsed.ts : 0, items };
   } catch {
     return null;
   }

--- a/next/src/pages/account/saved.astro
+++ b/next/src/pages/account/saved.astro
@@ -93,6 +93,10 @@ export const prerender = true;
 
   function renderItem(item: Saves.SavedItem): string {
     const labels = KIND_LABELS[item.kind];
+    // A kind we do not recognise skips its card rather than throwing and
+    // blanking the page. Unknown kinds are blocked at decodePlan now, but a
+    // store written before that fix can still hold one.
+    if (!labels) return '';
     return `
       <a class="saved-card" href="${escapeHtml(item.href)}">
         ${item.image_url ? `<div class="saved-card__img" style="background-image: url('${cssUrl(item.image_url)}');"></div>` : '<div class="saved-card__img saved-card__img--blank"></div>'}

--- a/next/src/pages/plan/index.astro
+++ b/next/src/pages/plan/index.astro
@@ -89,10 +89,16 @@ const piIndex = { places: piPlaces, venues: piVenues };
     return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
   }
 
-  function cssUrl(src: string): string { return src.replace(/["\\]/g, (m) => `\\${m}`); }
+  // Escapes the single quote too: the value is interpolated inside a
+  // single-quoted url('...'), so an apostrophe would otherwise break out.
+  function cssUrl(src: string): string { return src.replace(/["'\\]/g, (m) => `\\${m}`); }
 
   function renderItem(item: SharedItem): string {
     const labels = KIND_LABELS[item.kind];
+    // A kind we do not recognise skips its card rather than throwing and
+    // blanking the page. Unknown kinds are blocked at decodePlan now, but a
+    // store written before that fix can still hold one.
+    if (!labels) return '';
     return `
       <a class="saved-card" href="${escapeHtml(item.href)}">
         ${item.image_url ? `<div class="saved-card__img" style="background-image: url('${cssUrl(item.image_url)}');"></div>` : '<div class="saved-card__img saved-card__img--blank"></div>'}


### PR DESCRIPTION
Found during the PI-012 journey audit (#373). Not a ticket of its own; shipping it separately because it is a security fix and should not wait behind a feature branch.

## The defect

A shared plan travels in the URL, so anyone can craft one and send the link to a reader. `decodePlan` validated only the envelope: version `1` and `items` is an array. It then cast the payload and handed it to the renderers, which wrote each item's `href` into an anchor with HTML escaping only.

**HTML escaping does not make a href safe.** `javascript:` and `data:` URLs contain none of the characters an escaper replaces, so they survive it intact and stay clickable, on our own origin.

The persistence path is what makes it more than a reflected issue: a recipient can fork a shared plan into their own saved list. A hostile href could therefore be stored and re-rendered later from a surface that trusts its own saved data.

## The fix

Validation now happens in `decodePlan`, at the trust boundary, so every consumer is covered including the fork path rather than each render site separately.

- `kind` must be one of the nine known save kinds
- `slug` and `title` must be non-empty strings
- `href` must be a site-relative path: one leading slash, no scheme, no protocol-relative `//host`, no control characters
- `image_url` gets a slightly wider rule, site-relative **or** https, because saved covers are sometimes absolute URLs on the storage host. The stricter href rule would have silently stripped every shared image.

The href rule is an allowlist on purpose. A blocklist of bad schemes fails open on whatever is not on the list.

## Two smaller fixes in the same pass

- **A malformed item no longer blanks the page.** The `KIND_LABELS` lookup at both render sites threw on an unknown kind, so one bad entry left the recipient a blank plan with no empty state. It now skips that card. Unknown kinds are rejected at decode now, but a store written before this fix can still hold one.
- **`cssUrl` escapes the apostrophe.** The value is interpolated inside a single-quoted `url('...')`, so an apostrophe broke out of the CSS string.

## Verification

`share-link.test.mjs`, nine cases, wired into the build gate so the guard cannot be loosened silently. It covers every scheme that survives HTML escaping, protocol-relative and off-site links, control characters built from char codes, unknown kinds, missing fields, the image allowlist, and that one bad item drops out while the good ones survive.

Full build passes, 982 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUtNaf5gYAh9HUBkEPYHi3
