### PR TITLE
PI-011: a layering policy, and consent that outranks promotion

### DIFF
--- a/next/src/components/ConciergeDrawer.astro
+++ b/next/src/components/ConciergeDrawer.astro
@@ -193,9 +193,9 @@ const conciergeIcon = '/images/pi-concierge.svg';
     --pi-drawer-margin: 24px;
     position: fixed;
     inset: 0;
-    /* Sit above masthead (9999), mobile-nav (10010), utility row.
-       When open the drawer must occlude the entire header chrome. */
-    z-index: 10020;
+    /* Top of the drawer tier: when open it must occlude the masthead,
+       the mobile nav and the utility row. Scale: v6-tokens.css. */
+    z-index: calc(var(--z-drawer) + 2);
     pointer-events: none;
     /* Local design tokens (mirror /ask) */
     --pi-paper:       #FAF6EE;
@@ -526,7 +526,7 @@ const conciergeIcon = '/images/pi-concierge.svg';
     position: fixed;
     bottom: 22px;
     right: 22px;
-    z-index: 9001;
+    z-index: calc(var(--z-drawer) + 2);
     cursor: pointer;
     pointer-events: auto;
     /* Pill shape - avatar left, label right */

--- a/next/src/components/CookieBanner.astro
+++ b/next/src/components/CookieBanner.astro
@@ -181,6 +181,11 @@
     document.addEventListener('keydown', function (e) {
       if (e.key !== 'Escape' && e.key !== 'Esc') return;
       if (banner.getAttribute('data-state') !== 'visible') return;
+      // A modal promotional overlay (InsiderNotePopup sets body.inote-open)
+      // owns Escape while it is open. One keystroke aimed at closing that
+      // must not silently drop the consent prompt for the rest of the visit
+      // as a side effect.
+      if (document.body.classList.contains('inote-open')) return;
       hide();
     });
 
@@ -221,9 +226,22 @@
     /* A hairline that actually reads: 3.24:1 on --white, so the ghost
        button and the toggle track meet WCAG 1.4.11. */
     --cb-line: color-mix(in srgb, var(--text) 50%, var(--white));
-    /* Distance from the bottom edge. Overridden on mobile to clear the
-       V5BottomBar tab strip. */
-    --cb-bottom: var(--space-5);
+    /* Distance from the bottom edge, composed from independent parts
+       rather than set in one place:
+         --cb-gap     breathing room from whatever sits directly below
+         --cb-chrome  persistent site chrome to clear (mobile tab strip)
+         --cb-promo   promotional strip to clear (the newsletter bar)
+       Two bottom-anchored fixed elements overlap whatever their stacking
+       order, so the consent card RESERVES the space it needs instead of
+       merely outranking what is down there. Splitting the parts means a
+       rule that adjusts one can never silently discard another - the old
+       single --cb-bottom had exactly that failure, with the newsletter
+       clearance living in a max-width:1023px block that never fired at
+       the desktop widths where the collision actually happens. */
+    --cb-gap:    var(--space-5);
+    --cb-chrome: 0px;
+    --cb-promo:  0px;
+    --cb-bottom: calc(var(--cb-gap) + var(--cb-chrome) + var(--cb-promo));
 
     position: fixed;
     left: var(--space-5);
@@ -233,7 +251,7 @@
     max-height: calc(100dvh - var(--cb-bottom) - var(--space-6));
     overflow-y: auto;
     overscroll-behavior: contain;
-    z-index: 9000;
+    z-index: var(--z-consent);
     background: var(--white);
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-m);
@@ -250,6 +268,7 @@
     transition:
       transform var(--dur-slow) var(--ease-enter),
       opacity var(--dur-slow) var(--ease-enter),
+      bottom var(--dur-slow) var(--ease-enter),
       visibility 0s linear var(--dur-slow);
   }
   .cookie-banner[data-state='visible'] {
@@ -259,7 +278,23 @@
     transition:
       transform var(--dur-slow) var(--ease-enter),
       opacity var(--dur-slow) var(--ease-enter),
+      bottom var(--dur-slow) var(--ease-enter),
       visibility 0s linear 0s;
+  }
+
+  /* ─────────────────────────────────────────────────────────────────────
+     Clear the newsletter strip (InsiderNotePopup.astro), at EVERY width.
+     The strip is position:fixed, full-bleed, bottom:0, and it is live in
+     production. Raising the consent card above it is not enough: both want
+     the bottom of the viewport, so the card would simply sit on top of the
+     strip. It steps clear of it instead.
+     The strip publishes its measured height onto <html> as
+     --pi-promo-bar-height, together with data-pi-promo-bar="visible". The
+     fallback covers the frame before the first measurement and any future
+     caller that sets the flag without the height.
+     ───────────────────────────────────────────────────────────────────── */
+  :global(html[data-pi-promo-bar='visible']) .cookie-banner {
+    --cb-promo: calc(var(--pi-promo-bar-height, 4.5rem) + var(--space-3));
   }
 
   .cookie-banner__inner {
@@ -404,14 +439,16 @@
      ───────────────────────────────────────────────────────────────────── */
   @media (max-width: 1023px) {
     .cookie-banner {
-      --cb-bottom: calc(56px + env(safe-area-inset-bottom) + var(--space-3));
+      --cb-gap:    var(--space-3);
+      --cb-chrome: calc(56px + env(safe-area-inset-bottom));
     }
 
     /* Pages that never render the bar (journal reading, dispatch/account/
        access/ask flows) reclaim the reserved space. Browsers without :has()
-       drop this rule and keep the safe, bar-clearing default above. */
+       drop this rule and keep the safe, bar-clearing default above. Only
+       the chrome part is released; any newsletter-strip clearance stands. */
     :global(body:not(:has(#v5BottomBar))) .cookie-banner {
-      --cb-bottom: var(--space-3);
+      --cb-chrome: 0px;
     }
   }
 

--- a/next/src/components/InsiderNotePopup.astro
+++ b/next/src/components/InsiderNotePopup.astro
@@ -86,10 +86,27 @@ const endpoint = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsl
         document.dispatchEvent(new CustomEvent(name, { detail: detail || {} }));
         if (typeof window.gtag === 'function') window.gtag('event', name, detail || {});
       }
-      function reveal(el) { el.hidden = false; window.setTimeout(function () { el.dataset.inoteReveal = 'true'; }, 40); }
+      // The strip is position:fixed, full-bleed, bottom:0. Anything else
+      // anchored to the bottom of the viewport (the cookie consent card)
+      // has to step clear of it rather than stack over it, so publish the
+      // measured height and a visibility flag on <html>; CookieBanner.astro
+      // reads both. Resynced on reveal, on hide and on resize, because the
+      // strip's copy rewraps and its height is not a constant.
+      function syncBarOffset() {
+        var doc = document.documentElement;
+        if (!bar.hidden && bar.dataset.inoteReveal === 'true') {
+          doc.style.setProperty('--pi-promo-bar-height', Math.ceil(bar.getBoundingClientRect().height) + 'px');
+          doc.setAttribute('data-pi-promo-bar', 'visible');
+        } else {
+          doc.removeAttribute('data-pi-promo-bar');
+          doc.style.removeProperty('--pi-promo-bar-height');
+        }
+      }
+      function reveal(el) { el.hidden = false; window.setTimeout(function () { el.dataset.inoteReveal = 'true'; syncBarOffset(); }, 40); }
       function hide(el, callback) {
         el.dataset.inoteReveal = 'false';
-        window.setTimeout(function () { el.hidden = true; if (callback) callback(); }, 360);
+        syncBarOffset();
+        window.setTimeout(function () { el.hidden = true; if (callback) callback(); syncBarOffset(); }, 360);
       }
       function stopWatching() {
         window.removeEventListener('scroll', watch);
@@ -97,7 +114,7 @@ const endpoint = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsl
       }
       function open(source) {
         if ((source !== 'bar' && blocked()) || root.dataset.inoteReveal === 'true') return;
-        stopWatching(); lastFocus = document.activeElement; bar.hidden = true;
+        stopWatching(); lastFocus = document.activeElement; bar.hidden = true; syncBarOffset();
         reveal(root); document.body.classList.add('inote-open');
         window.setTimeout(function () { input.focus({ preventScroll: true }); }, 400);
         track('note_popup_shown', { source: source });
@@ -118,8 +135,18 @@ const endpoint = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsl
         if (root.hidden) return;
         if (event.key === 'Escape') { dismiss(true); return; }
         if (event.key !== 'Tab') return;
-        var focusable = Array.prototype.filter.call(
-          root.querySelectorAll('button, input, [href]'),
+        // Consent outranks promotional UI in the layering scale, so while
+        // the consent card is up it is painted ON TOP of this modal. A trap
+        // confined to the modal would leave a visible control unreachable by
+        // keyboard, so the cycle spans both surfaces. CookieBanner renders
+        // before this component in BaseLayout, so it leads in document order.
+        var consent = document.getElementById('cookie-banner');
+        var candidates = [];
+        if (consent && consent.getAttribute('data-state') === 'visible') {
+          candidates = candidates.concat(Array.prototype.slice.call(consent.querySelectorAll('button, input, [href]')));
+        }
+        candidates = candidates.concat(Array.prototype.slice.call(root.querySelectorAll('button, input, [href]')));
+        var focusable = candidates.filter(
           function (el) { return !el.disabled && el.getClientRects().length > 0; }
         );
         if (!focusable.length) return;
@@ -131,10 +158,14 @@ const endpoint = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsl
       bar.querySelector('.inote__bar-cta').addEventListener('click', function () { open('bar'); });
       bar.querySelector('.inote__bar-close').addEventListener('click', function () { hide(bar); });
       document.addEventListener('keydown', trap);
+      window.addEventListener('resize', syncBarOffset);
       window.__inoteCleanup = function () {
         stopWatching();
         document.removeEventListener('keydown', trap);
+        window.removeEventListener('resize', syncBarOffset);
         document.body.classList.remove('inote-open');
+        document.documentElement.removeAttribute('data-pi-promo-bar');
+        document.documentElement.style.removeProperty('--pi-promo-bar-height');
         window.__inoteCleanup = null;
       };
       form.addEventListener('submit', function (event) {
@@ -163,8 +194,8 @@ const endpoint = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsl
 
 <style is:global>
   .inote, .inote * { box-sizing: border-box; }
-  .inote__scrim { position:fixed; inset:0; z-index:10000; background:rgba(7,26,42,.62); backdrop-filter:blur(3px); opacity:0; transition:opacity .32s ease-out; }
-  .inote__wrap { position:fixed; inset:0; z-index:10001; display:flex; align-items:center; justify-content:center; padding:20px; pointer-events:none; overflow:auto; }
+  .inote__scrim { position:fixed; inset:0; z-index:var(--z-overlay); background:rgba(7,26,42,.62); backdrop-filter:blur(3px); opacity:0; transition:opacity .32s ease-out; }
+  .inote__wrap { position:fixed; inset:0; z-index:calc(var(--z-overlay) + 1); display:flex; align-items:center; justify-content:center; padding:20px; pointer-events:none; overflow:auto; }
   .inote__card { width:min(820px,100%); max-height:calc(100vh - 40px); overflow-y:auto; pointer-events:auto; background:#fff; color:#14202A; box-shadow:0 40px 90px rgba(7,26,42,.45); opacity:0; transform:translateY(14px) scale(.985); transition:opacity .38s ease-out,transform .42s cubic-bezier(.16,.84,.44,1); }
   .inote[data-inote-reveal=true] .inote__scrim { opacity:1; } .inote[data-inote-reveal=true] .inote__card { opacity:1; transform:none; }
   .inote__edge { height:6px; background:#F5C177; } .inote__grid { display:flex; flex-wrap:wrap; } .inote__panel { flex:1 1 340px; min-width:0; padding:38px 36px 36px; position:relative; }
@@ -172,7 +203,7 @@ const endpoint = 'https://tjjhpvslpysfklwpqmgz.supabase.co/functions/v1/pi-newsl
   .inote__panel--form { flex-basis:320px; background:#F2EFEA; display:flex; flex-direction:column; } .inote__eyebrow,.inote__kicker { margin:0; font:700 10px/1.2 var(--sans,Arial,sans-serif); letter-spacing:.2em; text-transform:uppercase; } .inote__eyebrow { color:#F5C177; } .inote__lede { margin:16px 0 14px; font:800 clamp(1.8rem,5vw,2.25rem)/1.02 var(--display,'Sora',Arial,sans-serif); letter-spacing:-.04em; color:#fff; } .inote__sub { margin:0; font:400 15px/1.6 var(--sans,Arial,sans-serif); color:#D7E2EA; } .inote__rule { height:1px; background:#2E4A63; margin:26px 0 18px; } .inote__issue { margin:0; color:#7A9CB6; font:700 11px/1.2 var(--sans,Arial,sans-serif); letter-spacing:.14em; text-transform:uppercase; }
   .inote__close { position:absolute; top:10px; right:12px; z-index:2; border:0; background:none; color:#D7E2EA; cursor:pointer; padding:6px; font-size:22px; line-height:1; } .inote__kicker { color:#8A5620; } .inote__ask { margin:12px 0 22px; font:600 21px/1.2 var(--display,'Sora',Arial,sans-serif); letter-spacing:-.025em; } .inote__label { display:block; margin-bottom:8px; color:#6A7680; font:400 12.5px/1.2 var(--sans,Arial,sans-serif); } .inote__input { width:100%; border:1px solid #C9C4BA; border-radius:0; background:#fff; padding:15px 16px; color:#14202A; font:400 15px/1.2 var(--sans,Arial,sans-serif); outline:none; } .inote__input:focus { border-color:#0B2E4A; box-shadow:0 0 0 2px rgba(11,46,74,.15); }
   .inote__button { width:100%; margin-top:12px; border:0; border-bottom:3px solid #C08F45; background:#F5C177; color:#14202A; cursor:pointer; padding:16px 20px; font:700 12px/1 var(--sans,Arial,sans-serif); letter-spacing:.16em; text-transform:uppercase; } .inote__button:hover { background:#F0B45E; } .inote__button:disabled { opacity:.6; cursor:default; } .inote__status { min-height:1.25em; margin:10px 0 0; color:#9B2C2C; font:400 13px/1.4 var(--sans,Arial,sans-serif); } .inote__fine { margin:14px 0 0; color:#6A7680; font:400 12.5px/1.6 var(--sans,Arial,sans-serif); } .inote__not-now { align-self:flex-start; margin-top:18px; border:0; border-bottom:1px solid #C9C4BA; background:none; color:#6A7680; cursor:pointer; padding:0; font:400 13px/1.4 var(--sans,Arial,sans-serif); } .inote__done { margin:auto 0; } .inote__done i { display:block; width:52px; height:3px; background:#8A5620; } .inote__done h2 { margin:16px 0 10px; font:700 26px/1.12 var(--display,'Sora',Arial,sans-serif); letter-spacing:-.03em; } .inote__done p { margin:0; color:#4B5862; font:400 14.5px/1.6 var(--sans,Arial,sans-serif); }
-  .inote__bar { position:fixed; right:0; bottom:0; left:0; z-index:10002; border-top:3px solid #F5C177; background:#0B2E4A; opacity:0; transform:translateY(100%); transition:opacity .3s ease-out,transform .34s cubic-bezier(.16,.84,.44,1); } .inote__bar[data-inote-reveal=true] { opacity:1; transform:none; } .inote__bar-inner { display:flex; max-width:1000px; align-items:center; justify-content:space-between; gap:20px; margin:0 auto; padding:14px 28px; } .inote__bar p { margin:0; color:#D7E2EA; font:400 14px/1.4 var(--sans,Arial,sans-serif); } .inote__bar-actions { display:flex; align-items:center; gap:16px; } .inote__bar-cta { border:0; background:#F5C177; color:#14202A; cursor:pointer; padding:11px 20px; font:700 11px/1 var(--sans,Arial,sans-serif); letter-spacing:.16em; text-transform:uppercase; white-space:nowrap; } .inote__bar-close { border:0; background:none; color:#D7E2EA; cursor:pointer; padding:6px; font-size:18px; line-height:1; } body.inote-open { overflow:hidden; }
+  .inote__bar { position:fixed; right:0; bottom:0; left:0; z-index:calc(var(--z-overlay) + 2); border-top:3px solid #F5C177; background:#0B2E4A; opacity:0; transform:translateY(100%); transition:opacity .3s ease-out,transform .34s cubic-bezier(.16,.84,.44,1); } .inote__bar[data-inote-reveal=true] { opacity:1; transform:none; } .inote__bar-inner { display:flex; max-width:1000px; align-items:center; justify-content:space-between; gap:20px; margin:0 auto; padding:14px 28px; } .inote__bar p { margin:0; color:#D7E2EA; font:400 14px/1.4 var(--sans,Arial,sans-serif); } .inote__bar-actions { display:flex; align-items:center; gap:16px; } .inote__bar-cta { border:0; background:#F5C177; color:#14202A; cursor:pointer; padding:11px 20px; font:700 11px/1 var(--sans,Arial,sans-serif); letter-spacing:.16em; text-transform:uppercase; white-space:nowrap; } .inote__bar-close { border:0; background:none; color:#D7E2EA; cursor:pointer; padding:6px; font-size:18px; line-height:1; } body.inote-open { overflow:hidden; }
   @media (max-width:640px) { .inote__panel { padding:24px 22px; } .inote__card { max-height:calc(100vh - 32px); } .inote__bar-inner { flex-direction:column; align-items:stretch; gap:12px; padding:14px 18px; } .inote__bar-actions { justify-content:space-between; } .inote__bar-cta { flex:1; min-height:48px; } }
   @media (prefers-reduced-motion:reduce) { .inote__scrim,.inote__card,.inote__bar { transition:none!important; transform:none!important; } }
 </style>

--- a/next/src/components/v5/chrome/V5BottomBar.astro
+++ b/next/src/components/v5/chrome/V5BottomBar.astro
@@ -153,7 +153,7 @@ function isActive(href: string): boolean {
       left: 0;
       right: 0;
       bottom: 0;
-      z-index: 10000;
+      z-index: var(--z-chrome);
       background: var(--bg);
       border-top: 1px solid var(--border);
       padding-bottom: env(safe-area-inset-bottom);

--- a/next/src/components/v5/chrome/V5MobileDrawer.astro
+++ b/next/src/components/v5/chrome/V5MobileDrawer.astro
@@ -150,7 +150,7 @@ const groups = [
        own stacking context. Use a literal opaque fallback as --bg may be
        overridden by an experimental theme. */
     min-height: 100dvh;
-    z-index: 10010;
+    z-index: calc(var(--z-drawer) + 1);
     display: flex;
     flex-direction: column;
     background-color: #fff;

--- a/next/src/lib/hero-editor/HeroEditorMount.astro
+++ b/next/src/lib/hero-editor/HeroEditorMount.astro
@@ -18,7 +18,7 @@
     position: fixed;
     left: 16px;
     bottom: 16px;
-    z-index: 10050;
+    z-index: var(--z-editor);
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
@@ -39,7 +39,7 @@
     position: fixed;
     top: 0;
     right: 0;
-    z-index: 10060;
+    z-index: calc(var(--z-editor) + 1);
     width: min(420px, 100vw);
     height: 100dvh;
     display: flex;

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -198,7 +198,7 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
 .masthead {
   position: sticky;
   top: 0;
-  z-index: 9999;
+  z-index: var(--z-chrome);
   /* Opaque, and on the palette. This was a hardcoded rgba(245,241,235,.97)
      - a warm v5 cream - which survived every palette migration because a
      raw rgba() is invisible to a token swap. Paired with the translucent
@@ -2979,8 +2979,9 @@ hr.rule { border: none; border-top: 1px solid var(--border); }
   /* Sticky under the masthead so the reader can always see where they
      are in the hierarchy on long pages. `--masthead-h` is set in JS by
      BaseLayout (ResizeObserver on .masthead); the fallback covers SSR
-     and the brief window before the script runs. z-index sits just
-     under the masthead (9999) so dropdowns/modals still layer above. */
+     and the brief window before the script runs. The z-index stays a
+     small local value, below the --z-chrome tier the masthead sits on,
+     so dropdowns and modals still layer above. */
   position: sticky;
   top: var(--masthead-h, 6rem);
   z-index: 50;
@@ -7155,7 +7156,7 @@ p.has-drop-cap::first-letter {
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 9998;
+  z-index: var(--z-drawer);
   background: var(--bg);
   padding: clamp(4rem, 10vh, 4.75rem) 0 0;
   overflow-y: auto;
@@ -8148,7 +8149,7 @@ p.has-drop-cap::first-letter {
 
 /* 1) Mobile-nav overlay sits above masthead and utility row so its
       own wordmark is not double-stacked. */
-.mobile-nav { z-index: 10010 !important; }
+.mobile-nav { z-index: calc(var(--z-drawer) + 1) !important; }
 
 /* 2) When the mobile-nav is open, hide the masthead so the wordmark
       doesn't ghost through the overlay. body.menu-open is toggled
@@ -8395,7 +8396,7 @@ body[data-path^="/ask"] .concierge-fab {
   position: fixed;
   left: 0.85rem;
   bottom: calc(env(safe-area-inset-bottom, 0px) + 0.85rem);
-  z-index: 90; /* below mobile-nav (10010) and masthead (9999) */
+  z-index: 90; /* local value: below every tier in the layering scale */
   box-shadow: 0 8px 24px rgba(0, 40, 34, 0.22);
   opacity: 0;
   transform: translateY(8px);

--- a/next/src/styles/inline-edit.css
+++ b/next/src/styles/inline-edit.css
@@ -11,7 +11,7 @@
   position: fixed;
   top: 1rem;
   right: 1rem;
-  z-index: 9999;
+  z-index: var(--z-editor);
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -58,7 +58,7 @@ body[data-pi-edit-mode="on"] .pi-edit-toggle__dot {
   position: fixed;
   top: 3.4rem;
   right: 1rem;
-  z-index: 9999;
+  z-index: var(--z-editor);
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -190,7 +190,7 @@ body[data-pi-edit-mode="on"] [role="img"]:not([data-pi-edit]):not([data-pi-no-ed
 
 .pi-edit-panel {
   position: fixed;
-  z-index: 10000;
+  z-index: calc(var(--z-editor) + 1);
   width: 320px;
   max-height: calc(100vh - 16px);
   background: #faf7f0;
@@ -590,7 +590,7 @@ body[data-pi-edit-mode="on"] [role="img"]:not([data-pi-edit]):not([data-pi-no-ed
   border-radius: var(--radius-l);
   font: 500 0.8rem/1 var(--font-ui);
   letter-spacing: 0.03em;
-  z-index: 10001;
+  z-index: calc(var(--z-editor) + 2);
   opacity: 0;
   transition: opacity 0.18s ease, transform 0.18s ease;
   pointer-events: none;
@@ -659,7 +659,7 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
 
 .pi-block-toolbar {
   position: absolute;
-  z-index: 10000;
+  z-index: calc(var(--z-editor) + 1);
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
@@ -742,7 +742,7 @@ body[data-pi-edit-mode="on"] [data-pi-prose-root] [data-pi-block-id].pi-block-ed
 
 .pi-link-popover {
   position: absolute;
-  z-index: 10001;
+  z-index: calc(var(--z-editor) + 2);
   width: 360px;
   max-width: calc(100vw - 16px);
   background: #faf7f0;

--- a/next/src/styles/search.css
+++ b/next/src/styles/search.css
@@ -39,13 +39,14 @@
 }
 
 /* ─── Search overlay (instant Pagefind dropdown) ────────────────── */
-/* z-index sits above the masthead (9999) but below the mobile-nav
-   overlay (10010), so the search overlay covers the sticky header
-   when open while staying respectful of the burger-menu's primacy. */
+/* Drawer tier (see the layering scale in src/styles/v6-tokens.css): above
+   the masthead, one step below the mobile-nav overlay, so the search
+   overlay covers the sticky header when open while staying respectful of
+   the burger-menu's primacy. */
 .site-search-overlay {
   position: fixed;
   inset: 0;
-  z-index: 10005;
+  z-index: var(--z-drawer);
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/next/src/styles/v6-tokens.css
+++ b/next/src/styles/v6-tokens.css
@@ -193,6 +193,60 @@
   --elev-2: 0 14px 28px -14px rgba(0, 40, 34, 0.26);
   --elev-3: 0 26px 52px -18px rgba(0, 40, 34, 0.34);
 
+  /* ── Layering scale - the single z-index vocabulary for site-wide
+     overlay chrome. Added 2026-09-13 (PI-011).
+
+     Before this there was no scale at all: every overlay carried an ad
+     hoc integer, each one apparently one-upping the previous highest
+     (9000 consent, 9001/10020 concierge, 9998/9999 chrome, 10000-10002
+     newsletter, 10005 search, 10010 mobile drawer, 10050/10060 editor).
+     Nothing recorded the intended order, so the newsletter strip ended up
+     above the consent card and covered its buttons.
+
+     The tiers, lowest to highest:
+       --z-base     page content, the default stacking ground
+       --z-sticky   in-page sticky furniture (breadcrumbs, filter bars)
+       --z-chrome   persistent site chrome: masthead, mobile tab bar
+       --z-drawer   full-viewport navigation surfaces: search overlay,
+                    mobile nav / mobile drawer, concierge drawer
+       --z-overlay  promotional and marketing overlays: the newsletter
+                    modal and its bottom strip
+       --z-consent  legal consent. MUST outrank promotion. A cookie
+                    banner a marketing panel can bury is not a consent
+                    mechanism, so nothing promotional may ever be raised
+                    above this tier.
+       --z-editor   admin and editor tooling. Sits on top of everything,
+                    consent included, because it is how the site gets
+                    repaired.
+
+     Rules for the next component author:
+       1. Pick a tier, not a number. Write var(--z-<tier>).
+       2. Need to order two surfaces inside one tier? Use
+          calc(var(--z-<tier>) + 1). The 1000-point gaps exist for that.
+       3. Do NOT invent a new higher integer. If nothing fits, add a tier
+          here, in order, and say why.
+       4. Small local stacking values (1 to ~1200, inside a component that
+          owns its own stacking context) are not this scale's business.
+          Leave them local. The scale deliberately starts at 2000 so that
+          every one of them stays below site chrome, exactly as before.
+       5. z-index never fixes a geometric collision. Two bottom-anchored
+          fixed elements still overlap when both sit at bottom:0, whatever
+          their stacking order. Reserve space instead - see --cb-promo in
+          CookieBanner.astro and --pi-promo-bar-height below. ── */
+  --z-base:    0;
+  --z-sticky:  2000;
+  --z-chrome:  3000;
+  --z-drawer:  4000;
+  --z-overlay: 5000;
+  --z-consent: 6000;
+  --z-editor:  7000;
+
+  /* Height of the bottom-anchored promotional strip, published by
+     InsiderNotePopup.astro onto <html> while the strip is on screen
+     (alongside data-pi-promo-bar="visible"). Bottom-anchored UI that must
+     stay clear of it reads this rather than guessing. Absent by default,
+     so every consumer needs a fallback. */
+
   /* ── Motion ── */
   --dur-fast: 120ms;
   --dur-med:  200ms;


### PR DESCRIPTION
Closes #372, apart from the accessibility sweep noted at the end.

## The defect, measured

At 1348x926 the consent card's box bottom sat at 902 and the newsletter strip's top at 851, so the card overlapped the strip by 51px. The Accept all button's centre was 8px inside the strip, which stacked above it at 10002 against 9000. The button was unclickable until an unrelated promotional bar was dismissed.

There was a bottom-clearing rule for this, but it sat inside a `max-width: 1023px` query, so it never fired at desktop widths, which is exactly where the collision was.

## The structural cause: no layering policy existed

Every z-index under `next/src` was an ad hoc integer, apparently each one-upping the previous highest: 9000 consent, 9001 concierge, 9998 and 9999 chrome, 10000 to 10002 newsletter, 10005 search, 10010 mobile drawer, 10020 concierge trigger, 10050 and 10060 editor.

Nothing decided that a promotional bar should outrank a consent control. Nothing prevented it.

There is now a scale in the design-token file, with a comment block explaining the tiers and the rule that consent outranks promotion:

| Token | Value | Tier |
|---|---|---|
| `--z-sticky` | 2000 | in-page sticky furniture |
| `--z-chrome` | 3000 | masthead, mobile tab bar |
| `--z-drawer` | 4000 | search, nav, concierge |
| `--z-overlay` | 5000 | promotional overlays |
| `--z-consent` | 6000 | legal consent |
| `--z-editor` | 7000 | admin tooling |

Numbers start at 2000 deliberately. Every small local stacking value already in the codebase tops out at 1200, so they all stay below site chrome exactly as before. Had the tiers been 100 apart, three components would silently have started outranking the masthead.

## Stacking order alone could not fix this

Both surfaces are fixed to the bottom of the viewport, so they overlap whatever the z-order. The consent offset is now composed from three independent parts: a gap, the mobile tab strip, and the promotional strip. Nothing reassigns the whole offset any more, which is the failure mode that let the old rule drop the desktop case.

The newsletter component publishes its **measured** height to the root element and resyncs on reveal, on hide and on resize, since the strip's copy rewraps. The consent card reads it in one rule with no media query, so it applies at every width.

## Proved in a real browser

Puppeteer against the built site, driving the real production path: scroll, modal opens, dismiss, strip reveals.

| State | Consent bottom | Strip | Accept all |
|---|---|---|---|
| strip hidden | 24px | absent | hittable |
| **strip revealed** | **111px** | 75px tall, top at 851 | **hittable, 36px clear** |
| strip dismissed | back to 24px | released | hittable |

A hit test at the button centre returns the consent button, and a real click through it wrote the consent record with its original shape while the newsletter snooze was preserved. Width sweep at 1920 down to 320: consent fully on screen everywhere, 36px clearance at desktop and 80px at mobile.

## Keyboard

Because consent now paints above the promotional modal, that modal's focus trap would have stranded a visible control. Its tab cycle now spans the consent card in document order, and Escape no longer silently drops the consent prompt for the visit.

## For James, not blocking

Consent now paints above the newsletter **modal**, not only the strip. That modal sets `aria-modal`, which makes everything outside it inert to assistive technology, so a screen-reader user may still not reach the consent card while it is open even though a sighted or keyboard user now can. The clean fix is for the newsletter to defer opening while consent is pending, which is a behaviour change I did not make unilaterally.

**The WCAG 2.2 AA sweep this ticket also calls for has not been done** and is deliberately out of this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUtNaf5gYAh9HUBkEPYHi3
