### PR TITLE
PI-009: count distinct results, not tagged nodes

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && npm run lint:coordinates && astro build && npm run lint:no-hidden-pages && npm run lint:seo-architecture && npm run lint:filter-chips && npm run audit:agent-readiness && npm run assert:link-graph && npm run assert:event-safeguards && npm run assert:campaigns-review-page && npm run assert:partner-portal-dashboard",
+    "build": "node scripts/clear-content-cache.mjs && npm run media:registry && npm run lint:no-pricing && npm run lint:house-style && npm run lint:region-images && npm run lint:surfaces && npm run lint:nav-budget && npm run lint:css-budget && npm run lint:coordinates && astro build && npm run lint:no-hidden-pages && npm run lint:seo-architecture && npm run lint:filter-chips && npm run audit:agent-readiness && npm run assert:link-graph && npm run assert:event-safeguards && npm run assert:count-semantics && npm run assert:campaigns-review-page && npm run assert:partner-portal-dashboard",
     "build:search": "npm run build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
@@ -60,7 +60,9 @@
     "audit:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json",
     "test:event-safeguards": "node --test scripts/audit-event-safeguards.test.mjs",
     "assert:event-safeguards": "node scripts/audit-event-safeguards.mjs --json ../ops/reports/events/event-safeguards.json --assert",
-    "test:share-link": "node --test src/lib/saves/share-link.test.mjs"
+    "test:share-link": "node --test src/lib/saves/share-link.test.mjs",
+    "assert:count-semantics": "node scripts/assert-count-semantics.mjs",
+    "test:count-semantics": "node --test scripts/count-semantics.test.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/next/scripts/assert-count-semantics.mjs
+++ b/next/scripts/assert-count-semantics.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * assert-count-semantics - fails the build when a listing page's heading and
+ * the count its filter bar will render disagree.
+ *
+ * /eat/ shipped "All 53 places to eat" above a status line that said
+ * "Showing all 60 places", every day, for as long as both existed. The two
+ * numbers came from different definitions: the heading counted directory
+ * items, the runtime counted every element on the page carrying a
+ * data-facets attribute. Six of those were The Six, which is the directory's
+ * own top picks rendered a second time, and one was a bridge container that
+ * represented no venue at all. Nothing in the pipeline compared them.
+ *
+ * The fix gave counting an explicit subject: an element is counted only when
+ * it also carries data-filter-countable (COUNTABLE_ATTR in
+ * lib/v5-filter-state.ts). This check holds that contract to the built HTML,
+ * which is the only place both numbers exist side by side.
+ *
+ * Runs on dist, like lint-filter-chips, so it checks what actually shipped.
+ *
+ * Usage:  node scripts/assert-count-semantics.mjs
+ * Exit:   0 every listing surface agrees; 1 any disagreement.
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST = fileURLToPath(new URL('../dist/', import.meta.url));
+
+/** Surfaces that must be present and must pass. A hub that stops emitting
+ *  countable markers would otherwise vanish from the check silently. */
+export const REQUIRED_SURFACES = [
+  'eat/index.html',
+  'wine/index.html',
+  'stay/index.html',
+  'explore/index.html',
+];
+
+export function decodeEntities(value) {
+  return value
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+/** Script and style bodies mention these attributes as plain strings. */
+function stripCode(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
+}
+
+const hasAttr = (tag, name) => new RegExp(`\\s${name}[=\\s/>]`).test(tag);
+
+/**
+ * What the page claims and what it will count.
+ *
+ *   facetNodes     every [data-facets] element: what the old counter counted
+ *   countableNodes [data-facets][data-filter-countable]: distinct results
+ *   runtimeCount   what the filter bar will actually print, mirroring
+ *                  countableSubset(): the countable nodes, or, when a page
+ *                  marks none, all of them
+ *   claims         each "All N ..." directory heading, with its number
+ */
+export function analyseHtml(html) {
+  const body = stripCode(html);
+
+  let facetNodes = 0;
+  let countableNodes = 0;
+  let orphanMarkers = 0;
+  for (const tag of body.match(/<[a-zA-Z][^>]*>/g) ?? []) {
+    const facets = hasAttr(tag, 'data-facets');
+    const countable = hasAttr(tag, 'data-filter-countable');
+    if (facets) facetNodes += 1;
+    if (facets && countable) countableNodes += 1;
+    if (!facets && countable) orphanMarkers += 1;
+  }
+
+  const headings = [];
+  const H2 = /<h2\b([^>]*)>([\s\S]*?)<\/h2>/gi;
+  let m;
+  while ((m = H2.exec(body)) !== null) {
+    const text = decodeEntities(m[2].replace(/<[^>]*>/g, '')).replace(/\s+/g, ' ').trim();
+    headings.push({ text, directory: /directory__heading/.test(m[1]) });
+  }
+  // A count claim is a heading that opens with "All <number>". Prefer the
+  // ones the directory modules render; fall back to any h2 so a hand-rolled
+  // listing page is still covered.
+  const claimed = headings.filter((h) => /^All\s+[\d,]+\b/.test(h.text));
+  const scoped = claimed.filter((h) => h.directory);
+  const chosen = scoped.length ? scoped : claimed;
+
+  return {
+    facetNodes,
+    countableNodes,
+    // Mirrors countableSubset() in lib/v5-filter-state.ts: a page that marks
+    // nothing countable falls back to counting every tagged node, which is
+    // the behaviour this check exists to catch on a page that should have
+    // opted in.
+    runtimeCount: countableNodes > 0 ? countableNodes : facetNodes,
+    orphanMarkers,
+    hasFilterCount: /\sdata-filter-count[=\s/>]/.test(body),
+    claims: chosen.map((h) => ({
+      text: h.text,
+      count: Number(h.text.match(/^All\s+([\d,]+)/)[1].replace(/,/g, '')),
+    })),
+  };
+}
+
+/** Verdict for one page. `null` when the page makes no count claim. */
+export function checkPage(name, html) {
+  const a = analyseHtml(html);
+  if (!a.hasFilterCount || a.claims.length === 0) return { name, ...a, skipped: true };
+  const failures = [];
+  if (a.claims.length > 1) {
+    failures.push(
+      `${a.claims.length} competing "All N" directory headings: ` +
+        a.claims.map((c) => `"${c.text}"`).join(', '),
+    );
+  }
+  for (const claim of a.claims) {
+    if (claim.count !== a.runtimeCount) {
+      failures.push(
+        `heading says ${claim.count} ("${claim.text}") but the filter bar will ` +
+          `count ${a.runtimeCount} (${a.facetNodes} elements carry data-facets, ` +
+          `${a.countableNodes} of them countable)`,
+      );
+    }
+  }
+  if (a.orphanMarkers > 0) {
+    failures.push(
+      `${a.orphanMarkers} element(s) carry data-filter-countable without data-facets, ` +
+        'so they are invisible to both the filter and the count',
+    );
+  }
+  return { name, ...a, skipped: false, failures };
+}
+
+function htmlFiles(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) htmlFiles(full, out);
+    else if (entry.endsWith('.html')) out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  if (!existsSync(DIST)) {
+    console.error('assert-count-semantics: dist/ not found. Run the build first.');
+    process.exit(1);
+  }
+
+  const failures = [];
+  const seen = new Set();
+  const rows = [];
+
+  for (const file of htmlFiles(DIST)) {
+    const name = relative(DIST, file).split(sep).join('/');
+    const result = checkPage(name, readFileSync(file, 'utf8'));
+    if (result.skipped) continue;
+    seen.add(name);
+    rows.push(result);
+    for (const f of result.failures) failures.push(`${name}: ${f}`);
+  }
+
+  for (const required of REQUIRED_SURFACES) {
+    if (!seen.has(required)) {
+      failures.push(
+        `${required}: expected a filtered listing with an "All N" heading, found none. ` +
+          'Did the page lose its FilterBar, its heading, or its data-filter-countable markers?',
+      );
+    }
+  }
+
+  for (const r of rows.sort((a, b) => a.name.localeCompare(b.name))) {
+    const offset = r.facetNodes - r.runtimeCount;
+    console.log(
+      `  ${r.name.padEnd(24)} heading ${String(r.claims[0].count).padStart(4)}  ` +
+        `counted ${String(r.runtimeCount).padStart(4)}  ` +
+        `data-facets nodes ${String(r.facetNodes).padStart(4)}  ` +
+        `(uncounted duplicates: ${offset})`,
+    );
+  }
+
+  if (failures.length) {
+    console.error(`\nassert-count-semantics: ${failures.length} failure(s)\n`);
+    for (const f of failures) console.error(`  - ${f}`);
+    console.error(
+      '\nHeading, filters and count must share one definition of a result. ' +
+        'Mark exactly one element per distinct result with data-filter-countable; ' +
+        'echo modules (The Six, bridge lists) filter without counting.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nassert-count-semantics: ${rows.length} listing surface(s) agree.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/next/scripts/count-semantics.test.mjs
+++ b/next/scripts/count-semantics.test.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * count-semantics.test.mjs - the regression test for PI-009.
+ *
+ * The defect: /eat/ rendered "All 53 places to eat" while the filter bar
+ * reported "Showing all 60 places". The heading counted directory items; the
+ * runtime counted every [data-facets] element, which included The Six (six
+ * venues already in the directory, rendered a second time) and one empty
+ * bridge container. A constant offset of seven that drifted with content.
+ *
+ * Two levels are covered here:
+ *   1. the pure semantics (countableSubset + itemMatches), on a fixture that
+ *      includes a venue in two categories and a duplicated pick;
+ *   2. the rendered contract, by running the build assert's HTML analyser
+ *      over a fixture page shaped like /eat/ (and over dist when present).
+ *
+ * Usage:  node --test scripts/count-semantics.test.mjs
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { analyseHtml, checkPage } from './assert-count-semantics.mjs';
+
+const { countableSubset, itemMatches, parseItemFacets, COUNTABLE_ATTR } = await import(
+  new URL('../src/lib/v5-filter-state.ts', import.meta.url).href
+);
+
+const DIST = fileURLToPath(new URL('../dist/', import.meta.url));
+
+/* ------------------------------------------------------------------ */
+/* Fixture: three venues, one of them in two categories, plus the two  */
+/* shapes that broke the count (a duplicated pick, a bridge container). */
+/* ------------------------------------------------------------------ */
+
+const VENUES = [
+  { slug: 'tedesca-osteria', facets: { place: ['red-hill'], cat: ['restaurant'], mood: ['long-lunch'] } },
+  // Multi-category: a brewery that is also a restaurant. It must match under
+  // either category and still count exactly once.
+  { slug: 'jetty-road-brewery', facets: { place: ['dromana'], cat: ['brewery', 'restaurant'], mood: ['casual'] } },
+  { slug: 'baker-bleu', facets: { place: ['sorrento'], cat: ['bakery'], mood: ['quick'] } },
+];
+
+/** The directory row: one per venue, the page's countable result. */
+const directoryItems = VENUES.map((v) => ({ facets: v.facets, countable: true }));
+/** The Six: two of the same venues, pinned above. Filterable, not countable. */
+const pinnedItems = [VENUES[0], VENUES[1]].map((v) => ({ facets: v.facets, countable: false }));
+/** The bridge container: carries facets, represents nothing. */
+const bridgeItems = [{ facets: { cat: ['winery'] }, countable: false }];
+
+const pageItems = [...pinnedItems, ...bridgeItems, ...directoryItems];
+
+const fixtureHtml = `<!DOCTYPE html><html><body>
+<section class="v5-six">
+  <ul>
+${pinnedItems
+  .map(
+    (it, i) =>
+      `    <li class="v5-six__item" data-facets='${JSON.stringify(it.facets)}' data-title="pick ${i}"></li>`,
+  )
+  .join('\n')}
+  </ul>
+</section>
+<section class="v5-directory">
+  <h2 class="v5-directory__heading" id="directory-heading">All ${VENUES.length} places to eat</h2>
+  <div class="v5-filterbar"><p><span data-filter-count></span></p></div>
+  <div class="eat-winery-kitchens" data-facets='{"cat":["winery"]}' data-title="Winery kitchens"></div>
+  <ul data-sort-container>
+${directoryItems
+  .map(
+    (it, i) =>
+      `    <li class="v5-directory__row" data-facets='${JSON.stringify(it.facets)}' data-filter-countable="true" data-title="${VENUES[i].slug}"></li>`,
+  )
+  .join('\n')}
+  </ul>
+</section>
+<script>document.querySelectorAll('[data-facets]');</script>
+</body></html>`;
+
+/* ------------------------------------------------------------------ */
+
+test('the attribute contract is exported, so pages and checks agree', () => {
+  assert.equal(COUNTABLE_ATTR, 'data-filter-countable');
+});
+
+test('counting counts distinct results, not tagged nodes', () => {
+  assert.equal(pageItems.length, 6, 'fixture page carries six data-facets nodes');
+  assert.equal(countableSubset(pageItems).length, VENUES.length);
+});
+
+test('a duplicated pick filters but does not count twice', () => {
+  const state = { cat: ['restaurant'] };
+  // Both the pinned card and its directory row match, so both stay visible.
+  const visible = pageItems.filter((it) => itemMatches(it.facets, state));
+  assert.equal(visible.length, 4, 'two pinned picks plus two directory rows');
+  // The count sees each venue once.
+  const counted = countableSubset(pageItems).filter((it) => itemMatches(it.facets, state));
+  assert.equal(counted.length, 2, 'Tedesca and Jetty Road, once each');
+});
+
+test('a multi-category venue is found under either category and counted once', () => {
+  for (const cat of ['brewery', 'restaurant']) {
+    const counted = countableSubset(pageItems).filter((it) => itemMatches(it.facets, { cat: [cat] }));
+    const hits = counted.filter((it) => (it.facets.cat ?? []).includes(cat));
+    assert.equal(hits.length, counted.length);
+    assert.ok(
+      counted.some((it) => (it.facets.place ?? []).includes('dromana')),
+      `Jetty Road should appear under ${cat}`,
+    );
+  }
+  const both = countableSubset(pageItems).filter((it) =>
+    itemMatches(it.facets, { cat: ['brewery', 'restaurant'] }),
+  );
+  assert.equal(both.length, 2, 'OR within a facet must not double-count the multi-category venue');
+});
+
+test('the empty bridge container never counts', () => {
+  const counted = countableSubset(pageItems);
+  assert.ok(!counted.some((it) => (it.facets.cat ?? []).includes('winery')));
+});
+
+test('a page that marks nothing countable still counts everything', () => {
+  const legacy = pageItems.map((it) => ({ facets: it.facets }));
+  assert.equal(countableSubset(legacy).length, legacy.length);
+});
+
+test('parseItemFacets tolerates the JSON the pages emit', () => {
+  assert.deepEqual(parseItemFacets('{"cat":["brewery","restaurant"]}'), {
+    cat: ['brewery', 'restaurant'],
+  });
+  assert.deepEqual(parseItemFacets('not json'), {});
+});
+
+/* ---------------- the rendered contract ---------------- */
+
+test('rendered heading equals the count the filter bar will produce', () => {
+  const a = analyseHtml(fixtureHtml);
+  assert.equal(a.claims.length, 1);
+  assert.equal(a.claims[0].count, VENUES.length);
+  assert.equal(a.countableNodes, VENUES.length);
+  assert.equal(a.runtimeCount, VENUES.length);
+  assert.equal(a.claims[0].count, a.runtimeCount);
+  assert.deepEqual(checkPage('fixture', fixtureHtml).failures, []);
+});
+
+test('the pre-fix shape is what this test would have caught', () => {
+  // Strip the opt-in markers: this is exactly the DOM that shipped.
+  const before = fixtureHtml.replace(/ data-filter-countable="true"/g, '');
+  const a = analyseHtml(before);
+  assert.equal(a.facetNodes, 6);
+  assert.equal(a.countableNodes, 0);
+  // With nothing marked, the runtime falls back to counting every tagged
+  // node, which is precisely the 53-versus-60 defect.
+  assert.equal(a.runtimeCount, 6);
+  const result = checkPage('fixture', before);
+  assert.ok(
+    result.failures.some((f) => /heading says 3 .*will count 6/.test(f)),
+    `expected a heading/count mismatch, got: ${JSON.stringify(result.failures)}`,
+  );
+});
+
+test('built hubs agree (skipped when dist/ is absent)', (t) => {
+  const pages = ['eat/index.html', 'wine/index.html', 'stay/index.html', 'explore/index.html'];
+  const present = pages.filter((p) => existsSync(new URL(p, `file://${DIST}`)));
+  if (present.length === 0) {
+    t.skip('no dist/ build to inspect; npm run build covers this via assert:count-semantics');
+    return;
+  }
+  for (const page of present) {
+    const html = readFileSync(new URL(page, `file://${DIST}`), 'utf8');
+    const result = checkPage(page, html);
+    assert.equal(result.skipped, false, `${page} made no "All N" count claim`);
+    assert.deepEqual(result.failures, [], `${page} heading and count disagree`);
+  }
+});

--- a/next/src/components/v5/MapView.astro
+++ b/next/src/components/v5/MapView.astro
@@ -177,7 +177,9 @@ const chips: { key: FacetKey; value: string; label: string }[] = standalone
                 data-verdict={it.verdict ?? ''}
                 data-metaline={metaLine}
                 data-title={it.title}
-                {...(standalone ? { 'data-facets': facetAttr } : { 'data-map-facets': facetAttr })}
+                {...(standalone
+                  ? { 'data-facets': facetAttr, 'data-filter-countable': 'true' }
+                  : { 'data-map-facets': facetAttr })}
               >
                 <button
                   type="button"

--- a/next/src/components/v5/hub/DirectoryRows.astro
+++ b/next/src/components/v5/hub/DirectoryRows.astro
@@ -6,8 +6,10 @@
  * elements per row (row link + save; stays add Book via `booking`).
  *
  * Filter contract (lib/v5-filter-state.ts): every row `li` carries
- * `data-facets` and `data-title`; the list is a `data-sort-container` so
- * SortControl can reorder it; a `[data-filter-empty]` EmptyState toggles at
+ * `data-facets`, `data-title` and, unless `countable={false}`,
+ * `data-filter-countable` (this is the catalogue layer, so a row here is the
+ * page's one node standing for that result); the list is a
+ * `data-sort-container` so SortControl can reorder it; a `[data-filter-empty]` EmptyState toggles at
  * zero results and its Clear action commits an empty filter state. The page
  * FilterBar owns counts and the live region.
  *
@@ -59,6 +61,15 @@ export interface Props {
   id?: string;
   emptyHeading?: string;
   emptyBody?: string;
+  /**
+   * Do these rows stand for distinct results the page's counts describe?
+   *
+   * True for the catalogue layer, which is the default use. Pass false for a
+   * secondary module built from rows the catalogue already lists (Wine's
+   * "Winery kitchens" bridge): those rows must still filter, but counting
+   * them again would report more results than the page holds.
+   */
+  countable?: boolean;
 }
 
 const {
@@ -72,6 +83,7 @@ const {
   id,
   emptyHeading,
   emptyBody,
+  countable = true,
 } = Astro.props;
 
 const headingId = `${id ?? `directory-${surface}`}-heading`;
@@ -97,6 +109,7 @@ const headingId = `${id ?? `directory-${surface}`}-heading`;
         <li
           class="v5-directory__row"
           data-facets={item.facets ? JSON.stringify(item.facets) : undefined}
+          data-filter-countable={countable && item.facets ? 'true' : undefined}
           data-title={item.sortTitle ?? item.title}
         >
           <Card

--- a/next/src/components/v5/hub/TheSix.astro
+++ b/next/src/components/v5/hub/TheSix.astro
@@ -11,6 +11,11 @@
  * the page FilterBar shows/hides The Six AND the directory together.
  * Editorial order is fixed: no data-sort-container on this list.
  *
+ * Filterable, never countable: every pick here is pinned FROM the directory
+ * below and is rendered a second time, so these `li`s deliberately omit
+ * `data-filter-countable` (COUNTABLE_ATTR in lib/v5-filter-state). Counting
+ * them is what put "Showing all 60 places" under "All 53 places to eat".
+ *
  * Generic and prop-driven for the Eat / Wine / Stay / Explore hub agents.
  */
 import Card from '../Card.astro';

--- a/next/src/lib/facets.ts
+++ b/next/src/lib/facets.ts
@@ -249,7 +249,10 @@ export const CHIP_PRESETS: Record<
     { key: 'mood', value: 'date-night', label: 'Date night' },
     { key: 'party', value: 'family', label: 'With kids' },
     { key: 'mood', value: 'quick', label: 'Quick & good' },
-    { key: 'cat', value: 'winery', label: 'Winery kitchens' },
+    // No winery chip on /eat/: eatTypes excludes 'winery', so the surface has
+    // never held one. The chip used to match only the empty Winery kitchens
+    // bridge container, which carried cat=winery while standing for no venue;
+    // both were removed 2026-09-13 (PI-009). Cellar doors live on /wine/.
   ],
   stay: [
     { key: 'party', value: 'couples', label: 'Couples' },

--- a/next/src/lib/v5-filter-state.ts
+++ b/next/src/lib/v5-filter-state.ts
@@ -13,6 +13,15 @@
  *     JSON: Partial<Record<FacetKey, string[]>> using values from the shared
  *     facets taxonomy (lib/facets.ts getFacets/FACET_OPTIONS). Example:
  *       <article data-facets='{"place":["red-hill"],"mood":["long-lunch"]}'>
+ *   - Filterable and countable are two different things. `data-facets` makes
+ *     an element filterable; `data-filter-countable` (COUNTABLE_ATTR) declares
+ *     that the element is the ONE node standing for a distinct result, and so
+ *     is what the counts describe. A page may legitimately render the same
+ *     result twice (a pinned The Six card and its directory row); both must
+ *     filter, only the directory row is countable. Containers and bridge
+ *     modules that merely carry facets are neither a result nor countable.
+ *     When a page marks nothing countable every `data-facets` element counts,
+ *     which is the original behaviour and keeps single-list surfaces working.
  *   - Optionally add `data-title="..."` (used by A-to-Z sort; falls back to
  *     the first heading's text).
  *   - Optionally wrap zero-result messaging in `[data-filter-empty]` (hidden
@@ -29,6 +38,19 @@
 /* ------------------------------------------------------------------ */
 /* Pure state helpers (DOM-free, node-testable)                        */
 /* ------------------------------------------------------------------ */
+
+/**
+ * Opt-in marker naming an element as one distinct countable result.
+ *
+ * Counting tagged nodes rather than results is what made /eat/ report
+ * "Showing all 60 places" under an "All 53 places to eat" heading: the six
+ * The Six cards are the same venues rendered a second time, and a winery
+ * bridge container carried facets while representing no venue at all.
+ *
+ * Presence is the signal; the value is ignored, so both `data-filter-countable`
+ * and `data-filter-countable="true"` count.
+ */
+export const COUNTABLE_ATTR = 'data-filter-countable';
 
 export const FILTER_KEYS = ['place', 'cat', 'mood', 'price', 'party', 'date'] as const;
 export type FilterKey = (typeof FILTER_KEYS)[number];
@@ -153,6 +175,16 @@ export function itemMatches(itemFacets: FilterState, state: FilterState): boolea
   return true;
 }
 
+/**
+ * The result set the page's counts describe: every item that opted in via
+ * COUNTABLE_ATTR, or, when a page marks none, all of them. DOM-free, so the
+ * semantics are testable without a browser.
+ */
+export function countableSubset<T extends { countable?: boolean }>(items: T[]): T[] {
+  const marked = items.filter((it) => it.countable === true);
+  return marked.length ? marked : items;
+}
+
 /* ------------------------------------------------------------------ */
 /* DOM controller (all functions guard on document)                    */
 /* ------------------------------------------------------------------ */
@@ -187,6 +219,8 @@ export function writeUrl(state: FilterState, opts: { push?: boolean } = {}): voi
 interface FacetedItem {
   el: HTMLElement;
   facets: FilterState;
+  /** Opted in via COUNTABLE_ATTR: this node is one distinct result. */
+  countable: boolean;
 }
 
 function collectItems(root: ParentNode): FacetedItem[] {
@@ -203,7 +237,11 @@ function collectItems(root: ParentNode): FacetedItem[] {
         }
       }
     }
-    items.push({ el, facets: parseItemFacets(el.getAttribute('data-facets')) });
+    items.push({
+      el,
+      facets: parseItemFacets(el.getAttribute('data-facets')),
+      countable: el.hasAttribute(COUNTABLE_ATTR),
+    });
   });
   return items;
 }
@@ -211,7 +249,7 @@ function collectItems(root: ParentNode): FacetedItem[] {
 /** Non-mutating count for the sheet's live "Show N places" preview. */
 export function countMatches(state: FilterState, root?: ParentNode): number {
   if (!hasDom()) return 0;
-  return collectItems(root || document).reduce(
+  return countableSubset(collectItems(root || document)).reduce(
     (n, it) => n + (itemMatches(it.facets, state) ? 1 : 0),
     0,
   );
@@ -259,6 +297,10 @@ export function announce(text: string): void {
  * Apply `state` to every [data-facets] item on the page: toggles the hidden
  * attribute plus a data-filtered-out marker (for CSS hooks), updates every
  * [data-filter-count], toggles [data-filter-empty], announces the count.
+ *
+ * Filtering spans every tagged element; the counts span only the countable
+ * ones, so a duplicated result (The Six over its directory row) still hides
+ * and shows in both places while counting once.
  */
 export function applyToDom(
   state: FilterState = current,
@@ -268,15 +310,16 @@ export function applyToDom(
   if (!hasDom()) return { shown: 0, total: 0 };
   const root = rootIn || document;
   const items = collectItems(root);
-  let shown = 0;
   for (const it of items) {
     const ok = itemMatches(it.facets, state);
-    if (ok) shown += 1;
     it.el.toggleAttribute('hidden', !ok);
     if (ok) delete it.el.dataset.filteredOut;
     else it.el.dataset.filteredOut = '1';
   }
-  const total = items.length;
+  const counted = countableSubset(items);
+  let shown = 0;
+  for (const it of counted) if (itemMatches(it.facets, state)) shown += 1;
+  const total = counted.length;
   const anyActive = !isEmptyState(state);
   const countText = anyActive ? `Showing ${shown} of ${total} ${noun}` : `Showing all ${total} ${noun}`;
   root.querySelectorAll<HTMLElement>('[data-filter-count]').forEach((el) => {

--- a/next/src/pages/dev/v5-filters.astro
+++ b/next/src/pages/dev/v5-filters.astro
@@ -9,6 +9,10 @@
  * PAGE-AGENT CONTRACT demonstrated here:
  *   1. Server-render every item; give each a data-facets JSON attribute
  *      built from getFacets(kind, data) (dummy values here) and a data-title.
+ *      Add data-filter-countable to the items that stand for distinct
+ *      results. The curated band and the directory here hold disjoint items,
+ *      so both are countable; a hub that pins its band FROM its directory
+ *      marks only the directory (see components/v5/hub/TheSix.astro).
  *   2. Put ONE FilterBar above the first result (it renders the live region
  *      #pi-results-status and the paired FilterSheet).
  *   3. Add data-sort-container to any grid whose order may change.
@@ -75,7 +79,7 @@ const directory = items.slice(6);
       <h2 id="curated-h">Editor's picks (curated band)</h2>
       <div class="demo__grid" data-sort-container>
         {curated.map((item) => (
-          <article class="demo__card demo__card--pick" data-facets={JSON.stringify(item.facets)} data-title={item.title}>
+          <article class="demo__card demo__card--pick" data-facets={JSON.stringify(item.facets)} data-filter-countable data-title={item.title}>
             <h3>{item.title}</h3>
             <p class="demo__meta">{item.town} &middot; {item.facets.cat[0]} &middot; band {item.facets.price[0]}</p>
             <p class="demo__meta">{item.facets.mood.join(', ')} &middot; {item.facets.party[0]}</p>
@@ -88,7 +92,7 @@ const directory = items.slice(6);
       <h2 id="directory-h">Directory (all {directory.length})</h2>
       <div class="demo__grid" data-sort-container>
         {directory.map((item) => (
-          <article class="demo__card" data-facets={JSON.stringify(item.facets)} data-title={item.title}>
+          <article class="demo__card" data-facets={JSON.stringify(item.facets)} data-filter-countable data-title={item.title}>
             <h3>{item.title}</h3>
             <p class="demo__meta">{item.town} &middot; {item.facets.cat[0]} &middot; band {item.facets.price[0]}</p>
             <p class="demo__meta">{item.facets.mood.join(', ')} &middot; {item.facets.party[0]}</p>

--- a/next/src/pages/eat/index.astro
+++ b/next/src/pages/eat/index.astro
@@ -5,13 +5,18 @@
  * Verdict first, catalogue underneath, one job: a confident shortlist for a
  * specific occasion in under a minute. Structure: breadcrumbless h1 + Editor
  * stand-first, intent chips + FilterBar (ONE filter state governs The Six
- * AND the directory), The Six, best-of rail, full non-winery directory as
- * compact rows (server-rendered, SEO), Winery kitchens bridge module,
- * From the Journal, FAQ (in-DOM, mirrors schema), Ask band.
+ * AND the directory), The Six, best-of rail, the full directory as compact
+ * rows (server-rendered, SEO), From the Journal, FAQ (in-DOM, mirrors
+ * schema), Ask band.
  *
  * SEO: URL, title, meta, canonical and both schemas unchanged (protect
- * list). Wineries are excluded from the directory (HUB-01); their links
- * move to /wine/ via the Winery kitchens module.
+ * list). Wineries are excluded from this surface entirely (HUB-01): eatTypes
+ * has never included 'winery', so the page never held one. The Winery
+ * kitchens bridge module that used to sit above the directory was removed
+ * 2026-09-13 (PI-009); it filtered `venuesAll` for a type that filter had
+ * already excluded, so it always rendered an empty shell while its container
+ * div carried data-facets and inflated the result count by one. The
+ * reciprocal module on /wine/ still points here.
  */
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
@@ -35,9 +40,8 @@ const venuesAll = (await getCollection('venues'))
   .filter((v) => v.data.status !== 'permanently_closed')
   .sort((a, b) => Number(b.data.authority?.hats ?? 0) - Number(a.data.authority?.hats ?? 0));
 
-// Wineries are excluded from the /eat/ directory (one venue, one URL; HUB-01)
-// and bridge to /wine/ via the Winery kitchens module below.
-const wineries = venuesAll.filter((v) => v.data.type === 'winery');
+// eatTypes (lib/editorial) excludes 'winery', so venuesAll holds none: this
+// is a defensive second pass, not a split (one venue, one URL; HUB-01).
 const venues = venuesAll.filter((v) => v.data.type !== 'winery');
 
 const placesAll = await getCollection('places');
@@ -164,13 +168,6 @@ for (const venue of venues) {
     partnerLabel: venue.data.featuredPartner ? 'Partner venue' : undefined,
   });
 }
-
-// ── Winery kitchens: the bridge to /wine/ (spec block 18). Kitchens first
-//    (lunch-attached facet), then every remaining cellar door link. ───────────
-const wineryKitchens = wineries.filter((v) =>
-  (getFacets('venue', v.data).mood ?? []).includes('lunch-attached'),
-);
-const wineryOther = wineries.filter((v) => !wineryKitchens.includes(v));
 
 // ── From the Journal (3 maximum). ───────────────────────────────────────────
 //    EDITORIAL: this rail is still the winter selection. The three pieces
@@ -334,30 +331,6 @@ export const prerender = true;
       facets={['cat', 'place', 'mood', 'price', 'party']}
     >
     </FilterBar>
-    <div
-      slot="before-list"
-      class="eat-winery-kitchens"
-      data-facets='{"cat":["winery"]}'
-      data-title="Winery kitchens"
-    >
-      <h3 class="eat-winery-kitchens__heading">Winery kitchens</h3>
-      <p class="eat-winery-kitchens__sub">
-        The vineyard dining rooms live with their wineries, one page per venue. The fires, the long lunches and the estate wine are what make the detour worth it.
-      </p>
-      <ul class="eat-winery-kitchens__list">
-        {wineryKitchens.map((venue) => (
-          <li>
-            <a href={`/wine/${routeSlug(venue)}/`} class="eat-winery-kitchens__link">{venue.data.name}</a>
-          </li>
-        ))}
-      </ul>
-      {wineryOther.length > 0 && (
-        <p class="eat-winery-kitchens__more">
-          Plus {wineryOther.length} more cellar doors without a kitchen:
-          <a href="/wine/">all wineries on /wine/ &rarr;</a>
-        </p>
-      )}
-    </div>
   </DirectoryRows>
 
   <!-- What's On, one line + link (spec block 18: strip becomes a line) -->
@@ -449,63 +422,6 @@ export const prerender = true;
   .eat-rail__link:focus-visible {
     outline: var(--focus-ring, 2px solid var(--accent));
     outline-offset: 2px;
-  }
-
-  .eat-winery-kitchens {
-    border: 1px solid var(--border);
-    border-radius: var(--radius-l, 28px);
-    background: var(--bg-alt);
-    padding: var(--space-6, 2rem);
-    margin-bottom: var(--space-6, 2rem);
-  }
-  .eat-winery-kitchens__heading {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: var(--fs-600, 1.4rem);
-    font-weight: var(--fw-display, 600);
-    letter-spacing: -0.01em;
-    color: var(--text);
-  }
-  .eat-winery-kitchens__sub {
-    margin: var(--space-2, 0.5rem) 0 var(--space-3, 0.75rem);
-    font-family: var(--font-ui, var(--font-ui));
-    font-size: var(--fs-200, 0.8125rem);
-    color: var(--soft);
-  }
-  .eat-winery-kitchens__list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
-    gap: var(--space-1, 0.25rem) var(--space-4, 1rem);
-  }
-  .eat-winery-kitchens__link {
-    display: inline-block;
-    padding: var(--space-1, 0.25rem) 0;
-    font-family: var(--font-ui, var(--font-ui));
-    font-size: var(--fs-300, 0.9375rem);
-    color: var(--text);
-    text-decoration: underline;
-    text-decoration-color: var(--border);
-    text-underline-offset: 3px;
-  }
-  .eat-winery-kitchens__link:hover {
-    color: var(--accent);
-    text-decoration-color: var(--accent);
-  }
-  .eat-winery-kitchens__link:focus-visible {
-    outline: var(--focus-ring, 2px solid var(--accent));
-    outline-offset: 2px;
-  }
-  .eat-winery-kitchens__more {
-    margin: var(--space-3, 0.75rem) 0 0;
-    font-family: var(--font-ui, var(--font-ui));
-    font-size: var(--fs-200, 0.8125rem);
-    color: var(--soft);
-  }
-  .eat-winery-kitchens__more a {
-    color: var(--accent);
   }
 
   .eat-whatson {

--- a/next/src/pages/explore/index.astro
+++ b/next/src/pages/explore/index.astro
@@ -11,7 +11,9 @@
  * directory rows.
  *
  * Filter model: one URL-persisted state (lib/v5-filter-state). Directory rows
- * carry data-facets; the curated browse layer (shelves/towns/verticals)
+ * carry data-facets and data-filter-countable (this list is the page's whole
+ * result set, so its rows are what the counts describe); the curated browse
+ * layer (shelves/towns/verticals)
  * yields to the filtered directory whenever any facet is active, so the
  * live count ("Showing N of 44 experiences") always matches one render of
  * the corpus. Shelf "All N" links apply the preset in page (no fetch) and
@@ -526,7 +528,12 @@ export const prerender = true;
       </p>
       <CardGrid label={`All ${directoryRows.length} experiences`} layout="rows">
         {directoryRows.map((r, i) => (
-          <li data-facets={JSON.stringify(r.facets)} data-title={r.name} class="x-directory__row">
+          <li
+            data-facets={JSON.stringify(r.facets)}
+            data-filter-countable
+            data-title={r.name}
+            class="x-directory__row"
+          >
             <Card
               as="div"
               variant="compact-row"

--- a/next/src/pages/wine/index.astro
+++ b/next/src/pages/wine/index.astro
@@ -276,7 +276,8 @@ const faqSchema = {
   />
 
   <!-- 4. Winery kitchens: reciprocal module, fixes HUB-01 both directions.
-       /eat/ carries the mirror module pointing here. -->
+       Every kitchen is also a row in the directory below, so this module
+       filters but does not count (countable={false}). -->
   <DirectoryRows
     id="winery-kitchens"
     eyebrow="The bridge to Eat & Drink"
@@ -286,6 +287,7 @@ const faqSchema = {
     noun="winery kitchens"
     items={kitchenItems}
     topLink={{ label: 'Restaurants, in Eat & Drink', href: '/eat/' }}
+    countable={false}
   />
 
   <div class="wine-mid container">


### PR DESCRIPTION
Closes #370.

## The defect was a constant offset, not two queries disagreeing

The heading counted venues at build time. The filter status counted DOM nodes at runtime, via `document.querySelectorAll('[data-facets]')` across the whole page, with no concept of what a node represented.

Measured on the built output, the gap was constant per hub and independent of content churn:

| Hub | Heading | Old counted | Offset |
|---|---|---|---|
| Eat | 53 | 60 | +7 |
| Wine | 47 | 59 | +12 |
| Stay | 31 | 37 | +6 |
| Explore | 54 | 54 | 0 |

Eat's seven was six pinned picks counted a second time plus one empty bridge container. Wine's twelve was six picks plus six bridge rows.

**The wineries hypothesis in the audit was wrong.** `eatTypes` never includes `winery`, so wineries were correctly excluded from both paths all along.

## The fix

An explicit opt-in marker, `data-filter-countable`, rather than scoping the query to a container. Scoping fails twice over: filtering must still reach the pinned picks, so the query has to span the document either way; and Wine renders two directory instances, so a container rule still needs a per-instance opt-out.

The marker expresses the distinction the bug is actually about. `data-facets` means filterable. `data-filter-countable` means this node stands for one distinct result.

Filtering behaviour is unchanged. Only the counts read the countable subset. A page that marks nothing counts everything, preserving the old behaviour for surfaces not yet migrated.

## After

All four hubs now read zero offset, and the build prints it per page:

```
eat/index.html      heading 53  counted 53  data-facets nodes 59  (uncounted duplicates: 6)
explore/index.html  heading 54  counted 54  data-facets nodes 54  (uncounted duplicates: 0)
stay/index.html     heading 31  counted 31  data-facets nodes 37  (uncounted duplicates: 6)
wine/index.html     heading 47  counted 47  data-facets nodes 59  (uncounted duplicates: 12)
```

The raw node total stays above the counted total by design: the pinned picks must remain filterable.

## Dead code removed, and a dead control found

The Eat winery split always produced an empty array, so its bridge module shipped a heading and a blurb over an empty list. Removed, along with about 55 lines of CSS.

That exposed something: the "Winery kitchens" filter chip on Eat was the only control matching that container, so tapping it hid all 53 rows and revealed an empty box. It had never worked. Removed too. If a genuine Eat to Wine bridge is wanted it needs its own ticket, because it would have to source wineries from the unfiltered collection.

## Verification

Regression test, ten cases, including a multi-category venue that must match under either category and count once. It asserts the pre-fix DOM fails, so the test would have caught this. A build-time assert names the four required surfaces, so a hub silently losing its markers fails rather than disappearing from the check.

Driven in a real headless browser: 26 checks pass, covering default load, filtering both layers, URL state and cold deep-link, the live count preview, clear-all, back and forward, no-result recovery, the other three hubs, and the map still counting all 216 pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUtNaf5gYAh9HUBkEPYHi3
